### PR TITLE
feat(cli): add progress bars and shell completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,6 +270,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c0da80818b2d95eca9aa614a30783e42f62bf5fdfee24e68cfb960b071ba8d1"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,6 +301,19 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "console"
@@ -504,8 +526,10 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
- "console",
+ "clap_complete",
+ "console 0.16.2",
  "exarch-core",
+ "indicatif",
  "predicates",
  "serde",
  "serde_json",
@@ -751,6 +775,20 @@ checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console 0.15.11",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-segmentation",
+ "unicode-width",
+ "web-time",
 ]
 
 [[package]]
@@ -1008,6 +1046,12 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
@@ -1777,6 +1821,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1815,11 +1869,20 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -1833,20 +1896,42 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1856,9 +1941,21 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1868,9 +1965,21 @@ checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1880,15 +1989,33 @@ checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,10 +46,12 @@ zstd = "0.13"
 
 # CLI dependencies
 clap = { version = "4.5", features = ["derive", "cargo", "wrap_help", "color"] }
+clap_complete = "4.5"
 anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 console = "0.16"
+indicatif = { version = "0.17", features = ["improved_unicode"] }
 
 # CLI testing
 assert_cmd = "2.1"

--- a/crates/exarch-cli/Cargo.toml
+++ b/crates/exarch-cli/Cargo.toml
@@ -18,10 +18,12 @@ path = "src/main.rs"
 [dependencies]
 exarch-core.workspace = true
 clap.workspace = true
+clap_complete.workspace = true
 anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 console.workspace = true
+indicatif.workspace = true
 
 [dev-dependencies]
 assert_cmd.workspace = true

--- a/crates/exarch-cli/src/cli.rs
+++ b/crates/exarch-cli/src/cli.rs
@@ -2,6 +2,7 @@
 
 use clap::Parser;
 use clap::Subcommand;
+use clap_complete::Shell;
 use std::path::PathBuf;
 
 #[derive(Parser)]
@@ -35,6 +36,15 @@ pub enum Commands {
     List(ListArgs),
     /// Verify archive integrity
     Verify(VerifyArgs),
+    /// Generate shell completions
+    Completion(CompletionArgs),
+}
+
+#[derive(clap::Args)]
+pub struct CompletionArgs {
+    /// Shell to generate completions for
+    #[arg(value_enum)]
+    pub shell: Shell,
 }
 
 #[derive(clap::Args)]

--- a/crates/exarch-cli/src/commands/completion.rs
+++ b/crates/exarch-cli/src/commands/completion.rs
@@ -1,0 +1,51 @@
+//! Shell completion generation command.
+
+use crate::cli::Cli;
+use clap::CommandFactory;
+use clap_complete::Shell;
+use std::io;
+
+/// Generates shell completions for the specified shell.
+///
+/// # Arguments
+///
+/// * `shell` - Target shell (bash, zsh, fish, powershell, elvish)
+///
+/// # Examples
+///
+/// ```no_run
+/// use clap_complete::Shell;
+/// use exarch_cli::commands::completion;
+///
+/// completion::execute(Shell::Bash);
+/// ```
+pub fn execute(shell: Shell) {
+    let mut cmd = Cli::command();
+    clap_complete::generate(shell, &mut cmd, "exarch", &mut io::stdout());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_completion_generation() {
+        // Test that completion generation doesn't panic
+        // We can't easily test the output without capturing stdout
+        for shell in [
+            Shell::Bash,
+            Shell::Zsh,
+            Shell::Fish,
+            Shell::PowerShell,
+            Shell::Elvish,
+        ] {
+            let result = std::panic::catch_unwind(|| {
+                let mut cmd = Cli::command();
+                let mut output = Vec::new();
+                clap_complete::generate(shell, &mut cmd, "exarch", &mut output);
+                output
+            });
+            assert!(result.is_ok(), "Completion generation failed for {shell:?}");
+        }
+    }
+}

--- a/crates/exarch-cli/src/commands/mod.rs
+++ b/crates/exarch-cli/src/commands/mod.rs
@@ -1,5 +1,6 @@
 //! Command implementations.
 
+pub mod completion;
 pub mod create;
 pub mod extract;
 pub mod list;

--- a/crates/exarch-cli/src/main.rs
+++ b/crates/exarch-cli/src/main.rs
@@ -5,6 +5,7 @@ mod cli;
 mod commands;
 mod error;
 mod output;
+mod progress;
 
 use anyhow::Result;
 use clap::Parser;
@@ -19,5 +20,9 @@ fn main() -> Result<()> {
         cli::Commands::Create(args) => commands::create::execute(args, &*formatter, cli.quiet),
         cli::Commands::List(args) => commands::list::execute(args, &*formatter),
         cli::Commands::Verify(args) => commands::verify::execute(args, &*formatter),
+        cli::Commands::Completion(args) => {
+            commands::completion::execute(args.shell);
+            Ok(())
+        }
     }
 }

--- a/crates/exarch-cli/src/progress.rs
+++ b/crates/exarch-cli/src/progress.rs
@@ -1,0 +1,166 @@
+//! Progress bar implementation for CLI operations.
+
+use console::Term;
+use exarch_core::ProgressCallback;
+use indicatif::ProgressBar;
+use indicatif::ProgressState;
+use indicatif::ProgressStyle;
+use std::fmt::Write;
+use std::path::Path;
+
+/// CLI progress bar wrapper implementing `ProgressCallback`.
+///
+/// Displays a progress bar with file count, bytes processed, speed, and ETA
+/// when running in a TTY. Automatically cleans up on drop.
+pub struct CliProgress {
+    bar: ProgressBar,
+    bytes_written: u64,
+}
+
+impl CliProgress {
+    /// Creates a new CLI progress bar.
+    ///
+    /// # Arguments
+    ///
+    /// * `total` - Total number of entries to process
+    /// * `message` - Message to display (e.g., "Extracting", "Creating")
+    #[must_use]
+    pub fn new(total: usize, message: &str) -> Self {
+        let bar = ProgressBar::new(total as u64);
+
+        // Template: "Extracting [████████░░░░] 42/100 files (15.2 MB, 5.1 MB/s, 12s)"
+        bar.set_style(
+            ProgressStyle::default_bar()
+                .template(
+                    "{msg} [{bar:40.cyan/blue}] {pos}/{len} files ({bytes}, {bytes_per_sec}, {eta})",
+                )
+                .unwrap_or_else(|_| ProgressStyle::default_bar())
+                .with_key("bytes", |state: &ProgressState, w: &mut dyn Write| {
+                    write!(w, "{}", humanize_bytes(state.pos())).unwrap_or(());
+                })
+                .with_key("bytes_per_sec", |state: &ProgressState, w: &mut dyn Write| {
+                    let per_sec = state.per_sec();
+                    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                    let bytes_per_sec = per_sec as u64;
+                    write!(w, "{}/s", humanize_bytes(bytes_per_sec)).unwrap_or(());
+                })
+                .with_key("eta", |state: &ProgressState, w: &mut dyn Write| {
+                    let eta = state.eta();
+                    write!(w, "{}", humanize_duration(eta)).unwrap_or(());
+                })
+                .progress_chars("█▓░"),
+        );
+
+        bar.set_message(message.to_string());
+
+        Self {
+            bar,
+            bytes_written: 0,
+        }
+    }
+
+    /// Checks if we should show progress (TTY detection).
+    #[must_use]
+    pub fn should_show() -> bool {
+        Term::stdout().is_term()
+    }
+}
+
+impl Drop for CliProgress {
+    fn drop(&mut self) {
+        self.bar.finish_and_clear();
+    }
+}
+
+impl ProgressCallback for CliProgress {
+    fn on_entry_start(&mut self, _path: &Path, _total: usize, _current: usize) {
+        // Entry start is handled by on_entry_complete incrementing the counter
+    }
+
+    fn on_bytes_written(&mut self, bytes: u64) {
+        self.bytes_written += bytes;
+        self.bar.set_position(self.bytes_written);
+    }
+
+    fn on_entry_complete(&mut self, _path: &Path) {
+        self.bar.inc(1);
+    }
+
+    fn on_complete(&mut self) {
+        self.bar.finish_and_clear();
+    }
+}
+
+/// Converts bytes to human-readable format (KB, MB, GB, TB).
+fn humanize_bytes(bytes: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = KB * 1024;
+    const GB: u64 = MB * 1024;
+    const TB: u64 = GB * 1024;
+
+    if bytes >= TB {
+        format!("{:.1} TB", bytes as f64 / TB as f64)
+    } else if bytes >= GB {
+        format!("{:.1} GB", bytes as f64 / GB as f64)
+    } else if bytes >= MB {
+        format!("{:.1} MB", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{:.1} KB", bytes as f64 / KB as f64)
+    } else {
+        format!("{bytes} B")
+    }
+}
+
+/// Converts duration to human-readable format.
+fn humanize_duration(duration: std::time::Duration) -> String {
+    let secs = duration.as_secs();
+    if secs >= 3600 {
+        format!("{}h{}m", secs / 3600, (secs % 3600) / 60)
+    } else if secs >= 60 {
+        format!("{}m{}s", secs / 60, secs % 60)
+    } else {
+        format!("{secs}s")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_humanize_bytes() {
+        assert_eq!(humanize_bytes(0), "0 B");
+        assert_eq!(humanize_bytes(512), "512 B");
+        assert_eq!(humanize_bytes(1024), "1.0 KB");
+        assert_eq!(humanize_bytes(1536), "1.5 KB");
+        assert_eq!(humanize_bytes(1024 * 1024), "1.0 MB");
+        assert_eq!(humanize_bytes(1024 * 1024 * 1024), "1.0 GB");
+        assert_eq!(humanize_bytes(1024_u64.pow(4)), "1.0 TB");
+    }
+
+    #[test]
+    fn test_humanize_duration() {
+        assert_eq!(humanize_duration(std::time::Duration::from_secs(0)), "0s");
+        assert_eq!(humanize_duration(std::time::Duration::from_secs(30)), "30s");
+        assert_eq!(
+            humanize_duration(std::time::Duration::from_secs(90)),
+            "1m30s"
+        );
+        assert_eq!(
+            humanize_duration(std::time::Duration::from_secs(3661)),
+            "1h1m"
+        );
+    }
+
+    #[test]
+    fn test_progress_callback() {
+        let mut progress = CliProgress::new(100, "Testing");
+
+        // Simulate processing entries
+        progress.on_entry_start(Path::new("test.txt"), 100, 1);
+        progress.on_bytes_written(1024);
+        progress.on_entry_complete(Path::new("test.txt"));
+
+        assert_eq!(progress.bytes_written, 1024);
+    }
+}

--- a/crates/exarch-cli/tests/cli_tests.rs
+++ b/crates/exarch-cli/tests/cli_tests.rs
@@ -1358,3 +1358,77 @@ fn test_create_tar_gz_matches_gzip_extension() {
         assert!(archive.exists());
     }
 }
+
+// ============================================================================
+// Completion Command Tests
+// ============================================================================
+
+#[test]
+fn test_completion_bash() {
+    exarch_cmd()
+        .arg("completion")
+        .arg("bash")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("_exarch"));
+}
+
+#[test]
+fn test_completion_zsh() {
+    exarch_cmd()
+        .arg("completion")
+        .arg("zsh")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("_exarch"));
+}
+
+#[test]
+fn test_completion_fish() {
+    exarch_cmd()
+        .arg("completion")
+        .arg("fish")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("exarch"));
+}
+
+#[test]
+fn test_completion_powershell() {
+    exarch_cmd()
+        .arg("completion")
+        .arg("powershell")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("exarch"));
+}
+
+#[test]
+fn test_completion_elvish() {
+    exarch_cmd()
+        .arg("completion")
+        .arg("elvish")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("exarch"));
+}
+
+#[test]
+fn test_completion_help() {
+    exarch_cmd()
+        .arg("completion")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Generate shell completions"));
+}
+
+#[test]
+fn test_completion_invalid_shell() {
+    exarch_cmd()
+        .arg("completion")
+        .arg("invalid_shell")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid value"));
+}

--- a/crates/exarch-core/src/creation/zip.rs
+++ b/crates/exarch-core/src/creation/zip.rs
@@ -4,6 +4,7 @@
 //! compression levels and security options.
 
 use crate::ExtractionError;
+use crate::ProgressCallback;
 use crate::Result;
 use crate::creation::config::CreationConfig;
 use crate::creation::filters;
@@ -48,6 +49,34 @@ pub fn create_zip<P: AsRef<Path>, Q: AsRef<Path>>(
 ) -> Result<CreationReport> {
     let file = File::create(output.as_ref())?;
     create_zip_internal(file, sources, config)
+}
+
+/// Creates a ZIP archive with progress reporting.
+///
+/// # Errors
+///
+/// Returns an error if output file cannot be created or I/O operations fail.
+#[allow(dead_code)] // Phase 4: will be used by CLI
+pub fn create_zip_with_progress<P: AsRef<Path>, Q: AsRef<Path>>(
+    output: P,
+    sources: &[Q],
+    config: &CreationConfig,
+    progress: &mut dyn ProgressCallback,
+) -> Result<CreationReport> {
+    let file = File::create(output.as_ref())?;
+    create_zip_internal_with_progress(file, sources, config, progress)
+}
+
+/// Internal function that creates ZIP with any writer and progress reporting.
+fn create_zip_internal_with_progress<W: Write + Seek, P: AsRef<Path>>(
+    writer: W,
+    sources: &[P],
+    config: &CreationConfig,
+    _progress: &mut dyn ProgressCallback,
+) -> Result<CreationReport> {
+    // TODO: Integrate progress callbacks
+    // For now, delegate to the non-progress version
+    create_zip_internal(writer, sources, config)
 }
 
 /// Internal function that creates ZIP with any writer.

--- a/crates/exarch-core/src/lib.rs
+++ b/crates/exarch-core/src/lib.rs
@@ -36,7 +36,9 @@ pub mod types;
 
 // Re-export main API types
 pub use api::create_archive;
+pub use api::create_archive_with_progress;
 pub use api::extract_archive;
+pub use api::extract_archive_with_progress;
 pub use api::list_archive;
 pub use api::verify_archive;
 pub use archive::Archive;
@@ -46,6 +48,8 @@ pub use error::ExtractionError;
 pub use error::QuotaResource;
 pub use error::Result;
 pub use report::ExtractionReport;
+pub use report::NoopProgress;
+pub use report::ProgressCallback;
 
 // Re-export creation types
 pub use creation::ArchiveCreator;

--- a/deny.toml
+++ b/deny.toml
@@ -4,7 +4,13 @@
 version = 2
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
-ignore = []
+ignore = [
+    # number_prefix is unmaintained but still functional
+    # Transitive dependency via indicatif (progress bars)
+    # No security vulnerabilities, just maintenance status
+    # Tracking: https://github.com/console-rs/indicatif/issues/688
+    "RUSTSEC-2025-0119",
+]
 
 [licenses]
 version = 2


### PR DESCRIPTION
## Summary

Phase 4 implementation adding CLI progress bars and shell completion support:

- **ProgressCallback trait** with `NoopProgress` zero-cost default implementation
- **Shell completions** for bash, zsh, fish, powershell, and elvish via `exarch completion <shell>`
- **Progress bar infrastructure** with TTY detection and `--quiet` flag integration
- **API variants** `*_with_progress` for future integration

## Changes

### Core Library (exarch-core)
- `report.rs`: Added `ProgressCallback` trait and `NoopProgress` implementation
- `api.rs`: Added `*_with_progress` API variants
- `creation/tar.rs`, `creation/zip.rs`: Added placeholder `*_with_progress` functions

### CLI (exarch-cli)
- `progress.rs`: NEW - `CliProgress` wrapper for indicatif
- `commands/completion.rs`: NEW - Shell completion generation
- Integrated progress bars into extract/create commands
- Added 7 completion tests

### Dependencies
| Crate | Version | Purpose |
|-------|---------|---------|
| indicatif | 0.17 | Progress bar rendering |
| clap_complete | 4.5 | Shell completion generation |
| console | 0.16 | Terminal detection |

### Security
- Added `RUSTSEC-2025-0119` suppression in `deny.toml` (unmaintained `number_prefix` via indicatif - no security impact)

## Test plan
- [x] 500 tests pass (cargo nextest)
- [x] Completion generation works for all 5 shells
- [x] TTY detection functions correctly
- [x] cargo deny check passes
- [x] cargo clippy passes
- [x] Documentation builds without warnings

## Usage

```bash
# Shell completions
exarch completion bash > ~/.bash_completion.d/exarch
exarch completion zsh > ~/.zsh/completions/_exarch
exarch completion fish > ~/.config/fish/completions/exarch.fish

# Progress bars (auto-detected on TTY)
exarch extract archive.tar.gz ./output
exarch create archive.tar.gz ./source --quiet  # suppress progress
```