### PR TITLE
chore: bump version to 0.1.2 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-01-01
+
+### Added
+- CVE test fixtures for path traversal, symlink escape, and hardlink attacks
+- FFI panic safety wrapper for Node.js `extractArchiveSync` function
+- Test cleanup (afterEach) to Node.js integration tests
+- Enabled CLI extraction integration tests
+
+### Fixed
+- ZIP creation root directory bug causing incorrect archive structure
+- Python CVE regression tests now fully enabled (7 tests)
+
+### Changed
+- Test infrastructure improvements for better reliability
+
 ## [0.1.1] - 2026-01-01
 
 ### Changed
@@ -85,6 +100,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 64KB reusable copy buffers
 - LRU cache for symlink target resolution
 
-[Unreleased]: https://github.com/bug-ops/exarch/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/bug-ops/exarch/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/bug-ops/exarch/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/bug-ops/exarch/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/bug-ops/exarch/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "exarch-cli"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -538,7 +538,7 @@ dependencies = [
 
 [[package]]
 name = "exarch-core"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bzip2",
  "criterion",
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "exarch-node"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "exarch-core",
  "napi",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "exarch-python"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "exarch-core",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Exarch Contributors"]
 edition = "2024"
 rust-version = "1.89.0"
@@ -20,7 +20,7 @@ categories = ["compression", "filesystem"]
 
 [workspace.dependencies]
 # Workspace crates
-exarch-core = { path = "crates/exarch-core", version = "0.1.1" }
+exarch-core = { path = "crates/exarch-core", version = "0.1.2" }
 
 # Dependencies (sorted alphabetically)
 bzip2 = "0.6"

--- a/crates/exarch-node/package-lock.json
+++ b/crates/exarch-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "exarch-rs",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "exarch-rs",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@biomejs/biome": "^2.0",

--- a/crates/exarch-node/package.json
+++ b/crates/exarch-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exarch-rs",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Memory-safe archive extraction library with built-in security validation",
   "main": "index.js",
   "types": "index.d.ts",

--- a/crates/exarch-python/pyproject.toml
+++ b/crates/exarch-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exarch"
-version = "0.1.1"
+version = "0.1.2"
 description = "Memory-safe archive extraction library with built-in security validation"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/crates/exarch-python/uv.lock
+++ b/crates/exarch-python/uv.lock
@@ -243,7 +243,7 @@ toml = [
 
 [[package]]
 name = "exarch"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- Bump version to 0.1.2 in all manifests (Cargo.toml, package.json, pyproject.toml)
- Add Phase 9 changes to CHANGELOG.md
- Update lock files (uv.lock, package-lock.json)

## Changes
### Added to CHANGELOG
- CVE test fixtures for path traversal, symlink escape, and hardlink attacks
- FFI panic safety wrapper for Node.js `extractArchiveSync` function
- Test cleanup (afterEach) to Node.js integration tests
- Enabled CLI extraction integration tests

### Fixed
- ZIP creation root directory bug causing incorrect archive structure
- Python CVE regression tests now fully enabled (7 tests)

## Test plan
- [ ] CI passes
- [ ] Version numbers are consistent across all manifests