### PR TITLE
feat(core): add solid archive support with memory limits (Phase 10.4)

### DIFF
--- a/crates/exarch-core/src/config.rs
+++ b/crates/exarch-core/src/config.rs
@@ -95,15 +95,29 @@ pub struct SecurityConfig {
     /// Default: `false` (solid archives rejected)
     pub allow_solid_archives: bool,
 
-    /// Maximum memory for decompressing solid blocks (bytes).
+    /// Maximum memory for solid archive extraction (bytes).
     ///
-    /// This limit applies to the decompressed size of a solid block,
-    /// not the entire archive. Solid blocks larger than this limit
-    /// will be rejected.
+    /// **7z Solid Archive Memory Model:**
+    ///
+    /// Solid compression in 7z stores multiple files in a single compressed
+    /// block. Extracting ANY file requires decompressing the ENTIRE solid block
+    /// into memory, which can cause memory exhaustion attacks.
+    ///
+    /// **Validation Strategy:**
+    /// - Pre-validates total uncompressed size of all files in archive
+    /// - This is a conservative heuristic (assumes single solid block)
+    /// - Reason: `sevenz-rust2` v0.20 doesn't expose solid block boundaries
+    ///
+    /// **Security Guarantee:**
+    /// - Total uncompressed data cannot exceed this limit
+    /// - Combined with `max_file_size`, prevents unbounded memory growth
+    /// - Enforced ONLY when `allow_solid_archives` is `true`
     ///
     /// **Note**: Only applies when `allow_solid_archives` is `true`.
     ///
     /// Default: 512 MB (536,870,912 bytes)
+    ///
+    /// **Recommendation:** Set to 1-2x available RAM for trusted archives only.
     pub max_solid_block_memory: u64,
 }
 


### PR DESCRIPTION
## Summary

Phase 10.4 implementation adds solid 7z archive extraction capability with robust security controls:

- **Solid archive detection**: Cache `is_solid` flag during archive opening for policy enforcement
- **Default-deny policy**: Solid archives rejected by default (`allow_solid_archives = false`)
- **Memory limit enforcement**: Pre-validate total uncompressed size against `max_solid_block_memory` (default 512 MB)
- **Overflow protection**: Use `checked_add` for defense-in-depth against integer overflow attacks
- **Performance optimization**: Use `Path::new` instead of `PathBuf::from` to eliminate allocations in pre-validation loop

## Changes

### Core Implementation
- `SevenZArchive` now caches `is_solid` flag from sevenz-rust2 library
- `extract()` enforces solid archive policy before extraction begins
- Heuristic pre-check validates total uncompressed size as memory limit (sevenz-rust2 doesn't expose solid block boundaries)

### Configuration
- Added enhanced documentation for `max_solid_block_memory` explaining the heuristic approach
- Documented that validation uses total archive size, not per-block size

### Tests Added
- `is_solid` flag detection verification (H-3)
- Boundary condition tests: exact limit, one byte under (H-1)
- Error message validation (H-2)
- Integration test for solid extraction success (M-4)
- Quota interaction tests

## Review Issues Addressed

| Issue | Priority | Description | Status |
|-------|----------|-------------|--------|
| Security H-1 | HIGH | Add explicit overflow check with `checked_add` | ✅ Fixed |
| Security H-2 | HIGH | Clarify solid block memory documentation | ✅ Fixed |
| Performance H-002 | HIGH | Eliminate PathBuf allocation in pre-validation | ✅ Fixed |
| Testing H-1 | HIGH | Add boundary condition tests | ✅ Fixed |
| Testing H-2 | HIGH | Add error message validation | ✅ Fixed |
| Testing H-3 | HIGH | Add `is_solid` flag detection test | ✅ Fixed |
| Testing M-4 | MEDIUM | Add integration test for success path | ✅ Fixed |

## Test plan

- [x] All 489 exarch-core tests pass
- [x] Clippy passes with no warnings
- [x] Documentation builds without warnings
- [x] Solid archive extraction success test added
- [x] Boundary condition tests verify exact limit behavior
- [x] Error message contains helpful debugging info

🤖 Generated with [Claude Code](https://claude.com/claude-code)