### PR TITLE
feat(core): enhance encrypted archive error message (Phase 10.6)

### DIFF
--- a/crates/exarch-core/src/formats/sevenz.rs
+++ b/crates/exarch-core/src/formats/sevenz.rs
@@ -4,7 +4,8 @@
 //!
 //! # Security Features
 //!
-//! - Encrypted archives rejected by default
+//! - Encrypted archives rejected (AES-256, AES-128, `ZipCrypto`, all encryption
+//!   methods)
 //! - Solid archives rejected by default (configurable)
 //! - Path traversal prevention
 //! - Decompression bomb detection
@@ -222,7 +223,8 @@ impl<R: Read + Seek> SevenZArchive<R> {
             let err_str = e.to_string().to_lowercase();
             if err_str.contains("encrypt") || err_str.contains("password") {
                 return ExtractionError::SecurityViolation {
-                    reason: "encrypted 7z archives are not supported".into(),
+                    reason: "encrypted 7z archive detected. Password-protected archives are not supported. \
+                             Decrypt the archive externally and try again.".into(),
                 };
             }
             ExtractionError::InvalidArchive(format!("failed to open 7z archive: {e}"))

--- a/crates/exarch-core/tests/sevenz_integration.rs
+++ b/crates/exarch-core/tests/sevenz_integration.rs
@@ -107,10 +107,20 @@ fn test_7z_encrypted_archive_rejected_at_new() {
 
     let result = SevenZArchive::new(cursor);
     assert!(result.is_err());
-    assert!(matches!(
-        result.unwrap_err(),
-        ExtractionError::SecurityViolation { .. }
-    ));
+    let err = result.unwrap_err();
+    assert!(matches!(err, ExtractionError::SecurityViolation { .. }));
+
+    // Verify error message is helpful
+    let msg = err.to_string();
+    assert!(msg.contains("encrypted"), "error should mention encryption");
+    assert!(
+        msg.contains("not supported"),
+        "error should say not supported"
+    );
+    assert!(
+        msg.contains("Decrypt") || msg.contains("decrypt"),
+        "error should suggest decrypting externally"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Enhance encrypted archive error message with actionable guidance
- Clarify module docs: all encryption methods rejected (AES-256, AES-128, ZipCrypto)
- Add comprehensive error message validation to integration test

## Changes

| File | Description |
|------|-------------|
| `sevenz.rs` | Enhanced error message: "Decrypt the archive externally and try again" |
| `sevenz.rs` | Updated module docs with encryption method list |
| `sevenz_integration.rs` | Enhanced test validates helpful error content |

## Security

Security behavior unchanged - encrypted archives are still rejected at construction time with `SecurityViolation` error. Error message does not disclose sensitive information.

## Test plan

- [x] All 497 tests pass
- [x] Enhanced test validates error message contains:
  - "encrypted" keyword
  - "not supported" phrase
  - "Decrypt" guidance
- [x] `cargo fmt`, `cargo clippy` pass