### PR TITLE
feat(ci): add Python musllinux wheel builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,18 @@ jobs:
             target: aarch64-unknown-linux-gnu
             maturin-args: --target aarch64-unknown-linux-gnu
 
+          # Linux x86_64 (musl)
+          - name: linux-musl-x86_64
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            manylinux: musllinux_1_2
+
+          # Linux aarch64 (musl)
+          - name: linux-musl-aarch64
+            os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            manylinux: musllinux_1_2
+
           # macOS x86_64
           - name: macos-x86_64
             os: macos-15-intel
@@ -158,7 +170,17 @@ jobs:
         with:
           shared-key: "python-${{ matrix.platform.name }}"
 
+      - name: Build wheels (musl)
+        if: matrix.platform.manylinux
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          manylinux: ${{ matrix.platform.manylinux }}
+          args: --release --strip --out wheels -i python3.11
+          working-directory: crates/exarch-python
+
       - name: Build wheels
+        if: ${{ !matrix.platform.manylinux }}
         working-directory: crates/exarch-python
         run: maturin build --release ${{ matrix.platform.maturin-args }} --strip --out wheels -i python3.11
 
@@ -397,7 +419,7 @@ jobs:
 
           ## Artifacts
 
-          - Python wheels for Linux (x86_64, aarch64), macOS (x86_64, aarch64), Windows (x86_64)
+          - Python wheels for Linux (x86_64, aarch64), Linux musl (x86_64, aarch64), macOS (x86_64, aarch64), Windows (x86_64)
           - Node.js native addons for Linux (x86_64, aarch64), macOS (x86_64, aarch64), Windows (x86_64)
           - Published to [crates.io](https://crates.io/crates/exarch-core), [PyPI](https://pypi.org/project/exarch), and [npm](https://www.npmjs.com/package/exarch-rs)
           EOF


### PR DESCRIPTION
## Summary

- Add `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` targets to the Python wheel build matrix
- Use `PyO3/maturin-action@v1` with `musllinux_1_2` containers for musl builds
- Existing glibc/macOS/Windows builds are unaffected

Closes #45