### PR TITLE
chore: release v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-02-06
+
+### Added
+- Python musllinux wheel builds for x86_64 and aarch64 (Alpine Linux support)
+
+### Security
+- Fix CVE-2026-25727: update `zip` 7.4.0 to resolve stack exhaustion DoS in transitive `time` dependency
+
+### Changed
+- Bump `pyo3` to 0.28, `clap` to latest minor, `zip` to 7.4.0
+- Bump CI actions: `lewagon/wait-on-check-action` 1.5.0, `softprops/action-gh-release` v2, `codecov/codecov-action` v5
+- Migrate biome config to v2 format
+
 ## [0.2.2] - 2026-01-03
 
 ### Added
@@ -153,7 +166,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 64KB reusable copy buffers
 - LRU cache for symlink target resolution
 
-[Unreleased]: https://github.com/bug-ops/exarch/compare/v0.2.2...HEAD
+[Unreleased]: https://github.com/bug-ops/exarch/compare/v0.2.3...HEAD
+[0.2.3]: https://github.com/bug-ops/exarch/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/bug-ops/exarch/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/bug-ops/exarch/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/bug-ops/exarch/compare/v0.1.2...v0.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "exarch-cli"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -576,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "exarch-core"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "bzip2",
  "criterion",
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "exarch-node"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "exarch-core",
  "napi",
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "exarch-python"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "exarch-core",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Exarch Contributors"]
 edition = "2024"
 rust-version = "1.89.0"
@@ -19,7 +19,7 @@ keywords = ["archive", "extraction", "security", "tar", "zip"]
 categories = ["compression", "filesystem"]
 
 [workspace.dependencies]
-exarch-core = { path = "crates/exarch-core", version = "0.2.2" }
+exarch-core = { path = "crates/exarch-core", version = "0.2.3" }
 anyhow = "1.0"
 assert_cmd = "2.1"
 bzip2 = "0.6"

--- a/crates/exarch-node/package.json
+++ b/crates/exarch-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exarch-rs",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Memory-safe archive extraction library with built-in security validation",
   "main": "index.js",
   "types": "index.d.ts",

--- a/crates/exarch-python/pyproject.toml
+++ b/crates/exarch-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exarch"
-version = "0.2.2"
+version = "0.2.3"
 description = "Memory-safe archive extraction library with built-in security validation"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/crates/exarch-python/uv.lock
+++ b/crates/exarch-python/uv.lock
@@ -243,7 +243,7 @@ toml = [
 
 [[package]]
 name = "exarch"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

- Bump version 0.2.2 -> 0.2.3 across all manifests (Cargo.toml, pyproject.toml, package.json, uv.lock)
- Update CHANGELOG.md with all changes since v0.2.2

### Included changes

- **Added**: Python musllinux wheel builds for x86_64 and aarch64 (#46)
- **Security**: Fix CVE-2026-25727 via zip 7.4.0 update (#47)
- **Changed**: Dependency bumps (pyo3 0.28, clap, zip 7.4.0), CI actions updates, biome v2 migration (#40-#44)