### PR TITLE
fix: statically link lzma on macOS to avoid missing Homebrew dylib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- macOS ARM64 wheel no longer embeds a dynamic path to Homebrew's liblzma; xz2 is now statically linked via `xz2/static` feature (#66)
+
 ## [0.2.5] - 2026-02-20
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ thiserror = "2.0"
 time = "0.3"
 tokio = "1.49"
 walkdir = "2.5"
-xz2 = "0.1"
+xz2 = { version = "0.1", features = ["static"] }
 zip = { version = "8.0", default-features = false }
 zstd = "0.13"
 


### PR DESCRIPTION
## Summary

- Enable `xz2/static` feature so liblzma is compiled from bundled sources at build time
- Eliminates the runtime dependency on Homebrew's `/opt/homebrew/opt/xz/lib/liblzma.5.dylib`
- macOS ARM64 wheels will now work on systems without Homebrew installed

## Root cause

`xz2` defaults to dynamic linking, picking up Homebrew's liblzma on macOS CI runners and embedding the absolute dylib path into the wheel. The wheel then fails on any system without Homebrew's xz.

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo +nightly fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo nextest run --workspace --lib --bins --exclude exarch-python` — 629 tests passed

Closes #66