### PR TITLE
chore: release v0.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.7] - 2026-03-07
+
+### Fixed
+
+- PAX archive extraction fails with `SecurityViolation` for `XGlobalHeader` entries (#69)
+- TAR `Continuous` and `GNUSparse` entry types incorrectly rejected as unsupported
+- `list_archive()` inconsistently reported PAX metadata as regular files
+
+### Changed
+
+- Suppress `clippy::needless_bitwise_bool` for intentional constant-time null byte check in exarch-node
+
 ## [0.2.6] - 2026-03-04
 
 ### Fixed
@@ -203,7 +215,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 64KB reusable copy buffers
 - LRU cache for symlink target resolution
 
-[Unreleased]: https://github.com/bug-ops/exarch/compare/v0.2.6...HEAD
+[Unreleased]: https://github.com/bug-ops/exarch/compare/v0.2.7...HEAD
+[0.2.7]: https://github.com/bug-ops/exarch/compare/v0.2.6...v0.2.7
 [0.2.6]: https://github.com/bug-ops/exarch/compare/v0.2.5...v0.2.6
 [0.2.5]: https://github.com/bug-ops/exarch/compare/v0.2.4...v0.2.5
 [0.2.4]: https://github.com/bug-ops/exarch/compare/v0.2.3...v0.2.4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "exarch-cli"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -576,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "exarch-core"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "bzip2",
  "criterion",
@@ -599,7 +599,7 @@ dependencies = [
 
 [[package]]
 name = "exarch-node"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "exarch-core",
  "napi",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "exarch-python"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "exarch-core",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.6"
+version = "0.2.7"
 authors = ["Exarch Contributors"]
 edition = "2024"
 rust-version = "1.89.0"
@@ -19,7 +19,7 @@ keywords = ["archive", "extraction", "security", "tar", "zip"]
 categories = ["compression", "filesystem"]
 
 [workspace.dependencies]
-exarch-core = { path = "crates/exarch-core", version = "0.2.6" }
+exarch-core = { path = "crates/exarch-core", version = "0.2.7" }
 anyhow = "1.0"
 assert_cmd = "2.1"
 bzip2 = "0.6"

--- a/crates/exarch-node/package.json
+++ b/crates/exarch-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exarch-rs",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Memory-safe archive extraction library with built-in security validation",
   "main": "index.js",
   "types": "index.d.ts",

--- a/crates/exarch-python/pyproject.toml
+++ b/crates/exarch-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exarch"
-version = "0.2.6"
+version = "0.2.7"
 description = "Memory-safe archive extraction library with built-in security validation"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/crates/exarch-python/uv.lock
+++ b/crates/exarch-python/uv.lock
@@ -257,7 +257,7 @@ toml = [
 
 [[package]]
 name = "exarch"
-version = "0.2.6"
+version = "0.2.7"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

- Bump version from 0.2.6 to 0.2.7
- Update CHANGELOG.md with release notes

### Fixed

- PAX archive extraction fails with `SecurityViolation` for `XGlobalHeader` entries (#69)
- TAR `Continuous` and `GNUSparse` entry types incorrectly rejected as unsupported
- `list_archive()` inconsistently reported PAX metadata as regular files

## Checklist

- [x] Version updated in all manifests (Cargo.toml, pyproject.toml, package.json)
- [x] Lock files regenerated (Cargo.lock, uv.lock)
- [x] CHANGELOG.md has release section with date
- [x] All CI checks pass locally (fmt, clippy, nextest)
- [x] Ready for tagging after merge