### PR TITLE
fix: add missing SecurityConfig properties to Python type stubs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `SecurityConfig.allowed_extensions` and `SecurityConfig.banned_path_components` were missing from Python type stubs (`exarch.pyi`), causing pyright to report `reportAttributeAccessIssue` (#72)
+
 ## [0.2.7] - 2026-03-07
 
 ### Fixed

--- a/crates/exarch-python/exarch.pyi
+++ b/crates/exarch-python/exarch.pyi
@@ -77,6 +77,12 @@ class SecurityConfig:
         """Sets whether to preserve permissions from archive."""
         ...
 
+    allowed_extensions: list[str]
+    """List of allowed file extensions (empty = allow all)."""
+
+    banned_path_components: list[str]
+    """List of banned path components."""
+
     def add_allowed_extension(self, ext: str) -> SecurityConfig:
         """Adds an allowed file extension."""
         ...


### PR DESCRIPTION
## Summary

- Adds `allowed_extensions: list[str]` and `banned_path_components: list[str]` to `SecurityConfig` in `exarch.pyi`
- Both properties have getter/setter implementations in `config.rs` but were absent from the stubs
- Pyright reported `reportAttributeAccessIssue` on valid property accesses

Closes #72

## Test plan

- [ ] Pre-commit checks pass (fmt, clippy, tests)
- [ ] Verify pyright no longer reports errors on the reproduction script from #72