### PR TITLE
fix: honor --force flag in extract subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `SecurityConfig.allowed_extensions` and `SecurityConfig.banned_path_components` were missing from Python type stubs (`exarch.pyi`), causing pyright to report `reportAttributeAccessIssue` (#72)
 - Use `entry.size()` instead of `entry.header().size()` for TAR quota enforcement to prevent PAX size bypass (#82)
+- Honor `--force` flag in `extract` subcommand; without `--force`, fail with a clear error listing conflicting files (#77)
 
 ## [0.2.7] - 2026-03-07
 

--- a/crates/exarch-cli/src/commands/extract.rs
+++ b/crates/exarch-cli/src/commands/extract.rs
@@ -6,10 +6,12 @@ use crate::output::OutputFormatter;
 use crate::progress::CliProgress;
 use anyhow::Context;
 use anyhow::Result;
+use exarch_core::ManifestEntryType;
 use exarch_core::NoopProgress;
 use exarch_core::SecurityConfig;
 use exarch_core::config::AllowedFeatures;
 use exarch_core::extract_archive_with_progress;
+use exarch_core::list_archive;
 use std::env;
 
 pub fn execute(args: &ExtractArgs, formatter: &dyn OutputFormatter) -> Result<()> {
@@ -17,6 +19,28 @@ pub fn execute(args: &ExtractArgs, formatter: &dyn OutputFormatter) -> Result<()
         Some(dir) => dir.clone(),
         None => env::current_dir().context("failed to get current directory")?,
     };
+
+    if !args.force {
+        let manifest = list_archive(&args.archive, &SecurityConfig::default())
+            .with_context(|| format!("failed to list archive: {}", args.archive.display()))?;
+
+        let conflicts: Vec<_> = manifest
+            .entries
+            .iter()
+            .filter(|e| e.entry_type == ManifestEntryType::File)
+            .map(|e| output_dir.join(&e.path))
+            .filter(|p| p.exists())
+            .collect();
+
+        if !conflicts.is_empty() {
+            let list = conflicts
+                .iter()
+                .map(|p| format!("  {}", p.display()))
+                .collect::<Vec<_>>()
+                .join("\n");
+            anyhow::bail!("destination files already exist (use --force to overwrite):\n{list}");
+        }
+    }
 
     let config = SecurityConfig {
         max_file_count: args.max_files,

--- a/crates/exarch-cli/tests/cli_tests.rs
+++ b/crates/exarch-cli/tests/cli_tests.rs
@@ -1419,3 +1419,56 @@ fn test_completion_invalid_shell() {
         .failure()
         .stderr(predicate::str::contains("invalid value"));
 }
+
+// ============================================================================
+// --force Flag Tests (Extract)
+// ============================================================================
+
+/// Without --force, extracting into a directory with conflicting files fails
+/// and the error message lists the conflicting files.
+#[test]
+fn test_extract_without_force_fails_on_conflict() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+
+    // First extraction populates the output directory.
+    exarch_cmd()
+        .arg("extract")
+        .arg(fixture_path("sample.tar.gz"))
+        .arg(temp.path())
+        .assert()
+        .success();
+
+    // Second extraction must fail because destination files already exist.
+    exarch_cmd()
+        .arg("extract")
+        .arg(fixture_path("sample.tar.gz"))
+        .arg(temp.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("already exist").and(predicate::str::contains("--force")));
+}
+
+/// With --force, extracting into a directory with conflicting files succeeds
+/// and silently overwrites them.
+#[test]
+fn test_extract_with_force_overwrites_conflicts() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+
+    // First extraction populates the output directory.
+    exarch_cmd()
+        .arg("extract")
+        .arg(fixture_path("sample.tar.gz"))
+        .arg(temp.path())
+        .assert()
+        .success();
+
+    // Second extraction with --force must succeed.
+    exarch_cmd()
+        .arg("extract")
+        .arg("--force")
+        .arg(fixture_path("sample.tar.gz"))
+        .arg(temp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Extraction complete"));
+}


### PR DESCRIPTION
## Summary

- The `--force` flag on the `extract` subcommand was parsed by clap but never read, causing extraction to always overwrite silently
- Without `--force`, extraction now fails with a clear error listing conflicting destination files
- With `--force`, existing files are silently overwritten (previous behavior preserved)

## Changes

- `crates/exarch-cli/src/commands/extract.rs`: added pre-extraction conflict check using `list_archive`
- `crates/exarch-cli/tests/cli_tests.rs`: added 2 integration tests covering both paths
- `CHANGELOG.md`: updated [Unreleased]

## Test plan

- [x] `cargo +nightly fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings` passes
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace` passes
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node --lib --bins` — 511 passed, 3 skipped
- [x] New test: extract without `--force` to conflicting destination → fails with actionable error
- [x] New test: extract with `--force` to conflicting destination → succeeds

Closes #77