### PR TITLE
fix: report correct file count in list quota error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Honor `--force` flag in `extract` subcommand; without `--force`, fail with a clear error listing conflicting files (#77)
 - Encrypted ZIP archives now correctly report a security violation instead of a misleading "corrupted or malformed" hint (#83)
 - `list -l` showed raw Unix file-type bits (e.g. `100644`) for ZIP entries instead of normalized permission bits (e.g. `644`); `ArchiveEntry.mode` now strips `S_IFREG`/`S_IFDIR` bits from ZIP `external_attributes` (#80)
+- `list` quota error message reported `current` equal to the limit instead of the actual would-be count (e.g. `10000 > 10000` instead of `10001 > 10000`) for both TAR and ZIP archives (#91)
 
 ## [0.2.7] - 2026-03-07
 

--- a/crates/exarch-core/src/inspection/list.rs
+++ b/crates/exarch-core/src/inspection/list.rs
@@ -162,7 +162,7 @@ fn list_tar_entries<R: std::io::Read>(
         if manifest.total_entries >= config.max_file_count {
             return Err(ExtractionError::QuotaExceeded {
                 resource: QuotaResource::FileCount {
-                    current: manifest.total_entries,
+                    current: manifest.total_entries + 1,
                     max: config.max_file_count,
                 },
             });
@@ -242,7 +242,7 @@ fn list_zip(
         if manifest.total_entries >= config.max_file_count {
             return Err(ExtractionError::QuotaExceeded {
                 resource: QuotaResource::FileCount {
-                    current: manifest.total_entries,
+                    current: manifest.total_entries + 1,
                     max: config.max_file_count,
                 },
             });
@@ -623,12 +623,43 @@ mod tests {
         };
 
         let result = list_archive(temp_file.path(), &config);
-        assert!(matches!(
-            result,
+        match result {
             Err(ExtractionError::QuotaExceeded {
-                resource: QuotaResource::FileCount { .. },
-            })
-        ));
+                resource: QuotaResource::FileCount { current, max },
+            }) => {
+                assert_eq!(max, 1);
+                assert_eq!(current, 2, "current must be max+1 (off-by-one fix)");
+            }
+            other => panic!("expected FileCount quota error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_list_zip_quota_exceeded_file_count() {
+        let temp_file = NamedTempFile::with_suffix(".zip").unwrap();
+        let file = std::fs::File::create(temp_file.path()).unwrap();
+        let mut zip = zip::ZipWriter::new(file);
+        let options = zip::write::SimpleFileOptions::default()
+            .compression_method(zip::CompressionMethod::Stored);
+        zip.start_file("a.txt", options).unwrap();
+        zip.start_file("b.txt", options).unwrap();
+        zip.finish().unwrap();
+
+        let config = SecurityConfig {
+            max_file_count: 1,
+            ..Default::default()
+        };
+
+        let result = list_archive(temp_file.path(), &config);
+        match result {
+            Err(ExtractionError::QuotaExceeded {
+                resource: QuotaResource::FileCount { current, max },
+            }) => {
+                assert_eq!(max, 1);
+                assert_eq!(current, 2, "current must be max+1 (off-by-one fix)");
+            }
+            other => panic!("expected FileCount quota error, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fixes off-by-one in `inspection/list.rs` quota error message for both TAR and ZIP loops
- The condition `total_entries >= max_file_count` fires before the current entry is counted, so `current` was incorrectly set to `manifest.total_entries` (equals the limit) instead of `manifest.total_entries + 1` (the would-be count)
- Result: error now correctly says `10001 > 10000` instead of the nonsensical `10000 > 10000`

## Changes

- `crates/exarch-core/src/inspection/list.rs`: `current: manifest.total_entries` → `current: manifest.total_entries + 1` at TAR (line ~165) and ZIP (line ~245) quota check sites
- Tests added/updated to assert `current == max_file_count + 1`

## Test plan

- [ ] `test_list_archive_quota_exceeded` (TAR): asserts `current == 2` when `max_file_count == 1`
- [ ] `test_list_zip_quota_exceeded_file_count` (ZIP): same assertion
- [ ] All 516 nextest tests pass
- [ ] fmt + clippy clean

Closes #91