### PR TITLE
fix: list command returns SecurityViolation for encrypted ZIP (#96)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `list -l` showed raw Unix file-type bits (e.g. `100644`) for ZIP entries instead of normalized permission bits (e.g. `644`); `ArchiveEntry.mode` now strips `S_IFREG`/`S_IFDIR` bits from ZIP `external_attributes` (#80)
 - World-writable files now have the write-other bit stripped by default instead of aborting extraction (consistent with setuid/setgid stripping) (#84)
 - `list` quota error message reported `current` equal to the limit instead of the actual would-be count (e.g. `10000 > 10000` instead of `10001 > 10000`) for both TAR and ZIP archives (#91)
+- `list` command reported a misleading "invalid archive" error for encrypted ZIP archives instead of a security violation; now correctly reports `SecurityViolation: archive is password-protected` (#96)
 
 ### Added
 

--- a/crates/exarch-core/src/inspection/list.rs
+++ b/crates/exarch-core/src/inspection/list.rs
@@ -249,8 +249,19 @@ fn list_zip(
         }
 
         let entry = archive.by_index(i).map_err(|e| {
+            if e.to_string().contains("Password required to decrypt file") {
+                return ExtractionError::SecurityViolation {
+                    reason: "archive is password-protected".into(),
+                };
+            }
             ExtractionError::InvalidArchive(format!("failed to read ZIP entry: {e}"))
         })?;
+
+        if entry.encrypted() {
+            return Err(ExtractionError::SecurityViolation {
+                reason: "archive is password-protected".into(),
+            });
+        }
 
         let path = entry
             .enclosed_name()
@@ -706,6 +717,38 @@ mod tests {
 
         assert_eq!(manifest.total_entries, 1);
         assert_eq!(manifest.entries[0].mode, Some(0o644));
+    }
+
+    #[test]
+    fn test_list_zip_encrypted_returns_security_violation() {
+        use std::io::Cursor;
+        use zip::ZipWriter;
+        use zip::unstable::write::FileOptionsExt;
+        use zip::write::SimpleFileOptions;
+
+        let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
+        let options = SimpleFileOptions::default()
+            .with_deprecated_encryption(b"password")
+            .unwrap();
+        writer.start_file("secret.txt", options).unwrap();
+        writer.write_all(b"secret data").unwrap();
+        let zip_data = writer.finish().unwrap().into_inner();
+
+        let mut temp_file = NamedTempFile::with_suffix(".zip").unwrap();
+        temp_file.write_all(&zip_data).unwrap();
+        temp_file.flush().unwrap();
+
+        let config = SecurityConfig::default();
+        let result = list_archive(temp_file.path(), &config);
+        match result {
+            Err(ExtractionError::SecurityViolation { reason }) => {
+                assert!(
+                    reason.contains("password-protected"),
+                    "expected 'password-protected' in reason: {reason}"
+                );
+            }
+            other => panic!("expected SecurityViolation, got: {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `list_zip` was calling `archive.by_index(i)` and mapping all errors as `InvalidArchive`, causing encrypted ZIP archives to produce a misleading "unsupported Zip archive: Password required" message instead of a security violation
- Applies the same dual-check pattern from the extract path (`zip.rs`): detect "Password required to decrypt file" in `map_err` and check `entry.encrypted()` after a successful open
- Adds a regression test covering the `list` path with an encrypted ZIP

Fixes #96.

## Test plan

- [ ] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node --lib --bins` — all 519 tests pass
- [ ] New test `inspection::list::tests::test_list_zip_encrypted_returns_security_violation` passes
- [ ] `cargo +nightly fmt --all -- --check` — clean
- [ ] `cargo clippy --all-targets --all-features --workspace -- -D warnings` — clean