### PR TITLE
chore: remove stale RUSTSEC-2025-0119 entry from deny.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `--allow-world-writable` CLI flag and `allow_world_writable` `SecurityConfig` option to opt in to preserving world-writable permissions (#84)
 
+### Changed
+
+- Removed stale `RUSTSEC-2025-0119` ignore entry from `deny.toml`; the advisory no longer matches any dependency in the tree (#76)
+
 ## [0.2.7] - 2026-03-07
 
 ### Fixed

--- a/deny.toml
+++ b/deny.toml
@@ -4,13 +4,7 @@
 version = 2
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
-ignore = [
-    # number_prefix is unmaintained but still functional
-    # Transitive dependency via indicatif (progress bars)
-    # No security vulnerabilities, just maintenance status
-    # Tracking: https://github.com/console-rs/indicatif/issues/688
-    "RUSTSEC-2025-0119",
-]
+ignore = []
 
 [licenses]
 version = 2


### PR DESCRIPTION
## Summary

- Removes the stale `RUSTSEC-2025-0119` ignore entry from `deny.toml`
- The `number_prefix` crate (transitive via indicatif) has since been updated; the advisory no longer matches any dependency
- `cargo deny check` no longer emits `advisory-not-detected` warning

## Test plan

- [x] `cargo deny check` passes without warnings for this advisory
- [x] `cargo +nightly fmt --check` passes
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings` passes

Closes #76