### PR TITLE
fix: handle empty 7z archives and solid archive false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix `list` and `verify` crash on valid empty 7z archives (#117)
+- Fix `verify` false positive [HIGH] for solid 7z archive entries where
+  `compressed_size=0` is a normal artifact of solid block compression (#118)
+- Add `--allow-solid-archives` flag to CLI `extract` command (#119)
 - Upgrade `tar` dependency to 0.4.45 to address RUSTSEC-2026-0067 (symlink
   `chmod` escape in `unpack_in`) and RUSTSEC-2026-0068 (PAX size header
   ignored when base header size is non-zero) (#112)

--- a/crates/exarch-cli/src/cli.rs
+++ b/crates/exarch-cli/src/cli.rs
@@ -81,6 +81,10 @@ pub struct ExtractArgs {
     #[arg(long)]
     pub allow_hardlinks: bool,
 
+    /// Allow solid 7z archives (multiple files compressed as one block)
+    #[arg(long)]
+    pub allow_solid_archives: bool,
+
     /// Allow world-writable files in extracted archives
     #[arg(long)]
     pub allow_world_writable: bool,
@@ -226,6 +230,16 @@ mod tests {
         assert_eq!(parse_byte_size("1T").unwrap(), 1024_u64.pow(4));
         assert!(parse_byte_size("invalid").is_err());
         assert!(parse_byte_size("").is_err());
+    }
+
+    #[test]
+    fn test_allow_solid_archives_flag() {
+        let cli =
+            Cli::try_parse_from(["exarch", "extract", "a.7z", "--allow-solid-archives"]).unwrap();
+        let Commands::Extract(args) = cli.command else {
+            panic!("expected Extract command");
+        };
+        assert!(args.allow_solid_archives);
     }
 
     #[test]

--- a/crates/exarch-cli/src/commands/extract.rs
+++ b/crates/exarch-cli/src/commands/extract.rs
@@ -55,6 +55,7 @@ pub fn execute(args: &ExtractArgs, formatter: &dyn OutputFormatter) -> Result<()
             world_writable: args.allow_world_writable,
         },
         preserve_permissions: args.preserve_permissions,
+        allow_solid_archives: args.allow_solid_archives,
         ..Default::default()
     };
 

--- a/crates/exarch-core/src/formats/sevenz.rs
+++ b/crates/exarch-core/src/formats/sevenz.rs
@@ -83,6 +83,7 @@
 //! ```
 
 use std::cell::RefCell;
+use std::io::ErrorKind;
 use std::io::Read;
 use std::io::Seek;
 use std::path::Path;
@@ -219,17 +220,32 @@ impl<R: Read + Seek> SevenZArchive<R> {
     pub fn new(mut source: R) -> Result<Self> {
         // Step 1: Verify it's a valid 7z archive by reading metadata
         let password = Password::empty();
-        let archive = Archive::read(&mut source, &password).map_err(|e| {
-            // SECURITY: Check if error indicates encryption
-            let err_str = e.to_string().to_lowercase();
-            if err_str.contains("encrypt") || err_str.contains("password") {
-                return ExtractionError::SecurityViolation {
-                    reason: "encrypted 7z archive detected. Password-protected archives are not supported. \
-                             Decrypt the archive externally and try again.".into(),
-                };
+        let archive = match Archive::read(&mut source, &password) {
+            Ok(a) => a,
+            Err(e) => {
+                // SECURITY: Check if error indicates encryption
+                let err_str = e.to_string().to_lowercase();
+                if err_str.contains("encrypt") || err_str.contains("password") {
+                    return Err(ExtractionError::SecurityViolation {
+                        reason: "encrypted 7z archive detected. Password-protected archives are not supported. \
+                                 Decrypt the archive externally and try again.".into(),
+                    });
+                }
+                // Handle valid empty 7z archives: sevenz-rust2 fails with UnexpectedEof on
+                // 32-byte archives that contain no files. Check for a valid 7z signature
+                // and small file size before treating as an empty archive.
+                if is_empty_sevenz_archive(&e, &mut source) {
+                    return Ok(Self {
+                        source,
+                        entries: vec![],
+                        is_solid: false,
+                    });
+                }
+                return Err(ExtractionError::InvalidArchive(format!(
+                    "failed to open 7z archive: {e}"
+                )));
             }
-            ExtractionError::InvalidArchive(format!("failed to open 7z archive: {e}"))
-        })?;
+        };
 
         // Step 2: SECURITY - Cache solid flag for later validation
         // NOTE: Actual enforcement happens in extract() via SecurityConfig
@@ -432,6 +448,12 @@ impl<R: Read + Seek> ArchiveFormat for SevenZArchive<R> {
             }
         }
 
+        // Empty archives: skip extraction entirely — decompress_with_extract_fn
+        // would fail with UnexpectedEof on valid 32-byte empty 7z archives.
+        if self.entries.is_empty() {
+            return Ok(ExtractionReport::new());
+        }
+
         // Step 3: Extract with FRESH validator to avoid quota double-counting
         // Note: sevenz-rust2 still parses archive internally, but we avoid
         // double parsing in our validation logic
@@ -548,6 +570,42 @@ impl SevenZEntryAdapter {
         entry.has_windows_attributes
             && (entry.windows_attributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0
     }
+}
+
+/// Checks whether a sevenz-rust2 parse failure is due to a valid empty 7z
+/// archive.
+///
+/// sevenz-rust2 fails with `UnexpectedEof` on valid 32-byte empty archives (0
+/// files). We detect this by requiring:
+/// 1. The error is an I/O error with `ErrorKind::UnexpectedEof`
+/// 2. The file starts with the 7z magic signature
+/// 3. The file size is exactly 32 bytes (the only valid empty archive size)
+fn is_empty_sevenz_archive<R: Read + Seek>(err: &sevenz_rust2::Error, source: &mut R) -> bool {
+    const SEVENZ_MAGIC: [u8; 6] = [0x37, 0x7A, 0xBC, 0xAF, 0x27, 0x1C];
+    // A valid empty 7z archive is exactly 32 bytes:
+    // signature (6) + version (2) + StartHeader CRC (4) + StartHeader (20).
+    // Files shorter than 32 bytes are truncated/corrupt, not empty archives.
+    const EMPTY_ARCHIVE_SIZE: u64 = 32;
+
+    let is_eof = matches!(err, sevenz_rust2::Error::Io(io_err, _) if io_err.kind() == ErrorKind::UnexpectedEof);
+    if !is_eof {
+        return false;
+    }
+
+    // Check file size
+    let Ok(size) = source.seek(std::io::SeekFrom::End(0)) else {
+        return false;
+    };
+    if size != EMPTY_ARCHIVE_SIZE {
+        return false;
+    }
+
+    // Check 7z magic signature
+    let Ok(_) = source.seek(std::io::SeekFrom::Start(0)) else {
+        return false;
+    };
+    let mut magic = [0u8; 6];
+    source.read_exact(&mut magic).is_ok() && magic == SEVENZ_MAGIC
 }
 
 /// Converts sevenz-rust2 errors to our `ExtractionError` type.
@@ -711,14 +769,6 @@ mod tests {
     #[test]
     fn test_empty_archive() {
         let data = load_fixture("empty.7z");
-        let cursor = Cursor::new(data.clone());
-
-        // Empty 7z archives may fail to parse with sevenz-rust2
-        // This is a known limitation - skip test if parsing fails
-        if SevenZArchive::new(cursor).is_err() {
-            return;
-        }
-
         let cursor = Cursor::new(data);
         let mut archive = SevenZArchive::new(cursor).unwrap();
 
@@ -729,6 +779,20 @@ mod tests {
 
         assert_eq!(report.files_extracted, 0);
         assert_eq!(report.directories_created, 0);
+    }
+
+    #[test]
+    fn test_empty_archive_extract() {
+        let path = std::path::Path::new("../../tests/fixtures/empty.7z");
+        let file = std::fs::File::open(path).unwrap();
+        let mut archive = SevenZArchive::new(file).unwrap();
+
+        let temp = TempDir::new().unwrap();
+        let config = SecurityConfig::default();
+
+        let report = archive.extract(temp.path(), &config).unwrap();
+        assert_eq!(report.files_extracted, 0);
+        assert_eq!(report.bytes_written, 0);
     }
 
     #[test]

--- a/crates/exarch-core/src/inspection/list.rs
+++ b/crates/exarch-core/src/inspection/list.rs
@@ -2,6 +2,9 @@
 
 use std::fs::File;
 use std::io::BufReader;
+use std::io::ErrorKind;
+use std::io::Read;
+use std::io::Seek;
 use std::path::Path;
 use std::path::PathBuf;
 use std::time::SystemTime;
@@ -329,17 +332,27 @@ fn list_sevenz(
 
     let mut file = File::open(archive_path)?;
     let password = Password::empty();
-    let archive = Archive::read(&mut file, &password).map_err(|e| {
-        let err_str = e.to_string().to_lowercase();
-        if err_str.contains("encrypt") || err_str.contains("password") {
-            return ExtractionError::SecurityViolation {
-                reason: "encrypted 7z archive detected. Password-protected archives are not \
-                         supported. Decrypt the archive externally and try again."
-                    .into(),
-            };
+    let archive = match Archive::read(&mut file, &password) {
+        Ok(a) => a,
+        Err(e) => {
+            let err_str = e.to_string().to_lowercase();
+            if err_str.contains("encrypt") || err_str.contains("password") {
+                return Err(ExtractionError::SecurityViolation {
+                    reason: "encrypted 7z archive detected. Password-protected archives are not \
+                             supported. Decrypt the archive externally and try again."
+                        .into(),
+                });
+            }
+            // Handle valid empty 7z archives: sevenz-rust2 fails with UnexpectedEof on
+            // 32-byte archives that contain no files.
+            if is_empty_sevenz_file(&e, &mut file) {
+                return Ok(ArchiveManifest::new(format));
+            }
+            return Err(ExtractionError::InvalidArchive(format!(
+                "failed to open 7z archive: {e}"
+            )));
         }
-        ExtractionError::InvalidArchive(format!("failed to open 7z archive: {e}"))
-    })?;
+    };
 
     let mut manifest = ArchiveManifest::new(format);
 
@@ -367,7 +380,18 @@ fn list_sevenz(
 
         let entry_type = sevenz_manifest_entry_type(entry);
         let size = entry.size;
-        let compressed_size = entry.has_stream.then_some(entry.compressed_size);
+        let compressed_size = if archive.is_solid {
+            // In solid archives, only the first entry per block has a meaningful
+            // compressed_size. Remaining entries report 0, which is a valid artifact of
+            // solid block compression — omit to avoid false positives in zip bomb
+            // detection.
+            entry
+                .has_stream
+                .then_some(entry.compressed_size)
+                .filter(|&cs| cs > 0)
+        } else {
+            entry.has_stream.then_some(entry.compressed_size)
+        };
         let modified = entry
             .has_last_modified_date
             .then(|| SystemTime::from(entry.last_modified_date));
@@ -414,6 +438,37 @@ fn sevenz_manifest_entry_type(entry: &sevenz_rust2::ArchiveEntry) -> ManifestEnt
         return ManifestEntryType::Symlink;
     }
     ManifestEntryType::File
+}
+
+/// Checks whether a sevenz-rust2 parse failure is due to a valid empty 7z
+/// archive.
+///
+/// sevenz-rust2 fails with `UnexpectedEof` on valid 32-byte empty archives (0
+/// files). Requires: `UnexpectedEof` I/O error + valid 7z magic + file size ==
+/// 32 bytes exactly.
+fn is_empty_sevenz_file(err: &sevenz_rust2::Error, file: &mut File) -> bool {
+    const SEVENZ_MAGIC: [u8; 6] = [0x37, 0x7A, 0xBC, 0xAF, 0x27, 0x1C];
+    // A valid empty 7z archive is exactly 32 bytes:
+    // signature (6) + version (2) + StartHeader CRC (4) + StartHeader (20).
+    const EMPTY_ARCHIVE_SIZE: u64 = 32;
+
+    let is_eof = matches!(err, sevenz_rust2::Error::Io(io_err, _) if io_err.kind() == ErrorKind::UnexpectedEof);
+    if !is_eof {
+        return false;
+    }
+
+    let Ok(size) = file.seek(std::io::SeekFrom::End(0)) else {
+        return false;
+    };
+    if size != EMPTY_ARCHIVE_SIZE {
+        return false;
+    }
+
+    let Ok(_) = file.seek(std::io::SeekFrom::Start(0)) else {
+        return false;
+    };
+    let mut magic = [0u8; 6];
+    file.read_exact(&mut magic).is_ok() && magic == SEVENZ_MAGIC
 }
 
 /// Returns `true` if the path contains traversal attempts.
@@ -1314,15 +1369,12 @@ mod tests {
     fn test_list_sevenz_empty() {
         let path = std::path::Path::new("../../tests/fixtures/empty.7z");
         let config = SecurityConfig::default();
-        // Empty 7z archives may fail to parse with sevenz-rust2 (known limitation).
-        // Accept either a successful empty manifest or an InvalidArchive error.
-        match list_archive(path, &config) {
-            Ok(manifest) => {
-                assert_eq!(manifest.total_entries, 0, "empty.7z should have no entries");
-            }
-            Err(ExtractionError::InvalidArchive(_)) => {}
-            Err(e) => panic!("unexpected error for empty.7z: {e}"),
-        }
+        let manifest = list_archive(path, &config).unwrap();
+        assert_eq!(manifest.total_entries, 0, "empty.7z should have no entries");
+        assert_eq!(
+            manifest.total_size, 0,
+            "empty.7z should have zero total size"
+        );
     }
 
     #[test]
@@ -1535,6 +1587,27 @@ mod tests {
     }
 
     #[test]
+    fn test_list_sevenz_solid_compressed_size() {
+        // Entries in solid archives should not have compressed_size=Some(0) with
+        // size>0. That combination would trigger a false positive in zip bomb
+        // detection.
+        let path = std::path::Path::new("../../tests/fixtures/solid.7z");
+        let config = SecurityConfig::default();
+        let manifest = list_archive(path, &config).unwrap();
+        for entry in &manifest.entries {
+            if entry.size > 0 {
+                assert_ne!(
+                    entry.compressed_size,
+                    Some(0),
+                    "entry {:?} has compressed_size=Some(0) with size={}, which is a false positive trigger",
+                    entry.path,
+                    entry.size
+                );
+            }
+        }
+    }
+
+    #[test]
     fn test_list_sevenz_unix_symlink_reported_as_file() {
         // Unix symlinks in 7z archives cannot be detected by sevenz-rust2 API.
         // They are reported as ManifestEntryType::File (known limitation).
@@ -1554,5 +1627,30 @@ mod tests {
                 entry.path.display()
             );
         }
+    }
+
+    #[test]
+    fn test_verify_sevenz_solid_no_false_positive() {
+        use crate::inspection::report::IssueSeverity;
+
+        let path = std::path::Path::new("../../tests/fixtures/solid.7z");
+        let config = SecurityConfig {
+            allow_solid_archives: true,
+            ..SecurityConfig::default()
+        };
+        let report = crate::verify_archive(path, &config).unwrap();
+        assert_ne!(
+            report.status,
+            crate::inspection::report::VerificationStatus::Fail,
+            "solid.7z should not fail verification when solid archives are allowed"
+        );
+        let has_false_positive = report.issues.iter().any(|issue| {
+            issue.severity == IssueSeverity::High
+                && issue.message.to_lowercase().contains("compressed_size")
+        });
+        assert!(
+            !has_false_positive,
+            "solid.7z verification should not produce High-severity compressed_size issue"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Fix `list`/`verify` crash with `UnexpectedEof` on valid empty 7z archives (#117)
- Fix `verify` false positive [HIGH] for solid 7z archive entries (#118)
- Add `--allow-solid-archives` flag to CLI `extract` command (#119)

## Changes

### #117 — Empty 7z archive crash

`sevenz-rust2` returns `UnexpectedEof` on valid 32-byte empty archives (0 files). Added `is_empty_sevenz_archive` / `is_empty_sevenz_file` helpers that detect the empty-archive case via three gates: `UnexpectedEof` error kind + valid 7z magic `[37 7A BC AF 27 1C]` + exact 32-byte file size. Applied in both `SevenZArchive::new` and `list_sevenz`. Truncated or corrupted archives still propagate errors.

### #118 — Solid archive verify false positive

In solid 7z archives, entries after the first in a compressed block have `compressed_size = 0` with `has_stream = true` — this is valid by the 7z spec. The verify logic incorrectly flagged this as [HIGH] (zip bomb check). Fix: in `list_sevenz`, when `archive.is_solid`, filter `compressed_size == 0` values via `.filter(|&cs| cs > 0)` so they are reported as `None` (unknown) rather than `Some(0)` (invalid metadata). Non-solid archives unaffected.

### #119 — Missing CLI flag

Added `--allow-solid-archives` to `ExtractArgs` (default: false, opt-in), wired into `SecurityConfig::allow_solid_archives` in `extract.rs`.

## Test plan

- `test_list_sevenz_empty` — asserts 0-entry success (previously accepted `InvalidArchive`)
- `test_empty_archive` / `test_empty_archive_extract` — extraction of empty archive yields 0 files
- `test_verify_sevenz_solid_no_false_positive` — solid.7z passes verify with no [HIGH] issues
- `test_list_sevenz_solid_compressed_size` — no entry has `compressed_size=Some(0)` with `size>0`
- `test_allow_solid_archives_flag` — clap parses `--allow-solid-archives` correctly

All 598 tests pass. fmt, clippy, doc, deny clean.

## Security

- Empty archive detection uses a three-gate check — truncated/corrupted files still error
- Solid `compressed_size` filtering does not weaken zip bomb quotas (`max_total_size`, `max_file_count` remain active)
- `--allow-solid-archives` is opt-in (default false), no side effects on other security checks

Closes #117, #118, #119