### PR TITLE
fix: add --max-files and --max-total-size to list and verify commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `exarch list` and `exarch verify` now accept `--max-files` and `--max-total-size`
+  flags, mirroring `exarch extract`. Archives with more than 10 000 entries (e.g.
+  ZIP64 archives) can now be listed or verified by passing `--max-files <N>` (#122).
+
 - `list_archive` and `verify_archive` now support 7z archives, consistent with
   TAR and ZIP (#79). Entries are iterated via `sevenz-rust2::Archive::read`
   (no decompression); solid archives are safe to list. Quota limits, path

--- a/crates/exarch-cli/src/cli.rs
+++ b/crates/exarch-cli/src/cli.rs
@@ -150,6 +150,14 @@ pub struct ListArgs {
     /// Show sizes in human-readable format
     #[arg(short = 'H', long)]
     pub human_readable: bool,
+
+    /// Maximum number of entries to list
+    #[arg(long, default_value = "10000")]
+    pub max_files: usize,
+
+    /// Maximum total size of entries in bytes (supports K, M, G, T suffixes)
+    #[arg(long, value_parser = parse_byte_size)]
+    pub max_total_size: Option<u64>,
 }
 
 #[derive(clap::Args)]
@@ -165,6 +173,14 @@ pub struct VerifyArgs {
     /// Run security validation
     #[arg(long)]
     pub check_security: bool,
+
+    /// Maximum number of entries to verify
+    #[arg(long, default_value = "10000")]
+    pub max_files: usize,
+
+    /// Maximum total size of entries in bytes (supports K, M, G, T suffixes)
+    #[arg(long, value_parser = parse_byte_size)]
+    pub max_total_size: Option<u64>,
 }
 
 /// Parse byte size with optional suffix (K, M, G, T)
@@ -218,5 +234,85 @@ mod tests {
         assert!(parse_byte_size("18446744073709551615K").is_err()); // u64::MAX / 1024 + 1
         assert!(parse_byte_size("18014398509481984M").is_err()); // u64::MAX / (1024^2) + 1
         assert!(parse_byte_size("17592186044416G").is_err()); // u64::MAX / (1024^3) + 1
+    }
+
+    #[test]
+    fn test_list_args_default_max_files() {
+        let cli = Cli::parse_from(["exarch", "list", "archive.zip"]);
+        let Commands::List(args) = cli.command else {
+            panic!("expected list command");
+        };
+        assert_eq!(args.max_files, 10000);
+        assert!(args.max_total_size.is_none());
+    }
+
+    #[test]
+    fn test_list_args_max_files_override() {
+        let cli = Cli::parse_from(["exarch", "list", "--max-files", "99999", "archive.zip"]);
+        let Commands::List(args) = cli.command else {
+            panic!("expected list command");
+        };
+        assert_eq!(args.max_files, 99999);
+    }
+
+    #[test]
+    fn test_list_args_max_total_size_override() {
+        let cli = Cli::parse_from(["exarch", "list", "--max-total-size", "2G", "archive.zip"]);
+        let Commands::List(args) = cli.command else {
+            panic!("expected list command");
+        };
+        assert_eq!(args.max_total_size, Some(2 * 1024 * 1024 * 1024));
+    }
+
+    #[test]
+    fn test_verify_args_default_max_files() {
+        let cli = Cli::parse_from(["exarch", "verify", "archive.zip"]);
+        let Commands::Verify(args) = cli.command else {
+            panic!("expected verify command");
+        };
+        assert_eq!(args.max_files, 10000);
+        assert!(args.max_total_size.is_none());
+    }
+
+    #[test]
+    fn test_verify_args_max_files_override() {
+        let cli = Cli::parse_from(["exarch", "verify", "--max-files", "65537", "archive.zip"]);
+        let Commands::Verify(args) = cli.command else {
+            panic!("expected verify command");
+        };
+        assert_eq!(args.max_files, 65537);
+    }
+
+    #[test]
+    fn test_verify_args_max_total_size_override() {
+        let cli = Cli::parse_from([
+            "exarch",
+            "verify",
+            "--max-total-size",
+            "500M",
+            "archive.zip",
+        ]);
+        let Commands::Verify(args) = cli.command else {
+            panic!("expected verify command");
+        };
+        assert_eq!(args.max_total_size, Some(500 * 1024 * 1024));
+    }
+
+    #[test]
+    fn test_list_args_both_flags() {
+        let cli = Cli::parse_from([
+            "exarch",
+            "list",
+            "--max-files",
+            "1000000",
+            "--max-total-size",
+            "10G",
+            "archive.zip",
+        ]);
+        let Commands::List(args) = cli.command else {
+            panic!("expected list command");
+        };
+        assert_eq!(args.max_files, 1_000_000);
+        assert_eq!(args.max_total_size, Some(10 * 1024 * 1024 * 1024));
     }
 }

--- a/crates/exarch-cli/src/commands/list.rs
+++ b/crates/exarch-cli/src/commands/list.rs
@@ -7,8 +7,13 @@ use exarch_core::SecurityConfig;
 use exarch_core::list_archive;
 
 pub fn execute(args: &ListArgs, formatter: &dyn OutputFormatter) -> Result<()> {
-    // Build config with default quota limits
-    let config = SecurityConfig::default();
+    let config = SecurityConfig {
+        max_file_count: args.max_files,
+        max_total_size: args
+            .max_total_size
+            .unwrap_or_else(|| SecurityConfig::default().max_total_size),
+        ..Default::default()
+    };
 
     // List archive
     let manifest = list_archive(&args.archive, &config)?;

--- a/crates/exarch-cli/src/commands/verify.rs
+++ b/crates/exarch-cli/src/commands/verify.rs
@@ -9,8 +9,13 @@ use exarch_core::VerificationStatus;
 use exarch_core::verify_archive;
 
 pub fn execute(args: &VerifyArgs, formatter: &dyn OutputFormatter) -> Result<()> {
-    // Build config
-    let config = SecurityConfig::default();
+    let config = SecurityConfig {
+        max_file_count: args.max_files,
+        max_total_size: args
+            .max_total_size
+            .unwrap_or_else(|| SecurityConfig::default().max_total_size),
+        ..Default::default()
+    };
 
     // Verify archive
     let report = verify_archive(&args.archive, &config)?;


### PR DESCRIPTION
## Summary

- Add `--max-files` and `--max-total-size` flags to `exarch list` and `exarch verify`, mirroring the existing flags on `exarch extract`
- `SecurityConfig` for list/verify is now built from CLI args instead of hardcoded defaults
- Archives with >10000 entries (e.g. ZIP64 with 65537 entries) can now be processed with `--max-files <N>`

## Test plan

- 7 new unit tests in `cli.rs` covering default values, per-flag overrides, and both flags together for both `list` and `verify`
- All 611 tests pass (`cargo nextest run`)
- Pre-commit checks pass: fmt, clippy, doc, nextest, cargo-deny

Closes #122