### PR TITLE
fix: propagate --allow-solid-archives to conflict-detection list step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `verify` false positive [HIGH] for solid 7z archive entries where
   `compressed_size=0` is a normal artifact of solid block compression (#118)
 - Add `--allow-solid-archives` flag to CLI `extract` command (#119)
+- `--allow-solid-archives` is now propagated to the conflict-detection `list_archive` call
+  in `extract`, fixing a `SecurityViolation` at the list step when solid 7z archives are
+  passed with `--allow-solid-archives` but without `--force` or `--atomic` (#124).
+  `--allow-solid-archives` is also exposed in the `list` and `verify` subcommands.
 - Upgrade `tar` dependency to 0.4.45 to address RUSTSEC-2026-0067 (symlink
   `chmod` escape in `unpack_in`) and RUSTSEC-2026-0068 (PAX size header
   ignored when base header size is non-zero) (#112)

--- a/crates/exarch-cli/src/cli.rs
+++ b/crates/exarch-cli/src/cli.rs
@@ -162,6 +162,10 @@ pub struct ListArgs {
     /// Maximum total size of entries in bytes (supports K, M, G, T suffixes)
     #[arg(long, value_parser = parse_byte_size)]
     pub max_total_size: Option<u64>,
+
+    /// Allow solid 7z archives (higher memory usage during listing)
+    #[arg(long)]
+    pub allow_solid_archives: bool,
 }
 
 #[derive(clap::Args)]
@@ -185,6 +189,10 @@ pub struct VerifyArgs {
     /// Maximum total size of entries in bytes (supports K, M, G, T suffixes)
     #[arg(long, value_parser = parse_byte_size)]
     pub max_total_size: Option<u64>,
+
+    /// Allow solid 7z archives (higher memory usage during verification)
+    #[arg(long)]
+    pub allow_solid_archives: bool,
 }
 
 /// Parse byte size with optional suffix (K, M, G, T)

--- a/crates/exarch-cli/src/commands/extract.rs
+++ b/crates/exarch-cli/src/commands/extract.rs
@@ -22,8 +22,14 @@ pub fn execute(args: &ExtractArgs, formatter: &dyn OutputFormatter) -> Result<()
     };
 
     if !args.force && !args.atomic {
-        let manifest = list_archive(&args.archive, &SecurityConfig::default())
-            .with_context(|| format!("failed to list archive: {}", args.archive.display()))?;
+        let manifest = list_archive(
+            &args.archive,
+            &SecurityConfig {
+                allow_solid_archives: args.allow_solid_archives,
+                ..Default::default()
+            },
+        )
+        .with_context(|| format!("failed to list archive: {}", args.archive.display()))?;
 
         let conflicts: Vec<_> = manifest
             .entries

--- a/crates/exarch-cli/src/commands/list.rs
+++ b/crates/exarch-cli/src/commands/list.rs
@@ -12,6 +12,7 @@ pub fn execute(args: &ListArgs, formatter: &dyn OutputFormatter) -> Result<()> {
         max_total_size: args
             .max_total_size
             .unwrap_or_else(|| SecurityConfig::default().max_total_size),
+        allow_solid_archives: args.allow_solid_archives,
         ..Default::default()
     };
 

--- a/crates/exarch-cli/src/commands/verify.rs
+++ b/crates/exarch-cli/src/commands/verify.rs
@@ -14,6 +14,7 @@ pub fn execute(args: &VerifyArgs, formatter: &dyn OutputFormatter) -> Result<()>
         max_total_size: args
             .max_total_size
             .unwrap_or_else(|| SecurityConfig::default().max_total_size),
+        allow_solid_archives: args.allow_solid_archives,
         ..Default::default()
     };
 


### PR DESCRIPTION
## Summary

- `--allow-solid-archives` was ignored in the conflict-detection `list_archive` call inside `extract`, causing a `SecurityViolation` at the list step even when the flag was explicitly passed (without `--force` or `--atomic`)
- The flag is now consistently applied to `SecurityConfig` in `extract`, `list`, and `verify` subcommands

## Root cause

`commands/extract.rs` line 25 passed `SecurityConfig::default()` (which has `allow_solid_archives: false`) to the pre-extraction conflict-detection listing, overriding the user-supplied flag before the main extraction config was built.

## Test plan

- [ ] `cargo run --bin exarch -- extract tests/fixtures/solid.7z /tmp/out/ --allow-solid-archives` no longer fails at the list step
- [ ] `cargo run --bin exarch -- list tests/fixtures/solid.7z --allow-solid-archives` works
- [ ] `cargo run --bin exarch -- verify tests/fixtures/solid.7z --allow-solid-archives` works
- [ ] All CI checks pass (fmt, clippy, doc, tests, deny)

Closes #124. Closes #119.