### PR TITLE
fix: expose allow_solid_archives in Python and Node.js bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in `extract`, fixing a `SecurityViolation` at the list step when solid 7z archives are
   passed with `--allow-solid-archives` but without `--force` or `--atomic` (#124).
   `--allow-solid-archives` is also exposed in the `list` and `verify` subcommands.
+- Expose `allow_solid_archives` in Python and Node.js bindings (`SecurityConfig`) (#127)
 - Upgrade `tar` dependency to 0.4.45 to address RUSTSEC-2026-0067 (symlink
   `chmod` escape in `unpack_in`) and RUSTSEC-2026-0068 (PAX size header
   ignored when base header size is non-zero) (#112)

--- a/crates/exarch-node/src/config.rs
+++ b/crates/exarch-node/src/config.rs
@@ -160,6 +160,17 @@ impl SecurityConfig {
         self
     }
 
+    /// Allows or denies solid 7z archives.
+    ///
+    /// Solid archives require reading all preceding entries to decompress any
+    /// entry, which may allow a crafted archive to consume excessive
+    /// memory. Disabled by default.
+    #[napi(js_name = "setAllowSolidArchives")]
+    pub fn set_allow_solid_archives(&mut self, allow: Option<bool>) -> &Self {
+        self.inner.allow_solid_archives = allow.unwrap_or(true);
+        self
+    }
+
     /// Sets whether to preserve permissions from archive.
     #[napi(js_name = "setPreservePermissions")]
     pub fn set_preserve_permissions(&mut self, preserve: Option<bool>) -> &Self {

--- a/crates/exarch-python/exarch.pyi
+++ b/crates/exarch-python/exarch.pyi
@@ -73,6 +73,10 @@ class SecurityConfig:
         """Allows or denies world-writable files."""
         ...
 
+    def allow_solid_archives(self, allow: bool = True) -> SecurityConfig:
+        """Allows or denies solid 7z archives."""
+        ...
+
     def preserve_permissions(self, preserve: bool = True) -> SecurityConfig:
         """Sets whether to preserve permissions from archive."""
         ...

--- a/crates/exarch-python/src/config.rs
+++ b/crates/exarch-python/src/config.rs
@@ -150,6 +150,17 @@ impl PySecurityConfig {
         slf
     }
 
+    /// Allows or denies solid 7z archives.
+    ///
+    /// Solid archives require reading all preceding entries to decompress any
+    /// entry, which may allow a crafted archive to consume excessive
+    /// memory. Disabled by default.
+    #[pyo3(signature = (allow=true))]
+    fn allow_solid_archives(mut slf: PyRefMut<'_, Self>, allow: bool) -> PyRefMut<'_, Self> {
+        slf.inner.allow_solid_archives = allow;
+        slf
+    }
+
     /// Sets whether to preserve permissions from archive.
     #[pyo3(signature = (preserve=true))]
     fn preserve_permissions(mut slf: PyRefMut<'_, Self>, preserve: bool) -> PyRefMut<'_, Self> {


### PR DESCRIPTION
## Summary

- Add `allow_solid_archives(allow: bool)` builder method to `PySecurityConfig` in Python bindings
- Add type stub `def allow_solid_archives(self, allow: bool = True) -> SecurityConfig` to `exarch.pyi`
- Add `setAllowSolidArchives(allow?: boolean)` method to `SecurityConfig` in Node.js bindings
- All new methods follow the existing builder pattern (`allow_symlinks`, `allow_hardlinks`, `allow_world_writable`)

Closes #127

## Test plan

- [ ] `cargo clippy --all-targets --all-features --workspace -- -D warnings` passes
- [ ] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` passes (615 passed)
- [ ] Python: `config = exarch.SecurityConfig().allow_solid_archives(True)` no longer raises `AttributeError`
- [ ] Node.js: `config.setAllowSolidArchives(true)` is callable