### PR TITLE
fix: bump pytest to 9.0.3 and pin Pygments to 2.20.0

### DIFF
--- a/crates/exarch-python/pyproject.toml
+++ b/crates/exarch-python/pyproject.toml
@@ -43,8 +43,9 @@ Issues = "https://github.com/bug-ops/exarch/issues"
 
 [dependency-groups]
 dev = [
-    "pytest>=8.0",
+    "pytest>=9.0.3",
     "pytest-cov>=6.0",
+    "Pygments>=2.20.0",
     "mypy>=1.0",
     "ruff>=0.8",
     "maturin>=1.0",


### PR DESCRIPTION
## Summary

- Bumps `pytest` from `>=8.0` to `>=9.0.3` to address Dependabot alert #7 (vulnerable tmpdir handling)
- Pins `Pygments>=2.20.0` explicitly to address Dependabot alert #6 (ReDoS via inefficient GUID regex); previously unversioned transitive dependency

## Affected file

`crates/exarch-python/pyproject.toml` — dev dependency group only, no runtime impact