### PR TITLE
fix: replace map().unwrap_or(false) with is_ok_and() in safe_symlink

### DIFF
--- a/crates/exarch-core/src/types/safe_symlink.rs
+++ b/crates/exarch-core/src/types/safe_symlink.rs
@@ -253,10 +253,7 @@ pub(crate) fn resolve_through_symlinks(
                 // If the current accumulated path is an on-disk symlink, resolve
                 // it before applying `..` so the pop operates on the real
                 // filesystem topology rather than the string representation.
-                if std::fs::symlink_metadata(&current)
-                    .map(|m| m.file_type().is_symlink())
-                    .unwrap_or(false)
-                {
+                if std::fs::symlink_metadata(&current).is_ok_and(|m| m.file_type().is_symlink()) {
                     current = std::fs::canonicalize(&current).map_err(|_| {
                         ExtractionError::SymlinkEscape {
                             path: link_path.to_path_buf(),
@@ -274,10 +271,7 @@ pub(crate) fn resolve_through_symlinks(
                 current.push(name);
                 // Resolve the component immediately if it is a symlink so that
                 // any subsequent `..` steps use the real resolved path.
-                if std::fs::symlink_metadata(&current)
-                    .map(|m| m.file_type().is_symlink())
-                    .unwrap_or(false)
-                {
+                if std::fs::symlink_metadata(&current).is_ok_and(|m| m.file_type().is_symlink()) {
                     current = std::fs::canonicalize(&current).map_err(|_| {
                         ExtractionError::SymlinkEscape {
                             path: link_path.to_path_buf(),


### PR DESCRIPTION
## Summary

Fixes two `clippy::map_unwrap_or` errors in `crates/exarch-core/src/types/safe_symlink.rs` (lines 256 and 277) that caused post-merge CI failures on `main`.

The pattern `.map(|m| ...).unwrap_or(false)` on a `Result` is replaced with `.is_ok_and(|m| ...)`, which is idiomatic Rust (stabilized in 1.70, well within MSRV 1.89).

## Why it passed in the PR but failed on main

The Clippy job in CI uses a `changes:` filter that skips Rust checks when only Python/non-Rust files change. The previous PR only touched `pyproject.toml`, so the Clippy job was skipped — revealing the pre-existing lint violation only on the unconditional `main` push run.