### PR TITLE
fix: use pull_request_target trigger in labeler workflow

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,7 @@
 name: Auto Labeler
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 permissions:


### PR DESCRIPTION
## Summary

The labeler workflow fails on PRs from forks with:

```
Error: Resource not accessible by integration
```

`pull_request` events from forks run with a read-only `GITHUB_TOKEN` — GitHub restricts write permissions as a security measure. `actions/labeler` requires `pull-requests: write` to apply labels, which is never granted to fork PRs under `pull_request`.

Switching to `pull_request_target` runs the workflow in the context of the base repository, where the token does have write access to labels. The `labeler.yml` config file is read from the base branch, so there is no untrusted code execution risk here (no `actions/checkout` of the PR head involved).