### PR TITLE
fix(detect): return UnsupportedFormat for bare .gz files (#155)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `detect_format` now returns `UnsupportedFormat` for bare `.gz` files (no `.tar`
+  stem) instead of silently routing them to `open_tar_gz` and producing
+  `InvalidArchive` at runtime. `.tar.gz` and `.tgz` paths are unaffected (#155).
+
 ## [0.2.9] - 2026-03-25
 
 ### Tests

--- a/crates/exarch-core/src/formats/detect.rs
+++ b/crates/exarch-core/src/formats/detect.rs
@@ -35,9 +35,14 @@ pub enum ArchiveType {
 
 /// Detects the archive type from a file path.
 ///
+/// `.gz` files are only accepted when the stem ends with `.tar`
+/// (i.e. `archive.tar.gz`). A bare `archive.gz` returns
+/// [`ExtractionError::UnsupportedFormat`].
+///
 /// # Errors
 ///
-/// Returns an error if the format cannot be determined.
+/// Returns [`ExtractionError::UnsupportedFormat`] if the extension is
+/// unrecognised or if a `.gz` file has no `.tar` stem.
 pub fn detect_format(path: &Path) -> Result<ArchiveType> {
     let extension = path
         .extension()
@@ -47,13 +52,15 @@ pub fn detect_format(path: &Path) -> Result<ArchiveType> {
     let ext_lower = extension.to_ascii_lowercase();
     match ext_lower.as_str() {
         "tar" => Ok(ArchiveType::Tar),
-        "gz" | "tgz" => {
+        "tgz" => Ok(ArchiveType::TarGz),
+        "gz" => {
             if let Some(stem) = path.file_stem()
                 && stem.to_string_lossy().ends_with(".tar")
             {
-                return Ok(ArchiveType::TarGz);
+                Ok(ArchiveType::TarGz)
+            } else {
+                Err(ExtractionError::UnsupportedFormat)
             }
-            Ok(ArchiveType::TarGz)
         }
         "bz2" | "tbz" | "tbz2" => Ok(ArchiveType::TarBz2),
         "xz" | "txz" => Ok(ArchiveType::TarXz),
@@ -77,12 +84,21 @@ mod tests {
     }
 
     #[test]
-    fn test_detect_tar_gz() {
+    fn test_detect_tar_gz_still_works() {
         let path = PathBuf::from("archive.tar.gz");
         assert_eq!(detect_format(&path).unwrap(), ArchiveType::TarGz);
 
         let path2 = PathBuf::from("archive.tgz");
         assert_eq!(detect_format(&path2).unwrap(), ArchiveType::TarGz);
+    }
+
+    #[test]
+    fn test_detect_bare_gz_returns_unsupported() {
+        let path = PathBuf::from("archive.gz");
+        assert!(matches!(
+            detect_format(&path),
+            Err(ExtractionError::UnsupportedFormat)
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Split the dead `"gz" | "tgz"` match arm into two separate arms
- `"tgz"` maps unconditionally to `TarGz`; `"gz"` checks the file stem and returns `UnsupportedFormat` when the stem does not end with `.tar`
- Prevents silent misrouting of plain `.gz` files to `open_tar_gz`, which produced `InvalidArchive` at runtime

## Changes

- `crates/exarch-core/src/formats/detect.rs`: split match arm, expand doc comment, add/rename tests
- `CHANGELOG.md`: add `[Unreleased] ### Fixed` entry

## Test plan

- [ ] `test_detect_tar_gz_still_works` — `archive.tar.gz` and `archive.tgz` return `Ok(TarGz)`
- [ ] `test_detect_bare_gz_returns_unsupported` — `archive.gz` returns `Err(UnsupportedFormat)`
- [ ] `cargo nextest run -p exarch-core --all-features` — 644 tests pass