### PR TITLE
fix(detect): use is_zip_family_alias for ZIP-family extension matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `detect_format` now uses `is_zip_family_alias` for ZIP-family extension
+  matching, ensuring the dedicated case-insensitive helper is the single
+  source of truth rather than a duplicated inline `contains` call.
+
 ### Added
 
 - Extract, list, and verify additional ZIP-based formats. JVM artifacts

--- a/crates/exarch-core/src/formats/detect.rs
+++ b/crates/exarch-core/src/formats/detect.rs
@@ -90,7 +90,7 @@ pub fn detect_format(path: &Path) -> Result<ArchiveType> {
         // JVM artifacts, app bundles, Python wheels, IDE/browser
         // extensions, EPUBs - all ZIP under the hood, so they extract
         // through the same path. See `ZIP_FAMILY_ALIASES` for the list.
-        ext if ZIP_FAMILY_ALIASES.contains(&ext) => Ok(ArchiveType::Zip),
+        ext if is_zip_family_alias(ext) => Ok(ArchiveType::Zip),
         _ => Err(ExtractionError::UnsupportedFormat),
     }
 }


### PR DESCRIPTION
## Summary

- Replaces the inline `ZIP_FAMILY_ALIASES.contains(&ext)` call in `detect_format` with the existing `is_zip_family_alias` helper
- `is_zip_family_alias` is the designated case-insensitive check and should be the single source of truth; the inline call was a redundant duplication that could silently drift
- All 775 tests pass

Closes #157

## Test plan

- [ ] `cargo nextest run -p exarch-core -- detect` — all detect tests pass including uppercase ZIP-family variants
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — no warnings