### PR TITLE
release: v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- `detect_format` now uses `is_zip_family_alias` for ZIP-family extension
-  matching, ensuring the dedicated case-insensitive helper is the single
-  source of truth rather than a duplicated inline `contains` call.
+## [0.3.0] - 2026-04-23
 
 ### Added
 
@@ -27,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a bare ZIP would be misleading. Callers who need the override can
   set `CreationConfig::format = Some(exarch_core::formats::detect::ArchiveType::Zip)`.
 ### Fixed
+
+- `detect_format` now uses `is_zip_family_alias` for ZIP-family extension
+  matching, ensuring the dedicated case-insensitive helper is the single
+  source of truth rather than a duplicated inline `contains` call.
 
 - `detect_format` now returns `UnsupportedFormat` for bare `.gz` files (no `.tar`
   stem) instead of silently routing them to `open_tar_gz` and producing
@@ -352,7 +352,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 64KB reusable copy buffers
 - LRU cache for symlink target resolution
 
-[Unreleased]: https://github.com/bug-ops/exarch/compare/v0.2.9...HEAD
+[Unreleased]: https://github.com/bug-ops/exarch/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/bug-ops/exarch/compare/v0.2.9...v0.3.0
 [0.2.9]: https://github.com/bug-ops/exarch/compare/v0.2.8...v0.2.9
 [0.2.8]: https://github.com/bug-ops/exarch/compare/v0.2.7...v0.2.8
 [0.2.7]: https://github.com/bug-ops/exarch/compare/v0.2.6...v0.2.7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "exarch-cli"
-version = "0.2.9"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "exarch-core"
-version = "0.2.9"
+version = "0.3.0"
 dependencies = [
  "bzip2",
  "criterion",
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "exarch-node"
-version = "0.2.9"
+version = "0.3.0"
 dependencies = [
  "exarch-core",
  "napi",
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "exarch-python"
-version = "0.2.9"
+version = "0.3.0"
 dependencies = [
  "exarch-core",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.9"
+version = "0.3.0"
 authors = ["Exarch Contributors"]
 edition = "2024"
 rust-version = "1.89.0"
@@ -19,7 +19,7 @@ keywords = ["archive", "extraction", "security", "tar", "zip"]
 categories = ["compression", "filesystem"]
 
 [workspace.dependencies]
-exarch-core = { path = "crates/exarch-core", version = "0.2.9" }
+exarch-core = { path = "crates/exarch-core", version = "0.3.0" }
 anyhow = "1.0"
 assert_cmd = "2.1"
 bzip2 = "0.6"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Memory-safe archive extraction and creation library with Python and Node.js bind
 
 ```toml
 [dependencies]
-exarch-core = "0.2"
+exarch-core = "0.3"
 ```
 
 > [!IMPORTANT]

--- a/crates/exarch-core/README.md
+++ b/crates/exarch-core/README.md
@@ -14,7 +14,7 @@ This crate is part of the [exarch](https://github.com/bug-ops/exarch) workspace.
 
 ```toml
 [dependencies]
-exarch-core = "0.2"
+exarch-core = "0.3"
 ```
 
 > [!IMPORTANT]

--- a/crates/exarch-node/package-lock.json
+++ b/crates/exarch-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "exarch-rs",
-  "version": "0.2.9",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "exarch-rs",
-      "version": "0.2.9",
+      "version": "0.3.0",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@biomejs/biome": "^2.0",

--- a/crates/exarch-node/package.json
+++ b/crates/exarch-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exarch-rs",
-  "version": "0.2.9",
+  "version": "0.3.0",
   "description": "Memory-safe archive extraction library with built-in security validation",
   "main": "index.js",
   "types": "index.d.ts",

--- a/crates/exarch-python/pyproject.toml
+++ b/crates/exarch-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exarch"
-version = "0.2.9"
+version = "0.3.0"
 description = "Memory-safe archive extraction library with built-in security validation"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

- Bump version from 0.2.9 to 0.3.0
- Update CHANGELOG.md with release section dated 2026-04-23
- Update version in pyproject.toml (exarch-python) and package.json (exarch-node)
- Update installation version pins in README files to "0.3"

## Checklist

- [x] Version updated in all manifests
- [x] CHANGELOG.md has release section with date
- [x] README reflects new version
- [x] All CI checks pass
- [ ] Ready for tagging after merge