### PR TITLE
fix(cli): --force now overwrites existing files; IO errors no longer duplicate OS message

### DIFF
--- a/crates/exarch-cli/src/commands/extract.rs
+++ b/crates/exarch-cli/src/commands/extract.rs
@@ -71,7 +71,7 @@ pub fn execute(args: &ExtractArgs, formatter: &dyn OutputFormatter) -> Result<()
 
     let options = ExtractionOptions {
         atomic: args.atomic,
-        skip_duplicates: true,
+        skip_duplicates: !args.force,
     };
 
     // When --atomic + --force: remove existing destination after successful

--- a/crates/exarch-core/src/error/types.rs
+++ b/crates/exarch-core/src/error/types.rs
@@ -58,7 +58,7 @@ impl std::fmt::Display for QuotaResource {
 pub enum ExtractionError {
     /// I/O operation failed.
     #[error("I/O error: {0}")]
-    Io(#[from] std::io::Error),
+    Io(std::io::Error),
 
     /// Archive format is unsupported or unrecognized.
     #[error("unsupported archive format")]
@@ -176,6 +176,12 @@ pub enum ExtractionError {
         /// Report of what was written before the error.
         report: crate::ExtractionReport,
     },
+}
+
+impl From<std::io::Error> for ExtractionError {
+    fn from(e: std::io::Error) -> Self {
+        Self::Io(e)
+    }
 }
 
 impl ExtractionError {
@@ -485,6 +491,34 @@ mod tests {
             // IO error may or may not have a source
             let _source = inner.source();
         }
+    }
+
+    // Regression test for #177: ExtractionError::Io must not expose the inner
+    // std::io::Error as an error source. The manual From impl intentionally omits
+    // #[source] so callers building error chains (anyhow, thiserror) do not append
+    // the OS message a second time after ExtractionError::Io's own Display.
+    #[test]
+    fn test_io_error_no_source_chain() {
+        use std::error::Error;
+
+        let os_message = "permission denied";
+        let io_err = std::io::Error::new(std::io::ErrorKind::PermissionDenied, os_message);
+        let err: ExtractionError = io_err.into();
+
+        // Display must contain the OS message exactly once.
+        let display = err.to_string();
+        assert_eq!(
+            display.matches(os_message).count(),
+            1,
+            "OS error message duplicated in Display: {display:?}"
+        );
+
+        // source() must be None — no chain continuation that would re-print the
+        // message.
+        assert!(
+            err.source().is_none(),
+            "ExtractionError::Io must not expose inner io::Error as source"
+        );
     }
 
     // L-11: ZipBomb edge case tests

--- a/crates/exarch-core/src/formats/common.rs
+++ b/crates/exarch-core/src/formats/common.rs
@@ -393,19 +393,13 @@ pub fn extract_file_generic<R: Read>(
     // Create parent directories if needed using cache
     dir_cache.ensure_parent_dir(&output_path)?;
 
-    if output_path.exists() {
-        if skip_duplicates {
-            report.files_skipped += 1;
-            report.warnings.push(format!(
-                "skipped duplicate entry: {}",
-                validated.safe_path.as_path().display()
-            ));
-            return Ok(());
-        }
-        return Err(ExtractionError::InvalidArchive(format!(
-            "duplicate entry: {}",
+    if output_path.exists() && skip_duplicates {
+        report.files_skipped += 1;
+        report.warnings.push(format!(
+            "skipped duplicate entry: {}",
             validated.safe_path.as_path().display()
-        )));
+        ));
+        return Ok(());
     }
 
     // CRITICAL: Check quota BEFORE writing (prevents partial files on overflow)
@@ -508,8 +502,7 @@ pub fn create_directory(
 /// - Platform does not support symlinks
 /// - Parent directory creation fails
 /// - Symlink creation fails (including when target path already exists)
-/// - A file or symlink already exists at the link path and `skip_duplicates` is
-///   false
+/// - Removing an existing path fails when `skip_duplicates` is false
 #[allow(unused_variables)]
 pub fn create_symlink(
     safe_symlink: &SafeSymlink,
@@ -537,10 +530,7 @@ pub fn create_symlink(
                 ));
                 return Ok(());
             }
-            return Err(ExtractionError::InvalidArchive(format!(
-                "duplicate entry: {}",
-                safe_symlink.link_path().display()
-            )));
+            std::fs::remove_file(&link_path)?;
         }
 
         // Create symlink
@@ -1046,5 +1036,47 @@ mod tests {
             "file must have exact mode 0o755 despite strict umask 0o077; \
              got 0o{permission_bits:o} — set_permissions bypass not working"
         );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_duplicate_symlink_overwrites_when_skip_disabled() {
+        use crate::config::AllowedFeatures;
+        use crate::types::SafeSymlink;
+
+        let temp = TempDir::new().expect("failed to create temp dir");
+        let dest = DestDir::new(temp.path().to_path_buf()).expect("failed to create dest");
+        let config = SecurityConfig {
+            allowed: AllowedFeatures {
+                symlinks: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        // Create the target file so the symlink has somewhere to point
+        std::fs::write(temp.path().join("target.txt"), b"data").expect("write target");
+
+        let link_safe_path =
+            SafePath::validate(&PathBuf::from("link.txt"), &dest, &config).expect("safe path");
+        // Validate before the symlink exists on disk
+        let safe_symlink =
+            SafeSymlink::validate(&link_safe_path, Path::new("target.txt"), &dest, &config)
+                .expect("safe symlink");
+
+        let mut report = ExtractionReport::default();
+        let mut dir_cache = DirCache::new();
+
+        // First creation
+        create_symlink(&safe_symlink, &dest, &mut report, &mut dir_cache, false)
+            .expect("first create_symlink should succeed");
+        assert_eq!(report.symlinks_created, 1);
+
+        // Second creation with skip_duplicates=false must overwrite without error
+        create_symlink(&safe_symlink, &dest, &mut report, &mut dir_cache, false)
+            .expect("second create_symlink should overwrite");
+        assert_eq!(report.symlinks_created, 2);
+        assert_eq!(report.files_skipped, 0);
+        assert!(temp.path().join("link.txt").exists());
     }
 }

--- a/crates/exarch-core/src/formats/tar.rs
+++ b/crates/exarch-core/src/formats/tar.rs
@@ -1889,7 +1889,7 @@ mod tests {
     }
 
     #[test]
-    fn test_duplicate_entry_error_when_disabled() {
+    fn test_duplicate_entry_overwrites_when_skip_disabled() {
         let tar_data = create_duplicate_entry_tar("legit.txt", b"first", b"second");
         let mut archive = TarArchive::new(Cursor::new(tar_data));
 
@@ -1900,7 +1900,14 @@ mod tests {
             skip_duplicates: false,
         };
 
-        let result = archive.extract(temp.path(), &config, &options);
-        assert!(result.is_err());
+        let report = archive.extract(temp.path(), &config, &options).unwrap();
+
+        // Both entries extracted (second overwrites first)
+        assert_eq!(report.files_extracted, 2);
+        assert_eq!(report.files_skipped, 0);
+
+        // File content is from the second (overwriting) entry
+        let content = std::fs::read(temp.path().join("legit.txt")).unwrap();
+        assert_eq!(content, b"second");
     }
 }


### PR DESCRIPTION
## Summary

- Fixes #176: `--force` flag now correctly overwrites existing regular files and symlinks during extraction. `ExtractionOptions::skip_duplicates` was hardcoded to `true` unconditionally; changed to `!args.force`. The overwrite paths in `extract_file_generic` and `create_symlink` (common.rs) were updated to fall through to write instead of returning an error.
- Fixes #177: IO error messages were duplicated in user-facing output. `ExtractionError::Io` used `#[from]` which implicitly added `#[source]`, causing anyhow's `{:#}` chain formatter to append the OS error string twice. Replaced with a manual `From<std::io::Error>` impl without `#[source]`.

## Changes

- `crates/exarch-cli/src/commands/extract.rs` — `skip_duplicates: !args.force`
- `crates/exarch-core/src/formats/common.rs` — overwrite path for regular files and symlinks when `skip_duplicates=false`
- `crates/exarch-core/src/error/types.rs` — manual `From<io::Error>` without `#[source]` + regression test
- `crates/exarch-core/src/formats/tar.rs` — updated unit test + regression test for symlink overwrite

## Test plan

- [ ] 780 tests pass (`cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node`)
- [ ] `cargo deny check --all-features` clean
- [ ] `cargo +nightly fmt --all -- --check` clean
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [ ] Regression test `test_io_error_no_source_chain` confirms #177 fix
- [ ] Regression test `test_duplicate_symlink_overwrites_when_skip_disabled` confirms symlink overwrite
- [ ] Existing CLI integration tests `test_extract_with_force_overwrites_conflicts` confirm #176 fix