### PR TITLE
refactor(core): remove dead SEVENZ_MAGIC constant from detect.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Removed dead constant `SEVENZ_MAGIC` and its `#[allow(dead_code)]` suppression from `formats/detect.rs`; the constant was unused in format detection logic (#175).
+
 ### Fixed
 
 - ZIP password-protection detection now performs a full linear scan of all entries instead of a 3-sample strategy, preventing false negatives for archives with encrypted entries outside the first/middle/last 100 positions (#171).

--- a/crates/exarch-core/src/formats/detect.rs
+++ b/crates/exarch-core/src/formats/detect.rs
@@ -5,15 +5,6 @@ use std::path::Path;
 use crate::ExtractionError;
 use crate::Result;
 
-/// 7z format magic bytes (signature).
-///
-/// 7z archives start with the signature: `37 7A BC AF 27 1C`
-/// This is the string "7z" followed by format version bytes.
-///
-/// This constant is defined for future magic byte detection implementation.
-#[allow(dead_code)]
-const SEVENZ_MAGIC: [u8; 6] = [0x37, 0x7A, 0xBC, 0xAF, 0x27, 0x1C];
-
 /// File extensions that wrap a ZIP container with extra structure.
 ///
 /// Signing, manifests, and ordering rules sit on top of the ZIP bytes


### PR DESCRIPTION
## Summary

- Removes `SEVENZ_MAGIC` constant and its `#[allow(dead_code)]` suppression from `crates/exarch-core/src/formats/detect.rs`
- The constant was not used in format detection logic and existed only as a placeholder for a future implementation

## Note on #173

Issue #173 (make `copy`, `io`, `test_utils` `pub(crate)`) was investigated but cannot be implemented without test refactoring:
- `copy` and `test_utils` are used by integration tests in `tests/` (separate crate, cannot access `pub(crate)` items)
- `io` is used by doc-tests in `io/counting.rs` (also compiled as a separate crate)

A follow-up issue should address the test structure before the visibility can be changed.

## Test plan

- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` — 787 passed
- [x] `cargo test --doc --workspace --all-features` — 111 passed
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace` — clean

Closes #175.