### PR TITLE
fix(core): validate CreationConfig and extend SecurityConfig checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - ZIP password-protection detection now performs a full linear scan of all entries instead of a 3-sample strategy, preventing false negatives for archives with encrypted entries outside the first/middle/last 100 positions (#171).
 - `SecurityConfig::validate()` added: construction-time validation rejects `max_compression_ratio <= 0`, `max_file_size == 0`, `max_total_size == 0`, and `max_path_depth == 0`; `extract_archive` and `create_archive` call `validate()` and return an error for invalid configs (#172).
+- `CreationConfig::validate()` is now called in `create_archive_with_progress`, ensuring invalid creation configs are caught before any I/O occurs (#180).
+- `SecurityConfig::validate()` now rejects `max_file_count == 0` and `max_solid_block_memory == 0` to prevent undefined extraction behavior (#181).
 
 ## [0.3.1] - 2026-05-19
 

--- a/crates/exarch-core/src/api.rs
+++ b/crates/exarch-core/src/api.rs
@@ -478,6 +478,8 @@ pub fn create_archive_with_progress<P: AsRef<Path>, Q: AsRef<Path>>(
     config: &CreationConfig,
     progress: &mut dyn ProgressCallback,
 ) -> Result<CreationReport> {
+    config.validate()?;
+
     let output = output_path.as_ref();
 
     // Block creation for the ZIP-family extensions (mirrors the 7z block
@@ -738,6 +740,26 @@ mod tests {
         let result = extract_archive(&path, dest.path(), &SecurityConfig::default());
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_create_archive_invalid_compression_level_rejected_before_io() {
+        let dest = tempfile::TempDir::new().unwrap();
+        let archive_path = dest.path().join("output.tar.gz");
+        let config = CreationConfig {
+            compression_level: Some(15),
+            ..CreationConfig::default()
+        };
+        let result = create_archive(&archive_path, &[] as &[&str], &config);
+        assert!(
+            matches!(
+                result,
+                Err(ExtractionError::InvalidCompressionLevel { level: 15 })
+            ),
+            "expected InvalidCompressionLevel, got {result:?}",
+        );
+        // Verify no I/O happened — output file must not exist
+        assert!(!archive_path.exists(), "output file must not be created");
     }
 
     #[test]

--- a/crates/exarch-core/src/config.rs
+++ b/crates/exarch-core/src/config.rs
@@ -197,6 +197,8 @@ impl SecurityConfig {
     /// - `max_file_size` is zero
     /// - `max_total_size` is zero
     /// - `max_path_depth` is zero
+    /// - `max_file_count` is zero
+    /// - `max_solid_block_memory` is zero
     ///
     /// # Examples
     ///
@@ -231,6 +233,16 @@ impl SecurityConfig {
         if self.max_path_depth == 0 {
             return Err(crate::ExtractionError::InvalidConfiguration {
                 reason: "max_path_depth must not be zero".into(),
+            });
+        }
+        if self.max_file_count == 0 {
+            return Err(crate::ExtractionError::InvalidConfiguration {
+                reason: "max_file_count must not be zero".into(),
+            });
+        }
+        if self.max_solid_block_memory == 0 {
+            return Err(crate::ExtractionError::InvalidConfiguration {
+                reason: "max_solid_block_memory must not be zero".into(),
             });
         }
         Ok(())
@@ -533,6 +545,24 @@ mod tests {
     fn test_validate_rejects_infinite_compression_ratio() {
         let cfg = SecurityConfig {
             max_compression_ratio: f64::INFINITY,
+            ..SecurityConfig::default()
+        };
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_rejects_zero_max_file_count() {
+        let cfg = SecurityConfig {
+            max_file_count: 0,
+            ..SecurityConfig::default()
+        };
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_rejects_zero_max_solid_block_memory() {
+        let cfg = SecurityConfig {
+            max_solid_block_memory: 0,
             ..SecurityConfig::default()
         };
         assert!(cfg.validate().is_err());


### PR DESCRIPTION
## Summary

- Call `CreationConfig::validate()?` at the top of `create_archive_with_progress` so invalid compression levels are rejected before any I/O begins, mirroring the extraction path (closes #180)
- Extend `SecurityConfig::validate()` to reject `max_file_count == 0` (would silently block all archives) and `max_solid_block_memory == 0` (undefined 7z extraction behaviour) (closes #181)

## Changes

- `crates/exarch-core/src/api.rs` — validation call added at line 481
- `crates/exarch-core/src/config.rs` — two new zero-value checks in `SecurityConfig::validate()`
- `CHANGELOG.md` — entries added under `[Unreleased]`

## Test plan

- [ ] `SecurityConfig::validate()` with `max_file_count = 0` returns `InvalidConfiguration` error
- [ ] `SecurityConfig::validate()` with `max_solid_block_memory = 0` returns `InvalidConfiguration` error
- [ ] `create_archive` with `compression_level = Some(15)` returns error before any I/O
- [ ] Boundary values (`max_file_count = 1`, `compression_level = Some(1)`, `compression_level = Some(9)`) are accepted
- [ ] 792 nextest + 111 doctests pass
- [ ] `cargo deny check` clean