### PR TITLE
fix(core): validate SecurityConfig in list_archive and verify_archive

### DIFF
--- a/crates/exarch-core/src/inspection/list.rs
+++ b/crates/exarch-core/src/inspection/list.rs
@@ -59,6 +59,7 @@ pub fn list_archive<P: AsRef<Path>>(
     archive_path: P,
     config: &SecurityConfig,
 ) -> Result<ArchiveManifest> {
+    config.validate()?;
     let archive_path = archive_path.as_ref();
     let format = detect_format(archive_path)?;
 
@@ -1762,6 +1763,22 @@ mod tests {
         assert!(
             !has_false_positive,
             "solid.7z verification should not produce High-severity compressed_size issue"
+        );
+    }
+
+    #[test]
+    fn list_archive_rejects_invalid_security_config() {
+        let config = SecurityConfig {
+            max_file_size: 0,
+            ..SecurityConfig::default()
+        };
+        let result = crate::list_archive("any.tar.gz", &config);
+        assert!(
+            matches!(
+                result,
+                Err(crate::ExtractionError::InvalidConfiguration { .. })
+            ),
+            "list_archive must return InvalidConfiguration for zero max_file_size"
         );
     }
 }

--- a/crates/exarch-core/src/inspection/verify.rs
+++ b/crates/exarch-core/src/inspection/verify.rs
@@ -70,6 +70,7 @@ pub fn verify_archive<P: AsRef<Path>>(
     archive_path: P,
     config: &SecurityConfig,
 ) -> Result<VerificationReport> {
+    config.validate()?;
     let archive_path = archive_path.as_ref();
 
     // List archive to get all entries
@@ -545,6 +546,22 @@ mod tests {
                 .iter()
                 .any(|i| i.category == IssueCategory::SuspiciousPath),
             "Should have SuspiciousPath issue for .sh extension"
+        );
+    }
+
+    #[test]
+    fn verify_archive_rejects_invalid_security_config() {
+        let config = SecurityConfig {
+            max_path_depth: 0,
+            ..SecurityConfig::default()
+        };
+        let result = crate::verify_archive("any.tar.gz", &config);
+        assert!(
+            matches!(
+                result,
+                Err(crate::ExtractionError::InvalidConfiguration { .. })
+            ),
+            "verify_archive must return InvalidConfiguration for zero max_path_depth"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Add `config.validate()?;` at the top of `list_archive` (`inspection/list.rs`) and `verify_archive` (`inspection/verify.rs`), mirroring the existing pattern in `api.rs:114` and `api.rs:481`.
- Callers passing logically invalid `SecurityConfig` values (e.g. `max_file_count = 0`, `max_path_depth = 0`) now receive `Err(InvalidConfiguration)` from the inspection paths, consistent with extraction and creation paths.

## Test plan

- [ ] `list_archive_rejects_invalid_security_config` — passes `max_file_size: 0`, asserts `Err(InvalidConfiguration { .. })`
- [ ] `verify_archive_rejects_invalid_security_config` — passes `max_path_depth: 0`, asserts `Err(InvalidConfiguration { .. })`
- [ ] Full suite: 791 tests pass
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [ ] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace` — clean

Closes #186