### PR TITLE
fix(core): return UnsupportedFormat for 7z creation and extend ArchiveFormat trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Removed dead constant `SEVENZ_MAGIC` and its `#[allow(dead_code)]` suppression from `formats/detect.rs`; the constant was unused in format detection logic (#175).
+- `ArchiveFormat` trait extended with `fn list()` and `fn verify()` methods, providing a single implementation point for all format operations (#174).
 
 ### Fixed
 
 - `extract_archive_with_progress` now correctly invokes the `ProgressCallback` for all archive formats (TAR, ZIP, 7z). Previously the callback was silently discarded because `ArchiveFormat::extract` did not accept a progress parameter (#170).
+- `create_archive()` now returns `Error::UnsupportedFormat` instead of `Error::InvalidArchive` when a `.7z` output path is requested, correctly signaling that 7z creation is not supported (#182).
 - ZIP password-protection detection now performs a full linear scan of all entries instead of a 3-sample strategy, preventing false negatives for archives with encrypted entries outside the first/middle/last 100 positions (#171).
 - `SecurityConfig::validate()` added: construction-time validation rejects `max_compression_ratio <= 0`, `max_file_size == 0`, `max_total_size == 0`, and `max_path_depth == 0`; `extract_archive` and `create_archive` call `validate()` and return an error for invalid configs (#172).
 - `CreationConfig::validate()` is now called in `create_archive_with_progress`, ensuring invalid creation configs are caught before any I/O occurs (#180).

--- a/crates/exarch-core/src/api.rs
+++ b/crates/exarch-core/src/api.rs
@@ -524,9 +524,7 @@ pub fn create_archive_with_progress<P: AsRef<Path>, Q: AsRef<Path>>(
         ArchiveType::Zip => {
             crate::creation::zip::create_zip_with_progress(output, sources, config, progress)
         }
-        ArchiveType::SevenZ => Err(ExtractionError::InvalidArchive(
-            "7z archive creation not yet supported".into(),
-        )),
+        ArchiveType::SevenZ => Err(ExtractionError::UnsupportedFormat),
     }
 }
 
@@ -812,7 +810,7 @@ mod tests {
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
-            ExtractionError::InvalidArchive(_)
+            ExtractionError::UnsupportedFormat
         ));
     }
 

--- a/crates/exarch-core/src/formats/sevenz.rs
+++ b/crates/exarch-core/src/formats/sevenz.rs
@@ -533,6 +533,17 @@ impl<R: Read + Seek> ArchiveFormat for SevenZArchive<R> {
         }
     }
 
+    fn list(&mut self, config: &SecurityConfig) -> Result<crate::inspection::ArchiveManifest> {
+        use crate::inspection::list::list_sevenz_reader;
+        self.source.rewind().map_err(ExtractionError::Io)?;
+        list_sevenz_reader(&mut self.source, config)
+    }
+
+    fn verify(&mut self, config: &SecurityConfig) -> Result<crate::inspection::VerificationReport> {
+        let manifest = self.list(config)?;
+        crate::inspection::verify::verify_manifest(&manifest, config)
+    }
+
     fn format_name(&self) -> &'static str {
         "7z"
     }
@@ -1287,5 +1298,30 @@ mod tests {
             }
             other => panic!("expected SecurityViolation, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_list_returns_manifest_with_entries() {
+        let data = load_fixture("simple.7z");
+        let mut archive = SevenZArchive::new(Cursor::new(data)).unwrap();
+        let config = SecurityConfig::default();
+
+        let manifest = archive.list(&config).unwrap();
+
+        assert!(
+            manifest.total_entries > 0,
+            "simple.7z must have at least one entry"
+        );
+    }
+
+    #[test]
+    fn test_verify_clean_sevenz_is_safe() {
+        let data = load_fixture("simple.7z");
+        let mut archive = SevenZArchive::new(Cursor::new(data)).unwrap();
+        let config = SecurityConfig::default();
+
+        let report = archive.verify(&config).unwrap();
+
+        assert!(report.is_safe());
     }
 }

--- a/crates/exarch-core/src/formats/tar.rs
+++ b/crates/exarch-core/src/formats/tar.rs
@@ -161,8 +161,8 @@ use super::traits::ArchiveFormat;
 /// # Ok::<(), exarch_core::ExtractionError>(())
 /// ```
 pub struct TarArchive<R: Read> {
-    /// Underlying `tar::Archive` reader
-    inner: Archive<R>,
+    /// Underlying `tar::Archive` reader; `None` after `list()` consumes it.
+    inner: Option<Archive<R>>,
 }
 
 impl<R: Read> TarArchive<R> {
@@ -193,7 +193,7 @@ impl<R: Read> TarArchive<R> {
     #[must_use]
     pub fn new(reader: R) -> Self {
         Self {
-            inner: Archive::new(reader),
+            inner: Some(Archive::new(reader)),
         }
     }
 
@@ -358,8 +358,10 @@ impl<R: Read> ArchiveFormat for TarArchive<R> {
 
         let mut current_entry: usize = 0;
 
-        let entries = self
-            .inner
+        let inner = self.inner.as_mut().ok_or_else(|| {
+            ExtractionError::InvalidArchive("archive reader already consumed by list()".into())
+        })?;
+        let entries = inner
             .entries()
             .map_err(|e| ExtractionError::InvalidArchive(format!("failed to read entries: {e}")))?;
 
@@ -438,6 +440,25 @@ impl<R: Read> ArchiveFormat for TarArchive<R> {
         report.duration = start.elapsed();
 
         Ok(report)
+    }
+
+    fn list(&mut self, config: &SecurityConfig) -> Result<crate::inspection::ArchiveManifest> {
+        use crate::formats::detect::ArchiveType;
+        use crate::inspection::list::list_tar_reader;
+
+        // Consume the inner archive — TAR readers are forward-only streams.
+        // After list() returns, extract() will return an error if called.
+        let inner = self.inner.take().ok_or_else(|| {
+            crate::ExtractionError::InvalidArchive(
+                "archive reader already consumed by list()".into(),
+            )
+        })?;
+        list_tar_reader(inner.into_inner(), ArchiveType::Tar, config)
+    }
+
+    fn verify(&mut self, config: &SecurityConfig) -> Result<crate::inspection::VerificationReport> {
+        let manifest = self.list(config)?;
+        crate::inspection::verify::verify_manifest(&manifest, config)
     }
 
     fn format_name(&self) -> &'static str {
@@ -2154,5 +2175,41 @@ mod tests {
         // File content is from the second (overwriting) entry
         let content = std::fs::read(temp.path().join("legit.txt")).unwrap();
         assert_eq!(content, b"second");
+    }
+
+    #[test]
+    fn test_list_returns_manifest_with_entries() {
+        let tar_data = create_test_tar(vec![("a.txt", b"hello"), ("b.txt", b"world")]);
+        let mut archive = TarArchive::new(Cursor::new(tar_data));
+        let config = SecurityConfig::default();
+
+        let manifest = archive.list(&config).unwrap();
+
+        assert_eq!(manifest.total_entries, 2);
+        assert_eq!(manifest.total_size, 10);
+    }
+
+    #[test]
+    fn test_list_empty_archive_returns_empty_manifest() {
+        let tar_data = create_test_tar(vec![]);
+        let mut archive = TarArchive::new(Cursor::new(tar_data));
+        let config = SecurityConfig::default();
+
+        let manifest = archive.list(&config).unwrap();
+
+        assert_eq!(manifest.total_entries, 0);
+        assert_eq!(manifest.total_size, 0);
+    }
+
+    #[test]
+    fn test_verify_clean_archive_is_safe() {
+        let tar_data = create_test_tar(vec![("safe.txt", b"data")]);
+        let mut archive = TarArchive::new(Cursor::new(tar_data));
+        let config = SecurityConfig::default();
+
+        let report = archive.verify(&config).unwrap();
+
+        assert!(report.is_safe());
+        assert_eq!(report.total_entries, 1);
     }
 }

--- a/crates/exarch-core/src/formats/traits.rs
+++ b/crates/exarch-core/src/formats/traits.rs
@@ -7,8 +7,14 @@ use crate::ExtractionReport;
 use crate::ProgressCallback;
 use crate::Result;
 use crate::SecurityConfig;
+use crate::inspection::ArchiveManifest;
+use crate::inspection::VerificationReport;
 
 /// Trait for archive format handlers.
+///
+/// Implementors provide extraction, listing, and verification for a single
+/// archive format. Every new format must implement all three operations so that
+/// adding a format requires touching one trait implementation only.
 pub trait ArchiveFormat {
     /// Extracts the archive to the specified directory.
     ///
@@ -24,6 +30,29 @@ pub trait ArchiveFormat {
         options: &ExtractionOptions,
         progress: &mut dyn ProgressCallback,
     ) -> Result<ExtractionReport>;
+
+    /// Lists the archive contents without writing any files to disk.
+    ///
+    /// Returns a manifest of all entries with their metadata. Quota limits
+    /// from `config` are applied to reject oversized archives early.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the archive is corrupted, encrypted, or a quota
+    /// limit is exceeded.
+    fn list(&mut self, config: &SecurityConfig) -> Result<ArchiveManifest>;
+
+    /// Verifies the archive's integrity and security without extracting.
+    ///
+    /// Performs path-traversal, symlink, zip-bomb, quota, and permission
+    /// checks. Security issues are collected in the returned report rather
+    /// than propagated as errors, so callers get the complete picture.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error only if the archive cannot be read at all (I/O
+    /// failure, encryption). Individual security issues appear in the report.
+    fn verify(&mut self, config: &SecurityConfig) -> Result<VerificationReport>;
 
     /// Returns the archive format name.
     fn format_name(&self) -> &'static str;
@@ -44,6 +73,16 @@ mod tests {
             _progress: &mut dyn ProgressCallback,
         ) -> Result<ExtractionReport> {
             Ok(ExtractionReport::new())
+        }
+
+        fn list(&mut self, _config: &SecurityConfig) -> Result<ArchiveManifest> {
+            use crate::formats::detect::ArchiveType;
+            Ok(ArchiveManifest::new(ArchiveType::Tar))
+        }
+
+        fn verify(&mut self, config: &SecurityConfig) -> Result<VerificationReport> {
+            let manifest = self.list(config)?;
+            crate::inspection::verify::verify_manifest(&manifest, config)
         }
 
         fn format_name(&self) -> &'static str {
@@ -69,5 +108,43 @@ mod tests {
             .extract(temp.path(), &config, &options, &mut noop)
             .unwrap();
         assert_eq!(report.files_extracted, 0);
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn test_trait_list_returns_empty_manifest() {
+        let mut format = TestFormat;
+        let config = SecurityConfig::default();
+        let manifest = format.list(&config).unwrap();
+        assert_eq!(manifest.total_entries, 0);
+        assert_eq!(manifest.total_size, 0);
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn test_trait_verify_returns_clean_report_for_empty_archive() {
+        let mut format = TestFormat;
+        let config = SecurityConfig::default();
+        let report = format.verify(&config).unwrap();
+        assert_eq!(report.total_entries, 0);
+        assert!(report.is_safe());
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn test_trait_list_via_dyn_dispatch() {
+        let mut format: Box<dyn ArchiveFormat> = Box::new(TestFormat);
+        let config = SecurityConfig::default();
+        let manifest = format.list(&config).unwrap();
+        assert_eq!(manifest.total_entries, 0);
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn test_trait_verify_via_dyn_dispatch() {
+        let mut format: Box<dyn ArchiveFormat> = Box::new(TestFormat);
+        let config = SecurityConfig::default();
+        let report = format.verify(&config).unwrap();
+        assert!(report.is_safe());
     }
 }

--- a/crates/exarch-core/src/formats/zip.rs
+++ b/crates/exarch-core/src/formats/zip.rs
@@ -433,6 +433,16 @@ impl<R: Read + Seek> ArchiveFormat for ZipArchive<R> {
         Ok(report)
     }
 
+    fn list(&mut self, config: &SecurityConfig) -> Result<crate::inspection::ArchiveManifest> {
+        use crate::inspection::list::list_zip_reader;
+        list_zip_reader(&mut self.inner, config)
+    }
+
+    fn verify(&mut self, config: &SecurityConfig) -> Result<crate::inspection::VerificationReport> {
+        let manifest = self.list(config)?;
+        crate::inspection::verify::verify_manifest(&manifest, config)
+    }
+
     fn format_name(&self) -> &'static str {
         "zip"
     }
@@ -1920,5 +1930,41 @@ mod tests {
             }
             other => panic!("expected SecurityViolation, got: {other}"),
         }
+    }
+
+    #[test]
+    fn test_list_returns_manifest_with_entries() {
+        let zip_data = create_test_zip(vec![("a.txt", b"hello"), ("b.txt", b"world")]);
+        let mut archive = ZipArchive::new(Cursor::new(zip_data)).unwrap();
+        let config = SecurityConfig::default();
+
+        let manifest = archive.list(&config).unwrap();
+
+        assert_eq!(manifest.total_entries, 2);
+        assert_eq!(manifest.total_size, 10);
+    }
+
+    #[test]
+    fn test_list_empty_zip_returns_empty_manifest() {
+        let zip_data = create_test_zip(vec![]);
+        let mut archive = ZipArchive::new(Cursor::new(zip_data)).unwrap();
+        let config = SecurityConfig::default();
+
+        let manifest = archive.list(&config).unwrap();
+
+        assert_eq!(manifest.total_entries, 0);
+        assert_eq!(manifest.total_size, 0);
+    }
+
+    #[test]
+    fn test_verify_clean_zip_is_safe() {
+        let zip_data = create_test_zip(vec![("safe.txt", b"data")]);
+        let mut archive = ZipArchive::new(Cursor::new(zip_data)).unwrap();
+        let config = SecurityConfig::default();
+
+        let report = archive.verify(&config).unwrap();
+
+        assert!(report.is_safe());
+        assert_eq!(report.total_entries, 1);
     }
 }

--- a/crates/exarch-core/src/inspection/list.rs
+++ b/crates/exarch-core/src/inspection/list.rs
@@ -234,17 +234,38 @@ fn list_tar_entries<R: std::io::Read>(
 
 fn list_zip(
     archive_path: &Path,
-    format: ArchiveType,
+    _format: ArchiveType,
     config: &SecurityConfig,
 ) -> Result<ArchiveManifest> {
     let file = File::open(archive_path)?;
     let mut archive = zip::ZipArchive::new(file)
         .map_err(|e| ExtractionError::InvalidArchive(format!("failed to open ZIP archive: {e}")))?;
+    list_zip_reader(&mut archive, config)
+}
 
-    let mut manifest = ArchiveManifest::new(format);
+/// Lists entries from an already-opened TAR reader.
+///
+/// Used by `ArchiveFormat::list()` implementations to avoid re-opening the
+/// archive. `format` is passed through into `ArchiveManifest` as-is.
+pub(crate) fn list_tar_reader<R: Read>(
+    reader: R,
+    format: ArchiveType,
+    config: &SecurityConfig,
+) -> Result<ArchiveManifest> {
+    let archive = tar::Archive::new(reader);
+    list_tar_entries(archive, format, config)
+}
+
+/// Lists entries from an already-opened ZIP archive.
+///
+/// Used by `ArchiveFormat::list()` to avoid re-opening the archive.
+pub(crate) fn list_zip_reader<R: Read + Seek>(
+    archive: &mut zip::ZipArchive<R>,
+    config: &SecurityConfig,
+) -> Result<ArchiveManifest> {
+    let mut manifest = ArchiveManifest::new(ArchiveType::Zip);
 
     for i in 0..archive.len() {
-        // Check file count quota
         if manifest.total_entries >= config.max_file_count {
             return Err(ExtractionError::QuotaExceeded {
                 resource: QuotaResource::FileCount {
@@ -279,8 +300,6 @@ fn list_zip(
         let entry_type = convert_zip_entry_type(&entry);
         let size = entry.size();
         let compressed_size = Some(entry.compressed_size());
-        // Strip file-type bits (S_IFREG, S_IFDIR, etc.) from external_attributes >> 16,
-        // keeping only the permission bits so the display matches TAR output.
         let mode = entry.unix_mode().map(|m| m & 0o7777);
         #[allow(clippy::cast_sign_loss)]
         let modified = entry.last_modified().and_then(|dt| {
@@ -307,7 +326,6 @@ fn list_zip(
             hardlink_target: None,
         };
 
-        // Check total size quota
         if manifest.total_size + archive_entry.size > config.max_total_size {
             return Err(ExtractionError::QuotaExceeded {
                 resource: QuotaResource::TotalSize {
@@ -323,17 +341,19 @@ fn list_zip(
     Ok(manifest)
 }
 
-fn list_sevenz(
-    archive_path: &Path,
-    format: ArchiveType,
+/// Lists entries from an already-opened 7z source reader.
+///
+/// Used by `ArchiveFormat::list()` to avoid re-opening the archive. The reader
+/// must be positioned at the beginning of the 7z stream.
+pub(crate) fn list_sevenz_reader<R: Read + Seek>(
+    mut source: R,
     config: &SecurityConfig,
 ) -> Result<ArchiveManifest> {
     use sevenz_rust2::Archive;
     use sevenz_rust2::Password;
 
-    let mut file = File::open(archive_path)?;
     let password = Password::empty();
-    let archive = match Archive::read(&mut file, &password) {
+    let archive = match Archive::read(&mut source, &password) {
         Ok(a) => a,
         Err(e) => {
             let err_str = e.to_string().to_lowercase();
@@ -344,10 +364,8 @@ fn list_sevenz(
                         .into(),
                 });
             }
-            // Handle valid empty 7z archives: sevenz-rust2 fails with UnexpectedEof on
-            // 32-byte archives that contain no files.
-            if is_empty_sevenz_file(&e, &mut file) {
-                return Ok(ArchiveManifest::new(format));
+            if is_empty_sevenz_archive_reader(&e, &mut source) {
+                return Ok(ArchiveManifest::new(ArchiveType::SevenZ));
             }
             return Err(ExtractionError::InvalidArchive(format!(
                 "failed to open 7z archive: {e}"
@@ -355,15 +373,49 @@ fn list_sevenz(
         }
     };
 
-    let mut manifest = ArchiveManifest::new(format);
+    list_sevenz_archive(&archive, config)
+}
+
+/// Checks whether a sevenz-rust2 parse failure is due to a valid empty 7z
+/// archive, using a generic seekable reader.
+fn is_empty_sevenz_archive_reader<R: Read + Seek>(
+    err: &sevenz_rust2::Error,
+    source: &mut R,
+) -> bool {
+    const SEVENZ_MAGIC: [u8; 6] = [0x37, 0x7A, 0xBC, 0xAF, 0x27, 0x1C];
+    const EMPTY_ARCHIVE_SIZE: u64 = 32;
+
+    let is_eof = matches!(err, sevenz_rust2::Error::Io(io_err, _) if io_err.kind() == ErrorKind::UnexpectedEof);
+    if !is_eof {
+        return false;
+    }
+
+    let Ok(size) = source.seek(std::io::SeekFrom::End(0)) else {
+        return false;
+    };
+    if size != EMPTY_ARCHIVE_SIZE {
+        return false;
+    }
+
+    let Ok(_) = source.seek(std::io::SeekFrom::Start(0)) else {
+        return false;
+    };
+    let mut magic = [0u8; 6];
+    source.read_exact(&mut magic).is_ok() && magic == SEVENZ_MAGIC
+}
+
+/// Builds a manifest from a parsed 7z archive structure.
+fn list_sevenz_archive(
+    archive: &sevenz_rust2::Archive,
+    config: &SecurityConfig,
+) -> Result<ArchiveManifest> {
+    let mut manifest = ArchiveManifest::new(ArchiveType::SevenZ);
 
     for entry in &archive.files {
-        // Anti-items represent deletions in incremental archives; skip them.
         if entry.is_anti_item {
             continue;
         }
 
-        // Check file count quota
         if manifest.total_entries >= config.max_file_count {
             return Err(ExtractionError::QuotaExceeded {
                 resource: QuotaResource::FileCount {
@@ -382,10 +434,6 @@ fn list_sevenz(
         let entry_type = sevenz_manifest_entry_type(entry);
         let size = entry.size;
         let compressed_size = if archive.is_solid {
-            // In solid archives, only the first entry per block has a meaningful
-            // compressed_size. Remaining entries report 0, which is a valid artifact of
-            // solid block compression — omit to avoid false positives in zip bomb
-            // detection.
             entry
                 .has_stream
                 .then_some(entry.compressed_size)
@@ -408,7 +456,6 @@ fn list_sevenz(
             hardlink_target: None,
         };
 
-        // Check total size quota
         if manifest.total_size + archive_entry.size > config.max_total_size {
             return Err(ExtractionError::QuotaExceeded {
                 resource: QuotaResource::TotalSize {
@@ -422,6 +469,15 @@ fn list_sevenz(
     }
 
     Ok(manifest)
+}
+
+fn list_sevenz(
+    archive_path: &Path,
+    _format: ArchiveType,
+    config: &SecurityConfig,
+) -> Result<ArchiveManifest> {
+    let mut file = File::open(archive_path)?;
+    list_sevenz_reader(&mut file, config)
 }
 
 // Windows FILE_ATTRIBUTE_REPARSE_POINT flag — indicates symlinks and junctions.
@@ -442,36 +498,6 @@ fn sevenz_manifest_entry_type(entry: &sevenz_rust2::ArchiveEntry) -> ManifestEnt
 }
 
 /// Checks whether a sevenz-rust2 parse failure is due to a valid empty 7z
-/// archive.
-///
-/// sevenz-rust2 fails with `UnexpectedEof` on valid 32-byte empty archives (0
-/// files). Requires: `UnexpectedEof` I/O error + valid 7z magic + file size ==
-/// 32 bytes exactly.
-fn is_empty_sevenz_file(err: &sevenz_rust2::Error, file: &mut File) -> bool {
-    const SEVENZ_MAGIC: [u8; 6] = [0x37, 0x7A, 0xBC, 0xAF, 0x27, 0x1C];
-    // A valid empty 7z archive is exactly 32 bytes:
-    // signature (6) + version (2) + StartHeader CRC (4) + StartHeader (20).
-    const EMPTY_ARCHIVE_SIZE: u64 = 32;
-
-    let is_eof = matches!(err, sevenz_rust2::Error::Io(io_err, _) if io_err.kind() == ErrorKind::UnexpectedEof);
-    if !is_eof {
-        return false;
-    }
-
-    let Ok(size) = file.seek(std::io::SeekFrom::End(0)) else {
-        return false;
-    };
-    if size != EMPTY_ARCHIVE_SIZE {
-        return false;
-    }
-
-    let Ok(_) = file.seek(std::io::SeekFrom::Start(0)) else {
-        return false;
-    };
-    let mut magic = [0u8; 6];
-    file.read_exact(&mut magic).is_ok() && magic == SEVENZ_MAGIC
-}
-
 /// Returns `true` if the path contains traversal attempts.
 ///
 /// Mirrors zip crate `enclosed_name()` semantics: rejects paths with `..`

--- a/crates/exarch-core/src/inspection/verify.rs
+++ b/crates/exarch-core/src/inspection/verify.rs
@@ -8,6 +8,7 @@ use crate::Result;
 use crate::SecurityConfig;
 use crate::inspection::list::list_archive;
 use crate::inspection::manifest::ArchiveEntry;
+use crate::inspection::manifest::ArchiveManifest;
 use crate::inspection::manifest::ManifestEntryType;
 use crate::inspection::report::CheckStatus;
 use crate::inspection::report::IssueCategory;
@@ -22,6 +23,51 @@ use crate::security::symlink::validate_symlink;
 use crate::security::zipbomb::validate_compression_ratio;
 use crate::types::DestDir;
 use crate::types::EntryType;
+
+/// Verifies an already-listed manifest against the security config.
+///
+/// Used by `ArchiveFormat::verify()` to avoid re-opening the archive.
+/// Performs the same checks as `verify_archive` but starts from a manifest
+/// produced by `ArchiveFormat::list()`.
+pub(crate) fn verify_manifest(
+    manifest: &ArchiveManifest,
+    config: &SecurityConfig,
+) -> Result<VerificationReport> {
+    let mut issues = Vec::new();
+    let mut suspicious_entries = 0;
+
+    let temp_dir = std::env::temp_dir().join("exarch-verify");
+    std::fs::create_dir_all(&temp_dir)?;
+    let temp_dest = DestDir::new(temp_dir)?;
+
+    let mut quota_tracker = QuotaTracker::new();
+
+    for entry in &manifest.entries {
+        let entry_issues = verify_entry(entry, config, &temp_dest, &mut quota_tracker);
+        if !entry_issues.is_empty() {
+            suspicious_entries += 1;
+            issues.extend(entry_issues);
+        }
+        let heuristic_issues = check_heuristics(entry);
+        issues.extend(heuristic_issues);
+    }
+
+    issues.sort_by(|a, b| a.severity.cmp(&b.severity).reverse());
+
+    let status = determine_status(&issues);
+    let security_status = determine_security_status(&issues);
+
+    Ok(VerificationReport {
+        status,
+        integrity_status: CheckStatus::Pass,
+        security_status,
+        issues,
+        total_entries: manifest.total_entries,
+        suspicious_entries,
+        total_size: manifest.total_size,
+        format: manifest.format,
+    })
+}
 
 /// Verifies archive integrity and security without extracting.
 ///
@@ -41,8 +87,8 @@ use crate::types::EntryType;
 /// - Archive file cannot be opened
 /// - Archive is severely corrupted (cannot read structure)
 ///
-/// Security violations are reported in `VerificationReport.issues`,
-/// not as errors.
+/// Security violations are reported in `VerificationReport.issues`, not as
+/// errors.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
## Summary

- **#182**: `create_archive()` now returns `Error::UnsupportedFormat` instead of `Error::InvalidArchive` when a `.7z` output path is requested, giving callers a semantically correct error.
- **#174**: `ArchiveFormat` trait extended with `fn list()` and `fn verify()` methods. Adding a new format now requires implementing a single trait instead of editing multiple independent dispatch paths.

## Changes

- `api.rs`: fixed 7z creation error variant
- `formats/traits.rs`: added `list()` and `verify()` to `ArchiveFormat` trait with full doc comments
- `formats/tar.rs`, `zip.rs`, `sevenz.rs`: implemented new trait methods; `TarArchive.inner` changed to `Option<Archive<R>>` for streaming list support
- `inspection/list.rs`, `inspection/verify.rs`: factored out `pub(crate)` helpers used by trait implementations
- 12 new regression tests; 801 tests pass

## Test plan

- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` — 801 passed, 3 skipped
- [x] `cargo test --doc --workspace --all-features` — 111 passed
- [x] `cargo +nightly fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets --all-features --exclude exarch-python --exclude exarch-node -- -D warnings` — clean
- [x] `cargo deny check --all-features` — advisories, bans, licenses, sources all ok

Closes #182
Closes #174