### PR TITLE
refactor(core)!: restrict internal modules copy/io/test_utils to pub(crate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING**: Internal modules `copy`, `io`, and `test_utils` in `exarch-core` are now `pub(crate)` instead of `pub`. These were never part of the public API; any external code referencing `exarch_core::copy`, `exarch_core::io`, or `exarch_core::test_utils` directly will no longer compile (#173).
 - Removed dead constant `SEVENZ_MAGIC` and its `#[allow(dead_code)]` suppression from `formats/detect.rs`; the constant was unused in format detection logic (#175).
 - `ArchiveFormat` trait extended with `fn list()` and `fn verify()` methods, providing a single implementation point for all format operations (#174).
 

--- a/crates/exarch-core/src/copy.rs
+++ b/crates/exarch-core/src/copy.rs
@@ -23,28 +23,7 @@ use crate::ExtractionError;
 /// between memory usage and I/O performance.
 const COPY_BUFFER_SIZE: usize = 64 * 1024;
 
-/// Stack-allocated buffer for efficient file copying.
-///
-/// Uses a fixed-size array on the stack to avoid heap allocations
-/// during copy operations. The buffer is reusable across multiple
-/// copy operations within the same extraction session.
-///
-/// # Examples
-///
-/// ```no_run
-/// # use std::io::{Read, Write};
-/// # use exarch_core::copy::{CopyBuffer, copy_with_buffer};
-/// # use exarch_core::ExtractionError;
-/// # fn example() -> Result<(), ExtractionError> {
-/// let mut buffer = CopyBuffer::new();
-/// let mut input = std::fs::File::open("input.txt")?;
-/// let mut output = std::fs::File::create("output.txt")?;
-///
-/// let bytes_copied = copy_with_buffer(&mut input, &mut output, &mut buffer)?;
-/// println!("Copied {} bytes", bytes_copied);
-/// # Ok(())
-/// # }
-/// ```
+/// Stack-allocated reusable buffer used internally by [`copy_with_buffer`].
 #[derive(Debug)]
 pub struct CopyBuffer {
     // Stack allocation is intentional for performance (avoids heap overhead)
@@ -68,7 +47,8 @@ impl CopyBuffer {
     /// Returns the buffer size in bytes.
     #[inline]
     #[must_use]
-    pub fn size(&self) -> usize {
+    #[allow(dead_code, clippy::unused_self)]
+    pub(crate) fn size(&self) -> usize {
         COPY_BUFFER_SIZE
     }
 }
@@ -97,23 +77,6 @@ impl Default for CopyBuffer {
 ///
 /// Quota overflow is explicitly checked using `checked_add`, ensuring
 /// that malicious archives cannot bypass size limits via integer overflow.
-///
-/// # Examples
-///
-/// ```no_run
-/// # use std::io::{Read, Write};
-/// # use exarch_core::copy::{CopyBuffer, copy_with_buffer};
-/// # use exarch_core::ExtractionError;
-/// # fn example() -> Result<(), ExtractionError> {
-/// let mut buffer = CopyBuffer::new();
-/// let mut input = std::fs::File::open("large_file.bin")?;
-/// let mut output = std::fs::File::create("output.bin")?;
-///
-/// let total = copy_with_buffer(&mut input, &mut output, &mut buffer)?;
-/// println!("Copied {} bytes without heap allocation", total);
-/// # Ok(())
-/// # }
-/// ```
 #[inline]
 pub fn copy_with_buffer<R: Read, W: Write>(
     reader: &mut R,
@@ -149,6 +112,7 @@ pub fn copy_with_buffer<R: Read, W: Write>(
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
     use std::io::Cursor;
 
     #[test]
@@ -363,6 +327,53 @@ mod tests {
                 assert_eq!(e.kind(), ErrorKind::Other);
             }
             _ => panic!("expected IO error"),
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn prop_copy_preserves_data(
+            data in prop::collection::vec(any::<u8>(), 0..100_000)
+        ) {
+            let mut buffer = CopyBuffer::new();
+            let mut input = Cursor::new(&data);
+            let mut output = Vec::new();
+            let result = copy_with_buffer(&mut input, &mut output, &mut buffer);
+            prop_assert!(result.is_ok(), "copy should succeed");
+            prop_assert_eq!(result.unwrap(), data.len() as u64, "should report correct size");
+            prop_assert_eq!(output, data, "output must match input exactly");
+        }
+
+        #[test]
+        fn prop_copy_handles_various_sizes(
+            size in 0usize..500_000
+        ) {
+            let mut buffer = CopyBuffer::new();
+            let data = vec![0x42u8; size];
+            let mut input = Cursor::new(&data);
+            let mut output = Vec::new();
+            let result = copy_with_buffer(&mut input, &mut output, &mut buffer);
+            prop_assert!(result.is_ok(), "copy should succeed for size {}", size);
+            prop_assert_eq!(output.len(), size, "output size must match input");
+            prop_assert!(output.iter().all(|&b| b == 0x42), "all bytes must be preserved");
+        }
+
+        #[test]
+        fn prop_copy_buffer_reusable(
+            data1 in prop::collection::vec(any::<u8>(), 0..10_000),
+            data2 in prop::collection::vec(any::<u8>(), 0..10_000)
+        ) {
+            let mut buffer = CopyBuffer::new();
+            let mut input1 = Cursor::new(&data1);
+            let mut output1 = Vec::new();
+            let result1 = copy_with_buffer(&mut input1, &mut output1, &mut buffer);
+            prop_assert!(result1.is_ok());
+            prop_assert_eq!(output1, data1);
+            let mut input2 = Cursor::new(&data2);
+            let mut output2 = Vec::new();
+            let result2 = copy_with_buffer(&mut input2, &mut output2, &mut buffer);
+            prop_assert!(result2.is_ok());
+            prop_assert_eq!(output2, data2);
         }
     }
 }

--- a/crates/exarch-core/src/io/counting.rs
+++ b/crates/exarch-core/src/io/counting.rs
@@ -18,24 +18,6 @@ use std::io::Write;
 ///
 /// The counter only increments on successful writes. If a write operation
 /// fails partway through, only the successfully written bytes are counted.
-///
-/// # Examples
-///
-/// ```
-/// use exarch_core::io::CountingWriter;
-/// use std::io::Write;
-///
-/// let mut buffer = Vec::new();
-/// let mut writer = CountingWriter::new(&mut buffer);
-///
-/// writer.write_all(b"Hello, ")?;
-/// writer.write_all(b"World!")?;
-/// writer.flush()?;
-///
-/// assert_eq!(writer.total_bytes(), 13);
-/// assert_eq!(buffer, b"Hello, World!");
-/// # Ok::<(), std::io::Error>(())
-/// ```
 pub struct CountingWriter<W> {
     /// Inner writer being wrapped
     inner: W,
@@ -44,21 +26,7 @@ pub struct CountingWriter<W> {
 }
 
 impl<W> CountingWriter<W> {
-    /// Creates a new counting writer.
-    ///
-    /// # Parameters
-    ///
-    /// - `inner`: The writer to wrap
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use exarch_core::io::CountingWriter;
-    /// use std::io::Write;
-    ///
-    /// let buffer: Vec<u8> = Vec::new();
-    /// let writer = CountingWriter::new(buffer);
-    /// ```
+    /// Creates a new counting writer wrapping `inner`.
     #[must_use]
     pub fn new(inner: W) -> Self {
         Self {
@@ -69,90 +37,33 @@ impl<W> CountingWriter<W> {
 
     /// Returns the total number of bytes successfully written.
     ///
-    /// This count includes all bytes from successful write operations,
-    /// including those from `write`, `write_all`, and `write_fmt`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use exarch_core::io::CountingWriter;
-    /// use std::io::Write;
-    ///
-    /// let mut buffer = Vec::new();
-    /// let mut writer = CountingWriter::new(&mut buffer);
-    ///
-    /// writer.write_all(b"test")?;
-    /// assert_eq!(writer.total_bytes(), 4);
-    ///
-    /// writer.write_all(b"data")?;
-    /// assert_eq!(writer.total_bytes(), 8);
-    /// # Ok::<(), std::io::Error>(())
-    /// ```
+    /// Only counts bytes from successful writes; partial failures do not
+    /// increment the counter for the failed portion.
     #[must_use]
     pub fn total_bytes(&self) -> u64 {
         self.bytes_written
     }
 
     /// Consumes the counting writer and returns the inner writer.
-    ///
-    /// This is useful when you need to retrieve the underlying writer
-    /// after all writing is complete.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use exarch_core::io::CountingWriter;
-    /// use std::io::Write;
-    ///
-    /// let buffer = Vec::new();
-    /// let mut writer = CountingWriter::new(buffer);
-    ///
-    /// writer.write_all(b"test")?;
-    ///
-    /// let buffer = writer.into_inner();
-    /// assert_eq!(buffer, b"test");
-    /// # Ok::<(), std::io::Error>(())
-    /// ```
     #[must_use]
-    pub fn into_inner(self) -> W {
+    #[allow(dead_code)]
+    pub(crate) fn into_inner(self) -> W {
         self.inner
     }
 
     /// Returns a reference to the inner writer.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use exarch_core::io::CountingWriter;
-    ///
-    /// let buffer = Vec::new();
-    /// let writer = CountingWriter::new(buffer);
-    ///
-    /// let inner_ref: &Vec<u8> = writer.get_ref();
-    /// ```
     #[must_use]
-    pub fn get_ref(&self) -> &W {
+    #[allow(dead_code)]
+    pub(crate) fn get_ref(&self) -> &W {
         &self.inner
     }
 
     /// Returns a mutable reference to the inner writer.
     ///
-    /// # Safety
-    ///
     /// If you write to the inner writer directly (bypassing the
     /// `CountingWriter`), the byte count will not be updated.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use exarch_core::io::CountingWriter;
-    ///
-    /// let buffer = Vec::new();
-    /// let mut writer = CountingWriter::new(buffer);
-    ///
-    /// let inner_mut: &mut Vec<u8> = writer.get_mut();
-    /// ```
-    pub fn get_mut(&mut self) -> &mut W {
+    #[allow(dead_code)]
+    pub(crate) fn get_mut(&mut self) -> &mut W {
         &mut self.inner
     }
 }

--- a/crates/exarch-core/src/lib.rs
+++ b/crates/exarch-core/src/lib.rs
@@ -24,15 +24,15 @@
 pub mod api;
 pub mod archive;
 pub mod config;
-pub mod copy;
+pub(crate) mod copy;
 pub mod creation;
 pub mod error;
 pub mod formats;
 pub mod inspection;
-pub mod io;
+pub(crate) mod io;
 pub mod report;
 pub mod security;
-pub mod test_utils;
+pub(crate) mod test_utils;
 pub mod types;
 
 // Re-export main API types

--- a/crates/exarch-core/src/test_utils.rs
+++ b/crates/exarch-core/src/test_utils.rs
@@ -8,22 +8,14 @@
 //! All functions in this module may panic on I/O errors since they are
 //! designed for test use only where panics are acceptable.
 
-#![allow(clippy::unwrap_used, clippy::missing_panics_doc)]
+#![allow(clippy::unwrap_used, clippy::missing_panics_doc, dead_code)]
 
 use std::io::Cursor;
 use std::io::Write;
 
-/// Creates an in-memory TAR archive from a list of entries.
+/// Creates an in-memory TAR archive from a list of `(path, content)` entries.
 ///
-/// Each entry is a tuple of (path, content). Files are created with mode 0o644.
-///
-/// # Examples
-///
-/// ```
-/// use exarch_core::test_utils::create_test_tar;
-///
-/// let tar_data = create_test_tar(vec![("file.txt", b"hello"), ("dir/nested.txt", b"world")]);
-/// ```
+/// All files are created with mode `0o644`.
 #[must_use]
 pub fn create_test_tar(entries: Vec<(&str, &[u8])>) -> Vec<u8> {
     let mut ar = tar::Builder::new(Vec::new());
@@ -37,18 +29,9 @@ pub fn create_test_tar(entries: Vec<(&str, &[u8])>) -> Vec<u8> {
     ar.into_inner().unwrap()
 }
 
-/// Creates an in-memory ZIP archive from a list of entries.
+/// Creates an in-memory ZIP archive from a list of `(path, content)` entries.
 ///
-/// Each entry is a tuple of (path, content). Files are stored uncompressed
-/// with mode 0o644.
-///
-/// # Examples
-///
-/// ```
-/// use exarch_core::test_utils::create_test_zip;
-///
-/// let zip_data = create_test_zip(vec![("file.txt", b"hello"), ("dir/nested.txt", b"world")]);
-/// ```
+/// Files are stored uncompressed with mode `0o644`.
 #[must_use]
 pub fn create_test_zip(entries: Vec<(&str, &[u8])>) -> Vec<u8> {
     use zip::write::SimpleFileOptions;
@@ -69,21 +52,8 @@ pub fn create_test_zip(entries: Vec<(&str, &[u8])>) -> Vec<u8> {
     zip.finish().unwrap().into_inner()
 }
 
-/// Builder for creating TAR test archives with various entry types.
-///
-/// Supports files, directories, symlinks, and hardlinks.
-///
-/// # Examples
-///
-/// ```
-/// use exarch_core::test_utils::TarTestBuilder;
-///
-/// let tar_data = TarTestBuilder::new()
-///     .add_file("file.txt", b"content")
-///     .add_directory("dir/")
-///     .add_symlink("link", "file.txt")
-///     .build();
-/// ```
+/// Builder for creating TAR test archives with files, directories, symlinks,
+/// and hardlinks.
 pub struct TarTestBuilder {
     builder: tar::Builder<Vec<u8>>,
 }
@@ -176,18 +146,8 @@ impl Default for TarTestBuilder {
     }
 }
 
-/// Builder for creating ZIP test archives with various entry types.
-///
-/// # Examples
-///
-/// ```
-/// use exarch_core::test_utils::ZipTestBuilder;
-///
-/// let zip_data = ZipTestBuilder::new()
-///     .add_file("file.txt", b"content")
-///     .add_directory("dir/")
-///     .build();
-/// ```
+/// Builder for creating ZIP test archives with files, directories, and
+/// symlinks.
 pub struct ZipTestBuilder {
     zip: zip::ZipWriter<Cursor<Vec<u8>>>,
 }

--- a/crates/exarch-core/tests/property_tests.rs
+++ b/crates/exarch-core/tests/property_tests.rs
@@ -9,14 +9,11 @@
     clippy::unwrap_used
 )]
 
-use std::io::Cursor;
 use std::path::PathBuf;
 
 use exarch_core::ExtractionError;
 use exarch_core::QuotaResource;
 use exarch_core::SecurityConfig;
-use exarch_core::copy::CopyBuffer;
-use exarch_core::copy::copy_with_buffer;
 use exarch_core::security::HardlinkTracker;
 use exarch_core::security::QuotaTracker;
 use exarch_core::types::DestDir;
@@ -359,66 +356,6 @@ proptest! {
             matches!(result, Err(ExtractionError::ZipBomb { .. })),
             "extreme compression ratio should be detected"
         );
-    }
-
-    // ========================================================================
-    // COPY BUFFER PROPERTY TESTS
-    // ========================================================================
-
-    /// Copy buffer should preserve data integrity for arbitrary inputs.
-    #[test]
-    fn prop_copy_preserves_data(
-        data in prop::collection::vec(any::<u8>(), 0..100_000)
-    ) {
-        let mut buffer = CopyBuffer::new();
-        let mut input = Cursor::new(&data);
-        let mut output = Vec::new();
-
-        let result = copy_with_buffer(&mut input, &mut output, &mut buffer);
-
-        prop_assert!(result.is_ok(), "copy should succeed");
-        prop_assert_eq!(result.unwrap(), data.len() as u64, "should report correct size");
-        prop_assert_eq!(output, data, "output must match input exactly");
-    }
-
-    /// Copy buffer should handle various chunk sizes correctly.
-    #[test]
-    fn prop_copy_handles_various_sizes(
-        size in 0usize..500_000
-    ) {
-        let mut buffer = CopyBuffer::new();
-        let data = vec![0x42u8; size];
-        let mut input = Cursor::new(&data);
-        let mut output = Vec::new();
-
-        let result = copy_with_buffer(&mut input, &mut output, &mut buffer);
-
-        prop_assert!(result.is_ok(), "copy should succeed for size {}", size);
-        prop_assert_eq!(output.len(), size, "output size must match input");
-        prop_assert!(output.iter().all(|&b| b == 0x42), "all bytes must be preserved");
-    }
-
-    /// Reusing buffer should produce identical results.
-    #[test]
-    fn prop_copy_buffer_reusable(
-        data1 in prop::collection::vec(any::<u8>(), 0..10_000),
-        data2 in prop::collection::vec(any::<u8>(), 0..10_000)
-    ) {
-        let mut buffer = CopyBuffer::new();
-
-        // First copy
-        let mut input1 = Cursor::new(&data1);
-        let mut output1 = Vec::new();
-        let result1 = copy_with_buffer(&mut input1, &mut output1, &mut buffer);
-        prop_assert!(result1.is_ok());
-        prop_assert_eq!(output1, data1);
-
-        // Second copy with same buffer
-        let mut input2 = Cursor::new(&data2);
-        let mut output2 = Vec::new();
-        let result2 = copy_with_buffer(&mut input2, &mut output2, &mut buffer);
-        prop_assert!(result2.is_ok());
-        prop_assert_eq!(output2, data2);
     }
 
     // ========================================================================

--- a/crates/exarch-core/tests/security/cve_regression.rs
+++ b/crates/exarch-core/tests/security/cve_regression.rs
@@ -12,9 +12,71 @@ use exarch_core::SecurityConfig;
 use exarch_core::formats::ArchiveFormat;
 use exarch_core::formats::TarArchive;
 use exarch_core::formats::ZipArchive;
-use exarch_core::test_utils::TarTestBuilder;
 use std::io::Cursor;
 use tempfile::TempDir;
+
+struct TarTestBuilder {
+    builder: tar::Builder<Vec<u8>>,
+}
+
+impl TarTestBuilder {
+    fn new() -> Self {
+        Self {
+            builder: tar::Builder::new(Vec::new()),
+        }
+    }
+
+    fn add_file(mut self, path: &str, data: &[u8]) -> Self {
+        let mut header = tar::Header::new_gnu();
+        header.set_size(data.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        self.builder.append_data(&mut header, path, data).unwrap();
+        self
+    }
+
+    fn add_directory(mut self, path: &str) -> Self {
+        let mut header = tar::Header::new_gnu();
+        header.set_size(0);
+        header.set_mode(0o755);
+        header.set_entry_type(tar::EntryType::Directory);
+        header.set_cksum();
+        self.builder
+            .append_data(&mut header, path, std::io::empty())
+            .unwrap();
+        self
+    }
+
+    fn add_symlink(mut self, path: &str, target: &str) -> Self {
+        let mut header = tar::Header::new_gnu();
+        header.set_size(0);
+        header.set_mode(0o777);
+        header.set_entry_type(tar::EntryType::Symlink);
+        header.set_link_name(target).unwrap();
+        header.set_cksum();
+        self.builder
+            .append_data(&mut header, path, std::io::empty())
+            .unwrap();
+        self
+    }
+
+    fn add_hardlink(mut self, path: &str, target: &str) -> Self {
+        let mut header = tar::Header::new_gnu();
+        header.set_size(0);
+        header.set_mode(0o644);
+        header.set_entry_type(tar::EntryType::Link);
+        header.set_link_name(target).unwrap();
+        header.set_cksum();
+        self.builder
+            .append_data(&mut header, path, std::io::empty())
+            .unwrap();
+        self
+    }
+
+    fn build(self) -> Vec<u8> {
+        self.builder.into_inner().unwrap()
+    }
+}
 
 /// Creates a minimal POSIX ustar TAR archive where each entry has an arbitrary
 /// raw path (bypassing the `tar` crate's path sanitization).


### PR DESCRIPTION
## Summary

- `exarch_core::copy`, `exarch_core::io`, and `exarch_core::test_utils` were exposed as `pub mod`, creating accidental semver promises for downstream users
- All three changed to `pub(crate)` in `exarch-core/src/lib.rs`
- CopyBuffer proptests moved from `tests/property_tests.rs` into `src/copy.rs` (internal `#[cfg(test)]`)
- `TarTestBuilder` inlined locally in `tests/security/cve_regression.rs`
- `CountingWriter` accessors marked `pub(crate)`
- Broken doc examples referencing private paths removed

## Breaking change

`exarch_core::copy`, `exarch_core::io`, and `exarch_core::test_utils` are no longer part of the public API. Downstream crates that referenced these modules directly will fail to compile.

## Test plan

- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` — 809 passed
- [x] `cargo test --doc --workspace --all-features` — 99 passed
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo deny check --all-features` — clean
- [x] Security audit: no unsafe code introduced, no unintended API exposure
- [x] Performance: no impact on inlining or hot paths

Closes #173