### PR TITLE
fix(cli): remove duplicate error data from ZipBomb and QuotaExceeded context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `SevenZArchive::extract` now fires `on_entry_start` and `on_entry_complete` per-entry, interleaved with actual I/O, instead of batching all start events before extraction and all complete events after (#191).
 - `SevenZArchive::verify` now calls `config.validate()` before any archive I/O, matching the guard applied by the public `verify_archive` entrypoint (#191).
+- JSON error output no longer duplicates the error message for `QuotaExceeded` and `ZipBomb` errors when using `--json`. The `message` field previously contained the `ExtractionError::Display` text twice due to `anyhow`'s `{:#}` formatter chaining the context string with the inner error display (#192).
 - `extract_archive_with_progress` now correctly invokes the `ProgressCallback` for all archive formats (TAR, ZIP, 7z). Previously the callback was silently discarded because `ArchiveFormat::extract` did not accept a progress parameter (#170).
 - `create_archive()` now returns `Error::UnsupportedFormat` instead of `Error::InvalidArchive` when a `.7z` output path is requested, correctly signaling that 7z creation is not supported (#182).
 - ZIP password-protection detection now performs a full linear scan of all entries instead of a 3-sample strategy, preventing false negatives for archives with encrypted entries outside the first/middle/last 100 positions (#171).

--- a/crates/exarch-cli/src/error.rs
+++ b/crates/exarch-cli/src/error.rs
@@ -42,24 +42,15 @@ pub fn convert_extraction_error(err: ExtractionError, archive: &Path) -> anyhow:
             archive.display(),
             path.display()
         ),
-        ExtractionError::ZipBomb {
-            compressed,
-            uncompressed,
-            ratio,
-        } => format!(
+        ExtractionError::ZipBomb { .. } => format!(
             "Security violation: Archive '{}' appears to be a zip bomb\n\
-             Compression ratio: {}:1 ({}KB → {}MB)\n\
              HINT: Use --max-compression-ratio to allow higher ratios if legitimate.",
             archive.display(),
-            *ratio as u64,
-            compressed / 1024,
-            uncompressed / 1024 / 1024
         ),
-        ExtractionError::QuotaExceeded { resource } => format!(
-            "Extraction limit exceeded for '{}': {}\n\
+        ExtractionError::QuotaExceeded { .. } => format!(
+            "Extraction limit exceeded for '{}'\n\
              HINT: Use --max-files, --max-total-size, or --max-file-size to increase limits.",
             archive.display(),
-            resource
         ),
         ExtractionError::SymlinkEscape { path } => format!(
             "Symlink rejected in '{}': {}\n\
@@ -132,7 +123,7 @@ mod tests {
         let converted = convert_extraction_error(err, Path::new("bomb.zip"));
         let msg = format!("{converted:?}");
         assert!(msg.contains("zip bomb"));
-        assert!(msg.contains("150:1"));
+        assert!(msg.contains("bomb.zip"));
     }
 
     #[test]

--- a/crates/exarch-cli/src/output/json.rs
+++ b/crates/exarch-cli/src/output/json.rs
@@ -436,4 +436,57 @@ mod tests {
 
         assert_eq!(kind, "Error");
     }
+
+    // Regression tests for issue #192: JSON error message must not duplicate text
+    // that ExtractionError::Display already emits.
+
+    #[test]
+    fn test_json_message_quota_exceeded_no_duplication() {
+        use crate::error::convert_extraction_error;
+        use exarch_core::QuotaResource;
+        use std::path::Path;
+
+        let err = ExtractionError::QuotaExceeded {
+            resource: QuotaResource::FileCount {
+                current: 11,
+                max: 10,
+            },
+        };
+        // ExtractionError::Display emits "quota exceeded: file count (11 > 10)"
+        let display_text = err.to_string();
+        let anyhow_err = convert_extraction_error(err, Path::new("archive.tar.gz"));
+        let message = format!("{anyhow_err:#}");
+
+        // The context must NOT repeat the Display text verbatim
+        let display_occurrences = message.matches(&display_text).count();
+        assert!(
+            display_occurrences <= 1,
+            "JSON message duplicates ExtractionError display text ({display_occurrences} occurrences): {message}"
+        );
+    }
+
+    #[test]
+    fn test_json_message_zip_bomb_no_duplication() {
+        use crate::error::convert_extraction_error;
+        use std::path::Path;
+
+        let compressed = 1_024_u64;
+        let uncompressed = 1_024 * 1_024 * 150_u64;
+        let ratio = 150.0_f64;
+        let err = ExtractionError::ZipBomb {
+            compressed,
+            uncompressed,
+            ratio,
+        };
+        // ExtractionError::Display emits the ratio info
+        let display_text = err.to_string();
+        let anyhow_err = convert_extraction_error(err, Path::new("bomb.zip"));
+        let message = format!("{anyhow_err:#}");
+
+        let display_occurrences = message.matches(&display_text).count();
+        assert!(
+            display_occurrences <= 1,
+            "JSON message duplicates ExtractionError display text ({display_occurrences} occurrences): {message}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- `convert_extraction_error` embedded inner error Display text (ratio, sizes, `resource`) into the context string for `ZipBomb` and `QuotaExceeded`
- `anyhow::Error::from(err).context(ctx)` then chained the original error, causing `format!("{error:#}")` in `json.rs` to render `"context: inner_err_display"` — duplicating the information
- Removed the redundant fields from both context strings; context now adds only the archive path and the HINT line; the typed error's `Display` contributes the detail values through the anyhow chain

## Test plan

- [ ] `cargo nextest run -p exarch-cli -p exarch-core --all-features` — 809 passed
- [ ] `cargo test --doc -p exarch-core -p exarch-cli --all-features` — 111 passed
- [ ] `cargo clippy -p exarch-core -p exarch-cli --all-targets --all-features -- -D warnings` — clean
- [ ] `cargo +nightly fmt --all -- --check` — clean

Closes #192