### PR TITLE
fix(cli): remove path duplication in SymlinkEscape/HardlinkEscape JSON output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- JSON `message` field no longer duplicates the path for `SymlinkEscape` and `HardlinkEscape` errors in `--json` CLI output. The path was embedded in both the anyhow context string and the `ExtractionError::Display` output, causing it to appear twice when formatted with `{:#}` (#196).
 - `SevenZArchive::extract` now fires `on_entry_start` and `on_entry_complete` per-entry, interleaved with actual I/O, instead of batching all start events before extraction and all complete events after (#191).
 - `SevenZArchive::verify` now calls `config.validate()` before any archive I/O, matching the guard applied by the public `verify_archive` entrypoint (#191).
 - JSON error output no longer duplicates the error message for `QuotaExceeded` and `ZipBomb` errors when using `--json`. The `message` field previously contained the `ExtractionError::Display` text twice due to `anyhow`'s `{:#}` formatter chaining the context string with the inner error display (#192).

--- a/crates/exarch-cli/src/error.rs
+++ b/crates/exarch-cli/src/error.rs
@@ -52,17 +52,15 @@ pub fn convert_extraction_error(err: ExtractionError, archive: &Path) -> anyhow:
              HINT: Use --max-files, --max-total-size, or --max-file-size to increase limits.",
             archive.display(),
         ),
-        ExtractionError::SymlinkEscape { path } => format!(
-            "Symlink rejected in '{}': {}\n\
+        ExtractionError::SymlinkEscape { .. } => format!(
+            "Symlink rejected in '{}'\n\
              HINT: Use --allow-symlinks to extract symlinks (only if trusted source).",
             archive.display(),
-            path.display()
         ),
-        ExtractionError::HardlinkEscape { path } => format!(
-            "Hardlink rejected in '{}': {}\n\
+        ExtractionError::HardlinkEscape { .. } => format!(
+            "Hardlink rejected in '{}'\n\
              HINT: Use --allow-hardlinks to extract hardlinks (only if trusted source).",
             archive.display(),
-            path.display()
         ),
         ExtractionError::Io(io_err) => {
             format!(
@@ -124,6 +122,32 @@ mod tests {
         let msg = format!("{converted:?}");
         assert!(msg.contains("zip bomb"));
         assert!(msg.contains("bomb.zip"));
+    }
+
+    #[test]
+    fn test_symlink_escape_path_appears_once() {
+        let path = PathBuf::from("link/to/escape");
+        let err = ExtractionError::SymlinkEscape { path };
+        let converted = convert_extraction_error(err, Path::new("archive.tar.gz"));
+        let msg = format!("{converted:#}");
+        assert_eq!(
+            msg.matches("link/to/escape").count(),
+            1,
+            "path should appear exactly once, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_hardlink_escape_path_appears_once() {
+        let path = PathBuf::from("hard/link/escape");
+        let err = ExtractionError::HardlinkEscape { path };
+        let converted = convert_extraction_error(err, Path::new("archive.tar.gz"));
+        let msg = format!("{converted:#}");
+        assert_eq!(
+            msg.matches("hard/link/escape").count(),
+            1,
+            "path should appear exactly once, got: {msg}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Removes `path.display()` from the anyhow context strings for `SymlinkEscape` and `HardlinkEscape` in `convert_extraction_error` (`exarch-cli/src/error.rs`)
- The path was already included via `ExtractionError::Display` (thiserror `#[error]` attribute), causing it to appear twice in the JSON `message` field when formatted with `{:#}`
- Follows the same fix applied to `QuotaExceeded` and `ZipBomb` in #192

## Test plan

- [ ] `test_symlink_escape_path_appears_once` — asserts path appears exactly once in `{:#}` output
- [ ] `test_hardlink_escape_path_appears_once` — same for hardlinks
- [ ] All 812 existing tests continue to pass

Closes #196