### PR TITLE
fix(cli): remove duplicate path from PathTraversal error context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- JSON `message` field no longer duplicates the path for `PathTraversal` errors in `--json` CLI output. The path was embedded in both the anyhow context string and the `ExtractionError::Display` output, causing it to appear twice when formatted with `{:#}` (#198).
 - JSON `message` field no longer duplicates the path for `SymlinkEscape` and `HardlinkEscape` errors in `--json` CLI output. The path was embedded in both the anyhow context string and the `ExtractionError::Display` output, causing it to appear twice when formatted with `{:#}` (#196).
 - `SevenZArchive::extract` now fires `on_entry_start` and `on_entry_complete` per-entry, interleaved with actual I/O, instead of batching all start events before extraction and all complete events after (#191).
 - `SevenZArchive::verify` now calls `config.validate()` before any archive I/O, matching the guard applied by the public `verify_archive` entrypoint (#191).

--- a/crates/exarch-cli/src/error.rs
+++ b/crates/exarch-cli/src/error.rs
@@ -36,11 +36,10 @@ pub fn convert_extraction_error(err: ExtractionError, archive: &Path) -> anyhow:
 
     let context = match &err {
         ExtractionError::PartialExtraction { .. } => unreachable!(),
-        ExtractionError::PathTraversal { path } => format!(
-            "Security violation: Archive '{}' attempted path traversal with '{}'\n\
+        ExtractionError::PathTraversal { .. } => format!(
+            "Security violation: Archive '{}' attempted path traversal\n\
              HINT: This archive may be malicious. Do not extract from untrusted sources.",
             archive.display(),
-            path.display()
         ),
         ExtractionError::ZipBomb { .. } => format!(
             "Security violation: Archive '{}' appears to be a zip bomb\n\
@@ -122,6 +121,19 @@ mod tests {
         let msg = format!("{converted:?}");
         assert!(msg.contains("zip bomb"));
         assert!(msg.contains("bomb.zip"));
+    }
+
+    #[test]
+    fn test_path_traversal_path_appears_once() {
+        let path = PathBuf::from("../../../etc/passwd");
+        let err = ExtractionError::PathTraversal { path };
+        let converted = convert_extraction_error(err, Path::new("archive.tar.gz"));
+        let msg = format!("{converted:#}");
+        assert_eq!(
+            msg.matches("../../../etc/passwd").count(),
+            1,
+            "path should appear exactly once, got: {msg}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Removes redundant `path.display()` from the `PathTraversal` arm of `convert_extraction_error` in `exarch-cli/src/error.rs`
- `ExtractionError::PathTraversal` already includes the path via its `Display` impl (`#[error("path traversal detected: {path}")]`); embedding it again in the anyhow context caused the path to appear twice in the JSON `message` field when formatted with `{:#}`
- Adds regression test `test_path_traversal_path_appears_once` following the same pattern as the existing `SymlinkEscape`/`HardlinkEscape` tests

Same root cause and fix pattern as #192 (QuotaExceeded/ZipBomb) and #196 (SymlinkEscape/HardlinkEscape).

Closes #198.

## Test plan

- [ ] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` — 815 tests pass
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [ ] `cargo +nightly fmt --all -- --check` — clean
- [ ] New test `test_path_traversal_path_appears_once` asserts the path appears exactly once with `{:#}` formatting