### PR TITLE
fix(cli): suppress --allow-symlinks hint when flag is already active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- CLI no longer emits `"HINT: Use --allow-symlinks"` when `--allow-symlinks` is already active and a symlink escape is blocked. The hint is now suppressed when the flag is set, since the escape is a genuine security violation rather than a configuration issue (#213).
+
 ### Changed
 
 - **BREAKING**: Internal modules `copy`, `io`, and `test_utils` in `exarch-core` are now `pub(crate)` instead of `pub`. These were never part of the public API; any external code referencing `exarch_core::copy`, `exarch_core::io`, or `exarch_core::test_utils` directly will no longer compile (#173).
 - `verify_archive` now delegates to `verify_manifest` after calling `list_archive`, eliminating ~80 lines of duplicated entry-processing logic (#190).
 - `ProgressCallback::on_complete` doc comment clarified: the method is called only on successful completion; implementors must not use it for cleanup.
+- Removed dead `format_success` and `format_warning` methods from the `OutputFormatter` trait and both implementations (`HumanFormatter`, `JsonFormatter`). Neither method was called from any command handler (#208).
 - Removed dead constant `SEVENZ_MAGIC` and its `#[allow(dead_code)]` suppression from `formats/detect.rs`; the constant was unused in format detection logic (#175).
 - `ArchiveFormat` trait extended with `fn list()` and `fn verify()` methods, providing a single implementation point for all format operations (#174).
 

--- a/crates/exarch-cli/src/commands/extract.rs
+++ b/crates/exarch-cli/src/commands/extract.rs
@@ -89,12 +89,14 @@ pub fn execute(args: &ExtractArgs, formatter: &dyn OutputFormatter) -> Result<()
         add_archive_context(
             extract_archive_full(&args.archive, &output_dir, &config, &options, &mut progress),
             &args.archive,
+            args.allow_symlinks,
         )?
     } else {
         let mut noop = NoopProgress;
         add_archive_context(
             extract_archive_full(&args.archive, &output_dir, &config, &options, &mut noop),
             &args.archive,
+            args.allow_symlinks,
         )?
     };
 

--- a/crates/exarch-cli/src/error.rs
+++ b/crates/exarch-cli/src/error.rs
@@ -41,8 +41,16 @@ impl std::error::Error for PartialExtractionContext {}
 ///
 /// The original `ExtractionError` is preserved as the error source so that
 /// callers can downcast via the anyhow chain (used by JSON error output).
+///
+/// `allow_symlinks` suppresses the `--allow-symlinks` hint for `SymlinkEscape`
+/// errors when the flag is already active — in that case the escape is a
+/// genuine security violation, not a configuration issue.
 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-pub fn convert_extraction_error(err: ExtractionError, archive: &Path) -> anyhow::Error {
+pub fn convert_extraction_error(
+    err: ExtractionError,
+    archive: &Path,
+    allow_symlinks: bool,
+) -> anyhow::Error {
     // Handle PartialExtraction before the borrow below.
     //
     // `PartialExtraction` is `#[error("{source}")]` with `#[source]`, so
@@ -71,11 +79,17 @@ pub fn convert_extraction_error(err: ExtractionError, archive: &Path) -> anyhow:
              HINT: Use --max-files, --max-total-size, or --max-file-size to increase limits.",
             archive.display(),
         ),
-        ExtractionError::SymlinkEscape { .. } => format!(
-            "Symlink rejected in '{}'\n\
-             HINT: Use --allow-symlinks to extract symlinks (only if trusted source).",
-            archive.display(),
-        ),
+        ExtractionError::SymlinkEscape { .. } => {
+            if allow_symlinks {
+                format!("Symlink escape blocked in '{}'", archive.display())
+            } else {
+                format!(
+                    "Symlink rejected in '{}'\n\
+                     HINT: Use --allow-symlinks to extract symlinks (only if trusted source).",
+                    archive.display(),
+                )
+            }
+        }
         ExtractionError::HardlinkEscape { .. } => format!(
             "Hardlink rejected in '{}'\n\
              HINT: Use --allow-hardlinks to extract hardlinks (only if trusted source).",
@@ -104,12 +118,16 @@ pub fn convert_extraction_error(err: ExtractionError, archive: &Path) -> anyhow:
     anyhow::Error::from(err).context(context)
 }
 
-/// Adds context to a generic error about archive operations
+/// Adds context to a generic error about archive operations.
+///
+/// `allow_symlinks` is forwarded to [`convert_extraction_error`] to suppress
+/// the `--allow-symlinks` hint when the flag is already active.
 pub fn add_archive_context<T>(
     result: Result<T, ExtractionError>,
     archive: &Path,
+    allow_symlinks: bool,
 ) -> anyhow::Result<T> {
-    result.map_err(|e| convert_extraction_error(e, archive))
+    result.map_err(|e| convert_extraction_error(e, archive, allow_symlinks))
 }
 
 #[cfg(test)]
@@ -123,7 +141,7 @@ mod tests {
         let err = ExtractionError::PathTraversal {
             path: PathBuf::from("../../../etc/passwd"),
         };
-        let converted = convert_extraction_error(err, Path::new("malicious.zip"));
+        let converted = convert_extraction_error(err, Path::new("malicious.zip"), false);
         let msg = format!("{converted:?}");
         assert!(msg.contains("path traversal"));
         assert!(msg.contains("malicious.zip"));
@@ -137,7 +155,7 @@ mod tests {
             uncompressed: 1024 * 1024 * 150,
             ratio: 150.0,
         };
-        let converted = convert_extraction_error(err, Path::new("bomb.zip"));
+        let converted = convert_extraction_error(err, Path::new("bomb.zip"), false);
         let msg = format!("{converted:?}");
         assert!(msg.contains("zip bomb"));
         assert!(msg.contains("bomb.zip"));
@@ -147,7 +165,7 @@ mod tests {
     fn test_path_traversal_path_appears_once() {
         let path = PathBuf::from("../../../etc/passwd");
         let err = ExtractionError::PathTraversal { path };
-        let converted = convert_extraction_error(err, Path::new("archive.tar.gz"));
+        let converted = convert_extraction_error(err, Path::new("archive.tar.gz"), false);
         let msg = format!("{converted:#}");
         assert_eq!(
             msg.matches("../../../etc/passwd").count(),
@@ -160,7 +178,7 @@ mod tests {
     fn test_symlink_escape_path_appears_once() {
         let path = PathBuf::from("link/to/escape");
         let err = ExtractionError::SymlinkEscape { path };
-        let converted = convert_extraction_error(err, Path::new("archive.tar.gz"));
+        let converted = convert_extraction_error(err, Path::new("archive.tar.gz"), false);
         let msg = format!("{converted:#}");
         assert_eq!(
             msg.matches("link/to/escape").count(),
@@ -170,10 +188,34 @@ mod tests {
     }
 
     #[test]
+    fn test_symlink_escape_hint_suppressed_when_flag_active() {
+        let path = PathBuf::from("link/to/escape");
+        let err = ExtractionError::SymlinkEscape { path };
+        let converted = convert_extraction_error(err, Path::new("archive.tar.gz"), true);
+        let msg = format!("{converted:#}");
+        assert!(
+            !msg.contains("--allow-symlinks"),
+            "hint must be suppressed when --allow-symlinks is active, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_symlink_escape_hint_shown_when_flag_inactive() {
+        let path = PathBuf::from("link/to/escape");
+        let err = ExtractionError::SymlinkEscape { path };
+        let converted = convert_extraction_error(err, Path::new("archive.tar.gz"), false);
+        let msg = format!("{converted:#}");
+        assert!(
+            msg.contains("--allow-symlinks"),
+            "hint must be shown when --allow-symlinks is not active, got: {msg}"
+        );
+    }
+
+    #[test]
     fn test_hardlink_escape_path_appears_once() {
         let path = PathBuf::from("hard/link/escape");
         let err = ExtractionError::HardlinkEscape { path };
-        let converted = convert_extraction_error(err, Path::new("archive.tar.gz"));
+        let converted = convert_extraction_error(err, Path::new("archive.tar.gz"), false);
         let msg = format!("{converted:#}");
         assert_eq!(
             msg.matches("hard/link/escape").count(),
@@ -186,7 +228,7 @@ mod tests {
     fn test_convert_io_error() {
         let io_err = io::Error::new(io::ErrorKind::NotFound, "file not found");
         let err = ExtractionError::Io(io_err);
-        let converted = convert_extraction_error(err, Path::new("archive.tar.gz"));
+        let converted = convert_extraction_error(err, Path::new("archive.tar.gz"), false);
         let msg = format!("{converted:?}");
         assert!(msg.contains("I/O error"));
     }
@@ -215,7 +257,7 @@ mod tests {
             source: Box::new(inner),
             report,
         };
-        let converted = convert_extraction_error(err, Path::new("archive.tar.gz"));
+        let converted = convert_extraction_error(err, Path::new("archive.tar.gz"), false);
         let msg = format!("{converted:#}");
         let occurrences = msg.matches("hardlink_escape_path").count();
         assert_eq!(
@@ -245,7 +287,7 @@ mod tests {
             source: Box::new(inner),
             report,
         };
-        let converted = convert_extraction_error(err, Path::new("archive.tar.gz"));
+        let converted = convert_extraction_error(err, Path::new("archive.tar.gz"), false);
         let msg = format!("{converted:#}");
         let occurrences = msg.matches("symlink_escape_path").count();
         assert_eq!(

--- a/crates/exarch-cli/src/output/formatter.rs
+++ b/crates/exarch-cli/src/output/formatter.rs
@@ -27,14 +27,6 @@ pub trait OutputFormatter {
 
     /// Format error message for the given operation
     fn format_error(&self, operation: &str, error: &anyhow::Error);
-
-    /// Format success message for the given operation.
-    #[allow(dead_code)]
-    fn format_success(&self, operation: &str, message: &str);
-
-    /// Format warning message for the given operation.
-    #[allow(dead_code)]
-    fn format_warning(&self, operation: &str, message: &str);
 }
 
 /// Generic JSON output structure

--- a/crates/exarch-cli/src/output/human.rs
+++ b/crates/exarch-cli/src/output/human.rs
@@ -175,34 +175,6 @@ impl OutputFormatter for HumanFormatter {
         }
     }
 
-    fn format_success(&self, _operation: &str, message: &str) {
-        if self.quiet {
-            return;
-        }
-
-        if self.use_colors {
-            let _ = self
-                .term
-                .write_line(&format!("{} {message}", style("✓").green().bold()));
-        } else {
-            let _ = self.term.write_line(message);
-        }
-    }
-
-    fn format_warning(&self, _operation: &str, message: &str) {
-        if self.quiet {
-            return;
-        }
-
-        if self.use_colors {
-            let _ = self
-                .term
-                .write_line(&format!("{} {message}", style("⚠").yellow().bold()));
-        } else {
-            let _ = self.term.write_line(&format!("WARNING: {message}"));
-        }
-    }
-
     fn format_manifest_short(&self, manifest: &ArchiveManifest) -> Result<()> {
         if self.quiet {
             return Ok(());

--- a/crates/exarch-cli/src/output/json.rs
+++ b/crates/exarch-cli/src/output/json.rs
@@ -134,36 +134,6 @@ impl OutputFormatter for JsonFormatter {
         let _ = Self::output(&output);
     }
 
-    fn format_success(&self, operation: &str, message: &str) {
-        #[derive(Serialize)]
-        struct SuccessData {
-            message: String,
-        }
-
-        let output = JsonOutput::success(
-            operation,
-            SuccessData {
-                message: message.to_string(),
-            },
-        );
-        let _ = Self::output(&output);
-    }
-
-    fn format_warning(&self, operation: &str, message: &str) {
-        #[derive(Serialize)]
-        struct WarningData {
-            message: String,
-        }
-
-        let output = JsonOutput::success(
-            operation,
-            WarningData {
-                message: message.to_string(),
-            },
-        );
-        let _ = Self::output(&output);
-    }
-
     fn format_manifest_short(&self, manifest: &ArchiveManifest) -> Result<()> {
         #[derive(Serialize)]
         struct ManifestEntry {
@@ -436,26 +406,6 @@ mod tests {
         assert_eq!(kind, "Error");
     }
 
-    // Regression tests for issue #202: format_success/format_warning must use the
-    // caller-supplied operation name, not a hardcoded sentinel.
-
-    #[test]
-    fn test_format_success_uses_operation_name() {
-        // Capture stdout is not straightforward in unit tests; verify the JSON output
-        // structure by constructing it directly with the same logic.
-        let op = "extract";
-        let output = JsonOutput::success(op, serde_json::json!({"message": "done"}));
-        let json = serde_json::to_string(&output).unwrap();
-        assert!(
-            json.contains(r#""operation":"extract""#),
-            "operation must be 'extract', got: {json}"
-        );
-        assert!(
-            !json.contains(r#""operation":"unknown""#),
-            "operation must not be 'unknown', got: {json}"
-        );
-    }
-
     // Regression tests for issue #192: JSON error message must not duplicate text
     // that ExtractionError::Display already emits.
 
@@ -473,7 +423,7 @@ mod tests {
         };
         // ExtractionError::Display emits "quota exceeded: file count (11 > 10)"
         let display_text = err.to_string();
-        let anyhow_err = convert_extraction_error(err, Path::new("archive.tar.gz"));
+        let anyhow_err = convert_extraction_error(err, Path::new("archive.tar.gz"), false);
         let message = format!("{anyhow_err:#}");
 
         // The context must NOT repeat the Display text verbatim
@@ -499,7 +449,7 @@ mod tests {
         };
         // ExtractionError::Display emits the ratio info
         let display_text = err.to_string();
-        let anyhow_err = convert_extraction_error(err, Path::new("bomb.zip"));
+        let anyhow_err = convert_extraction_error(err, Path::new("bomb.zip"), false);
         let message = format!("{anyhow_err:#}");
 
         let display_occurrences = message.matches(&display_text).count();


### PR DESCRIPTION
## Summary

- Fixes #213: when `--allow-symlinks` is active and a symlink escape is blocked, the error message no longer appends the misleading `HINT: Use --allow-symlinks` (the user already passed it — the block is intentional security enforcement).
- Fixes #208: removes dead `format_success` and `format_warning` methods from `OutputFormatter` trait and both implementations (`HumanFormatter`, `JsonFormatter`).

## Changes

- `crates/exarch-cli/src/error.rs` — `convert_extraction_error` and `add_archive_context` accept `allow_symlinks: bool`; `SymlinkEscape` branches on it to suppress the hint.
- `crates/exarch-cli/src/commands/extract.rs` — passes `args.allow_symlinks` to both call sites.
- `crates/exarch-cli/src/output/formatter.rs`, `human.rs`, `json.rs` — dead methods removed along with their `#[allow(dead_code)]` annotations and the associated test.

## Test plan

- [ ] `cargo +nightly fmt --all -- --check` passes
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [ ] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` — 821 passed
- [ ] `cargo test --doc --workspace --all-features` — 99 passed
- [ ] New regression tests: `test_symlink_escape_hint_suppressed_when_flag_active` and `test_symlink_escape_hint_shown_when_flag_inactive` both pass