### PR TITLE
docs(core): document TarArchive::list() consuming behavior and fix CopyBuffer visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `TarArchive::list()` and `TarArchive::extract()` now have `///` doc comments explaining that `list()` consumes the internal reader (TAR is forward-only) and that calling `extract()` on the same instance afterward returns `InvalidArchive`. Callers must open a fresh instance for extraction (#211).
+- `CopyBuffer::size()` visibility corrected from `pub(crate)` to `pub`, consistent with the other items in the crate-internal `mod copy`. The `pub(crate)` module boundary in `lib.rs` already enforces the encapsulation; redundant `pub(crate)` on items inside a `pub(crate)` module triggers the `redundant_pub_crate` clippy lint (#203).
+
 - **BREAKING**: Internal modules `copy`, `io`, and `test_utils` in `exarch-core` are now `pub(crate)` instead of `pub`. These were never part of the public API; any external code referencing `exarch_core::copy`, `exarch_core::io`, or `exarch_core::test_utils` directly will no longer compile (#173).
 - `verify_archive` now delegates to `verify_manifest` after calling `list_archive`, eliminating ~80 lines of duplicated entry-processing logic (#190).
 - `ProgressCallback::on_complete` doc comment clarified: the method is called only on successful completion; implementors must not use it for cleanup.

--- a/crates/exarch-core/src/copy.rs
+++ b/crates/exarch-core/src/copy.rs
@@ -48,7 +48,7 @@ impl CopyBuffer {
     #[inline]
     #[must_use]
     #[allow(dead_code, clippy::unused_self)]
-    pub(crate) fn size(&self) -> usize {
+    pub fn size(&self) -> usize {
         COPY_BUFFER_SIZE
     }
 }

--- a/crates/exarch-core/src/formats/tar.rs
+++ b/crates/exarch-core/src/formats/tar.rs
@@ -334,6 +334,14 @@ impl<R: Read> TarArchive<R> {
 }
 
 impl<R: Read> ArchiveFormat for TarArchive<R> {
+    /// Extracts the archive contents to `output_dir`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExtractionError::InvalidArchive`] if [`list`](Self::list) was
+    /// called on this instance before `extract`. Because TAR is a forward-only
+    /// stream, `list` consumes the internal reader; calling `extract` afterward
+    /// is not possible. Open a fresh [`TarArchive`] instance instead.
     fn extract(
         &mut self,
         output_dir: &Path,
@@ -442,6 +450,26 @@ impl<R: Read> ArchiveFormat for TarArchive<R> {
         Ok(report)
     }
 
+    /// Lists the entries in the archive without extracting them.
+    ///
+    /// # Reader consumption
+    ///
+    /// TAR is a forward-only stream format. This method consumes the internal
+    /// reader via `self.inner.take()`. After `list()` returns, the reader is
+    /// gone and any subsequent call to [`extract`](Self::extract) on **the same
+    /// instance** will return `Err(ExtractionError::InvalidArchive(...))`.
+    ///
+    /// To extract after listing, open a **new** [`TarArchive`] from the
+    /// original source:
+    ///
+    /// ```ignore
+    /// // Correct: two independent instances
+    /// let mut archive1 = TarArchive::open(&path)?;
+    /// let manifest = archive1.list(&config)?;
+    ///
+    /// let mut archive2 = TarArchive::open(&path)?;
+    /// let report = archive2.extract(&dest, &config, &options, &mut NoopProgress)?;
+    /// ```
     fn list(&mut self, config: &SecurityConfig) -> Result<crate::inspection::ArchiveManifest> {
         use crate::formats::detect::ArchiveType;
         use crate::inspection::list::list_tar_reader;


### PR DESCRIPTION
## Summary

- Adds `///` doc comments to `TarArchive::list()` and `TarArchive::extract()` explaining that `list()` consumes the internal reader (TAR is forward-only) and that calling `extract()` on the same instance afterward returns `InvalidArchive`. Includes an `ignore` code example showing the correct pattern (open two independent instances). (#211)
- Corrects `CopyBuffer::size()` visibility from `pub(crate)` to `pub`, consistent with the other items in `mod copy`. The module-level `pub(crate)` in `lib.rs` already enforces the encapsulation boundary; `pub(crate)` on items inside a `pub(crate)` module is redundant and triggers the `redundant_pub_crate` clippy lint. (#203)

## Test plan

- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` — 820 tests pass
- [x] `cargo test --doc --workspace --all-features` — 99 doc-tests pass
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace` — no warnings
- [x] No logic changes; only doc comments and one visibility correction