### PR TITLE
refactor(config): add #[non_exhaustive] and fluent builder to SecurityConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - CLI no longer emits `"HINT: Use --allow-symlinks"` when `--allow-symlinks` is already active and a symlink escape is blocked. The hint is now suppressed when the flag is set, since the escape is a genuine security violation rather than a configuration issue (#213).
 
+### Breaking Changes
+
+- `SecurityConfig`, `AllowedFeatures`, and `ExtractionOptions` are now `#[non_exhaustive]`. External crates can no longer construct these structs via struct literal syntax; use `Default::default()` or the new fluent builder methods instead (#221).
+
 ### Changed
+
+- Added 15 fluent builder methods to `SecurityConfig` (`with_max_file_size`, `with_max_total_size`, `with_max_compression_ratio`, `with_max_file_count`, `with_max_path_depth`, `with_allowed`, `with_allow_symlinks`, `with_allow_hardlinks`, `with_allow_absolute_paths`, `with_allow_world_writable`, `with_preserve_permissions`, `with_allowed_extensions`, `with_banned_path_components`, `with_allow_solid_archives`, `with_max_solid_block_memory`) and 2 to `ExtractionOptions` (`with_atomic`, `with_skip_duplicates`) (#218).
 
 - `TarArchive::list()` and `TarArchive::extract()` now have `///` doc comments explaining that `list()` consumes the internal reader (TAR is forward-only) and that calling `extract()` on the same instance afterward returns `InvalidArchive`. Callers must open a fresh instance for extraction (#211).
 - `CopyBuffer::size()` visibility corrected from `pub(crate)` to `pub`, consistent with the other items in the crate-internal `mod copy`. The `pub(crate)` module boundary in `lib.rs` already enforces the encapsulation; redundant `pub(crate)` on items inside a `pub(crate)` module triggers the `redundant_pub_crate` clippy lint (#203).

--- a/crates/exarch-cli/src/commands/extract.rs
+++ b/crates/exarch-cli/src/commands/extract.rs
@@ -10,7 +10,6 @@ use exarch_core::ExtractionOptions;
 use exarch_core::ManifestEntryType;
 use exarch_core::NoopProgress;
 use exarch_core::SecurityConfig;
-use exarch_core::config::AllowedFeatures;
 use exarch_core::extract_archive_full;
 use exarch_core::list_archive;
 use std::env;
@@ -24,14 +23,12 @@ pub fn execute(args: &ExtractArgs, formatter: &dyn OutputFormatter) -> Result<()
     if !args.force && !args.atomic {
         let manifest = list_archive(
             &args.archive,
-            &SecurityConfig {
-                max_file_count: args.max_files,
-                max_total_size: args.max_total_size.unwrap_or(500 * 1024 * 1024),
-                max_file_size: args.max_file_size.unwrap_or(50 * 1024 * 1024),
-                max_compression_ratio: f64::from(args.max_compression_ratio),
-                allow_solid_archives: args.allow_solid_archives,
-                ..Default::default()
-            },
+            &SecurityConfig::default()
+                .with_max_file_count(args.max_files)
+                .with_max_total_size(args.max_total_size.unwrap_or(500 * 1024 * 1024))
+                .with_max_file_size(args.max_file_size.unwrap_or(50 * 1024 * 1024))
+                .with_max_compression_ratio(f64::from(args.max_compression_ratio))
+                .with_allow_solid_archives(args.allow_solid_archives),
         )
         .with_context(|| format!("failed to list archive: {}", args.archive.display()))?;
 
@@ -53,26 +50,20 @@ pub fn execute(args: &ExtractArgs, formatter: &dyn OutputFormatter) -> Result<()
         }
     }
 
-    let config = SecurityConfig {
-        max_file_count: args.max_files,
-        max_total_size: args.max_total_size.unwrap_or(500 * 1024 * 1024),
-        max_file_size: args.max_file_size.unwrap_or(50 * 1024 * 1024),
-        max_compression_ratio: f64::from(args.max_compression_ratio),
-        allowed: AllowedFeatures {
-            symlinks: args.allow_symlinks,
-            hardlinks: args.allow_hardlinks,
-            absolute_paths: false,
-            world_writable: args.allow_world_writable,
-        },
-        preserve_permissions: args.preserve_permissions,
-        allow_solid_archives: args.allow_solid_archives,
-        ..Default::default()
-    };
+    let config = SecurityConfig::default()
+        .with_max_file_count(args.max_files)
+        .with_max_total_size(args.max_total_size.unwrap_or(500 * 1024 * 1024))
+        .with_max_file_size(args.max_file_size.unwrap_or(50 * 1024 * 1024))
+        .with_max_compression_ratio(f64::from(args.max_compression_ratio))
+        .with_allow_symlinks(args.allow_symlinks)
+        .with_allow_hardlinks(args.allow_hardlinks)
+        .with_allow_world_writable(args.allow_world_writable)
+        .with_preserve_permissions(args.preserve_permissions)
+        .with_allow_solid_archives(args.allow_solid_archives);
 
-    let options = ExtractionOptions {
-        atomic: args.atomic,
-        skip_duplicates: !args.force,
-    };
+    let options = ExtractionOptions::default()
+        .with_atomic(args.atomic)
+        .with_skip_duplicates(!args.force);
 
     // When --atomic + --force: remove existing destination after successful
     // extraction (handled inside extract_atomic via rename semantics) but we

--- a/crates/exarch-cli/src/commands/list.rs
+++ b/crates/exarch-cli/src/commands/list.rs
@@ -7,14 +7,10 @@ use exarch_core::SecurityConfig;
 use exarch_core::list_archive;
 
 pub fn execute(args: &ListArgs, formatter: &dyn OutputFormatter) -> Result<()> {
-    let config = SecurityConfig {
-        max_file_count: args.max_files,
-        max_total_size: args
-            .max_total_size
-            .unwrap_or_else(|| SecurityConfig::default().max_total_size),
-        allow_solid_archives: args.allow_solid_archives,
-        ..Default::default()
-    };
+    let config = SecurityConfig::default()
+        .with_max_file_count(args.max_files)
+        .with_max_total_size(args.max_total_size.unwrap_or(500 * 1024 * 1024))
+        .with_allow_solid_archives(args.allow_solid_archives);
 
     // List archive
     let manifest = list_archive(&args.archive, &config)?;

--- a/crates/exarch-cli/src/commands/verify.rs
+++ b/crates/exarch-cli/src/commands/verify.rs
@@ -9,14 +9,10 @@ use exarch_core::VerificationStatus;
 use exarch_core::verify_archive;
 
 pub fn execute(args: &VerifyArgs, formatter: &dyn OutputFormatter) -> Result<()> {
-    let config = SecurityConfig {
-        max_file_count: args.max_files,
-        max_total_size: args
-            .max_total_size
-            .unwrap_or_else(|| SecurityConfig::default().max_total_size),
-        allow_solid_archives: args.allow_solid_archives,
-        ..Default::default()
-    };
+    let config = SecurityConfig::default()
+        .with_max_file_count(args.max_files)
+        .with_max_total_size(args.max_total_size.unwrap_or(500 * 1024 * 1024))
+        .with_allow_solid_archives(args.allow_solid_archives);
 
     // Verify archive
     let report = verify_archive(&args.archive, &config)?;

--- a/crates/exarch-core/benches/extraction.rs
+++ b/crates/exarch-core/benches/extraction.rs
@@ -64,13 +64,11 @@ fn test_fixtures_dir() -> PathBuf {
 /// Disables zip bomb detection to allow testing highly compressed data,
 /// and increases size/depth limits for stress testing benchmarks.
 fn benchmark_config() -> SecurityConfig {
-    SecurityConfig {
-        max_compression_ratio: f64::MAX,    // Disable zip bomb detection
-        max_file_size: 500 * 1024 * 1024,   // 500 MB
-        max_total_size: 1024 * 1024 * 1024, // 1 GB
-        max_path_depth: 100,                // Allow deep path benchmarks
-        ..SecurityConfig::default()
-    }
+    SecurityConfig::default()
+        .with_max_compression_ratio(f64::MAX)
+        .with_max_file_size(500 * 1024 * 1024)
+        .with_max_total_size(1024 * 1024 * 1024)
+        .with_max_path_depth(100)
 }
 
 /// Returns fixture path if it exists, otherwise None.
@@ -270,11 +268,9 @@ fn benchmark_large_files(c: &mut Criterion) {
                     let mut archive = ZipArchive::new(cursor).unwrap();
 
                     // Use config with increased limits for benchmarks
-                    let config = SecurityConfig {
-                        max_file_size: 200 * 1024 * 1024,  // 200 MB
-                        max_total_size: 500 * 1024 * 1024, // 500 MB
-                        ..SecurityConfig::default()
-                    };
+                    let config = SecurityConfig::default()
+                        .with_max_file_size(200 * 1024 * 1024)
+                        .with_max_total_size(500 * 1024 * 1024);
 
                     archive
                         .extract(

--- a/crates/exarch-core/src/config.rs
+++ b/crates/exarch-core/src/config.rs
@@ -5,6 +5,7 @@
 ///
 /// All features default to `false` (deny-by-default security policy).
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct AllowedFeatures {
     /// Allow symlinks in extracted archives.
     pub symlinks: bool,
@@ -41,14 +42,14 @@ pub struct AllowedFeatures {
 /// // Use secure defaults
 /// let config = SecurityConfig::default();
 ///
-/// // Customize for specific needs
-/// let custom = SecurityConfig {
-///     max_file_size: 100 * 1024 * 1024,   // 100 MB
-///     max_total_size: 1024 * 1024 * 1024, // 1 GB
-///     ..Default::default()
-/// };
+/// // Customize via fluent builder
+/// let custom = SecurityConfig::default()
+///     .with_max_file_size(100 * 1024 * 1024)
+///     .with_max_total_size(1024 * 1024 * 1024)
+///     .with_allow_symlinks(true);
 /// ```
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct SecurityConfig {
     /// Maximum size for a single file in bytes.
     pub max_file_size: u64,
@@ -208,10 +209,7 @@ impl SecurityConfig {
     /// let config = SecurityConfig::default();
     /// assert!(config.validate().is_ok());
     ///
-    /// let bad = SecurityConfig {
-    ///     max_file_size: 0,
-    ///     ..SecurityConfig::default()
-    /// };
+    /// let bad = SecurityConfig::default().with_max_file_size(0);
     /// assert!(bad.validate().is_err());
     /// ```
     pub fn validate(&self) -> crate::Result<()> {
@@ -248,6 +246,272 @@ impl SecurityConfig {
         Ok(())
     }
 
+    /// Sets the maximum size for a single extracted file in bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exarch_core::SecurityConfig;
+    ///
+    /// let config = SecurityConfig::default().with_max_file_size(100 * 1024 * 1024);
+    /// assert_eq!(config.max_file_size, 100 * 1024 * 1024);
+    /// ```
+    #[must_use]
+    #[inline]
+    pub fn with_max_file_size(mut self, size: u64) -> Self {
+        self.max_file_size = size;
+        self
+    }
+
+    /// Sets the maximum total size for all extracted files in bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exarch_core::SecurityConfig;
+    ///
+    /// let config = SecurityConfig::default().with_max_total_size(1024 * 1024 * 1024);
+    /// assert_eq!(config.max_total_size, 1024 * 1024 * 1024);
+    /// ```
+    #[must_use]
+    #[inline]
+    pub fn with_max_total_size(mut self, size: u64) -> Self {
+        self.max_total_size = size;
+        self
+    }
+
+    /// Sets the maximum allowed compression ratio (uncompressed / compressed).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exarch_core::SecurityConfig;
+    ///
+    /// let config = SecurityConfig::default().with_max_compression_ratio(50.0);
+    /// assert_eq!(config.max_compression_ratio, 50.0);
+    /// ```
+    #[must_use]
+    #[inline]
+    pub fn with_max_compression_ratio(mut self, ratio: f64) -> Self {
+        self.max_compression_ratio = ratio;
+        self
+    }
+
+    /// Sets the maximum number of files that can be extracted.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exarch_core::SecurityConfig;
+    ///
+    /// let config = SecurityConfig::default().with_max_file_count(500);
+    /// assert_eq!(config.max_file_count, 500);
+    /// ```
+    #[must_use]
+    #[inline]
+    pub fn with_max_file_count(mut self, count: usize) -> Self {
+        self.max_file_count = count;
+        self
+    }
+
+    /// Sets the maximum path depth allowed.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exarch_core::SecurityConfig;
+    ///
+    /// let config = SecurityConfig::default().with_max_path_depth(16);
+    /// assert_eq!(config.max_path_depth, 16);
+    /// ```
+    #[must_use]
+    #[inline]
+    pub fn with_max_path_depth(mut self, depth: usize) -> Self {
+        self.max_path_depth = depth;
+        self
+    }
+
+    /// Sets the feature flags controlling allowed archive features.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exarch_core::SecurityConfig;
+    /// use exarch_core::config::AllowedFeatures;
+    ///
+    /// let features = AllowedFeatures::default();
+    /// let config = SecurityConfig::default().with_allowed(features);
+    /// assert!(!config.allowed.symlinks);
+    /// ```
+    #[must_use]
+    #[inline]
+    pub fn with_allowed(mut self, allowed: AllowedFeatures) -> Self {
+        self.allowed = allowed;
+        self
+    }
+
+    /// Enables or disables symlinks in extracted archives.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exarch_core::SecurityConfig;
+    ///
+    /// let config = SecurityConfig::default().with_allow_symlinks(true);
+    /// assert!(config.allowed.symlinks);
+    /// ```
+    #[must_use]
+    #[inline]
+    pub fn with_allow_symlinks(mut self, allow: bool) -> Self {
+        self.allowed.symlinks = allow;
+        self
+    }
+
+    /// Enables or disables hardlinks in extracted archives.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exarch_core::SecurityConfig;
+    ///
+    /// let config = SecurityConfig::default().with_allow_hardlinks(true);
+    /// assert!(config.allowed.hardlinks);
+    /// ```
+    #[must_use]
+    #[inline]
+    pub fn with_allow_hardlinks(mut self, allow: bool) -> Self {
+        self.allowed.hardlinks = allow;
+        self
+    }
+
+    /// Enables or disables absolute paths in archive entries.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exarch_core::SecurityConfig;
+    ///
+    /// let config = SecurityConfig::default().with_allow_absolute_paths(true);
+    /// assert!(config.allowed.absolute_paths);
+    /// ```
+    #[must_use]
+    #[inline]
+    pub fn with_allow_absolute_paths(mut self, allow: bool) -> Self {
+        self.allowed.absolute_paths = allow;
+        self
+    }
+
+    /// Enables or disables world-writable files.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exarch_core::SecurityConfig;
+    ///
+    /// let config = SecurityConfig::default().with_allow_world_writable(true);
+    /// assert!(config.allowed.world_writable);
+    /// ```
+    #[must_use]
+    #[inline]
+    pub fn with_allow_world_writable(mut self, allow: bool) -> Self {
+        self.allowed.world_writable = allow;
+        self
+    }
+
+    /// Enables or disables preserving file permissions from the archive.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exarch_core::SecurityConfig;
+    ///
+    /// let config = SecurityConfig::default().with_preserve_permissions(true);
+    /// assert!(config.preserve_permissions);
+    /// ```
+    #[must_use]
+    #[inline]
+    pub fn with_preserve_permissions(mut self, preserve: bool) -> Self {
+        self.preserve_permissions = preserve;
+        self
+    }
+
+    /// Sets the list of allowed file extensions.
+    ///
+    /// An empty list allows all extensions.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exarch_core::SecurityConfig;
+    ///
+    /// let config = SecurityConfig::default()
+    ///     .with_allowed_extensions(vec!["txt".to_string(), "pdf".to_string()]);
+    /// assert!(config.is_extension_allowed("txt"));
+    /// assert!(!config.is_extension_allowed("exe"));
+    /// ```
+    #[must_use]
+    #[inline]
+    pub fn with_allowed_extensions(mut self, extensions: Vec<String>) -> Self {
+        self.allowed_extensions = extensions;
+        self
+    }
+
+    /// Sets the list of banned path components.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exarch_core::SecurityConfig;
+    ///
+    /// let config = SecurityConfig::default().with_banned_path_components(vec![".git".to_string()]);
+    /// assert!(!config.is_path_component_allowed(".git"));
+    /// assert!(config.is_path_component_allowed(".ssh"));
+    /// ```
+    #[must_use]
+    #[inline]
+    pub fn with_banned_path_components(mut self, components: Vec<String>) -> Self {
+        self.banned_path_components = components;
+        self
+    }
+
+    /// Enables or disables extraction from solid 7z archives.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exarch_core::SecurityConfig;
+    ///
+    /// let config = SecurityConfig::default().with_allow_solid_archives(true);
+    /// assert!(config.allow_solid_archives);
+    /// ```
+    #[must_use]
+    #[inline]
+    pub fn with_allow_solid_archives(mut self, allow: bool) -> Self {
+        self.allow_solid_archives = allow;
+        self
+    }
+
+    /// Sets the maximum memory for solid archive extraction in bytes.
+    ///
+    /// Only applies when `allow_solid_archives` is `true`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exarch_core::SecurityConfig;
+    ///
+    /// let config = SecurityConfig::default()
+    ///     .with_allow_solid_archives(true)
+    ///     .with_max_solid_block_memory(1024 * 1024 * 1024);
+    /// assert_eq!(config.max_solid_block_memory, 1024 * 1024 * 1024);
+    /// ```
+    #[must_use]
+    #[inline]
+    pub fn with_max_solid_block_memory(mut self, size: u64) -> Self {
+        self.max_solid_block_memory = size;
+        self
+    }
+
     /// Validates whether a path component is allowed.
     ///
     /// Comparison is case-insensitive to prevent bypass on case-insensitive
@@ -277,6 +541,7 @@ impl SecurityConfig {
 /// Separate from `SecurityConfig` to keep security settings focused.
 /// These options control operational behavior like atomicity.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct ExtractionOptions {
     /// Extract atomically: use a temp dir in the same parent as the output
     /// directory, rename on success, and delete on failure.
@@ -302,6 +567,45 @@ impl Default for ExtractionOptions {
             atomic: false,
             skip_duplicates: true,
         }
+    }
+}
+
+impl ExtractionOptions {
+    /// Enables or disables atomic extraction.
+    ///
+    /// When enabled, extraction is all-or-nothing: the output directory is not
+    /// created if extraction fails.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exarch_core::ExtractionOptions;
+    ///
+    /// let opts = ExtractionOptions::default().with_atomic(true);
+    /// assert!(opts.atomic);
+    /// ```
+    #[must_use]
+    #[inline]
+    pub fn with_atomic(mut self, atomic: bool) -> Self {
+        self.atomic = atomic;
+        self
+    }
+
+    /// Enables or disables skipping duplicate entries silently.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exarch_core::ExtractionOptions;
+    ///
+    /// let opts = ExtractionOptions::default().with_skip_duplicates(false);
+    /// assert!(!opts.skip_duplicates);
+    /// ```
+    #[must_use]
+    #[inline]
+    pub fn with_skip_duplicates(mut self, skip: bool) -> Self {
+        self.skip_duplicates = skip;
+        self
     }
 }
 

--- a/crates/exarch-core/tests/sevenz_integration.rs
+++ b/crates/exarch-core/tests/sevenz_integration.rs
@@ -59,10 +59,7 @@ fn test_7z_security_config_integration() {
     let mut archive = SevenZArchive::new(cursor).unwrap();
 
     let temp = TempDir::new().unwrap();
-    let config = SecurityConfig {
-        max_file_size: 1024, // 1 KB limit
-        ..SecurityConfig::default()
-    };
+    let config = SecurityConfig::default().with_max_file_size(1024);
 
     let result = archive.extract(
         temp.path(),
@@ -157,10 +154,7 @@ fn test_7z_quota_file_count() {
     let mut archive = SevenZArchive::new(cursor).unwrap();
 
     let temp = TempDir::new().unwrap();
-    let config = SecurityConfig {
-        max_file_count: 1, // Only 1 file allowed
-        ..SecurityConfig::default()
-    };
+    let config = SecurityConfig::default().with_max_file_count(1);
 
     let result = archive.extract(
         temp.path(),
@@ -178,10 +172,7 @@ fn test_7z_quota_total_size() {
     let mut archive = SevenZArchive::new(cursor).unwrap();
 
     let temp = TempDir::new().unwrap();
-    let config = SecurityConfig {
-        max_total_size: 10, // Very small limit
-        ..SecurityConfig::default()
-    };
+    let config = SecurityConfig::default().with_max_total_size(10);
 
     let result = archive.extract(
         temp.path(),
@@ -204,11 +195,9 @@ fn test_7z_solid_archive_extraction_success() {
     let mut archive = SevenZArchive::new(cursor).unwrap();
 
     let temp = TempDir::new().unwrap();
-    let config = SecurityConfig {
-        allow_solid_archives: true,
-        max_solid_block_memory: 100 * 1024 * 1024, // 100 MB
-        ..SecurityConfig::default()
-    };
+    let config = SecurityConfig::default()
+        .with_allow_solid_archives(true)
+        .with_max_solid_block_memory(100 * 1024 * 1024);
 
     let report = archive
         .extract(
@@ -234,12 +223,10 @@ fn test_7z_solid_archive_with_file_count_quota() {
     let mut archive = SevenZArchive::new(cursor).unwrap();
 
     let temp = TempDir::new().unwrap();
-    let config = SecurityConfig {
-        allow_solid_archives: true,
-        max_solid_block_memory: 100 * 1024 * 1024,
-        max_file_count: 1, // Solid has more than 1 file
-        ..SecurityConfig::default()
-    };
+    let config = SecurityConfig::default()
+        .with_allow_solid_archives(true)
+        .with_max_solid_block_memory(100 * 1024 * 1024)
+        .with_max_file_count(1);
 
     let result = archive.extract(
         temp.path(),
@@ -511,10 +498,7 @@ fn test_7z_partial_extraction_accurate_report() {
 
     // skip_duplicates=false so the second "file.txt" triggers an error after
     // the first has already been written to disk.
-    let options = ExtractionOptions {
-        skip_duplicates: false,
-        ..ExtractionOptions::default()
-    };
+    let options = ExtractionOptions::default().with_skip_duplicates(false);
     let result = archive.extract(
         out_temp.path(),
         &SecurityConfig::default(),


### PR DESCRIPTION
## Summary

- Add `#[non_exhaustive]` to `SecurityConfig`, `ExtractionOptions`, and `AllowedFeatures` to allow future field additions without semver breaks (#221)
- Add 17 `#[inline]` fluent builder methods (`with_*`) to `SecurityConfig` and 2 to `ExtractionOptions`, matching the ergonomics of the Node.js binding (#218)
- Migrate all external struct literals in CLI commands, integration tests, and benchmarks

## Breaking changes

Struct literal construction of `SecurityConfig`, `ExtractionOptions`, and `AllowedFeatures` from external crates no longer compiles. Replace with:
```rust
// builder API (new)
let config = SecurityConfig::default()
    .with_max_file_size(100 * 1024 * 1024)
    .with_allow_symlinks(true);

// or append ..Default::default() to existing literals
let config = SecurityConfig { max_file_size: 100 * 1024 * 1024, ..Default::default() };
```

## Test plan

- [x] 824 unit/integration tests pass (`cargo nextest`)
- [x] 116 doctests pass (`cargo test --doc`)
- [x] `cargo clippy` clean
- [x] `cargo deny check` clean
- [x] Docs build clean (`RUSTDOCFLAGS="-D warnings" cargo doc`)
- [x] Security audit: deny-by-default preserved, `validate()` called at all API entry points
- [x] Performance: builder methods are zero-cost (pure field setters, `#[inline]`)

Closes #221, closes #218