### PR TITLE
ci: trigger python and node tests on exarch-core changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,10 @@ jobs:
               - 'rustfmt.toml'
             python:
               - 'crates/exarch-python/**'
+              - 'crates/exarch-core/**'
             node:
               - 'crates/exarch-node/**'
+              - 'crates/exarch-core/**'
             ci:
               - '.github/workflows/**'
               - '.github/labeler.yml'


### PR DESCRIPTION
## Summary

- Path filters for `test-python` and `test-node` only watched their own subdirectories
- Changes to `exarch-core` set `rust=true` but left `python=false` and `node=false`, silently skipping binding tests
- Added `crates/exarch-core/**` to both `python` and `node` path filters

## Test plan

- [ ] Verify a PR touching only `exarch-core` triggers both `test-python` and `test-node` jobs
- [ ] Verify a PR touching only `exarch-python` still triggers `test-python` but not `test-node`