### PR TITLE
docs(specs): add SDD specification package

### DIFF
--- a/specs/001-exarch-system/plan.md
+++ b/specs/001-exarch-system/plan.md
@@ -1,0 +1,515 @@
+---
+aliases:
+  - exarch Technical Plan
+tags:
+  - sdd
+  - plan
+  - archive
+  - security
+  - rust
+created: 2026-05-20
+status: draft
+related:
+  - "[[spec]]"
+  - "[[constitution]]"
+  - "[[MOC-specs]]"
+---
+
+# Technical Plan: exarch System
+
+> [!info] References
+> **Spec**: [[spec]]
+> **Version**: 0.3.1
+
+## 1. Architecture
+
+### Approach
+
+Four-crate workspace where all logic lives in `exarch-core`. The three
+consumer crates (`exarch-cli`, `exarch-python`, `exarch-node`) are thin
+adapters that convert types and dispatch to the core library.
+
+The core library is organized around a typed security pipeline: raw archive
+bytes are never written to disk until an entry passes the full validation
+chain. Format handlers implement the `ArchiveFormat` trait, which enforces
+a uniform extract/list/verify interface regardless of underlying format.
+
+### Component Diagram
+
+```mermaid
+graph TD
+    CLI[exarch-cli<br/>clap + indicatif] --> CORE
+    PY[exarch-python<br/>pyo3 + GIL mgmt] --> CORE
+    NODE[exarch-node<br/>napi-rs + tokio] --> CORE
+
+    subgraph CORE[exarch-core]
+        API[api.rs<br/>extract / create / list / verify]
+        DETECT[formats::detect<br/>ArchiveType detection]
+        TAR[formats::TarArchive]
+        ZIP[formats::ZipArchive]
+        SEVENZ[formats::SevenZArchive]
+        VALIDATOR[security::EntryValidator]
+        SAFEPATH[types::SafePath]
+        QUOTA[security::QuotaTracker]
+        HARDLINK[security::HardlinkTracker]
+        SYMLINK[security::validate_symlink]
+        ZIPBOMB[security::validate_compression_ratio]
+        PERMS[security::sanitize_permissions]
+        CREATION[creation::ArchiveCreator<br/>FormatCreator impls]
+        INSPECTION[inspection::list / verify]
+
+        API --> DETECT
+        API --> TAR
+        API --> ZIP
+        API --> SEVENZ
+        API --> CREATION
+        API --> INSPECTION
+        TAR --> VALIDATOR
+        ZIP --> VALIDATOR
+        SEVENZ --> VALIDATOR
+        VALIDATOR --> SAFEPATH
+        VALIDATOR --> QUOTA
+        VALIDATOR --> ZIPBOMB
+        VALIDATOR --> SYMLINK
+        VALIDATOR --> HARDLINK
+        VALIDATOR --> PERMS
+    end
+```
+
+### Key Design Decisions
+
+| Decision | Choice | Rationale | Alternatives Considered |
+|----------|--------|-----------|------------------------|
+| Security pipeline ordering | path → quota → compression ratio → type-specific | Cheap checks first; fail fast before I/O | Post-write validation (rejected: leaves partial output) |
+| `SafePath` as newtype | Cannot be constructed without passing validation | Type-safe guarantee that a path is safe | Runtime flag on `PathBuf` (rejected: not statically enforced) |
+| `EntryValidator` holds references | `&SecurityConfig`, `&DestDir` | No cloning per entry; measurable perf benefit | Clone per entry (rejected: measurable overhead at 10k+ files) |
+| 7z creation unsupported | Return `UnsupportedFormat` | `sevenz-rust2` write support is experimental | Expose write path (deferred: correctness risk) |
+| ZIP-family aliases rejected for creation | Return `InvalidArchive` with explanation | Silently producing a bare ZIP with `.apk` extension is misleading | Allow it silently (rejected: would confuse callers expecting valid APK structure) |
+| Atomic extraction via temp-dir + rename | `ExtractionOptions::atomic` | All-or-nothing semantics on same filesystem | Copy-then-delete (rejected: not atomic) |
+| Deny-by-default for symlinks/hardlinks | `AllowedFeatures` all false | Defense in depth; explicit opt-in | Allow-by-default (rejected: too many CVE-pattern escapes) |
+| Solid 7z rejection by default | `allow_solid_archives: false` | Memory exhaustion risk; decompresses entire block | Per-file limit (insufficient: solid block ignores per-file granularity) |
+
+## 2. Project Structure
+
+```
+exarch/
+├── Cargo.toml                          # workspace definition
+├── CHANGELOG.md
+├── tests/
+│   └── fixtures/                       # shared test archives (simple.7z, etc.)
+└── crates/
+    ├── exarch-core/
+    │   ├── src/
+    │   │   ├── lib.rs                  # re-exports; module declarations
+    │   │   ├── api.rs                  # extract_archive, create_archive, list_archive, verify_archive
+    │   │   ├── archive.rs              # Archive, ArchiveBuilder (high-level builder API)
+    │   │   ├── config.rs               # SecurityConfig, ExtractionOptions, AllowedFeatures
+    │   │   ├── report.rs               # ExtractionReport, ProgressCallback, NoopProgress
+    │   │   ├── error/
+    │   │   │   ├── mod.rs
+    │   │   │   ├── types.rs            # ExtractionError enum
+    │   │   │   └── messages.rs         # FfiErrorMessage for FFI-safe error passing
+    │   │   ├── formats/
+    │   │   │   ├── mod.rs              # re-exports TarArchive, ZipArchive, SevenZArchive
+    │   │   │   ├── traits.rs           # ArchiveFormat, FormatCreator traits
+    │   │   │   ├── detect.rs           # detect_format(), ArchiveType enum, ZIP_FAMILY_ALIASES
+    │   │   │   ├── common.rs           # DirCache (avoid redundant canonicalize syscalls)
+    │   │   │   ├── compression.rs      # shared compression helpers
+    │   │   │   ├── tar.rs              # TarArchive<R: Read> impl ArchiveFormat
+    │   │   │   ├── zip.rs              # ZipArchive impl ArchiveFormat
+    │   │   │   └── sevenz.rs           # SevenZArchive impl ArchiveFormat
+    │   │   ├── security/
+    │   │   │   ├── mod.rs
+    │   │   │   ├── context.rs          # ValidationContext (per-entry state, dir_cache ref)
+    │   │   │   ├── path.rs             # validate_path() → SafePath
+    │   │   │   ├── symlink.rs          # validate_symlink() → SafeSymlink
+    │   │   │   ├── hardlink.rs         # HardlinkTracker
+    │   │   │   ├── quota.rs            # QuotaTracker (file count, bytes)
+    │   │   │   ├── zipbomb.rs          # validate_compression_ratio()
+    │   │   │   ├── permissions.rs      # sanitize_permissions() (Unix only)
+    │   │   │   └── validator.rs        # EntryValidator orchestrator, ValidatedEntry
+    │   │   ├── types/
+    │   │   │   ├── mod.rs
+    │   │   │   ├── safe_path.rs        # SafePath newtype
+    │   │   │   ├── safe_symlink.rs     # SafeSymlink newtype
+    │   │   │   ├── entry_type.rs       # EntryType enum (File, Directory, Symlink, Hardlink)
+    │   │   │   └── dest_dir.rs         # DestDir (canonicalized output directory)
+    │   │   ├── creation/
+    │   │   │   ├── mod.rs              # re-exports creators, CreationConfig, CreationReport
+    │   │   │   ├── config.rs           # CreationConfig
+    │   │   │   ├── creator.rs          # ArchiveCreator
+    │   │   │   ├── tar.rs              # TarCreator, TarGzCreator, TarBz2Creator, TarXzCreator, TarZstCreator
+    │   │   │   ├── zip.rs              # ZipCreator
+    │   │   │   ├── compression.rs      # compression level helpers
+    │   │   │   ├── filters.rs          # file filtering (exclude patterns, hidden files)
+    │   │   │   ├── progress.rs         # progress helpers for creation
+    │   │   │   ├── report.rs           # CreationReport
+    │   │   │   └── walker.rs           # directory walking (walkdir wrapper)
+    │   │   ├── inspection/
+    │   │   │   ├── mod.rs
+    │   │   │   ├── list.rs             # list_archive() per format
+    │   │   │   ├── verify.rs           # verify_archive() + verify_manifest()
+    │   │   │   ├── manifest.rs         # ArchiveManifest, ArchiveEntry, ManifestEntryType
+    │   │   │   └── report.rs           # VerificationReport, VerificationIssue, etc.
+    │   │   ├── io/
+    │   │   │   ├── mod.rs
+    │   │   │   └── counting.rs         # CountingWriter (tracks bytes written for progress)
+    │   │   ├── copy.rs                 # CopyBuffer (reusable buffer for file I/O)
+    │   │   └── test_utils.rs           # shared test helpers
+    │   └── benches/
+    │       ├── creation.rs
+    │       ├── extraction.rs
+    │       ├── validation.rs
+    │       └── progress.rs
+    ├── exarch-cli/
+    │   └── src/
+    │       ├── main.rs                 # arg parsing, dispatch
+    │       ├── cli.rs                  # clap structs (Cli, Commands, ExtractArgs, etc.)
+    │       ├── error.rs                # CLI error type, exit code mapping
+    │       ├── progress.rs             # indicatif-based ProgressCallback impl
+    │       ├── commands/
+    │       │   ├── extract.rs
+    │       │   ├── create.rs
+    │       │   ├── list.rs
+    │       │   ├── verify.rs
+    │       │   └── completion.rs
+    │       └── output/
+    │           ├── formatter.rs        # OutputFormatter trait
+    │           ├── human.rs            # human-readable text output
+    │           └── json.rs             # JSON output (serde_json)
+    ├── exarch-python/
+    │   └── src/
+    │       ├── lib.rs                  # pymodule, pyfunction wrappers, path_to_string
+    │       ├── config.rs               # PySecurityConfig, PyCreationConfig
+    │       ├── error.rs                # convert_error(), register_exceptions()
+    │       └── report.rs               # PyExtractionReport, PyCreationReport, etc.
+    └── exarch-node/
+        └── src/
+            ├── lib.rs                  # #[napi] async functions
+            ├── config.rs               # SecurityConfig, CreationConfig JS classes
+            ├── error.rs                # convert_error()
+            ├── report.rs               # ExtractionReport, CreationReport, etc. JS types
+            └── utils.rs                # validate_path() for Node boundary checks
+```
+
+## 3. Data Model
+
+### Security Pipeline Types
+
+```rust
+// Entry type classification — raw, before validation
+pub enum EntryType {
+    File,
+    Directory,
+    Symlink { target: PathBuf },
+    Hardlink { target: PathBuf },
+}
+
+// After full validation; can only be constructed inside security module
+pub struct SafePath(PathBuf); // invariant: no traversal, within dest, depth ok
+
+pub struct SafeSymlink(PathBuf); // invariant: target resolves within dest
+
+pub struct ValidatedEntry {
+    pub safe_path: SafePath,
+    pub entry_type: ValidatedEntryType,
+    pub mode: Option<u32>,          // sanitized (setuid/setgid stripped)
+}
+
+pub enum ValidatedEntryType {
+    File,
+    Directory,
+    Symlink(SafeSymlink),
+    Hardlink { target: SafePath },
+}
+```
+
+### SecurityConfig Defaults
+
+| Field | Default |
+|-------|---------|
+| `max_file_size` | 50 MB |
+| `max_total_size` | 500 MB |
+| `max_compression_ratio` | 100.0× |
+| `max_file_count` | 10,000 |
+| `max_path_depth` | 32 |
+| `allowed.symlinks` | false |
+| `allowed.hardlinks` | false |
+| `allowed.absolute_paths` | false |
+| `allowed.world_writable` | false |
+| `preserve_permissions` | false |
+| `allowed_extensions` | [] (all allowed) |
+| `banned_path_components` | `.git`, `.ssh`, `.gnupg`, `.aws`, `.kube`, `.docker`, `.env` |
+| `allow_solid_archives` | false |
+| `max_solid_block_memory` | 512 MB |
+
+### ArchiveType Detection Rules
+
+| Extension(s) | ArchiveType |
+|---|---|
+| `.tar` | `Tar` |
+| `.tar.gz`, `.tgz` | `TarGz` |
+| `.tar.bz2`, `.tbz`, `.tbz2` | `TarBz2` |
+| `.tar.xz`, `.txz` | `TarXz` |
+| `.tar.zst`, `.tzst` | `TarZst` |
+| `.zip` | `Zip` |
+| `.jar`, `.war`, `.ear`, `.nar`, `.nbm`, `.apk`, `.aab`, `.ipa`, `.appx`, `.msix`, `.whl`, `.vsix`, `.xpi`, `.epub` | `Zip` (extraction) / error (creation) |
+| `.7z` | `SevenZ` |
+| `.gz` (no `.tar` stem) | Error: `UnsupportedFormat` |
+| anything else | Error: `UnsupportedFormat` |
+
+> [!note]
+> Detection is extension-based, case-insensitive. Magic byte detection is NOT currently implemented — format is inferred from the file extension only.
+
+## 4. API Design
+
+### Rust Public API (exarch-core)
+
+```rust
+// Extraction
+pub fn extract_archive<P, Q>(archive: P, output: Q, config: &SecurityConfig)
+    -> Result<ExtractionReport>;
+
+pub fn extract_archive_with_progress<P, Q>(archive: P, output: Q, config: &SecurityConfig,
+    progress: &mut dyn ProgressCallback) -> Result<ExtractionReport>;
+
+pub fn extract_archive_with_options<P, Q>(archive: P, output: Q, config: &SecurityConfig,
+    options: &ExtractionOptions) -> Result<ExtractionReport>;
+
+pub fn extract_archive_with_options_and_progress<P, Q>(archive: P, output: Q,
+    config: &SecurityConfig, options: &ExtractionOptions,
+    progress: &mut dyn ProgressCallback) -> Result<ExtractionReport>;
+
+// Creation
+pub fn create_archive<P, Q>(output: P, sources: &[Q], config: &CreationConfig)
+    -> Result<CreationReport>;
+
+pub fn create_archive_with_progress<P, Q>(output: P, sources: &[Q], config: &CreationConfig,
+    progress: &mut dyn ProgressCallback) -> Result<CreationReport>;
+
+// Inspection
+pub fn list_archive<P>(archive: P, config: &SecurityConfig) -> Result<ArchiveManifest>;
+pub fn verify_archive<P>(archive: P, config: &SecurityConfig) -> Result<VerificationReport>;
+```
+
+### ProgressCallback Trait
+
+```rust
+pub trait ProgressCallback: Send {
+    fn on_entry_start(&mut self, path: &Path, total: usize, current: usize);
+    fn on_bytes_written(&mut self, bytes: u64);
+    fn on_entry_complete(&mut self, path: &Path);
+    fn on_complete(&mut self);  // NOT called on failure
+}
+```
+
+### ArchiveFormat Trait
+
+```rust
+pub trait ArchiveFormat {
+    fn extract(&mut self, output_dir: &Path, config: &SecurityConfig,
+        options: &ExtractionOptions, progress: &mut dyn ProgressCallback)
+        -> Result<ExtractionReport>;
+    fn list(&mut self, config: &SecurityConfig) -> Result<ArchiveManifest>;
+    fn verify(&mut self, config: &SecurityConfig) -> Result<VerificationReport>;
+    fn format_name(&self) -> &'static str;
+}
+
+pub trait FormatCreator {
+    fn create(&self, output: &Path, sources: &[&Path], config: &CreationConfig,
+        progress: &mut dyn ProgressCallback) -> Result<CreationReport>;
+    fn format_name(&self) -> &'static str;
+}
+```
+
+### CLI Commands
+
+```
+exarch [--verbose] [--quiet] [--json] <COMMAND>
+
+exarch extract <ARCHIVE> [OUTPUT_DIR]
+    [--max-files N] [--max-total-size SIZE] [--max-file-size SIZE]
+    [--max-compression-ratio N] [--allow-symlinks] [--allow-hardlinks]
+    [--allow-solid-archives] [--allow-world-writable]
+    [--preserve-permissions] [--force] [--atomic]
+
+exarch create <OUTPUT> <SOURCE>...
+    [-l/--compression-level 1-9] [--follow-symlinks] [--include-hidden]
+    [-x/--exclude PATTERN]... [--strip-prefix PREFIX] [-f/--force]
+
+exarch list <ARCHIVE>
+    [-l/--long] [-H/--human-readable]
+    [--max-files N] [--max-total-size SIZE] [--allow-solid-archives]
+
+exarch verify <ARCHIVE>
+    [--check-integrity] [--check-security]
+    [--max-files N] [--max-total-size SIZE] [--allow-solid-archives]
+
+exarch completion <SHELL>    # bash | zsh | fish | powershell | elvish
+```
+
+### Python API
+
+```python
+# Module: exarch
+
+def extract_archive(archive_path, output_dir, config=None) -> ExtractionReport
+def create_archive(output_path, sources, config=None) -> CreationReport
+def create_archive_with_progress(output_path, sources, config=None, progress=None) -> CreationReport
+def list_archive(archive_path, config=None) -> ArchiveManifest
+def verify_archive(archive_path, config=None) -> VerificationReport
+
+class SecurityConfig:
+    def max_file_size(self, size: int) -> SecurityConfig
+    def max_total_size(self, size: int) -> SecurityConfig
+    def allow_symlinks(self, allow: bool) -> SecurityConfig
+    # ... etc
+
+class CreationConfig:
+    def compression_level(self, level: int) -> CreationConfig
+    # ... etc
+
+# Exception hierarchy
+ExarchError(Exception)
+  PathTraversalError(ExarchError)
+  SymlinkEscapeError(ExarchError)
+  HardlinkEscapeError(ExarchError)
+  ZipBombError(ExarchError)
+  QuotaExceededError(ExarchError)
+  UnsupportedFormatError(ExarchError)
+  InvalidArchiveError(ExarchError)
+  SecurityViolationError(ExarchError)
+  InvalidPermissionsError(ExarchError)
+```
+
+### Node.js API
+
+```typescript
+// All functions are async (Promise-based)
+function extractArchive(archivePath: string, outputDir: string,
+    config?: SecurityConfig): Promise<ExtractionReport>
+
+function createArchive(outputPath: string, sources: string[],
+    config?: CreationConfig): Promise<CreationReport>
+
+function listArchive(archivePath: string,
+    config?: SecurityConfig): Promise<ArchiveManifest>
+
+function verifyArchive(archivePath: string,
+    config?: SecurityConfig): Promise<VerificationReport>
+
+class SecurityConfig {
+    maxFileSize(size: number): this
+    maxTotalSize(size: number): this
+    allowSymlinks(allow: boolean): this
+    // ... etc
+}
+```
+
+## 5. Integration Points
+
+| System | Direction | Protocol | Notes |
+|--------|-----------|----------|-------|
+| Filesystem | outbound | OS syscalls | Extraction writes via `std::fs`; atomic mode uses `tempfile` + `fs::rename` |
+| Python runtime | inbound | FFI (pyo3) | GIL released during I/O when no progress callback; `PyProgressAdapter` holds GIL via `Python::attach` |
+| Node.js runtime | inbound | FFI (napi-rs) | Operations run on libuv thread pool via `tokio::task::spawn_blocking` equivalent |
+| `sevenz-rust2` crate | outbound | Rust API | External crate for 7z parsing; solid block detection depends on its API surface |
+| `zip` crate | outbound | Rust API | ZIP reading/writing; `ZipArchive` and `ZipWriter` types |
+| `tar` crate | outbound | Rust API | TAR reading; `Archive<R>` generic over decompressor |
+
+## 6. Security
+
+The security architecture is described in full in [[spec#3. Functional Requirements]].
+Key implementation notes:
+
+**Path validation** (`security/path.rs`): Uses `PathBuf::components()` to detect
+`..` without calling `canonicalize()` for each entry (expensive). `canonicalize()`
+is called only when a symlink has been seen previously (tracked by `symlink_seen`
+flag in `EntryValidator`). `DirCache` caches directories created by the extractor
+to skip `canonicalize()` for known-safe parents.
+
+**Quota tracking** (`security/quota.rs`): `QuotaTracker` accumulates file count and
+total bytes. Checked before writing each entry. Not reversible — once exceeded,
+extraction halts.
+
+**Compression ratio** (`security/zipbomb.rs`): Ratio computed as
+`uncompressed_size / compressed_size`. Only checked when `compressed_size` is
+known (ZIP has it in the local file header; TAR compressed streams do not expose
+it per-entry, so zip bomb detection is format-dependent).
+
+**Permission sanitization** (`security/permissions.rs`): On Unix, `mode & !0o6000`
+strips setuid/setgid. World-writable check (`mode & 0o002`) can raise an error if
+`allowed.world_writable` is false.
+
+**Solid 7z** (`formats/sevenz.rs`): Pre-validates total uncompressed size of all
+entries against `max_solid_block_memory` before extraction begins. Conservative
+heuristic: assumes single solid block (actual block boundaries not exposed by
+`sevenz-rust2` v0.21).
+
+## 7. Testing Strategy
+
+| Level | Framework | What to Test | Notes |
+|-------|-----------|-------------|-------|
+| Unit | `cargo test` / nextest | Individual security checks, config validation, path parsing | Per-module in `#[cfg(test)]` blocks |
+| Property | `proptest` | Path traversal variants, arbitrary archive entry paths | In `security/path.rs`, `security/symlink.rs` |
+| Integration | nextest + fixture archives | Full extract/create/list/verify cycles per format | `tests/` directory; fixture archives in `tests/fixtures/` |
+| Benchmark | `criterion` | Extraction throughput, creation throughput, validation overhead, progress overhead | `exarch-core/benches/`; run with `cargo bench -p exarch-core` |
+| Memory profiling | `dhat` | Heap allocation patterns during extraction | `exarch-core/benches/` |
+| Python | `pytest` + `maturin develop` | Python API, GIL behavior, error mapping | `exarch-python/tests/` |
+| Node.js | `npm test` | Async Promise API, error mapping | `exarch-node/` |
+
+> [!warning]
+> Windows path separator handling (`\` vs `/`) is a known edge case in path validation. Ensure a Windows CI job exists before merging any path-related change.
+
+## 8. Performance Considerations
+
+- **Expected extraction scale**: archives with up to 10,000 files and 500 MB uncompressed at a time (matching default quota limits)
+- **Bottlenecks**: decompression CPU-bound for xz/bz2; I/O-bound for gz/zst; 7z solid archives decompress entire block into memory before writing
+- **`BufReader`**: wraps all TAR file handles to reduce syscall count
+- **`CopyBuffer`**: reusable buffer in `copy.rs` for file I/O; avoids per-entry allocations
+- **`DirCache`**: avoids repeated `canonicalize()` for directory parents already created by the extractor
+- **`EntryValidator` with references**: eliminates one `SecurityConfig` + `DestDir` clone per extraction call (measurable at high file counts)
+- **`SmallVec`**: used in path component accumulation to avoid heap allocation for short paths
+
+## 9. Rollout Plan
+
+The system is already implemented at v0.3.1. This plan documents the current
+architecture as a baseline for future feature work.
+
+When adding new formats or changing security defaults:
+1. Open a GitHub issue with P-label
+2. Branch from `main` using naming convention
+3. Implement + tests + benches (if performance-sensitive)
+4. Pre-commit checks (see [[constitution]])
+5. Update `CHANGELOG.md`
+6. Open PR targeting `main`
+
+## 10. Constitution Compliance
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| All security logic in exarch-core | Compliant | Bindings contain only type mapping and boundary validation |
+| `deny(unsafe_code)` workspace-wide | Compliant | One justified exception: `unsafe impl Send for PyProgressAdapter` in Python bindings |
+| Fluent builder APIs | Compliant | `SecurityConfig`, `CreationConfig`, `ExtractionOptions` all use `with_*` builders |
+| `ProgressCallback::on_complete` not called on failure | Compliant | Verified by regression test (issue #170) |
+| Deny-by-default security policy | Compliant | All `AllowedFeatures` flags false; `allow_solid_archives` false |
+| MSRV 1.93.0 | Compliant | Checked in CI |
+| Conventional Commits | Compliant | Enforced by PR review |
+| `missing_docs` warning | Compliant | All public items documented |
+
+## 11. Risks and Mitigations
+
+| Risk | Impact | Probability | Mitigation |
+|------|--------|-------------|------------|
+| `sevenz-rust2` API change breaks 7z extraction | High | Medium | Pin version; track upstream releases |
+| Solid 7z heuristic (assume single block) too conservative | Medium | Low | Revisit if `sevenz-rust2` exposes block boundaries in future |
+| Windows path validation edge cases | High | Medium | Add Windows CI job; test `\` vs `/` separator handling |
+| Python GIL + TOCTOU race on archive files | Medium | Low | Document accepted tradeoff; users must ensure exclusive access |
+| New ZIP CVE in upstream `zip` crate | High | Low | Monitor RUSTSEC advisories via `cargo deny`; `rust-security-maintenance` agent runs after every change |
+| Compression ratio check not available per-entry in TAR | Medium | High (already known) | Document limitation; quota check still limits total decompressed output |
+
+## See Also
+
+- [[spec]] — feature specification
+- [[constitution]] — project principles
+- [[MOC-specs]] — all specifications

--- a/specs/001-exarch-system/spec.md
+++ b/specs/001-exarch-system/spec.md
@@ -1,0 +1,371 @@
+---
+aliases:
+  - exarch System Spec
+  - exarch-core Spec
+tags:
+  - sdd
+  - spec
+  - archive
+  - security
+  - rust
+created: 2026-05-20
+status: draft
+related:
+  - "[[constitution]]"
+  - "[[MOC-specs]]"
+---
+
+# Feature: exarch System
+
+> [!info] Metadata
+> **Version**: 0.3.1
+> **MSRV**: Rust 1.93.0
+> **License**: MIT OR Apache-2.0
+> **Crates**: exarch-core, exarch-cli, exarch-python, exarch-node
+
+## 1. Overview
+
+### Problem Statement
+
+Archive extraction is a common attack surface: path traversal, zip bombs,
+symlink escapes, and hardlink attacks have affected almost every major
+archive library. Existing Rust archive crates expose raw decompression
+APIs without integrated security validation, requiring each consumer to
+re-implement the same set of mitigations — inconsistently.
+
+exarch provides a single, security-first archive library with deny-by-default
+policies, a typed validation pipeline, and bindings for CLI, Python, and
+Node.js so that the security burden is paid once and shared across ecosystems.
+
+### Goal
+
+Provide a memory-safe, security-first archive library (Rust API + CLI +
+Python + Node.js bindings) that makes it safe to extract untrusted archives
+by default without requiring callers to understand the attack surface.
+
+### Out of Scope
+
+- RAR archive support
+- Archive encryption or signing
+- Streaming/incremental extraction over network (local files only)
+- 7z archive creation (extraction only)
+- ZIP-family aliases (`.apk`, `.whl`, `.jar`, etc.) creation without explicit format override
+- GUI or web interface
+
+## 2. User Stories
+
+### US-001: Secure Extraction (Rust API)
+
+AS A Rust developer integrating archive extraction into a server or CLI tool
+I WANT to call `extract_archive(path, output_dir, &config)` and receive an error on any security violation
+SO THAT I do not have to implement path traversal checks, zip bomb detection, or symlink validation myself
+
+**Acceptance criteria:**
+```
+GIVEN a valid archive and a SecurityConfig with default settings
+WHEN I call extract_archive()
+THEN all entries are written to output_dir, no entry escapes output_dir,
+     and the returned ExtractionReport contains file/byte counts
+```
+
+```
+GIVEN an archive containing a path traversal entry (e.g. "../etc/passwd")
+WHEN I call extract_archive()
+THEN extraction fails with ExtractionError::PathTraversal before any file is written
+```
+
+### US-002: Archive Creation (Rust API)
+
+AS A Rust developer building a backup or packaging tool
+I WANT to call `create_archive(output_path, &sources, &config)` to produce TAR/ZIP archives
+SO THAT I can create archives with sane compression defaults and file filtering without manual format handling
+
+**Acceptance criteria:**
+```
+GIVEN a list of source paths and an output path with a recognized extension
+WHEN I call create_archive()
+THEN an archive is produced containing all source files, and CreationReport.files_added reflects the count
+```
+
+```
+GIVEN a 7z output path
+WHEN I call create_archive()
+THEN the call fails with ExtractionError::UnsupportedFormat
+```
+
+### US-003: Archive Inspection
+
+AS A security engineer or operator
+I WANT to list and verify archive contents without extracting to disk
+SO THAT I can pre-check untrusted archives before deployment
+
+**Acceptance criteria:**
+```
+GIVEN an archive with known contents
+WHEN I call list_archive()
+THEN an ArchiveManifest is returned with correct entry paths, sizes, and types without writing any files to disk
+```
+
+```
+GIVEN an archive containing a zip bomb entry (compression ratio > 100×)
+WHEN I call verify_archive()
+THEN VerificationReport.issues contains a ZipBomb issue with Critical severity and status is Fail
+```
+
+### US-004: CLI Extraction
+
+AS A system administrator or script author
+I WANT to run `exarch extract archive.tar.gz /output` from the shell
+SO THAT I can extract archives safely without installing Python or Node.js
+
+**Acceptance criteria:**
+```
+GIVEN a valid archive and an output directory
+WHEN I run `exarch extract archive.tar.gz /output`
+THEN files are extracted, a progress bar is shown, and exit code is 0
+```
+
+```
+GIVEN the --json flag
+WHEN I run `exarch extract archive.tar.gz /output --json`
+THEN stdout contains a JSON object with extraction statistics and no progress bar
+```
+
+### US-005: Python Bindings
+
+AS A Python developer building a data pipeline or security tool
+I WANT to call `exarch.extract_archive(path, output)` from Python
+SO THAT I benefit from the same security guarantees without reimplementing them in Python
+
+**Acceptance criteria:**
+```
+GIVEN a valid archive path and output directory
+WHEN I call extract_archive(archive_path, output_dir) from Python
+THEN the extraction runs with GIL released, files are extracted, and an ExtractionReport object is returned
+```
+
+```
+GIVEN a path containing null bytes
+WHEN I call any exarch function with that path
+THEN a ValueError is raised immediately without calling into Rust core
+```
+
+### US-006: Node.js Bindings
+
+AS A Node.js developer building a CI/CD tool or file processing service
+I WANT async Promise-based archive operations
+SO THAT I can extract archives without blocking the Node.js event loop
+
+**Acceptance criteria:**
+```
+GIVEN a valid archive path and output directory
+WHEN I await extractArchive(archivePath, outputDir)
+THEN extraction runs on the libuv thread pool, files are extracted, and an ExtractionReport is resolved
+```
+
+## 3. Functional Requirements
+
+### 3.1 Security Pipeline
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN any archive entry path is validated, THE SYSTEM SHALL reject paths containing `../`, absolute paths, null bytes, or components matching `banned_path_components` (case-insensitive) | must |
+| FR-002 | WHEN a file entry's uncompressed size exceeds `max_file_size`, THE SYSTEM SHALL reject it with `QuotaExceeded` | must |
+| FR-003 | WHEN the cumulative uncompressed size across all file entries exceeds `max_total_size`, THE SYSTEM SHALL reject further entries with `QuotaExceeded` | must |
+| FR-004 | WHEN a file entry has a known compressed size and the ratio (uncompressed / compressed) exceeds `max_compression_ratio`, THE SYSTEM SHALL reject it with `ZipBomb` | must |
+| FR-005 | WHEN a symlink entry is encountered and `allowed.symlinks` is false, THE SYSTEM SHALL skip the entry (default deny) | must |
+| FR-006 | WHEN a symlink entry is encountered and `allowed.symlinks` is true, THE SYSTEM SHALL validate that the resolved symlink target does not escape `output_dir` | must |
+| FR-007 | WHEN a hardlink entry is encountered and `allowed.hardlinks` is false, THE SYSTEM SHALL skip the entry | must |
+| FR-008 | WHEN a hardlink entry is encountered and `allowed.hardlinks` is true, THE SYSTEM SHALL validate that the hardlink target path is within `output_dir` and has been previously seen | must |
+| FR-009 | WHEN extracting files on Unix, THE SYSTEM SHALL strip setuid (0o4000) and setgid (0o2000) bits from all file permissions | must |
+| FR-010 | WHEN a 7z archive is detected as solid and `allow_solid_archives` is false, THE SYSTEM SHALL reject extraction | must |
+| FR-011 | WHEN a 7z solid archive extraction is permitted, THE SYSTEM SHALL reject it if the total uncompressed size exceeds `max_solid_block_memory` | must |
+| FR-012 | WHEN the path depth of an entry exceeds `max_path_depth`, THE SYSTEM SHALL reject the entry | must |
+| FR-013 | WHEN `allowed_extensions` is non-empty and an entry's extension is not in the list, THE SYSTEM SHALL skip the entry | should |
+
+### 3.2 Format Support
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-020 | WHEN an archive path has extension `.tar`, `.tgz`, `.tar.gz`, `.tar.bz2`, `.tbz`, `.tbz2`, `.tar.xz`, `.txz`, `.tar.zst`, `.tzst`, THE SYSTEM SHALL extract it as a TAR archive with the appropriate decompressor | must |
+| FR-021 | WHEN an archive path has extension `.zip` or any ZIP-family alias (`.jar`, `.war`, `.apk`, `.whl`, etc.), THE SYSTEM SHALL extract it as a ZIP archive | must |
+| FR-022 | WHEN an archive path has extension `.7z`, THE SYSTEM SHALL extract it using the 7z handler (extraction only) | must |
+| FR-023 | WHEN format detection is ambiguous or the extension is unrecognized, THE SYSTEM SHALL return `ExtractionError::UnsupportedFormat` | must |
+| FR-024 | WHEN creating archives, THE SYSTEM SHALL support TAR (all compression variants) and ZIP; 7z creation SHALL return `UnsupportedFormat` | must |
+| FR-025 | WHEN creating archives for ZIP-family aliases without an explicit `CreationConfig::format` override, THE SYSTEM SHALL return an error explaining that the format requires extra structure | should |
+
+### 3.3 Configuration API
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-030 | `SecurityConfig` SHALL use a fluent builder API (`with_*` methods returning `Self`) and implement `Default` with secure deny-by-default settings | must |
+| FR-031 | `SecurityConfig::validate()` SHALL return an error if any limit field is zero or `max_compression_ratio` is not a positive finite number | must |
+| FR-032 | `CreationConfig` SHALL support: `follow_symlinks`, `include_hidden`, `max_file_size`, `exclude_patterns`, `strip_prefix`, `compression_level` (1-9), `preserve_permissions`, `format` override | must |
+| FR-033 | `ExtractionOptions` SHALL support: `atomic` (temp-dir + rename), `skip_duplicates` (default true) | must |
+| FR-034 | WHEN `ExtractionOptions::atomic` is true, THE SYSTEM SHALL extract to a temp dir in the same parent as the output directory and atomically rename on success; on failure it SHALL delete the temp dir | must |
+
+### 3.4 Progress Reporting
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-040 | THE SYSTEM SHALL expose a `ProgressCallback` trait with `on_entry_start`, `on_bytes_written`, `on_entry_complete`, `on_complete` | must |
+| FR-041 | THE SYSTEM SHALL provide a `NoopProgress` implementation that satisfies the trait without overhead | must |
+| FR-042 | `on_complete` SHALL NOT be called if extraction fails or is partial | must |
+
+### 3.5 Inspection
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-050 | `list_archive()` SHALL return an `ArchiveManifest` with total entry count, total size, and per-entry metadata (path, size, type, compressed size, modified time, permissions) without writing any files to disk | must |
+| FR-051 | `verify_archive()` SHALL return a `VerificationReport` with `status` (Pass/Fail/Warning), `issues` list (each with severity, category, message), and `total_entries` count | must |
+| FR-052 | `VerificationReport` issues SHALL distinguish severity levels: Critical, High, Medium, Low | must |
+
+### 3.6 CLI Interface
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-060 | THE CLI SHALL provide subcommands: `extract`, `create`, `list`, `verify`, `completion` | must |
+| FR-061 | THE CLI SHALL support global flags: `--verbose`, `--quiet`, `--json` | must |
+| FR-062 | WHEN `--json` is set, THE CLI SHALL output machine-readable JSON to stdout; human-readable text output SHALL go to stderr | must |
+| FR-063 | `extract` SHALL support: `--max-files`, `--max-total-size` (with K/M/G/T suffixes), `--max-file-size`, `--max-compression-ratio`, `--allow-symlinks`, `--allow-hardlinks`, `--allow-solid-archives`, `--allow-world-writable`, `--preserve-permissions`, `--force`, `--atomic` | must |
+| FR-064 | `create` SHALL support: `--compression-level` (1-9), `--follow-symlinks`, `--include-hidden`, `--exclude` (repeatable glob), `--strip-prefix`, `--force` | must |
+| FR-065 | `list` and `verify` SHALL support: `--long`, `--human-readable`, `--max-files`, `--max-total-size`, `--allow-solid-archives` | must |
+| FR-066 | `completion` SHALL generate shell completion scripts for bash, zsh, fish, and PowerShell | should |
+
+### 3.7 Python Bindings
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-070 | THE SYSTEM SHALL expose Python functions: `extract_archive`, `create_archive`, `create_archive_with_progress`, `list_archive`, `verify_archive` | must |
+| FR-071 | ALL Python functions SHALL accept `str` or `pathlib.Path` for path arguments | must |
+| FR-072 | WHEN paths contain null bytes or exceed 4096 bytes, THE SYSTEM SHALL raise `ValueError` at the Python boundary before calling into Rust | must |
+| FR-073 | WHEN no Python progress callback is provided, THE SYSTEM SHALL release the GIL during extraction/creation | must |
+| FR-074 | WHEN a Python progress callback is provided, THE SYSTEM SHALL NOT release the GIL (callback requires GIL to call Python) | must |
+| FR-075 | Rust `ExtractionError` variants SHALL map to specific Python exception types registered on the module | must |
+
+### 3.8 Node.js Bindings
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-080 | THE SYSTEM SHALL expose async Node.js functions that return Promises: `extractArchive`, `createArchive`, `listArchive`, `verifyArchive` | must |
+| FR-081 | ALL async operations SHALL run on the libuv thread pool (not the main event loop thread) | must |
+| FR-082 | WHEN paths contain null bytes or exceed 4096 bytes, THE SYSTEM SHALL reject with a JavaScript Error before spawning a thread | must |
+| FR-083 | Rust `ExtractionError` variants SHALL map to named JavaScript Error types | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Security | Default config limits: 50 MB per file, 500 MB total, 100× compression ratio, 10,000 files, path depth 32 |
+| NFR-002 | Security | All security checks run before any bytes are written to disk for each entry |
+| NFR-003 | Security | Solid 7z archives are rejected by default; must be explicitly enabled |
+| NFR-004 | Security | Banned path components checked case-insensitively on every entry |
+| NFR-005 | Performance | Extraction throughput regression > 10% vs baseline triggers P1 review |
+| NFR-006 | Performance | `BufReader` used for all TAR file handles; `CopyBuffer` for all byte copying |
+| NFR-007 | Reliability | Atomic extraction mode ensures all-or-nothing semantics (no partial output on failure) |
+| NFR-008 | Reliability | Progress `on_complete` not called on failure — callers can rely on this for cleanup signaling |
+| NFR-009 | Safety | `deny(unsafe_code)` workspace-wide; Python binding contains one justified `unsafe impl Send` for `PyProgressAdapter` |
+| NFR-010 | Compatibility | MSRV 1.93.0; no const generics or APIs introduced after 1.93 |
+| NFR-011 | Portability | Path separator handling must be tested on Windows (backslash vs forward slash edge cases in path validation) |
+| NFR-012 | Observability | CLI progress bar uses `indicatif` in human mode; suppressed in `--json` and `--quiet` modes |
+
+## 5. Data Model
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| `SecurityConfig` | Security policy for extraction operations | `max_file_size`, `max_total_size`, `max_compression_ratio`, `max_file_count`, `max_path_depth`, `allowed` (features), `banned_path_components`, `allowed_extensions`, `allow_solid_archives`, `max_solid_block_memory` |
+| `AllowedFeatures` | Feature flags for deny-by-default policy | `symlinks`, `hardlinks`, `absolute_paths`, `world_writable` |
+| `CreationConfig` | Configuration for archive creation | `follow_symlinks`, `include_hidden`, `max_file_size`, `exclude_patterns`, `strip_prefix`, `compression_level`, `preserve_permissions`, `format` |
+| `ExtractionOptions` | Operational options for extraction (non-security) | `atomic`, `skip_duplicates` |
+| `SafePath` | Newtype for a validated archive entry path | Wraps `PathBuf`; can only be constructed after traversal/depth/component checks pass |
+| `ValidatedEntry` | Validated archive entry ready for extraction | `safe_path: SafePath`, `entry_type: ValidatedEntryType`, `mode: Option<u32>` |
+| `ValidatedEntryType` | Enum of validated entry types | `File`, `Directory`, `Symlink(SafeSymlink)`, `Hardlink { target: SafePath }` |
+| `EntryValidator` | Stateful validator orchestrating all security checks per entry | Holds `QuotaTracker`, `HardlinkTracker`, `symlink_seen` flag |
+| `ExtractionReport` | Result of an extraction operation | `files_extracted`, `directories_created`, `symlinks_created`, `bytes_written`, `duration`, `files_skipped`, `warnings` |
+| `CreationReport` | Result of an archive creation | `files_added`, `bytes_written`, `duration` |
+| `ArchiveManifest` | Listing of archive contents | `total_entries`, `total_size`, `format`, `entries: Vec<ArchiveEntry>` |
+| `ArchiveEntry` | Metadata for a single archive entry | `path`, `size`, `entry_type`, `compressed_size`, `modified`, `permissions` |
+| `VerificationReport` | Security and integrity check results | `status: VerificationStatus`, `issues: Vec<VerificationIssue>`, `total_entries` |
+| `VerificationIssue` | A single identified security or integrity issue | `severity: IssueSeverity`, `category: IssueCategory`, `message`, `path` |
+| `ArchiveType` | Enum of supported archive formats | `Tar`, `TarGz`, `TarBz2`, `TarXz`, `TarZst`, `Zip`, `SevenZ` |
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Archive path does not exist | `ExtractionError::Io` returned immediately |
+| Extension unrecognized or bare `.gz` without `.tar` stem | `ExtractionError::UnsupportedFormat` |
+| ZIP-family alias (`.apk`, `.whl`) extraction | Proceeds as ZIP |
+| ZIP-family alias creation without format override | `ExtractionError::InvalidArchive` with explanation |
+| 7z creation | `ExtractionError::UnsupportedFormat` |
+| Duplicate entry paths in archive | Logged as warning in `ExtractionReport.warnings` when `skip_duplicates` is true; error when false |
+| Atomic extraction to existing non-empty directory | `ExtractionError::OutputExists` on rename failure; temp dir cleaned up |
+| Path traversal `../` or absolute path | `ExtractionError::PathTraversal` |
+| File exceeds `max_file_size` | `ExtractionError::QuotaExceeded { resource: FileSizeBytes }` |
+| Total size exceeds `max_total_size` | `ExtractionError::QuotaExceeded { resource: TotalSizeBytes }` |
+| File count exceeds `max_file_count` | `ExtractionError::QuotaExceeded { resource: FileCount }` |
+| Compression ratio > `max_compression_ratio` | `ExtractionError::ZipBomb` |
+| Symlink with `allowed.symlinks = false` | Entry skipped (not an error) |
+| Symlink pointing outside output_dir | `ExtractionError::SymlinkEscape` |
+| Hardlink with `allowed.hardlinks = false` | Entry skipped |
+| Hardlink to a path not previously seen in this archive | `ExtractionError::HardlinkEscape` |
+| setuid/setgid bits on Unix | Stripped silently; `mode` in `ValidatedEntry` reflects sanitized value |
+| Solid 7z archive with `allow_solid_archives = false` | `ExtractionError::InvalidArchive` or format-specific rejection |
+| Path depth > `max_path_depth` | `ExtractionError::PathTraversal` (depth exceeded) |
+| Banned component (`.git`) in path | `ExtractionError::PathTraversal` (banned component) |
+| `SecurityConfig` with zero limit | `SecurityConfig::validate()` returns `InvalidConfiguration` before extraction begins |
+| Python: null byte in path | `ValueError` raised at Python boundary |
+| Python: path exceeds 4096 bytes | `ValueError` raised at Python boundary |
+| Node.js: null byte in path | JavaScript `Error` raised synchronously before Promise is created |
+| `verify_archive` on corrupt archive | Structural issues reported in `VerificationReport.issues`; method returns `Ok` if archive can be read at all |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | Path traversal attempts blocked | 100% of known CVE-pattern archives rejected |
+| SC-002 | Zip bomb detection | Archives with ratio > 100× rejected before first byte written |
+| SC-003 | Symlink escape prevention | Symlinks resolving outside `output_dir` always rejected |
+| SC-004 | Extraction throughput regression | < 10% regression vs baseline on `cargo bench` |
+| SC-005 | Test coverage (new code) | All security checks have property-based or integration tests |
+| SC-006 | Doc-test pass rate | 100% — `cargo test --doc --workspace --all-features` must pass |
+| SC-007 | Clippy clean | Zero warnings with `--all-features --all-targets -D warnings` |
+| SC-008 | MSRV compliance | `cargo check -p exarch-core --all-features` passes on Rust 1.93.0 |
+| SC-009 | Atomic extraction correctness | No partial output on extraction failure; temp dir cleaned up |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Run `cargo +nightly fmt --all` after any code change
+- Run `cargo clippy --workspace --all-targets --all-features -- -D warnings` after code changes
+- Add `///` doc comments to every new `pub` item
+- Include `# Examples` in doc comments for non-trivial public APIs
+- Use `?` for error propagation — never `unwrap()` or `expect()` in non-test code
+- Update `CHANGELOG.md` (`[Unreleased]`) at end of each implementation phase
+
+### Ask First
+- Adding new external dependencies
+- Changing `SecurityConfig` default values (security policy change)
+- Modifying the `ArchiveFormat` or `FormatCreator` trait signatures (breaking API change)
+- Enabling any feature in `AllowedFeatures` by default
+- Raising or removing any quota default
+
+### Never
+- Commit secrets, credentials, or API keys
+- Add `#[allow(unsafe_code)]` without explicit justification in PR description
+- Remove existing security checks or lower default quota limits without a security review
+- Add `unwrap()` or `expect()` outside of test modules
+- Bypass clippy lints with `#[allow(...)]` without a comment explaining why
+
+## 9. Open Questions
+
+- [NEEDS CLARIFICATION: Should `verify_archive` attempt checksum validation for ZIP (CRC-32) and 7z formats, or only structural/security checks? Currently structural only.]
+- [NEEDS CLARIFICATION: Is there a plan to support 7z creation in a future version, or is read-only permanently by design?]
+- [NEEDS CLARIFICATION: Windows path separator handling in path validation — is there a CI job that runs the test suite on Windows?]
+- [NEEDS CLARIFICATION: Should `ProgressCallback` expose a cancellation mechanism (e.g., return bool to abort)?]
+
+## 10. See Also
+
+- [[constitution]] — project principles
+- [[MOC-specs]] — all specifications
+- [[001-exarch-system/plan]] — technical plan

--- a/specs/001-security-pipeline/spec.md
+++ b/specs/001-security-pipeline/spec.md
@@ -1,0 +1,241 @@
+---
+aliases:
+  - Security Pipeline Spec
+  - exarch Security Spec
+tags:
+  - sdd
+  - spec
+  - security
+  - rust
+created: 2026-05-20
+status: draft
+related:
+  - "[[constitution]]"
+  - "[[MOC-specs]]"
+  - "[[002-format-handlers/spec]]"
+  - "[[003-config-api/spec]]"
+---
+
+# Feature: Security Pipeline
+
+> [!info] Metadata
+> **Subsystem**: exarch-core / security
+> **MSRV**: Rust 1.93.0
+> **Source**: extracted from [[001-exarch-system/spec]]
+
+## 1. Overview
+
+### Problem Statement
+
+Archive extraction is a primary attack surface: path traversal, zip bombs,
+symlink escapes, and hardlink attacks have affected nearly every major archive
+library. Existing Rust crates expose raw decompression without integrated
+validation, leaving each consumer to re-implement mitigations inconsistently.
+
+### Goal
+
+Provide a single, typed security pipeline inside `exarch-core` that validates
+every archive entry before any bytes reach disk. The pipeline is the only
+place where security decisions are made — format handlers and bindings must
+route all entries through it.
+
+### Out of Scope
+
+- Security configuration API (see [[003-config-api/spec]])
+- Format-specific parsing (see [[002-format-handlers/spec]])
+- Progress reporting during validation (see [[004-progress-tracking/spec]])
+- GUI or web interface
+
+## 2. User Stories
+
+### US-001: Path Traversal Prevention
+
+AS A Rust developer using `extract_archive()`
+I WANT every archive entry path to be validated before any file is written
+SO THAT traversal sequences (`../`), absolute paths, null bytes, and banned
+components are rejected before I/O begins
+
+**Acceptance criteria:**
+```
+GIVEN an archive containing a path traversal entry (e.g. "../etc/passwd")
+WHEN extract_archive() is called
+THEN extraction fails with ExtractionError::PathTraversal before any file is written
+```
+
+```
+GIVEN an archive entry path containing a banned component (e.g. ".git/config")
+WHEN extract_archive() is called
+THEN extraction fails with ExtractionError::PathTraversal (banned component)
+```
+
+### US-002: Zip Bomb Detection
+
+AS A security engineer
+I WANT archives with extreme compression ratios to be rejected
+SO THAT a malicious archive cannot exhaust disk space or memory
+
+**Acceptance criteria:**
+```
+GIVEN an archive entry where uncompressed_size / compressed_size > max_compression_ratio
+WHEN the entry is validated
+THEN the entry is rejected with ExtractionError::ZipBomb before any bytes are written
+```
+
+### US-003: Symlink and Hardlink Control
+
+AS A system administrator
+I WANT symlinks and hardlinks to be denied by default
+SO THAT attackers cannot use them to escape the extraction directory
+
+**Acceptance criteria:**
+```
+GIVEN a symlink entry and SecurityConfig with allowed.symlinks = false
+WHEN the entry is validated
+THEN the entry is skipped (not an error)
+```
+
+```
+GIVEN a symlink entry and SecurityConfig with allowed.symlinks = true
+WHEN the resolved target escapes output_dir
+THEN extraction fails with ExtractionError::SymlinkEscape
+```
+
+### US-004: Quota Enforcement
+
+AS A server operator
+I WANT per-file and total-size limits enforced during extraction
+SO THAT a single archive cannot exhaust disk space
+
+**Acceptance criteria:**
+```
+GIVEN a file entry whose uncompressed size exceeds max_file_size
+WHEN the entry is validated
+THEN extraction fails with ExtractionError::QuotaExceeded { resource: FileSizeBytes }
+```
+
+```
+GIVEN cumulative uncompressed size across entries exceeds max_total_size
+WHEN the next entry is validated
+THEN extraction fails with ExtractionError::QuotaExceeded { resource: TotalSizeBytes }
+```
+
+### US-005: Permission Sanitization
+
+AS A system administrator on Unix
+I WANT setuid and setgid bits stripped from extracted files
+SO THAT an archive cannot install privileged executables
+
+**Acceptance criteria:**
+```
+GIVEN a file entry with setuid or setgid bits set (mode & 0o6000 != 0)
+WHEN the entry is extracted on Unix
+THEN the written file has those bits cleared; ValidatedEntry.mode reflects the sanitized value
+```
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN any archive entry path is validated, THE SYSTEM SHALL reject paths containing `../`, absolute paths, null bytes, or components matching `banned_path_components` (case-insensitive) | must |
+| FR-002 | WHEN a file entry's uncompressed size exceeds `max_file_size`, THE SYSTEM SHALL reject it with `QuotaExceeded` | must |
+| FR-003 | WHEN the cumulative uncompressed size across all file entries exceeds `max_total_size`, THE SYSTEM SHALL reject further entries with `QuotaExceeded` | must |
+| FR-004 | WHEN a file entry has a known compressed size and the ratio (uncompressed / compressed) exceeds `max_compression_ratio`, THE SYSTEM SHALL reject it with `ZipBomb` before writing any bytes | must |
+| FR-005 | WHEN a symlink entry is encountered and `allowed.symlinks` is false, THE SYSTEM SHALL skip the entry without returning an error | must |
+| FR-006 | WHEN a symlink entry is encountered and `allowed.symlinks` is true, THE SYSTEM SHALL validate that the resolved symlink target does not escape `output_dir` | must |
+| FR-007 | WHEN a hardlink entry is encountered and `allowed.hardlinks` is false, THE SYSTEM SHALL skip the entry | must |
+| FR-008 | WHEN a hardlink entry is encountered and `allowed.hardlinks` is true, THE SYSTEM SHALL validate that the hardlink target path is within `output_dir` and references a path previously seen in this archive | must |
+| FR-009 | WHEN extracting files on Unix, THE SYSTEM SHALL strip setuid (0o4000) and setgid (0o2000) bits from all file permissions | must |
+| FR-010 | WHEN the path depth of an entry exceeds `max_path_depth`, THE SYSTEM SHALL reject the entry with `ExtractionError::PathTraversal` | must |
+| FR-011 | WHEN `allowed_extensions` is non-empty and an entry's extension is not in the list, THE SYSTEM SHALL skip the entry | should |
+| FR-012 | WHEN the file count across all entries exceeds `max_file_count`, THE SYSTEM SHALL reject further entries with `QuotaExceeded { resource: FileCount }` | must |
+| FR-013 | WHEN `allowed.world_writable` is false and a file entry has world-writable permissions (`mode & 0o002 != 0`), THE SYSTEM SHALL strip that bit or reject the entry | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Security | All security checks run before any bytes are written to disk for each entry |
+| NFR-002 | Security | Path component matching is case-insensitive to prevent bypass on case-insensitive filesystems |
+| NFR-003 | Security | Default limits: 50 MB per file, 500 MB total, 100× compression ratio, 10,000 files, depth 32 |
+| NFR-004 | Security | Default banned components: `.git`, `.ssh`, `.gnupg`, `.aws`, `.kube`, `.docker`, `.env` |
+| NFR-005 | Safety | `deny(unsafe_code)` workspace-wide — no exceptions in this module |
+| NFR-006 | Performance | `canonicalize()` is NOT called per-entry for path traversal; `PathBuf::components()` used instead |
+| NFR-007 | Performance | `DirCache` caches directories created by the extractor to avoid repeated `canonicalize()` syscalls |
+| NFR-008 | Reliability | Quota tracking (`QuotaTracker`) is not reversible — once exceeded, extraction halts |
+
+## 5. Data Model
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| `SafePath` | Newtype for a validated archive entry path; can only be constructed after all traversal, depth, and component checks pass | Wraps `PathBuf`; invariant: no traversal, within dest, depth within limit |
+| `SafeSymlink` | Newtype for a symlink target confirmed to resolve within `output_dir` | Wraps `PathBuf` |
+| `ValidatedEntry` | Archive entry that has passed the full security pipeline | `safe_path: SafePath`, `entry_type: ValidatedEntryType`, `mode: Option<u32>` (sanitized) |
+| `ValidatedEntryType` | Enum of post-validation entry classifications | `File`, `Directory`, `Symlink(SafeSymlink)`, `Hardlink { target: SafePath }` |
+| `EntryValidator` | Stateful orchestrator running all security checks in order per entry | Holds `QuotaTracker`, `HardlinkTracker`, `symlink_seen` flag; references `SecurityConfig` and `DestDir` |
+| `QuotaTracker` | Accumulates file count and total bytes; rejects on limit exceeded | `file_count`, `total_bytes` |
+| `HardlinkTracker` | Records all file paths seen in this archive to validate hardlink targets | `seen: HashSet<PathBuf>` |
+| `DestDir` | Canonicalized output directory; used as the trust boundary for symlink/hardlink validation | Wraps `PathBuf` |
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Path traversal `../` or absolute path | `ExtractionError::PathTraversal` |
+| Null byte in path | `ExtractionError::PathTraversal` |
+| Banned component (e.g. `.git`) in path | `ExtractionError::PathTraversal` (banned component) |
+| Path depth > `max_path_depth` | `ExtractionError::PathTraversal` (depth exceeded) |
+| File exceeds `max_file_size` | `ExtractionError::QuotaExceeded { resource: FileSizeBytes }` |
+| Total size exceeds `max_total_size` | `ExtractionError::QuotaExceeded { resource: TotalSizeBytes }` |
+| File count exceeds `max_file_count` | `ExtractionError::QuotaExceeded { resource: FileCount }` |
+| Compression ratio > `max_compression_ratio` | `ExtractionError::ZipBomb` (before any bytes written) |
+| Compression ratio not available (TAR streams) | Zip bomb check skipped for that entry; quota still enforced |
+| Symlink with `allowed.symlinks = false` | Entry skipped (not an error) |
+| Symlink pointing outside `output_dir` | `ExtractionError::SymlinkEscape` |
+| Hardlink with `allowed.hardlinks = false` | Entry skipped |
+| Hardlink to a path not previously seen | `ExtractionError::HardlinkEscape` |
+| setuid/setgid bits on Unix | Stripped silently; `ValidatedEntry.mode` reflects sanitized value |
+| `SecurityConfig` with zero limit | `SecurityConfig::validate()` returns `InvalidConfiguration` before extraction begins |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | Path traversal attempts blocked | 100% of known CVE-pattern archives rejected |
+| SC-002 | Zip bomb detection | Archives with ratio > 100× rejected before first byte written |
+| SC-003 | Symlink escape prevention | Symlinks resolving outside `output_dir` always rejected |
+| SC-004 | Security checks have property-based or integration tests | All checks covered |
+| SC-005 | `deny(unsafe_code)` in security module | Zero `unsafe` blocks |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Run all security checks before any I/O for every entry
+- Use `PathBuf::components()` for traversal detection — do not call `canonicalize()` per-entry
+- Add `///` doc comments to every `pub` item in this module
+- Keep security checks in `exarch-core/src/security/` — never in bindings or CLI
+
+### Ask First
+- Changing `SecurityConfig` default values (security policy change)
+- Modifying `EntryValidator` trait or `ValidatedEntry` structure (breaking API change)
+- Enabling any `AllowedFeatures` flag by default
+- Raising or removing any quota default
+
+### Never
+- Remove existing security checks or lower default quota limits without a security review
+- Add `#[allow(unsafe_code)]` in any security module
+- Call `canonicalize()` inside the hot per-entry validation path
+- Allow `ExtractionError` variants to be constructed outside `exarch-core`
+
+## 9. Open Questions
+
+- [NEEDS CLARIFICATION: Should `ProgressCallback` expose a cancellation mechanism (return bool) so callers can abort mid-stream from the security callback?]
+- [NEEDS CLARIFICATION: Windows path separator handling (`\` vs `/`) — is there a CI job covering Windows path validation edge cases?]
+- [NEEDS CLARIFICATION: Should world-writable entries be stripped or rejected? Current behavior unclear.]
+
+## 10. See Also
+
+- [[constitution]] — project principles (security section)
+- [[MOC-specs]] — all specifications
+- [[002-format-handlers/spec]] — format handlers that route entries through this pipeline
+- [[003-config-api/spec]] — `SecurityConfig`, `AllowedFeatures` configuration types
+- [[001-exarch-system/spec]] — original monolithic spec (archived)

--- a/specs/001-security-pipeline/tasks.md
+++ b/specs/001-security-pipeline/tasks.md
@@ -1,0 +1,122 @@
+---
+aliases:
+  - Security Pipeline Tasks
+tags:
+  - sdd
+  - tasks
+  - security
+  - rust
+created: 2026-05-20
+status: draft
+related:
+  - "[[spec]]"
+  - "[[001-exarch-system/plan]]"
+  - "[[constitution]]"
+---
+
+# Implementation Tasks: Security Pipeline
+
+> [!info] References
+> **Spec**: [[spec]]
+> **Plan**: [[001-exarch-system/plan]]
+> **Total tasks**: 2
+
+> [!warning] Scope
+> The security pipeline is substantially implemented. The only open gap is
+> FR-011 / FR-013: `allowed_extensions` is defined in `SecurityConfig` but
+> the `EntryValidator` never reads it, so extension filtering is silently
+> skipped during extraction. GitHub issue #230 tracks this.
+
+## Progress
+
+- [ ] T001: Enforce `allowed_extensions` in `EntryValidator`
+- [ ] T002: Add integration tests for extension filtering
+
+---
+
+## Dependency Graph
+
+```mermaid
+graph TD
+    T001[T001: enforce allowed_extensions in EntryValidator] --> T002[T002: integration tests]
+```
+
+---
+
+### T001: Enforce `allowed_extensions` in `EntryValidator`
+
+**Context**: `SecurityConfig::allowed_extensions` is populated by callers and
+exposed through the builder API, but `EntryValidator::validate()` never consults
+it. As a result the field is silently ignored and FR-011 is unimplemented.
+The fix is a single check inside `EntryValidator::validate()` after path
+validation succeeds: if `allowed_extensions` is non-empty and the entry
+extension (case-insensitive) is not in the list, return `Action::Skip`.
+**Spec reference**: [[spec#FR-011]]
+**GitHub issue**: #230
+**Acceptance criteria**:
+- [ ] `EntryValidator::validate()` reads `config.allowed_extensions` when the vec is non-empty
+- [ ] Extension matching is case-insensitive (e.g. `.TXT` matches `"txt"`)
+- [ ] Entries with no extension are skipped when `allowed_extensions` is non-empty
+- [ ] Entries with an allowed extension are not affected
+- [ ] When `allowed_extensions` is empty (default), behaviour is unchanged
+- [ ] Unit tests in `security/validator.rs` cover the skip and allow paths
+- [ ] `deny(unsafe_code)` still holds; no new `unsafe` blocks
+**Dependencies**: none
+**Files**:
+- `crates/exarch-core/src/security/validator.rs` — add extension check in `validate()`
+- `crates/exarch-core/src/security/context.rs` — check if `ValidationContext` needs extension data
+**Complexity**: low
+
+---
+
+### T002: Integration tests for extension filtering
+
+**Context**: Unit tests in `validator.rs` verify the skip logic in isolation.
+Integration tests are needed to confirm that extraction through the full API
+path (`extract_archive()` → format handler → `EntryValidator`) also honours the
+filter, for both TAR and ZIP handlers.
+**Spec reference**: [[spec#FR-011]], [[spec#SC-004]]
+**GitHub issue**: #230
+**Acceptance criteria**:
+- [ ] Integration test: extract a TAR archive with `allowed_extensions = ["txt"]`; only `.txt` files appear in output directory
+- [ ] Integration test: extract a ZIP archive with `allowed_extensions = ["rs"]`; only `.rs` files extracted
+- [ ] Integration test: `allowed_extensions = []` (empty) extracts all files
+- [ ] Tests use fixtures from `crates/exarch-core/tests/fixtures/` or create temp archives with `test_utils`
+- [ ] All tests pass under `cargo nextest run -p exarch-core`
+**Dependencies**: T001
+**Files**:
+- `crates/exarch-core/tests/` — new integration test file or extend existing extract tests
+**Complexity**: low
+
+---
+
+## Implementation Notes
+
+### Order of execution
+
+T001 must land first; T002 is a follow-up that can be done in the same PR or
+a separate one. Both are small enough for a single session each.
+
+### Common patterns
+
+- Look at `security/quota.rs` (`QuotaTracker`) and `security/path.rs` for how
+  `SecurityConfig` fields are accessed inside `validate()`.
+- Extension extraction: use `Path::extension()` and compare with
+  `eq_ignore_ascii_case`.
+- For the `Action::Skip` return path, follow the existing pattern used for
+  `allowed.symlinks = false` in `validator.rs`.
+
+### Gotchas
+
+- Entries with no extension (`Path::extension()` returns `None`) must be treated
+  as non-matching when `allowed_extensions` is non-empty.
+- Extension comparison must strip the leading dot if `SecurityConfig` stores
+  extensions without it (confirm by reading `with_allowed_extensions` doc-test).
+- Do not call `to_lowercase()` on heap-allocated strings in the hot path; use
+  `eq_ignore_ascii_case` instead (aligns with NFR-006 / NFR-002).
+
+## See Also
+
+- [[spec]] — feature specification
+- [[001-exarch-system/plan]] — technical plan
+- [[MOC-specs]] — all specifications

--- a/specs/002-format-handlers/spec.md
+++ b/specs/002-format-handlers/spec.md
@@ -1,0 +1,259 @@
+---
+aliases:
+  - Format Handlers Spec
+  - Archive Format Spec
+tags:
+  - sdd
+  - spec
+  - archive
+  - rust
+created: 2026-05-20
+status: draft
+related:
+  - "[[constitution]]"
+  - "[[MOC-specs]]"
+  - "[[001-security-pipeline/spec]]"
+  - "[[003-config-api/spec]]"
+  - "[[004-progress-tracking/spec]]"
+---
+
+# Feature: Format Handlers
+
+> [!info] Metadata
+> **Subsystem**: exarch-core / formats
+> **MSRV**: Rust 1.93.0
+> **Source**: extracted from [[001-exarch-system/spec]]
+
+## 1. Overview
+
+### Problem Statement
+
+Each archive format (TAR variants, ZIP, 7z) requires different parsing logic,
+decompression stacks, and entry iteration models. Without a uniform abstraction,
+format-specific quirks bleed into security and reporting code, making it hard
+to add formats or change security policy uniformly.
+
+### Goal
+
+Provide a single `ArchiveFormat` trait that every format handler implements,
+giving the rest of `exarch-core` a uniform extract/list/verify interface
+regardless of the underlying format. A complementary `FormatCreator` trait
+covers archive creation. Format detection is performed once at the API boundary
+using both file extension and a fixed set of ZIP-family aliases.
+
+### Out of Scope
+
+- RAR archive support
+- Archive encryption or signing
+- 7z archive creation (extraction only — `FormatCreator` not implemented for 7z)
+- Streaming/incremental extraction over network (local files only)
+- Magic byte detection (format is determined from extension only)
+
+## 2. User Stories
+
+### US-001: TAR Extraction
+
+AS A Rust developer
+I WANT to extract `.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tar.zst`, and `.tar` archives
+with a single call
+SO THAT I do not need to select the correct decompressor manually
+
+**Acceptance criteria:**
+```
+GIVEN an archive path with a recognized TAR extension
+WHEN extract_archive() is called
+THEN the correct decompressor is selected automatically and extraction proceeds
+through the security pipeline
+```
+
+### US-002: ZIP Extraction including Aliases
+
+AS A developer or operator
+I WANT `.jar`, `.apk`, `.whl`, and other ZIP-family archives to be extractable
+SO THAT I can inspect their contents without a separate tool
+
+**Acceptance criteria:**
+```
+GIVEN an archive path with a ZIP-family alias extension (e.g. .apk, .jar, .whl)
+WHEN extract_archive() is called
+THEN the archive is treated as ZIP and extraction proceeds normally
+```
+
+### US-003: ZIP-Family Alias Creation Rejection
+
+AS A developer
+I WANT archive creation to reject ZIP-family aliases without an explicit format override
+SO THAT I am not silently given a bare ZIP file named .apk
+
+**Acceptance criteria:**
+```
+GIVEN an output path with a ZIP-family alias extension and no CreationConfig::format override
+WHEN create_archive() is called
+THEN the call fails with ExtractionError::InvalidArchive with an explanatory message
+```
+
+### US-004: 7z Extraction Only
+
+AS A developer
+I WANT `.7z` archives to be extractable
+SO THAT I can use exarch as a single tool for all common formats
+
+**Acceptance criteria:**
+```
+GIVEN a valid .7z archive
+WHEN extract_archive() is called
+THEN extraction proceeds through the security pipeline and files are written to output_dir
+```
+
+```
+GIVEN a .7z output path
+WHEN create_archive() is called
+THEN the call fails with ExtractionError::UnsupportedFormat
+```
+
+### US-005: Solid 7z Rejection by Default
+
+AS A server operator
+I WANT solid 7z archives to be rejected unless explicitly enabled
+SO THAT a malicious solid archive cannot exhaust memory
+
+**Acceptance criteria:**
+```
+GIVEN a solid 7z archive and SecurityConfig with allow_solid_archives = false
+WHEN extract_archive() is called
+THEN extraction fails before decompressing the solid block
+```
+
+### US-006: Format Detection
+
+AS A developer
+I WANT the correct handler selected automatically from the archive extension
+SO THAT I do not need to specify the format explicitly
+
+**Acceptance criteria:**
+```
+GIVEN an archive path with an unrecognized extension
+WHEN any archive operation is called
+THEN ExtractionError::UnsupportedFormat is returned immediately
+```
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-020 | WHEN an archive path has extension `.tar`, `.tgz`, `.tar.gz`, `.tar.bz2`, `.tbz`, `.tbz2`, `.tar.xz`, `.txz`, `.tar.zst`, `.tzst`, THE SYSTEM SHALL extract it as a TAR archive with the appropriate decompressor | must |
+| FR-021 | WHEN an archive path has extension `.zip` or any ZIP-family alias, THE SYSTEM SHALL extract it as a ZIP archive | must |
+| FR-022 | WHEN an archive path has extension `.7z`, THE SYSTEM SHALL extract it using the 7z handler | must |
+| FR-023 | WHEN format detection finds an unrecognized or ambiguous extension (e.g. bare `.gz` without `.tar` stem), THE SYSTEM SHALL return `ExtractionError::UnsupportedFormat` | must |
+| FR-024 | WHEN creating archives, THE SYSTEM SHALL support TAR (all compression variants) and ZIP; 7z creation SHALL return `UnsupportedFormat` | must |
+| FR-025 | WHEN creating archives for ZIP-family aliases without an explicit `CreationConfig::format` override, THE SYSTEM SHALL return `ExtractionError::InvalidArchive` with an explanation | should |
+| FR-026 | WHEN a 7z archive is solid and `allow_solid_archives` is false, THE SYSTEM SHALL reject extraction before decompressing the solid block | must |
+| FR-027 | WHEN a 7z solid archive extraction is permitted, THE SYSTEM SHALL reject it if total uncompressed size exceeds `max_solid_block_memory` | must |
+| FR-028 | Every format handler SHALL route all entries through `EntryValidator` before writing to disk | must |
+| FR-029 | WHEN listing or verifying an archive, THE SYSTEM SHALL NOT write any files to disk | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Performance | `BufReader` wraps all TAR file handles to reduce syscall count |
+| NFR-002 | Performance | `CopyBuffer` (reusable buffer) used for all byte copying in format handlers |
+| NFR-003 | Reliability | Solid 7z archives are rejected by default (`allow_solid_archives: false`) |
+| NFR-004 | Portability | Format detection is case-insensitive on extension matching |
+| NFR-005 | Maintainability | Every format handler implements `ArchiveFormat` — no format-specific logic in `api.rs` |
+
+## 5. Data Model
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| `ArchiveType` | Enum of supported archive formats | `Tar`, `TarGz`, `TarBz2`, `TarXz`, `TarZst`, `Zip`, `SevenZ` |
+| `ArchiveFormat` | Trait implemented by every format handler | Methods: `extract`, `list`, `verify`, `format_name` |
+| `FormatCreator` | Trait for archive creation; implemented by TAR variants and ZIP | Methods: `create`, `format_name` |
+| `TarArchive<R>` | TAR handler generic over decompressor type | Implements `ArchiveFormat` |
+| `ZipArchive` | ZIP handler | Implements `ArchiveFormat` and `FormatCreator` |
+| `SevenZArchive` | 7z handler (read-only) | Implements `ArchiveFormat` only |
+
+### ArchiveType Detection Rules
+
+| Extension(s) | ArchiveType |
+|---|---|
+| `.tar` | `Tar` |
+| `.tar.gz`, `.tgz` | `TarGz` |
+| `.tar.bz2`, `.tbz`, `.tbz2` | `TarBz2` |
+| `.tar.xz`, `.txz` | `TarXz` |
+| `.tar.zst`, `.tzst` | `TarZst` |
+| `.zip` | `Zip` |
+| `.jar`, `.war`, `.ear`, `.nar`, `.nbm`, `.apk`, `.aab`, `.ipa`, `.appx`, `.msix`, `.whl`, `.vsix`, `.xpi`, `.epub` | `Zip` (extraction) / error (creation) |
+| `.7z` | `SevenZ` |
+| `.gz` (no `.tar` stem), anything else | `UnsupportedFormat` |
+
+> [!note]
+> Format detection is extension-based, case-insensitive. Magic byte detection is NOT currently implemented.
+
+### Trait Signatures
+
+```
+ArchiveFormat:
+  extract(output_dir, config, options, progress) -> Result<ExtractionReport>
+  list(config) -> Result<ArchiveManifest>
+  verify(config) -> Result<VerificationReport>
+  format_name() -> &'static str
+
+FormatCreator:
+  create(output, sources, config, progress) -> Result<CreationReport>
+  format_name() -> &'static str
+```
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Archive path does not exist | `ExtractionError::Io` returned immediately |
+| Extension unrecognized or bare `.gz` without `.tar` stem | `ExtractionError::UnsupportedFormat` |
+| ZIP-family alias extraction | Proceeds as ZIP |
+| ZIP-family alias creation without format override | `ExtractionError::InvalidArchive` with explanation |
+| 7z creation | `ExtractionError::UnsupportedFormat` |
+| Solid 7z with `allow_solid_archives = false` | Extraction rejected before decompressing |
+| Solid 7z with total uncompressed size > `max_solid_block_memory` | `ExtractionError::QuotaExceeded` or format-specific rejection |
+| Corrupt archive (unreadable headers) | `ExtractionError::InvalidArchive`; `verify_archive` returns `VerificationReport` with issues |
+| Compression ratio unavailable per-entry (TAR streams) | Zip bomb check skipped for that entry; total quota still enforced |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | All TAR compression variants extract correctly | Integration tests for each variant pass |
+| SC-002 | ZIP-family aliases extract as ZIP | Test coverage for at least `.jar`, `.apk`, `.whl` |
+| SC-003 | 7z solid archive rejection | Test with solid fixture; rejected when `allow_solid_archives = false` |
+| SC-004 | `ArchiveFormat` implementors are interchangeable | No format-specific code in `api.rs` |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Route all entries through `EntryValidator` before any I/O
+- Implement `format_name()` returning a human-readable static string
+- Use `BufReader` for TAR file handles
+
+### Ask First
+- Modifying `ArchiveFormat` or `FormatCreator` trait signatures (breaking API change)
+- Adding a new format handler
+- Changing ZIP-family alias list
+
+### Never
+- Write files to disk during `list()` or `verify()`
+- Implement security logic inside a format handler (delegate to `EntryValidator`)
+- Implement 7z creation without security review of `sevenz-rust2` write support
+
+## 9. Open Questions
+
+- [NEEDS CLARIFICATION: Is there a plan to support 7z creation in a future version, or is read-only permanently by design?]
+- [NEEDS CLARIFICATION: Should magic byte detection be added alongside extension detection for robustness?]
+
+## 10. See Also
+
+- [[constitution]] — format abstraction principles
+- [[MOC-specs]] — all specifications
+- [[001-security-pipeline/spec]] — `EntryValidator` that format handlers must use
+- [[003-config-api/spec]] — `SecurityConfig`, `CreationConfig`, `ExtractionOptions`
+- [[004-progress-tracking/spec]] — `ProgressCallback` passed to `extract` and `create`
+- [[001-exarch-system/spec]] — original monolithic spec (archived)

--- a/specs/002-format-handlers/tasks.md
+++ b/specs/002-format-handlers/tasks.md
@@ -1,0 +1,95 @@
+---
+aliases:
+  - Format Handlers Tasks
+tags:
+  - sdd
+  - tasks
+  - archive
+  - rust
+created: 2026-05-20
+status: draft
+related:
+  - "[[spec]]"
+  - "[[001-exarch-system/plan]]"
+  - "[[constitution]]"
+---
+
+# Implementation Tasks: Format Handlers
+
+> [!info] References
+> **Spec**: [[spec]]
+> **Plan**: [[001-exarch-system/plan]]
+> **Total tasks**: 1
+
+> [!warning] Scope
+> Format handler extraction, listing, and verification are fully implemented
+> for TAR variants, ZIP, and 7z. The single open gap is FR-025: ZIP-family
+> alias creation rejection is implemented in `api.rs` but does not surface a
+> clear, user-facing error message containing the alias name and the available
+> override mechanism. GitHub issue #231 tracks this.
+
+## Progress
+
+- [ ] T001: Improve ZIP-family alias creation error message
+
+---
+
+## Dependency Graph
+
+```mermaid
+graph TD
+    T001[T001: improve ZIP-family alias creation error message]
+```
+
+---
+
+### T001: Improve ZIP-family alias creation error message
+
+**Context**: `reject_zip_family_creation()` in `api.rs` already returns
+`ExtractionError::InvalidArchive` when a caller tries to create an archive with
+a ZIP-family alias extension (e.g. `.apk`, `.whl`) without an explicit
+`CreationConfig::format` override. However the current error string does not
+tell the user which extension was detected or how to bypass the guard. FR-025
+says the error should contain "an explanatory message"; the spec acceptance
+criterion requires a message that names the alias and the override.
+**Spec reference**: [[spec#FR-025]], [[spec#US-003]]
+**GitHub issue**: #231
+**Acceptance criteria**:
+- [ ] The `InvalidArchive` error message includes the detected alias extension (e.g. `.apk`)
+- [ ] The message explains that the extension is a ZIP-family alias and creation is blocked by default
+- [ ] The message references the `CreationConfig::format` override as the escape hatch
+- [ ] Existing unit test `test_create_archive_zip_family_not_supported` is updated to assert the improved message content
+- [ ] Existing test `test_create_archive_zip_family_override_bypasses_guard` continues to pass
+- [ ] No behaviour change — only the error message text changes
+**Dependencies**: none
+**Files**:
+- `crates/exarch-core/src/api.rs` — `reject_zip_family_creation()` function (line ~611)
+**Complexity**: low
+
+---
+
+## Implementation Notes
+
+### Order of execution
+
+Single task; can be merged independently.
+
+### Common patterns
+
+- The existing error is constructed with `ExtractionError::InvalidArchive`.
+  Extend the message string inline — no new error variant needed.
+- Retrieve the extension from the `output` path argument already available in
+  `reject_zip_family_creation()`.
+
+### Gotchas
+
+- `ExtractionError::InvalidArchive` carries a `String` message field; confirm
+  the exact field name before editing.
+- Keep the message concise — it will appear in CLI stderr output and in Python
+  / Node.js `ExarchError` messages.
+
+## See Also
+
+- [[spec]] — feature specification
+- [[001-exarch-system/plan]] — technical plan
+- [[MOC-specs]] — all specifications

--- a/specs/003-config-api/spec.md
+++ b/specs/003-config-api/spec.md
@@ -1,0 +1,214 @@
+---
+aliases:
+  - Config API Spec
+  - SecurityConfig Spec
+tags:
+  - sdd
+  - spec
+  - config
+  - rust
+created: 2026-05-20
+status: draft
+related:
+  - "[[constitution]]"
+  - "[[MOC-specs]]"
+  - "[[001-security-pipeline/spec]]"
+  - "[[002-format-handlers/spec]]"
+---
+
+# Feature: Configuration API
+
+> [!info] Metadata
+> **Subsystem**: exarch-core / config, creation
+> **MSRV**: Rust 1.93.0
+> **Source**: extracted from [[001-exarch-system/spec]]
+
+## 1. Overview
+
+### Problem Statement
+
+Security policy, creation options, and extraction behavior must be expressible
+at the call site without mutating shared state. A single mutable global config
+or stringly-typed options map would make it easy to accidentally weaken security
+defaults or produce invalid configurations.
+
+### Goal
+
+Provide three immutable, builder-pattern configuration types — `SecurityConfig`,
+`CreationConfig`, and `ExtractionOptions` — that encode all tunable parameters
+with secure deny-by-default values, validated before use.
+
+### Out of Scope
+
+- Runtime configuration file parsing (TOML/YAML/JSON)
+- Environment-variable-driven configuration
+- Dynamic config mutation after construction
+
+## 2. User Stories
+
+### US-001: Secure Default Extraction
+
+AS A Rust developer
+I WANT to call `extract_archive()` with `SecurityConfig::default()` and get safe behavior
+SO THAT I do not need to know the security parameters to be protected
+
+**Acceptance criteria:**
+```
+GIVEN SecurityConfig::default()
+THEN symlinks, hardlinks, absolute paths, world-writable files, and solid archives are all denied;
+     max_file_size is 50 MB, max_total_size is 500 MB, max_compression_ratio is 100.0,
+     max_file_count is 10,000, max_path_depth is 32
+```
+
+### US-002: Custom Security Policy
+
+AS A developer integrating exarch into a controlled environment
+I WANT to override specific limits via a fluent builder
+SO THAT I can raise or lower limits appropriate to my use case
+
+**Acceptance criteria:**
+```
+GIVEN SecurityConfig::default().with_max_file_size(200 * 1024 * 1024).with_allow_symlinks(true)
+WHEN passed to extract_archive()
+THEN extraction allows symlinks and accepts files up to 200 MB
+```
+
+### US-003: Configuration Validation
+
+AS A developer
+I WANT SecurityConfig::validate() to catch invalid configurations early
+SO THAT extraction does not start with a zero or non-finite limit
+
+**Acceptance criteria:**
+```
+GIVEN SecurityConfig::default().with_max_file_size(0)
+WHEN validate() is called
+THEN it returns ExtractionError::InvalidConfiguration before extraction begins
+```
+
+### US-004: Archive Creation Configuration
+
+AS A developer building a packaging tool
+I WANT to control compression level, file filtering, and symlink handling during creation
+SO THAT I can produce well-formed archives without manual format handling
+
+**Acceptance criteria:**
+```
+GIVEN CreationConfig::default().with_compression_level(9).with_exclude_patterns(vec!["*.log"])
+WHEN create_archive() is called
+THEN all .log files are excluded and maximum compression is applied
+```
+
+### US-005: Atomic Extraction
+
+AS A server operator
+I WANT to enable atomic extraction so that no partial output is left on failure
+SO THAT a failed extraction does not leave a half-written directory
+
+**Acceptance criteria:**
+```
+GIVEN ExtractionOptions::default().with_atomic(true)
+WHEN extraction fails mid-archive
+THEN no files are present in the output directory; the temp dir is cleaned up
+```
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-030 | `SecurityConfig` SHALL use a fluent builder API (`with_*` methods returning `Self`) and implement `Default` with secure deny-by-default settings | must |
+| FR-031 | `SecurityConfig` SHALL be annotated `#[non_exhaustive]` so new fields do not constitute a breaking change for struct literal construction | must |
+| FR-032 | `SecurityConfig::validate()` SHALL return an error if any limit field is zero or `max_compression_ratio` is not a positive finite number | must |
+| FR-033 | `CreationConfig` SHALL support: `follow_symlinks`, `include_hidden`, `max_file_size`, `exclude_patterns` (glob), `strip_prefix`, `compression_level` (1–9), `preserve_permissions`, `format` override | must |
+| FR-034 | `ExtractionOptions` SHALL support: `atomic` (temp-dir + rename), `skip_duplicates` (default true) | must |
+| FR-035 | WHEN `ExtractionOptions::atomic` is true, THE SYSTEM SHALL extract to a temp dir in the same parent as the output directory and atomically rename on success | must |
+| FR-036 | WHEN atomic extraction fails, THE SYSTEM SHALL delete the temp dir before returning the error | must |
+| FR-037 | All three config types SHALL implement `Default` with documented defaults | must |
+| FR-038 | `AllowedFeatures` SHALL be a separate struct with boolean flags: `symlinks`, `hardlinks`, `absolute_paths`, `world_writable`; all default to false | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Safety | Configuration is immutable after construction — no interior mutability |
+| NFR-002 | Reliability | Atomic extraction (`ExtractionOptions::atomic`) ensures all-or-nothing semantics on same filesystem |
+| NFR-003 | Usability | Fluent builder chains are ergonomic: each `with_*` method returns `Self` |
+| NFR-004 | Compatibility | `#[non_exhaustive]` on `SecurityConfig` prevents downstream struct literal construction |
+
+## 5. Data Model
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| `SecurityConfig` | Security policy for extraction and inspection operations | `max_file_size`, `max_total_size`, `max_compression_ratio`, `max_file_count`, `max_path_depth`, `allowed: AllowedFeatures`, `banned_path_components`, `allowed_extensions`, `allow_solid_archives`, `max_solid_block_memory` |
+| `AllowedFeatures` | Feature flags for deny-by-default policy | `symlinks: bool`, `hardlinks: bool`, `absolute_paths: bool`, `world_writable: bool` |
+| `CreationConfig` | Configuration for archive creation | `follow_symlinks`, `include_hidden`, `max_file_size`, `exclude_patterns`, `strip_prefix`, `compression_level` (1–9), `preserve_permissions`, `format: Option<ArchiveType>` |
+| `ExtractionOptions` | Operational options for extraction (non-security) | `atomic: bool`, `skip_duplicates: bool` |
+
+### SecurityConfig Defaults
+
+| Field | Default |
+|-------|---------|
+| `max_file_size` | 50 MB (52,428,800 bytes) |
+| `max_total_size` | 500 MB (524,288,000 bytes) |
+| `max_compression_ratio` | 100.0 |
+| `max_file_count` | 10,000 |
+| `max_path_depth` | 32 |
+| `allowed.symlinks` | false |
+| `allowed.hardlinks` | false |
+| `allowed.absolute_paths` | false |
+| `allowed.world_writable` | false |
+| `preserve_permissions` | false |
+| `allowed_extensions` | `[]` (all allowed) |
+| `banned_path_components` | `.git`, `.ssh`, `.gnupg`, `.aws`, `.kube`, `.docker`, `.env` |
+| `allow_solid_archives` | false |
+| `max_solid_block_memory` | 512 MB |
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| `SecurityConfig` with zero `max_file_size` | `validate()` returns `InvalidConfiguration` |
+| `SecurityConfig` with `max_compression_ratio` of 0.0, negative, or NaN | `validate()` returns `InvalidConfiguration` |
+| `compression_level` outside 1–9 | `CreationConfig` builder panics or returns error at construction |
+| `atomic = true` and output on a different filesystem than temp dir | `fs::rename` may fail; caller receives `ExtractionError::Io` |
+| `skip_duplicates = false` and duplicate entry | `ExtractionError::InvalidArchive` (duplicate entry) |
+| Atomic extraction fails mid-archive | Temp dir deleted; `ExtractionError` returned; no files in output dir |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | `SecurityConfig::default()` covers all deny-by-default policies | Verified by unit test |
+| SC-002 | `validate()` rejects all invalid configurations | Property-based tests with zero/negative/NaN inputs |
+| SC-003 | Atomic extraction leaves no partial output | Integration test: inject failure mid-archive |
+| SC-004 | Fluent builder produces correct configuration | Unit tests for each `with_*` method |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Validate `SecurityConfig` before passing to any operation
+- Use `Default` implementations as the canonical starting point for config construction
+- Document the default value for every field in `///` doc comments
+
+### Ask First
+- Changing any `SecurityConfig` default value (security policy change)
+- Adding a new field to `SecurityConfig` (must also update `#[non_exhaustive]` considerations)
+- Enabling any `AllowedFeatures` flag by default
+
+### Never
+- Add mutable state to any config type after construction
+- Bypass `validate()` in any code path that accepts a `SecurityConfig`
+- Raise or remove quota defaults without a security review
+
+## 9. Open Questions
+
+- [NEEDS CLARIFICATION: Should `CreationConfig::compression_level` validate range at construction (panic/error) or defer to the compression backend?]
+- [NEEDS CLARIFICATION: Should `ExtractionOptions` include a `max_concurrency` field for future parallel extraction?]
+
+## 10. See Also
+
+- [[constitution]] — immutable config and fluent builder principles
+- [[MOC-specs]] — all specifications
+- [[001-security-pipeline/spec]] — consumes `SecurityConfig` and `AllowedFeatures`
+- [[002-format-handlers/spec]] — consumes `CreationConfig` and `ExtractionOptions`
+- [[001-exarch-system/spec]] — original monolithic spec (archived)

--- a/specs/003-config-api/tasks.md
+++ b/specs/003-config-api/tasks.md
@@ -1,0 +1,39 @@
+---
+aliases:
+  - Config API Tasks
+tags:
+  - sdd
+  - tasks
+  - config
+  - rust
+created: 2026-05-20
+status: done
+related:
+  - "[[spec]]"
+  - "[[001-exarch-system/plan]]"
+  - "[[constitution]]"
+---
+
+# Implementation Tasks: Configuration API
+
+> [!info] References
+> **Spec**: [[spec]]
+> **Plan**: [[001-exarch-system/plan]]
+> **Total tasks**: 0
+
+> [!note] No open work
+> The Configuration API subsystem is fully implemented. `SecurityConfig`,
+> `AllowedFeatures`, `CreationConfig`, and `ExtractionOptions` all expose
+> fluent builder APIs, carry `#[non_exhaustive]`, and are documented with
+> `///` doc comments and `# Examples` sections. All builder methods have
+> unit tests. No functional requirements from the spec remain unimplemented.
+
+## Progress
+
+(no tasks)
+
+## See Also
+
+- [[spec]] — feature specification
+- [[001-exarch-system/plan]] — technical plan
+- [[MOC-specs]] — all specifications

--- a/specs/004-progress-tracking/spec.md
+++ b/specs/004-progress-tracking/spec.md
@@ -1,0 +1,198 @@
+---
+aliases:
+  - Progress Tracking Spec
+  - ProgressCallback Spec
+tags:
+  - sdd
+  - spec
+  - progress
+  - rust
+created: 2026-05-20
+status: draft
+related:
+  - "[[constitution]]"
+  - "[[MOC-specs]]"
+  - "[[002-format-handlers/spec]]"
+  - "[[005-cli/spec]]"
+---
+
+# Feature: Progress Tracking
+
+> [!info] Metadata
+> **Subsystem**: exarch-core / report, io
+> **MSRV**: Rust 1.93.0
+> **Source**: extracted from [[001-exarch-system/spec]]
+
+## 1. Overview
+
+### Problem Statement
+
+Long-running archive operations (extraction of thousands of files, creation of
+compressed archives) need a way to report progress to the caller without
+coupling the core library to any specific UI framework or output format.
+At the same time, zero-overhead extraction must remain possible when no
+progress reporting is needed.
+
+### Goal
+
+Define a `ProgressCallback` trait with zero overhead when unused (`NoopProgress`)
+and clear lifecycle semantics (entry start, bytes written, entry complete, all
+complete), so that the CLI, Python, and Node.js layers can wire in their own
+reporters without modifying `exarch-core`.
+
+### Out of Scope
+
+- Cancellation via the progress callback (potential future addition — see Open Questions)
+- Estimated time remaining (ETA) calculation
+- Thread-safe multi-producer progress reporting
+
+## 2. User Stories
+
+### US-001: Zero-Overhead Extraction
+
+AS A Rust developer calling `extract_archive()` without a progress handler
+I WANT extraction to have no overhead from progress tracking
+SO THAT performance is not penalized in the common case
+
+**Acceptance criteria:**
+```
+GIVEN extract_archive() called without a progress argument
+THEN NoopProgress is used internally; no allocations or virtual dispatch per entry
+```
+
+### US-002: Per-Entry Progress Reporting
+
+AS A CLI tool author
+I WANT to receive callbacks as each archive entry is started, written to, and completed
+SO THAT I can update a progress bar in real time
+
+**Acceptance criteria:**
+```
+GIVEN a custom ProgressCallback implementation
+WHEN extract_archive_with_progress() is called
+THEN on_entry_start is called before writing the entry,
+     on_bytes_written is called for each write chunk,
+     on_entry_complete is called after the entry is fully written
+```
+
+### US-003: Completion Signal on Success Only
+
+AS A caller using the progress callback for cleanup signaling
+I WANT on_complete to be called only when extraction fully succeeds
+SO THAT I can distinguish complete success from partial or failed extraction
+
+**Acceptance criteria:**
+```
+GIVEN extraction that fails mid-archive
+WHEN the error is returned
+THEN on_complete has NOT been called
+```
+
+```
+GIVEN extraction that succeeds for all entries
+WHEN ExtractionReport is returned
+THEN on_complete has been called exactly once
+```
+
+### US-004: Creation Progress
+
+AS A developer using create_archive_with_progress()
+I WANT progress callbacks during archive creation
+SO THAT I can report file-packing progress to the user
+
+**Acceptance criteria:**
+```
+GIVEN a custom ProgressCallback and create_archive_with_progress()
+WHEN archive creation runs
+THEN on_entry_start and on_entry_complete are called for each source file added
+```
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-040 | THE SYSTEM SHALL expose a `ProgressCallback` trait with methods: `on_entry_start(path, total, current)`, `on_bytes_written(bytes)`, `on_entry_complete(path)`, `on_complete()` | must |
+| FR-041 | THE SYSTEM SHALL provide a `NoopProgress` implementation that satisfies `ProgressCallback` with no runtime overhead | must |
+| FR-042 | `on_complete` SHALL NOT be called if extraction fails or is partial | must |
+| FR-043 | `ProgressCallback` SHALL be `Send` so it can be used across thread boundaries (Node.js, Python) | must |
+| FR-044 | Format handlers SHALL accept `&mut dyn ProgressCallback` and call it consistently for each entry | must |
+| FR-045 | `on_bytes_written` SHALL be called with the number of bytes written in the current chunk, not a cumulative total | must |
+| FR-046 | `on_entry_start` SHALL receive the total number of entries (if known) and the current entry index | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Performance | `NoopProgress` must compile away to nothing; no virtual dispatch when `NoopProgress` is used as a concrete type |
+| NFR-002 | Performance | Progress overhead measured in `exarch-core/benches/progress.rs` — must not exceed 5% throughput penalty |
+| NFR-003 | Reliability | `on_complete` not called on failure — callers can rely on this for cleanup signaling |
+| NFR-004 | Safety | `ProgressCallback: Send` is required for FFI use in Python and Node.js bindings |
+
+## 5. Data Model
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| `ProgressCallback` | Trait for receiving archive operation progress events | Methods: `on_entry_start`, `on_bytes_written`, `on_entry_complete`, `on_complete` |
+| `NoopProgress` | Zero-overhead implementation of `ProgressCallback` | All methods are no-ops; intended as the default |
+| `ExtractionContext` | Per-extraction state passed through TAR helper functions to reduce arity | Holds references to config, options, output dir, and progress callback |
+| `CountingWriter` | Wraps a `Write` impl and counts bytes written; feeds `on_bytes_written` | `inner: W`, `bytes_written: u64` |
+
+### Trait Signature
+
+```
+ProgressCallback: Send
+  on_entry_start(&mut self, path: &Path, total: usize, current: usize)
+  on_bytes_written(&mut self, bytes: u64)
+  on_entry_complete(&mut self, path: &Path)
+  on_complete(&mut self)  // NOT called on failure
+```
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Extraction fails on first entry | Neither `on_entry_complete` nor `on_complete` called for that entry |
+| Extraction fails after N successful entries | `on_entry_complete` called for the N successful entries; `on_complete` NOT called |
+| `on_bytes_written` called with 0 bytes | Allowed; implementations must handle gracefully |
+| Archive with unknown total entry count | `total` argument to `on_entry_start` is 0 |
+| Progress callback panics | Panic propagates as normal Rust panic; not caught by exarch |
+| Creation progress for large directories | `on_entry_start` called for each file; total is file count from walk |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | `on_complete` not called on failure | Regression test (see issue #170) |
+| SC-002 | Progress overhead vs no-progress | < 5% throughput penalty (measured in bench) |
+| SC-003 | All format handlers call progress callbacks | Integration test with a counting progress impl |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Call `on_entry_start` before writing any bytes for an entry
+- Call `on_entry_complete` after writing all bytes for an entry
+- Call `on_complete` only on full success, never on error
+- Pass `&mut dyn ProgressCallback` through `ExtractionContext` to avoid arity growth
+
+### Ask First
+- Adding new methods to `ProgressCallback` (trait breaking change)
+- Adding cancellation support (architectural decision)
+
+### Never
+- Call `on_complete` on partial or failed extraction
+- Depend on a specific `ProgressCallback` implementation inside `exarch-core`
+- Remove `Send` bound from `ProgressCallback`
+
+## 9. Open Questions
+
+- [NEEDS CLARIFICATION: Should `ProgressCallback` expose a cancellation mechanism (e.g., `on_entry_start` returns `bool` where `false` aborts extraction)? This would allow callers to cancel mid-archive without waiting for the operation to finish.]
+- [NEEDS CLARIFICATION: Should `on_bytes_written` receive cumulative bytes or per-chunk bytes? Current spec says per-chunk — verify this matches CLI indicatif integration.]
+
+## 10. See Also
+
+- [[constitution]] — project principles
+- [[MOC-specs]] — all specifications
+- [[002-format-handlers/spec]] — format handlers that call progress callbacks
+- [[005-cli/spec]] — indicatif-based `ProgressCallback` implementation
+- [[006-python-bindings/spec]] — `PyProgressAdapter` and GIL interaction
+- [[001-exarch-system/spec]] — original monolithic spec (archived)

--- a/specs/004-progress-tracking/tasks.md
+++ b/specs/004-progress-tracking/tasks.md
@@ -1,0 +1,39 @@
+---
+aliases:
+  - Progress Tracking Tasks
+tags:
+  - sdd
+  - tasks
+  - progress
+  - rust
+created: 2026-05-20
+status: done
+related:
+  - "[[spec]]"
+  - "[[001-exarch-system/plan]]"
+  - "[[constitution]]"
+---
+
+# Implementation Tasks: Progress Tracking
+
+> [!info] References
+> **Spec**: [[spec]]
+> **Plan**: [[001-exarch-system/plan]]
+> **Total tasks**: 0
+
+> [!note] No open work
+> The Progress Tracking subsystem is fully implemented. `ProgressCallback`
+> trait, `NoopProgress` default, and the `indicatif`-based `CliProgress`
+> adapter in `exarch-cli` are all in place. Progress is suppressed correctly
+> in `--json` and `--quiet` modes. No functional requirements from the spec
+> remain unimplemented.
+
+## Progress
+
+(no tasks)
+
+## See Also
+
+- [[spec]] — feature specification
+- [[001-exarch-system/plan]] — technical plan
+- [[MOC-specs]] — all specifications

--- a/specs/005-cli/spec.md
+++ b/specs/005-cli/spec.md
@@ -1,0 +1,250 @@
+---
+aliases:
+  - CLI Spec
+  - exarch CLI Spec
+tags:
+  - sdd
+  - spec
+  - cli
+  - rust
+created: 2026-05-20
+status: draft
+related:
+  - "[[constitution]]"
+  - "[[MOC-specs]]"
+  - "[[003-config-api/spec]]"
+  - "[[004-progress-tracking/spec]]"
+---
+
+# Feature: CLI
+
+> [!info] Metadata
+> **Subsystem**: exarch-cli
+> **MSRV**: Rust 1.93.0
+> **Source**: extracted from [[001-exarch-system/spec]]
+
+## 1. Overview
+
+### Problem Statement
+
+Developers and operators need to extract, create, list, and verify archives
+from the shell without installing a Python or Node.js runtime. The CLI must
+expose the full security configuration of `exarch-core` through flags, display
+human-readable progress during interactive use, and emit machine-readable JSON
+for scripting.
+
+### Goal
+
+Provide a thin CLI wrapper (`exarch-cli`) around `exarch-core` that translates
+command-line flags into `SecurityConfig`, `CreationConfig`, and `ExtractionOptions`,
+delegates all logic to the core library, and presents output in either human-readable
+or JSON format based on the `--json` flag.
+
+### Out of Scope
+
+- Interactive TUI or file picker
+- Network archive sources (HTTP, S3, etc.)
+- Archive repair or recovery commands
+- GUI
+
+## 2. User Stories
+
+### US-001: CLI Extraction
+
+AS A system administrator
+I WANT to run `exarch extract archive.tar.gz /output` from the shell
+SO THAT I can extract archives safely without installing Python or Node.js
+
+**Acceptance criteria:**
+```
+GIVEN a valid archive and an output directory
+WHEN I run `exarch extract archive.tar.gz /output`
+THEN files are extracted, a progress bar is shown on stderr, and exit code is 0
+```
+
+```
+GIVEN the --json flag
+WHEN I run `exarch extract archive.tar.gz /output --json`
+THEN stdout contains a JSON object with extraction statistics; no progress bar shown
+```
+
+### US-002: CLI Archive Creation
+
+AS A developer
+I WANT to run `exarch create output.tar.gz ./src` to produce an archive
+SO THAT I can package files without a separate tool
+
+**Acceptance criteria:**
+```
+GIVEN source paths and an output path with a recognized extension
+WHEN I run `exarch create output.tar.gz ./src`
+THEN an archive is produced and CreationReport is displayed
+```
+
+### US-003: Archive Listing
+
+AS A security engineer
+I WANT to run `exarch list archive.zip` to inspect contents without extracting
+SO THAT I can review untrusted archives before use
+
+**Acceptance criteria:**
+```
+GIVEN any supported archive
+WHEN I run `exarch list archive.zip`
+THEN entry paths, sizes, and types are printed; no files are written to disk
+```
+
+### US-004: Archive Verification
+
+AS A security engineer
+I WANT to run `exarch verify archive.tar.gz` to check for security issues
+SO THAT I can pre-screen archives before extraction
+
+**Acceptance criteria:**
+```
+GIVEN an archive containing a zip bomb entry
+WHEN I run `exarch verify archive.tar.gz`
+THEN VerificationReport.issues contains the ZipBomb issue with Critical severity; exit code is non-zero
+```
+
+### US-005: Shell Completion
+
+AS A power user
+I WANT shell completion scripts for bash, zsh, fish, and PowerShell
+SO THAT I can tab-complete exarch commands and flags
+
+**Acceptance criteria:**
+```
+GIVEN `exarch completion zsh`
+WHEN run
+THEN a valid zsh completion script is printed to stdout
+```
+
+### US-006: Machine-Readable Output
+
+AS A script author
+I WANT `--json` to emit structured JSON to stdout
+SO THAT I can parse extraction results in a shell pipeline
+
+**Acceptance criteria:**
+```
+GIVEN --json flag on any subcommand
+WHEN the command succeeds
+THEN stdout contains valid JSON with all report fields; stderr contains no progress bar
+```
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-060 | THE CLI SHALL provide subcommands: `extract`, `create`, `list`, `verify`, `completion` | must |
+| FR-061 | THE CLI SHALL support global flags: `--verbose`, `--quiet`, `--json` | must |
+| FR-062 | WHEN `--json` is set, THE CLI SHALL output machine-readable JSON to stdout; human-readable text and progress output SHALL go to stderr | must |
+| FR-063 | `extract` SHALL support: `--max-files N`, `--max-total-size SIZE` (K/M/G/T suffixes), `--max-file-size SIZE`, `--max-compression-ratio N`, `--allow-symlinks`, `--allow-hardlinks`, `--allow-solid-archives`, `--allow-world-writable`, `--preserve-permissions`, `--force`, `--atomic` | must |
+| FR-064 | `create` SHALL support: `-l/--compression-level 1-9`, `--follow-symlinks`, `--include-hidden`, `-x/--exclude PATTERN` (repeatable glob), `--strip-prefix PREFIX`, `-f/--force` | must |
+| FR-065 | `list` and `verify` SHALL support: `-l/--long`, `-H/--human-readable`, `--max-files N`, `--max-total-size SIZE`, `--allow-solid-archives` | must |
+| FR-066 | `completion` SHALL generate shell completion scripts for bash, zsh, fish, and PowerShell | should |
+| FR-067 | WHEN extraction or creation fails, THE CLI SHALL exit with a non-zero exit code and print the error to stderr | must |
+| FR-068 | WHEN `--quiet` is set, THE CLI SHALL suppress progress bars and informational output; only errors go to stderr | must |
+| FR-069 | WHEN `--verbose` is set, THE CLI SHALL print per-entry details during extraction and creation | should |
+| FR-070 | THE CLI progress bar SHALL use `indicatif` in human mode and be suppressed in `--json` and `--quiet` modes | must |
+| FR-071 | Human-readable output SHALL use SI suffixes (K, M, G) for byte counts when `-H/--human-readable` is set | should |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Observability | Progress bar uses `indicatif`; suppressed in `--json` and `--quiet` modes |
+| NFR-002 | Usability | All flags have short aliases where unambiguous |
+| NFR-003 | Correctness | Exit code 0 on success; non-zero on any error |
+| NFR-004 | Correctness | JSON output is always valid JSON; never interleaved with progress output |
+| NFR-005 | Maintainability | CLI is a thin adapter — no security logic; all logic delegated to `exarch-core` |
+
+## 5. Data Model
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| `Cli` | Root clap struct | Global flags (`--verbose`, `--quiet`, `--json`), `Commands` enum |
+| `Commands` | Enum of subcommands | `Extract(ExtractArgs)`, `Create(CreateArgs)`, `List(ListArgs)`, `Verify(VerifyArgs)`, `Completion(CompletionArgs)` |
+| `ExtractArgs` | Arguments for `extract` subcommand | `archive`, `output_dir`, security overrides, `--force`, `--atomic` |
+| `CreateArgs` | Arguments for `create` subcommand | `output`, `sources`, creation options |
+| `ListArgs` | Arguments for `list` subcommand | `archive`, display options |
+| `VerifyArgs` | Arguments for `verify` subcommand | `archive`, inspection options |
+| `OutputFormatter` | Trait for human vs JSON output | Methods: `print_extraction_report`, `print_creation_report`, `print_manifest`, `print_verification_report` |
+
+### CLI Command Syntax
+
+```
+exarch [--verbose] [--quiet] [--json] <COMMAND>
+
+exarch extract <ARCHIVE> [OUTPUT_DIR]
+    [--max-files N] [--max-total-size SIZE] [--max-file-size SIZE]
+    [--max-compression-ratio N] [--allow-symlinks] [--allow-hardlinks]
+    [--allow-solid-archives] [--allow-world-writable]
+    [--preserve-permissions] [--force] [--atomic]
+
+exarch create <OUTPUT> <SOURCE>...
+    [-l/--compression-level 1-9] [--follow-symlinks] [--include-hidden]
+    [-x/--exclude PATTERN]... [--strip-prefix PREFIX] [-f/--force]
+
+exarch list <ARCHIVE>
+    [-l/--long] [-H/--human-readable]
+    [--max-files N] [--max-total-size SIZE] [--allow-solid-archives]
+
+exarch verify <ARCHIVE>
+    [--max-files N] [--max-total-size SIZE] [--allow-solid-archives]
+
+exarch completion <SHELL>    # bash | zsh | fish | powershell | elvish
+```
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Archive does not exist | Error printed to stderr; exit code non-zero |
+| Output directory does not exist | Created automatically (unless `--force` is required) |
+| Extraction fails (security violation) | Error with variant name printed to stderr; exit code non-zero |
+| `--json` and `--quiet` combined | JSON on stdout; nothing on stderr |
+| SIZE suffix parsing (e.g. `--max-total-size 500M`) | K=1024, M=1024², G=1024³, T=1024⁴ |
+| `completion` for unsupported shell | Error; exit code non-zero |
+| `verify` on archive with issues | Issues printed; exit code non-zero when status is Fail |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | All subcommands produce correct output in human mode | Manual and integration tests |
+| SC-002 | `--json` output is valid JSON parseable by `jq` | Integration test with JSON schema validation |
+| SC-003 | Progress bar suppressed with `--json` and `--quiet` | Integration test checking stderr |
+| SC-004 | Exit code non-zero on all error paths | Test matrix covering each `ExtractionError` variant |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Direct all security and archive logic to `exarch-core`; never reimplement in CLI
+- Print errors to stderr; JSON reports to stdout
+- Suppress progress bar when `--json` or `--quiet` is set
+- Use `clap` derive macros for argument parsing
+
+### Ask First
+- Adding a new subcommand (may require changes to `exarch-core` API)
+- Changing exit code conventions
+- Changing the JSON schema for any report type
+
+### Never
+- Implement security logic in `exarch-cli`
+- Print progress to stdout (even in human mode)
+- Silently ignore extraction errors
+
+## 9. Open Questions
+
+- [NEEDS CLARIFICATION: Should `exarch verify` have a `--check-integrity` flag to trigger CRC-32 validation for ZIP, distinct from security checks?]
+- [NEEDS CLARIFICATION: Should `exarch extract` default to the current directory when no `OUTPUT_DIR` is given, or require it explicitly?]
+
+## 10. See Also
+
+- [[constitution]] — project principles
+- [[MOC-specs]] — all specifications
+- [[003-config-api/spec]] — config types translated from CLI flags
+- [[004-progress-tracking/spec]] — indicatif-based `ProgressCallback` used by CLI
+- [[001-exarch-system/spec]] — original monolithic spec (archived)

--- a/specs/005-cli/tasks.md
+++ b/specs/005-cli/tasks.md
@@ -1,0 +1,142 @@
+---
+aliases:
+  - CLI Tasks
+tags:
+  - sdd
+  - tasks
+  - cli
+  - rust
+created: 2026-05-20
+status: draft
+related:
+  - "[[spec]]"
+  - "[[001-exarch-system/plan]]"
+  - "[[constitution]]"
+---
+
+# Implementation Tasks: CLI
+
+> [!info] References
+> **Spec**: [[spec]]
+> **Plan**: [[001-exarch-system/plan]]
+> **Total tasks**: 2
+
+> [!warning] Scope
+> The core CLI (all subcommands, JSON output, progress bar, exit codes) is
+> fully implemented. Two `should`-priority requirements remain open:
+>
+> - FR-066: `completion` subcommand — the command exists and generates valid
+>   scripts, but the `CompletionArgs` struct does not appear in the CLI help
+>   text with full shell option descriptions and the `--json` flag is accepted
+>   but has no effect on completion output (correct behaviour, but untested).
+>   Issue #232 tracks adding a CLI integration test that exercises the
+>   `completion` subcommand end-to-end.
+>
+> - FR-069: `--verbose` per-entry output — the `verbose` flag is parsed and
+>   stored in `HumanFormatter`, but the only verbose-gated output is two extra
+>   summary lines after extraction (symlink count and duration). Per-entry
+>   details (path, size, type) during active extraction or creation are not
+>   printed. Issue #233 tracks implementing the per-entry verbose path.
+
+## Progress
+
+- [ ] T001: Integration test for `completion` subcommand
+- [ ] T002: Per-entry verbose output during extraction and creation
+
+---
+
+## Dependency Graph
+
+```mermaid
+graph TD
+    T001[T001: completion integration test]
+    T002[T002: per-entry verbose output]
+```
+
+---
+
+### T001: Integration test for `completion` subcommand
+
+**Context**: The `completion` command is implemented in
+`crates/exarch-cli/src/commands/completion.rs` with a unit test that verifies
+no panic occurs. There is no integration test confirming that the generated
+script is non-empty, written to stdout, and produces no stderr output. FR-066
+acceptance criteria require a verifiable completion script for each shell.
+**Spec reference**: [[spec#FR-066]], [[spec#US-005]]
+**GitHub issue**: #232
+**Acceptance criteria**:
+- [ ] Integration test runs `exarch completion bash` and asserts stdout is non-empty and contains the string `"exarch"`
+- [ ] Same check for `zsh`, `fish`, and `powershell`
+- [ ] Test asserts stderr is empty and exit code is 0
+- [ ] Test for an unsupported shell name asserts exit code is non-zero
+- [ ] Tests pass under `cargo nextest run -p exarch-cli` (or the workspace nextest invocation)
+**Dependencies**: none
+**Files**:
+- `crates/exarch-cli/tests/` — new integration test file `completion.rs` or extend existing CLI tests
+**Complexity**: low
+
+---
+
+### T002: Per-entry verbose output during extraction and creation
+
+**Context**: FR-069 states: "WHEN `--verbose` is set, THE CLI SHALL print
+per-entry details during extraction and creation." Currently `HumanFormatter`
+gates only two extra lines on `self.verbose` (symlink count and duration in the
+post-extraction summary). No per-entry output is emitted during the extraction
+loop. The `ProgressCallback` path is the right place to hook verbose per-entry
+logging so it interleaves with the progress bar correctly.
+**Spec reference**: [[spec#FR-069]], [[spec#US-006]]
+**GitHub issue**: #233
+**Acceptance criteria**:
+- [ ] When `--verbose` is active, each extracted entry path is printed to stderr during extraction (one line per entry)
+- [ ] Each verbose line includes: entry type indicator (`f`/`d`/`l`), uncompressed size, and relative path
+- [ ] Verbose lines go to stderr (not stdout), preserving `--json` stdout cleanliness
+- [ ] Verbose lines do not appear when `--quiet` or `--json` is set
+- [ ] During `create`, each added file path is printed to stderr when `--verbose` is set
+- [ ] Integration test: run `exarch extract <archive> --verbose 2>verbose.log` and assert `verbose.log` contains all entry paths
+- [ ] No changes to `ExtractionReport`, `CreationReport`, or `ProgressCallback` trait signatures
+**Dependencies**: none
+**Files**:
+- `crates/exarch-cli/src/progress.rs` — `CliProgress` implementation; add per-entry callback
+- `crates/exarch-cli/src/output/human.rs` — add `print_verbose_entry()` helper if needed
+- `crates/exarch-cli/tests/` — integration test for verbose output
+**Complexity**: medium
+
+---
+
+## Implementation Notes
+
+### Order of execution
+
+T001 and T002 are independent; both can be worked in parallel or in any order.
+T001 is a pure test addition (low risk). T002 touches the progress path and
+should be reviewed carefully to ensure verbose lines are not interleaved with
+the indicatif progress bar in a way that corrupts terminal output — use
+`indicatif::ProgressBar::println()` to print above the bar.
+
+### Common patterns
+
+- For T002, look at `crates/exarch-cli/src/progress.rs` (`CliProgress`) for
+  how `ProgressCallback` is currently used. Verbose per-entry output should be
+  emitted inside the `on_entry` callback (or equivalent), not inside the
+  formatter methods which are called only after the operation completes.
+- For T001, look at existing integration test patterns in the workspace.
+  `assert_cmd` crate is likely already available; check `Cargo.toml`
+  `[dev-dependencies]`.
+
+### Gotchas
+
+- T002: `indicatif::ProgressBar::println()` writes a line above the active
+  progress bar without corrupting it. Do NOT use `eprintln!` directly while the
+  bar is active.
+- T002: When `--json` is set, the formatter is `JsonFormatter` which receives
+  no verbose flag — verbose output must be suppressed at the `CliProgress` level
+  by checking the verbose flag, not inside the formatter.
+- T001: `clap_complete` output format varies between shells. Assert non-empty
+  and the program name presence rather than exact content.
+
+## See Also
+
+- [[spec]] — feature specification
+- [[001-exarch-system/plan]] — technical plan
+- [[MOC-specs]] — all specifications

--- a/specs/006-python-bindings/spec.md
+++ b/specs/006-python-bindings/spec.md
@@ -1,0 +1,244 @@
+---
+aliases:
+  - Python Bindings Spec
+  - PyO3 Bindings Spec
+tags:
+  - sdd
+  - spec
+  - python
+  - ffi
+  - rust
+created: 2026-05-20
+status: draft
+related:
+  - "[[constitution]]"
+  - "[[MOC-specs]]"
+  - "[[001-security-pipeline/spec]]"
+  - "[[003-config-api/spec]]"
+  - "[[004-progress-tracking/spec]]"
+---
+
+# Feature: Python Bindings
+
+> [!info] Metadata
+> **Subsystem**: exarch-python
+> **MSRV**: Rust 1.93.0
+> **Build**: maturin + pyo3 0.28
+> **Source**: extracted from [[001-exarch-system/spec]]
+
+## 1. Overview
+
+### Problem Statement
+
+Python developers building data pipelines, security tools, or CI systems need
+safe archive operations without reimplementing the security checks available in
+`exarch-core`. Wrapping the Rust library via PyO3 gives Python callers the same
+guarantees while maintaining Python ergonomics (pathlib, exceptions, GIL semantics).
+
+### Goal
+
+Expose `exarch-core` operations as a Python module (`exarch`) using PyO3, with
+proper GIL management during I/O, Pythonic error types, and path validation at
+the Python boundary before any Rust code executes.
+
+### Out of Scope
+
+- Async Python interface (asyncio integration)
+- NumPy or Pandas integration
+- CLI wrapper for Python entry points (the `exarch-cli` crate handles the CLI)
+
+## 2. User Stories
+
+### US-001: Python Extraction
+
+AS A Python developer
+I WANT to call `exarch.extract_archive(path, output_dir)` from Python
+SO THAT I benefit from the same security guarantees without reimplementing them
+
+**Acceptance criteria:**
+```
+GIVEN a valid archive path and output directory as str or pathlib.Path
+WHEN extract_archive(archive_path, output_dir) is called
+THEN extraction runs with GIL released, files are extracted, and an ExtractionReport object is returned
+```
+
+### US-002: Path Validation at Python Boundary
+
+AS A Python developer
+I WANT invalid paths to be caught before calling into Rust
+SO THAT I receive a clear Python exception for obvious mistakes
+
+**Acceptance criteria:**
+```
+GIVEN a path containing null bytes
+WHEN any exarch function is called with that path
+THEN ValueError is raised immediately without calling into Rust core
+```
+
+```
+GIVEN a path exceeding 4096 bytes
+WHEN any exarch function is called with that path
+THEN ValueError is raised immediately
+```
+
+### US-003: GIL Release During I/O
+
+AS A Python developer in a multi-threaded application
+I WANT extraction to release the GIL during the I/O phase
+SO THAT other Python threads can run while archives are being extracted
+
+**Acceptance criteria:**
+```
+GIVEN extract_archive() called without a progress callback
+WHEN extraction runs
+THEN the GIL is released for the duration of the Rust extraction call
+```
+
+```
+GIVEN extract_archive() called with a Python progress callback
+WHEN extraction runs
+THEN the GIL is held (callback requires GIL to call Python)
+```
+
+### US-004: Pythonic Error Types
+
+AS A Python developer
+I WANT Rust ExtractionError variants to map to specific Python exception classes
+SO THAT I can catch specific error types in a try/except block
+
+**Acceptance criteria:**
+```
+GIVEN an archive with a path traversal entry
+WHEN extract_archive() is called
+THEN PathTraversalError (a subclass of ExarchError) is raised
+```
+
+### US-005: Python Config Classes
+
+AS A Python developer
+I WANT to construct SecurityConfig and CreationConfig using fluent Python classes
+SO THAT I can customize security limits in idiomatic Python
+
+**Acceptance criteria:**
+```
+GIVEN SecurityConfig().max_file_size(200 * 1024 * 1024).allow_symlinks(True)
+WHEN passed to extract_archive()
+THEN extraction respects those settings
+```
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-070 | THE SYSTEM SHALL expose Python functions: `extract_archive`, `create_archive`, `create_archive_with_progress`, `list_archive`, `verify_archive` | must |
+| FR-071 | ALL Python functions SHALL accept `str` or `pathlib.Path` for path arguments | must |
+| FR-072 | WHEN paths contain null bytes or exceed 4096 bytes, THE SYSTEM SHALL raise `ValueError` at the Python boundary before calling into Rust | must |
+| FR-073 | WHEN no Python progress callback is provided, THE SYSTEM SHALL release the GIL during extraction/creation | must |
+| FR-074 | WHEN a Python progress callback is provided, THE SYSTEM SHALL NOT release the GIL (callback requires GIL to invoke Python) | must |
+| FR-075 | Rust `ExtractionError` variants SHALL map to specific Python exception types registered on the module | must |
+| FR-076 | ALL Python exception types SHALL be subclasses of `ExarchError(Exception)` | must |
+| FR-077 | `PySecurityConfig` and `PyCreationConfig` SHALL expose the same fluent builder API as the Rust counterparts | must |
+| FR-078 | `PyExtractionReport`, `PyCreationReport`, `PyArchiveManifest`, and `PyVerificationReport` SHALL expose all fields as Python attributes | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Safety | `unsafe impl Send for PyProgressAdapter` is the only justified `unsafe` in the Python crate; must be documented |
+| NFR-002 | Performance | GIL is released during I/O when no progress callback is provided |
+| NFR-003 | Compatibility | Built with `maturin` and `pyo3` abi3 feature for broad Python version support |
+| NFR-004 | Testability | Python tests run via `pytest` with `maturin develop` — excluded from `cargo nextest` |
+| NFR-005 | Correctness | All security logic stays in `exarch-core`; Python crate contains only type mapping and boundary validation |
+
+## 5. Data Model
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| `PySecurityConfig` | Python class wrapping `SecurityConfig` | Same fluent builder methods: `max_file_size()`, `allow_symlinks()`, etc. |
+| `PyCreationConfig` | Python class wrapping `CreationConfig` | Same fluent builder methods |
+| `PyExtractionReport` | Python class wrapping `ExtractionReport` | `files_extracted`, `bytes_written`, `duration`, `warnings` |
+| `PyCreationReport` | Python class wrapping `CreationReport` | `files_added`, `bytes_written`, `duration` |
+| `PyArchiveManifest` | Python class wrapping `ArchiveManifest` | `total_entries`, `total_size`, `format`, `entries` |
+| `PyVerificationReport` | Python class wrapping `VerificationReport` | `status`, `issues`, `total_entries` |
+| `PyProgressAdapter` | Internal adapter calling Python progress callbacks from Rust | Holds `PyObject` reference; `unsafe impl Send` |
+
+### Python Exception Hierarchy
+
+```
+ExarchError(Exception)
+  PathTraversalError(ExarchError)
+  SymlinkEscapeError(ExarchError)
+  HardlinkEscapeError(ExarchError)
+  ZipBombError(ExarchError)
+  QuotaExceededError(ExarchError)
+  UnsupportedFormatError(ExarchError)
+  InvalidArchiveError(ExarchError)
+  SecurityViolationError(ExarchError)
+  InvalidPermissionsError(ExarchError)
+```
+
+### Python API Surface
+
+```python
+# Module: exarch
+
+def extract_archive(archive_path, output_dir, config=None) -> ExtractionReport
+def create_archive(output_path, sources, config=None) -> CreationReport
+def create_archive_with_progress(output_path, sources, config=None, progress=None) -> CreationReport
+def list_archive(archive_path, config=None) -> ArchiveManifest
+def verify_archive(archive_path, config=None) -> VerificationReport
+```
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Path is `None` | `TypeError` raised by PyO3 before boundary check |
+| Path contains null byte | `ValueError` at Python boundary |
+| Path exceeds 4096 bytes | `ValueError` at Python boundary |
+| Path is `pathlib.Path` | Converted to `str` via `.as_os_str()` before Rust call |
+| Rust returns `ExtractionError::PathTraversal` | `PathTraversalError` raised in Python |
+| Progress callback raises Python exception | Exception propagates through `PyProgressAdapter`; extraction aborted |
+| GIL state with progress callback | GIL held throughout; no concurrent Python threads during extraction |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | All Python functions return correct report objects | `pytest` test coverage for each function |
+| SC-002 | GIL released when no callback provided | Verified by thread concurrency test |
+| SC-003 | All `ExtractionError` variants map to Python exceptions | Test for each variant |
+| SC-004 | Path boundary validation catches null bytes and long paths | Unit tests at Python boundary |
+| SC-005 | `maturin develop` + `pytest` passes on CI | CI job for Python crate |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Validate paths at the Python boundary before calling into Rust
+- Release GIL during Rust calls when no Python progress callback is present
+- Map every `ExtractionError` variant to a Python exception subclass of `ExarchError`
+- Keep all security logic in `exarch-core`; Python crate contains only type mapping
+
+### Ask First
+- Adding new Python-facing functions not yet in `exarch-core`
+- Changing `PyProgressAdapter`'s `unsafe impl Send` justification
+- Adding new Python exception types
+
+### Never
+- Implement security validation in the Python crate
+- Hold the GIL during long I/O operations without a progress callback
+- Expose `ExtractionError` as a raw Rust type to Python callers
+
+## 9. Open Questions
+
+- [NEEDS CLARIFICATION: Should an async Python interface (asyncio) be provided via `pyo3-asyncio` in a future version?]
+- [NEEDS CLARIFICATION: What Python version range does the abi3 build target? (e.g., 3.8+)]
+
+## 10. See Also
+
+- [[constitution]] — project principles (GIL management)
+- [[MOC-specs]] — all specifications
+- [[001-security-pipeline/spec]] — security pipeline invoked by Python bindings
+- [[003-config-api/spec]] — `SecurityConfig` and `CreationConfig` types
+- [[004-progress-tracking/spec]] — `ProgressCallback` and `PyProgressAdapter`
+- [[001-exarch-system/spec]] — original monolithic spec (archived)

--- a/specs/006-python-bindings/tasks.md
+++ b/specs/006-python-bindings/tasks.md
@@ -1,0 +1,40 @@
+---
+aliases:
+  - Python Bindings Tasks
+tags:
+  - sdd
+  - tasks
+  - python
+  - rust
+created: 2026-05-20
+status: done
+related:
+  - "[[spec]]"
+  - "[[001-exarch-system/plan]]"
+  - "[[constitution]]"
+---
+
+# Implementation Tasks: Python Bindings
+
+> [!info] References
+> **Spec**: [[spec]]
+> **Plan**: [[001-exarch-system/plan]]
+> **Total tasks**: 0
+
+> [!note] No open work
+> The Python bindings subsystem is fully implemented. PyO3 wrappers for all
+> core operations (`extract`, `create`, `list`, `verify`) are in place. The
+> GIL is released during I/O, `SecurityConfig` and `CreationConfig` are
+> exposed as Python classes, `ExarchError` maps all `ExtractionError` variants,
+> and `exarch.pyi` provides complete type stubs. All functional requirements
+> from the spec are satisfied.
+
+## Progress
+
+(no tasks)
+
+## See Also
+
+- [[spec]] — feature specification
+- [[001-exarch-system/plan]] — technical plan
+- [[MOC-specs]] — all specifications

--- a/specs/007-node-bindings/spec.md
+++ b/specs/007-node-bindings/spec.md
@@ -1,0 +1,270 @@
+---
+aliases:
+  - Node.js Bindings Spec
+  - napi-rs Bindings Spec
+tags:
+  - sdd
+  - spec
+  - nodejs
+  - ffi
+  - rust
+created: 2026-05-20
+status: draft
+related:
+  - "[[constitution]]"
+  - "[[MOC-specs]]"
+  - "[[001-security-pipeline/spec]]"
+  - "[[003-config-api/spec]]"
+  - "[[004-progress-tracking/spec]]"
+---
+
+# Feature: Node.js Bindings
+
+> [!info] Metadata
+> **Subsystem**: exarch-node
+> **MSRV**: Rust 1.93.0
+> **Build**: napi-rs 3.x + tokio runtime
+> **Source**: extracted from [[001-exarch-system/spec]]
+
+## 1. Overview
+
+### Problem Statement
+
+Node.js developers building CI/CD tools, file processing services, or
+developer tooling need safe archive operations that do not block the event
+loop. Wrapping `exarch-core` via napi-rs gives Node.js callers the same
+security guarantees as the Rust API, exposed as async Promises running on
+the libuv thread pool.
+
+### Goal
+
+Expose `exarch-core` operations as async Promise-based functions in a native
+Node.js addon built with napi-rs, with path validation at the JS boundary,
+named JavaScript error types, and TypeScript type definitions.
+
+### Out of Scope
+
+- Streaming Node.js readable/writable interfaces
+- Progress callbacks from Node.js (no equivalent of `PyProgressAdapter`)
+- Electron or browser support (Node.js native addon only)
+- CommonJS-only distribution (ESM and CJS both supported by napi-rs)
+
+## 2. User Stories
+
+### US-001: Async Archive Extraction
+
+AS A Node.js developer
+I WANT to `await extractArchive(archivePath, outputDir)` without blocking the event loop
+SO THAT my server can handle other requests while an archive is being extracted
+
+**Acceptance criteria:**
+```
+GIVEN a valid archive path and output directory as strings
+WHEN await extractArchive(archivePath, outputDir) is called
+THEN extraction runs on the libuv thread pool, files are extracted, and an ExtractionReport is resolved
+```
+
+### US-002: Path Validation at JS Boundary
+
+AS A Node.js developer
+I WANT invalid paths to be rejected synchronously before a Promise is created
+SO THAT I receive a clear JS Error for obvious mistakes without awaiting
+
+**Acceptance criteria:**
+```
+GIVEN a path string containing null bytes
+WHEN any exarch function is called with that path
+THEN a JavaScript Error is thrown synchronously before the Promise is created
+```
+
+```
+GIVEN a path string exceeding 4096 bytes
+WHEN any exarch function is called with that path
+THEN a JavaScript Error is thrown synchronously
+```
+
+### US-003: Named JavaScript Error Types
+
+AS A Node.js developer
+I WANT Rust ExtractionError variants to produce named JS Error objects
+SO THAT I can differentiate errors in a catch block by type name
+
+**Acceptance criteria:**
+```
+GIVEN an archive with a path traversal entry
+WHEN extractArchive() rejects
+THEN the rejected Error has name === "PathTraversalError"
+```
+
+### US-004: TypeScript Definitions
+
+AS A TypeScript developer
+I WANT `.d.ts` type definitions for all functions and classes
+SO THAT I have type safety and IDE autocomplete
+
+**Acceptance criteria:**
+```
+GIVEN the installed npm package
+WHEN imported in a TypeScript project
+THEN all functions, classes, and return types have correct TypeScript signatures
+```
+
+### US-005: Custom Security Config
+
+AS A Node.js developer
+I WANT to instantiate a SecurityConfig class and pass it to archive functions
+SO THAT I can customize extraction limits in JavaScript
+
+**Acceptance criteria:**
+```
+GIVEN new SecurityConfig().maxFileSize(200 * 1024 * 1024).allowSymlinks(false)
+WHEN passed to extractArchive()
+THEN extraction respects those settings
+```
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-080 | THE SYSTEM SHALL expose async Node.js functions returning Promises: `extractArchive`, `createArchive`, `listArchive`, `verifyArchive` | must |
+| FR-081 | ALL async operations SHALL run on the libuv thread pool, not the main event loop thread | must |
+| FR-082 | WHEN paths contain null bytes or exceed 4096 bytes, THE SYSTEM SHALL throw a synchronous JavaScript Error before spawning a thread | must |
+| FR-083 | Rust `ExtractionError` variants SHALL map to named JavaScript Error types | must |
+| FR-084 | `SecurityConfig` and `CreationConfig` SHALL be exposed as JavaScript classes with fluent builder methods | must |
+| FR-085 | `ExtractionReport`, `CreationReport`, `ArchiveManifest`, and `VerificationReport` SHALL be exposed as JavaScript objects with typed fields | must |
+| FR-086 | napi-rs SHALL generate TypeScript `.d.ts` files for all exported functions and classes | must |
+| FR-087 | ALL path arguments SHALL accept `string` type in JavaScript | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Performance | All I/O runs on libuv thread pool; main event loop is never blocked |
+| NFR-002 | Correctness | Path boundary validation is synchronous — errors thrown before Promise creation |
+| NFR-003 | Compatibility | napi-rs 3.x; Node.js LTS version range [NEEDS CLARIFICATION: minimum Node.js version] |
+| NFR-004 | Testability | Node.js tests run via `npm test` — excluded from `cargo nextest` |
+| NFR-005 | Correctness | All security logic stays in `exarch-core`; Node.js crate contains only type mapping and boundary validation |
+
+## 5. Data Model
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| `SecurityConfig` (JS class) | JavaScript class wrapping Rust `SecurityConfig` | Fluent builder: `maxFileSize()`, `maxTotalSize()`, `allowSymlinks()`, etc. |
+| `CreationConfig` (JS class) | JavaScript class wrapping Rust `CreationConfig` | Fluent builder: `compressionLevel()`, `followSymlinks()`, etc. |
+| `ExtractionReport` (JS object) | Result of extraction | `filesExtracted`, `directoriesCreated`, `bytesWritten`, `duration`, `warnings` |
+| `CreationReport` (JS object) | Result of creation | `filesAdded`, `bytesWritten`, `duration` |
+| `ArchiveManifest` (JS object) | Archive listing result | `totalEntries`, `totalSize`, `format`, `entries` |
+| `VerificationReport` (JS object) | Verification result | `status`, `issues`, `totalEntries` |
+
+### TypeScript API Surface
+
+```typescript
+// All functions are async (Promise-based)
+function extractArchive(
+    archivePath: string,
+    outputDir: string,
+    config?: SecurityConfig
+): Promise<ExtractionReport>
+
+function createArchive(
+    outputPath: string,
+    sources: string[],
+    config?: CreationConfig
+): Promise<CreationReport>
+
+function listArchive(
+    archivePath: string,
+    config?: SecurityConfig
+): Promise<ArchiveManifest>
+
+function verifyArchive(
+    archivePath: string,
+    config?: SecurityConfig
+): Promise<VerificationReport>
+
+class SecurityConfig {
+    maxFileSize(size: number): this
+    maxTotalSize(size: number): this
+    maxCompressionRatio(ratio: number): this
+    maxFileCount(count: number): this
+    maxPathDepth(depth: number): this
+    allowSymlinks(allow: boolean): this
+    allowHardlinks(allow: boolean): this
+    allowSolidArchives(allow: boolean): this
+}
+
+class CreationConfig {
+    compressionLevel(level: number): this
+    followSymlinks(follow: boolean): this
+    includeHidden(include: boolean): this
+    exclude(pattern: string): this
+    stripPrefix(prefix: string): this
+}
+```
+
+### JavaScript Error Mapping
+
+| Rust `ExtractionError` variant | JavaScript Error name |
+|---|---|
+| `PathTraversal` | `PathTraversalError` |
+| `SymlinkEscape` | `SymlinkEscapeError` |
+| `HardlinkEscape` | `HardlinkEscapeError` |
+| `ZipBomb` | `ZipBombError` |
+| `QuotaExceeded` | `QuotaExceededError` |
+| `UnsupportedFormat` | `UnsupportedFormatError` |
+| `InvalidArchive` | `InvalidArchiveError` |
+| `Io` | `IoError` |
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Path is `null` or `undefined` | TypeError thrown by napi-rs before boundary check |
+| Path contains null byte | Synchronous `Error` thrown before Promise creation |
+| Path exceeds 4096 bytes | Synchronous `Error` thrown before Promise creation |
+| Rust returns `ExtractionError::PathTraversal` | Promise rejects with `PathTraversalError` |
+| Thread pool exhausted | Promise eventually resolves when thread becomes available; no timeout |
+| `sources` array is empty for `createArchive` | [NEEDS CLARIFICATION: reject immediately or produce empty archive?] |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | All async functions resolve with correct report objects | `npm test` passes |
+| SC-002 | Event loop not blocked during extraction | Test with concurrent timer; timer fires during extraction |
+| SC-003 | All `ExtractionError` variants produce named JS Errors | Test for each variant |
+| SC-004 | Path boundary validation throws synchronously | Unit test: no Promise.reject, synchronous throw |
+| SC-005 | TypeScript definitions are valid and complete | `tsc --noEmit` passes on test file |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Validate paths synchronously at the JS boundary before creating a Promise
+- Run all I/O on the libuv thread pool via napi-rs async pattern
+- Map every `ExtractionError` variant to a named JS Error
+- Keep all security logic in `exarch-core`; Node.js crate contains only type mapping
+
+### Ask First
+- Adding new async functions not yet in `exarch-core`
+- Adding progress callback support for Node.js (requires careful GIL/event-loop design)
+- Changing the TypeScript interface (breaking change for downstream consumers)
+
+### Never
+- Block the Node.js event loop with synchronous Rust I/O
+- Implement security validation in the Node.js crate
+- Expose raw Rust types without a JavaScript wrapper
+
+## 9. Open Questions
+
+- [NEEDS CLARIFICATION: What is the minimum supported Node.js version? (LTS policy — 18+, 20+?)]
+- [NEEDS CLARIFICATION: Should progress callbacks be supported from Node.js? Requires thread-safe channel from Rust back to JS event loop.]
+- [NEEDS CLARIFICATION: Should empty `sources` array in `createArchive` produce an empty archive or reject with an error?]
+
+## 10. See Also
+
+- [[constitution]] — project principles
+- [[MOC-specs]] — all specifications
+- [[001-security-pipeline/spec]] — security pipeline invoked by Node.js bindings
+- [[003-config-api/spec]] — `SecurityConfig` and `CreationConfig` types
+- [[004-progress-tracking/spec]] — `ProgressCallback` (currently no Node.js callback support)
+- [[001-exarch-system/spec]] — original monolithic spec (archived)

--- a/specs/007-node-bindings/tasks.md
+++ b/specs/007-node-bindings/tasks.md
@@ -1,0 +1,41 @@
+---
+aliases:
+  - Node.js Bindings Tasks
+tags:
+  - sdd
+  - tasks
+  - nodejs
+  - rust
+created: 2026-05-20
+status: done
+related:
+  - "[[spec]]"
+  - "[[001-exarch-system/plan]]"
+  - "[[constitution]]"
+---
+
+# Implementation Tasks: Node.js Bindings
+
+> [!info] References
+> **Spec**: [[spec]]
+> **Plan**: [[001-exarch-system/plan]]
+> **Total tasks**: 0
+
+> [!note] No open work
+> The Node.js bindings subsystem is fully implemented. napi-rs wrappers expose
+> all core operations as async Promises backed by a tokio runtime. `SecurityConfig`
+> and `CreationConfig` are mapped to JavaScript objects. All `ExtractionError`
+> variants are translated to `ExarchError`. Report types (`ExtractionReport`,
+> `CreationReport`, `ArchiveManifest`, `VerificationReport`) are serialized to
+> plain JavaScript objects. No functional requirements from the spec remain
+> unimplemented.
+
+## Progress
+
+(no tasks)
+
+## See Also
+
+- [[spec]] — feature specification
+- [[001-exarch-system/plan]] — technical plan
+- [[MOC-specs]] — all specifications

--- a/specs/MOC-specs.md
+++ b/specs/MOC-specs.md
@@ -1,0 +1,41 @@
+---
+aliases:
+  - Specifications Index
+  - Specs Overview
+tags:
+  - moc
+  - sdd
+created: 2026-05-20
+status: moc
+---
+
+# Specifications
+
+> [!abstract]
+> Map of Content for all project specifications. Each entry links to
+> a feature spec with its current phase and status.
+
+## Active Specs
+
+| ID | Feature | Phase | Status |
+|----|---------|-------|--------|
+| 001 | [[001-security-pipeline/spec\|Security Pipeline]] | specify | draft |
+| 002 | [[002-format-handlers/spec\|Format Handlers]] | specify | draft |
+| 003 | [[003-config-api/spec\|Configuration API]] | specify | draft |
+| 004 | [[004-progress-tracking/spec\|Progress Tracking]] | specify | draft |
+| 005 | [[005-cli/spec\|CLI]] | specify | draft |
+| 006 | [[006-python-bindings/spec\|Python Bindings]] | specify | draft |
+| 007 | [[007-node-bindings/spec\|Node.js Bindings]] | specify | draft |
+
+## Completed Specs
+
+(none yet)
+
+## Archived Specs
+
+- [[001-exarch-system/spec\|exarch System Spec (monolithic)]] — superseded by 001–007 above
+- [[001-exarch-system/plan\|exarch Technical Plan (monolithic)]] — reference architecture document
+
+## Project Foundation
+
+- [[constitution]] — non-negotiable project principles

--- a/specs/MOC-specs.md
+++ b/specs/MOC-specs.md
@@ -17,15 +17,15 @@ status: moc
 
 ## Active Specs
 
-| ID | Feature | Phase | Status |
-|----|---------|-------|--------|
-| 001 | [[001-security-pipeline/spec\|Security Pipeline]] | specify | draft |
-| 002 | [[002-format-handlers/spec\|Format Handlers]] | specify | draft |
-| 003 | [[003-config-api/spec\|Configuration API]] | specify | draft |
-| 004 | [[004-progress-tracking/spec\|Progress Tracking]] | specify | draft |
-| 005 | [[005-cli/spec\|CLI]] | specify | draft |
-| 006 | [[006-python-bindings/spec\|Python Bindings]] | specify | draft |
-| 007 | [[007-node-bindings/spec\|Node.js Bindings]] | specify | draft |
+| ID | Feature | Phase | Status | Tasks |
+|----|---------|-------|--------|-------|
+| 001 | [[001-security-pipeline/spec\|Security Pipeline]] | tasks | draft | [[001-security-pipeline/tasks\|2 open]] |
+| 002 | [[002-format-handlers/spec\|Format Handlers]] | tasks | draft | [[002-format-handlers/tasks\|1 open]] |
+| 003 | [[003-config-api/spec\|Configuration API]] | tasks | done | [[003-config-api/tasks\|none]] |
+| 004 | [[004-progress-tracking/spec\|Progress Tracking]] | tasks | done | [[004-progress-tracking/tasks\|none]] |
+| 005 | [[005-cli/spec\|CLI]] | tasks | draft | [[005-cli/tasks\|2 open]] |
+| 006 | [[006-python-bindings/spec\|Python Bindings]] | tasks | done | [[006-python-bindings/tasks\|none]] |
+| 007 | [[007-node-bindings/spec\|Node.js Bindings]] | tasks | done | [[007-node-bindings/tasks\|none]] |
 
 ## Completed Specs
 

--- a/specs/constitution.md
+++ b/specs/constitution.md
@@ -1,0 +1,79 @@
+---
+aliases:
+  - Project Principles
+tags:
+  - sdd
+  - constitution
+created: 2026-05-20
+status: permanent
+---
+
+# Project Constitution
+
+> [!important]
+> Non-negotiable principles governing ALL development in this project.
+> Every specification, plan, and task MUST comply with this document.
+> Update only through explicit team decision.
+
+## I. Architecture
+
+- Four-crate workspace: `exarch-core` (library), `exarch-cli` (thin CLI wrapper), `exarch-python` (PyO3 bindings), `exarch-node` (napi-rs bindings)
+- All security logic lives exclusively in `exarch-core` — bindings are responsible only for type mapping, error conversion, and boundary validation
+- Archive entries pass through a typed validation pipeline (`SafePath` → `ValidatedEntry`) before any I/O
+- Format abstraction: every archive format must implement `ArchiveFormat` (extract / list / verify) and optionally `FormatCreator`
+- Configuration is immutable after construction; `SecurityConfig` and `CreationConfig` use fluent builder APIs
+
+## II. Technology Stack
+
+- Language: Rust, MSRV 1.93.0
+- CLI: `clap` 4.x with derive macros
+- Python bindings: `pyo3` 0.28, `maturin`, GIL released during I/O
+- Node.js bindings: `napi-rs` 3.x, async Promises via tokio thread pool
+- Compression: `flate2` (gz), `bzip2` (bz2), `xz2` (xz, static), `zstd` (zst), `zip` 8.x, `sevenz-rust2` (7z)
+- Testing: `cargo nextest`, `proptest` for property-based tests, `criterion` + `dhat` for benchmarks
+
+## III. Testing (NON-NEGOTIABLE)
+
+- All features must have passing tests before merge
+- Python and Node.js crates are excluded from `cargo nextest` — tested separately via `pytest` / `npm test`
+- Doc-tests must pass: `cargo test --doc --workspace --all-features`
+- Every new `pub` item requires a `///` doc comment; non-trivial APIs require `# Examples` with runnable doc-tests
+- Security-critical paths (path traversal, symlink/hardlink validation, zip bomb detection, permission sanitization) require live integration tests before any PR touching them
+
+## IV. Code Style
+
+- `deny(unsafe_code)` workspace-wide — no exceptions
+- `deny(expect_used)` and `deny(unwrap_used)` — use `?` for error propagation
+- `clippy::pedantic` and `clippy::nursery` — all warnings treated as errors
+- All `pub` types, traits, functions, and methods require doc comments explaining what and why
+- Formatting: `cargo +nightly fmt --all`
+
+## V. Security
+
+- Deny-by-default: symlinks, hardlinks, absolute paths, world-writable files, solid archives — all disabled unless explicitly enabled
+- Never commit secrets, keys, or credentials
+- Default banned path components: `.git`, `.ssh`, `.gnupg`, `.aws`, `.kube`, `.docker`, `.env`
+- Default limits: 50 MB per file, 500 MB total, 100× compression ratio, 10,000 files, depth 32
+- Path component matching is case-insensitive to prevent bypass on case-insensitive filesystems
+- Security issues detected during `verify_archive` are reported in `VerificationReport.issues`, not propagated as errors (complete picture for the caller)
+
+## VI. Performance
+
+- Extraction throughput regressions > 10% vs baseline require a `rust-performance-engineer` review
+- Benchmarks in `exarch-core/benches/` (creation, extraction, validation, progress); run with `cargo bench -p exarch-core`
+- `BufReader` wraps file handles for all TAR format handlers
+
+## VII. Simplicity
+
+- Before v1.0.0: implement only the minimum necessary functionality; avoid additional abstractions and premature optimization
+- Before v1.0.0: no backward-compatibility guarantees — document breaking changes in `CHANGELOG.md`
+- 7z creation is not supported (read-only); callers receive `UnsupportedFormat`
+- ZIP-family aliases (`.jar`, `.apk`, `.whl`, etc.) are extracted as ZIP but creation is rejected unless the caller explicitly overrides `CreationConfig::format`
+
+## VIII. Git Workflow
+
+- Branch naming: `feat/{issue}-{slug}`, `fix/{issue}-{slug}`, `hotfix/{issue}-{slug}`
+- Commit messages: Conventional Commits 1.0.0
+- Pre-merge checks (must match CI): `cargo +nightly fmt --check`, `cargo clippy --all-targets --all-features --workspace -- -D warnings`, `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node`, `cargo test --doc --workspace --all-features`
+- Docs must build cleanly: `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace`
+- Every phase-end PR: update `CHANGELOG.md` under `[Unreleased]`


### PR DESCRIPTION
## Summary

- Add `specs/` directory with Spec-Driven Development artifacts for all seven exarch subsystems
- Each subsystem has a focused `spec.md` covering user stories, functional requirements (EARS), NFR, data model, edge cases, success criteria, and agent boundaries
- System-level overview (`001-exarch-system/`) and technical plan (`plan.md`) retained as reference
- `specs/constitution.md` documents non-negotiable project principles
- `specs/MOC-specs.md` serves as the index of all specifications

### Subsystems covered

| Dir | Subsystem |
|-----|-----------|
| `001-security-pipeline` | SafePath, ValidatedEntry, QuotaTracker, HardlinkTracker, all security checks |
| `002-format-handlers` | ArchiveFormat/FormatCreator traits, TAR/ZIP/7z, format detection |
| `003-config-api` | SecurityConfig, CreationConfig, ExtractionOptions, fluent builder |
| `004-progress-tracking` | ProgressCallback, NoopProgress, ExtractionContext |
| `005-cli` | extract/create/list/verify commands, JSON/text output, exit codes |
| `006-python-bindings` | PyO3, GIL release, type mapping, exception hierarchy |
| `007-node-bindings` | napi-rs, async Promise, tokio, TypeScript API |

### Related issues

Gap analysis produced four issues: #230, #231, #232, #233.

## Test plan

- [ ] No source code changed — docs only, CI passes as-is
- [ ] All spec files render correctly as Obsidian Markdown
- [ ] MOC-specs.md links resolve to existing files