### PR TITLE
fix(archive): use InvalidConfiguration for missing builder fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `ArchiveBuilder::extract` now returns `ExtractionError::InvalidConfiguration` instead of `ExtractionError::SecurityViolation` when `archive_path` or `output_dir` are not set. The previous variant caused `error_code()` to return `"SECURITY_VIOLATION"` for what is a caller configuration mistake (#235).
+- Corrected the `Archive::open` doc-comment which incorrectly claimed the constructor validates file existence. The function is infallible; I/O errors surface on `extract()` (#237).
+
 - `create_tar_zst_with_progress` now calls `zstd::Encoder::finish()` explicitly and propagates any I/O error via `?`. Previously the encoder relied on `Drop` to call `try_finish()`, which silently discarded flush errors and could produce a truncated `.tar.zst` archive on disk-full or other I/O failure (#226).
 
 ### Removed

--- a/crates/exarch-core/src/archive.rs
+++ b/crates/exarch-core/src/archive.rs
@@ -19,7 +19,8 @@ impl Archive {
     ///
     /// # Errors
     ///
-    /// Returns an error if the file doesn't exist or cannot be accessed.
+    /// This constructor is infallible. I/O errors surface later when
+    /// [`Archive::extract`] is called.
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Self> {
         let path = path.as_ref().to_path_buf();
         Ok(Self {
@@ -111,13 +112,13 @@ impl ArchiveBuilder {
     pub fn extract(self) -> Result<ExtractionReport> {
         let archive_path =
             self.archive_path
-                .ok_or_else(|| crate::ExtractionError::SecurityViolation {
+                .ok_or_else(|| crate::ExtractionError::InvalidConfiguration {
                     reason: "archive path not set".to_string(),
                 })?;
 
         let output_dir =
             self.output_dir
-                .ok_or_else(|| crate::ExtractionError::SecurityViolation {
+                .ok_or_else(|| crate::ExtractionError::InvalidConfiguration {
                     reason: "output directory not set".to_string(),
                 })?;
 
@@ -145,13 +146,19 @@ mod tests {
     fn test_archive_builder_missing_path() {
         let builder = ArchiveBuilder::new().output_dir("/tmp/test");
         let result = builder.extract();
-        assert!(result.is_err());
+        assert!(matches!(
+            result,
+            Err(crate::ExtractionError::InvalidConfiguration { .. })
+        ));
     }
 
     #[test]
     fn test_archive_builder_missing_output() {
         let builder = ArchiveBuilder::new().archive("test.tar");
         let result = builder.extract();
-        assert!(result.is_err());
+        assert!(matches!(
+            result,
+            Err(crate::ExtractionError::InvalidConfiguration { .. })
+        ));
     }
 }


### PR DESCRIPTION
## Summary

- `ArchiveBuilder::extract` returned `ExtractionError::SecurityViolation` when `archive_path` or `output_dir` were not set, causing `error_code()` to emit `"SECURITY_VIOLATION"` for a caller configuration mistake. Both `ok_or_else` calls now use `InvalidConfiguration`, consistent with `creation/creator.rs` (#235).
- Corrected the `Archive::open` doc-comment which incorrectly claimed the constructor validates file existence. The function is infallible; I/O errors surface on `extract()` (#237).
- Updated unit tests to assert the exact `InvalidConfiguration` variant instead of just `is_err()`.

## Test plan

- [ ] `cargo nextest run -p exarch-core` — 826 tests pass
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — no warnings
- [ ] `cargo +nightly fmt --all -- --check` — no diff
- [ ] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace` — builds cleanly

Closes #235, closes #237