### PR TITLE
refactor(inspection): cache validate_path result in verify_entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `verify_entry` in `exarch-core::inspection::verify` now calls `validate_path` once per entry and caches the result, eliminating a redundant second call (and the associated `canonicalize` syscalls) for symlink and hardlink entries (#236).
+
 ### Fixed
 
 - `ArchiveBuilder::extract` now returns `ExtractionError::InvalidConfiguration` instead of `ExtractionError::SecurityViolation` when `archive_path` or `output_dir` are not set. The previous variant caused `error_code()` to return `"SECURITY_VIOLATION"` for what is a caller configuration mistake (#235).

--- a/crates/exarch-core/src/inspection/verify.rs
+++ b/crates/exarch-core/src/inspection/verify.rs
@@ -140,9 +140,11 @@ fn verify_entry(
         },
     };
 
-    // Path validation
-    if let Err(e) = validate_path(&entry.path, dest, config) {
-        issues.push(VerificationIssue::from_error(&e, Some(entry.path.clone())));
+    // Path validation — result cached to avoid repeated syscalls for
+    // symlink/hardlink checks
+    let path_result = validate_path(&entry.path, dest, config);
+    if let Err(ref e) = path_result {
+        issues.push(VerificationIssue::from_error(e, Some(entry.path.clone())));
     }
 
     // Quota validation using record_file (combines all checks)
@@ -158,18 +160,16 @@ fn verify_entry(
     }
 
     // Symlink validation
-    if let EntryType::Symlink { ref target } = entry_type {
-        // Safe path for link
-        if let Ok(safe_link_path) = validate_path(&entry.path, dest, config)
-            && let Err(e) = validate_symlink(&safe_link_path, target, dest, config)
-        {
-            issues.push(VerificationIssue::from_error(&e, Some(entry.path.clone())));
-        }
+    if let EntryType::Symlink { ref target } = entry_type
+        && let Ok(ref safe_link_path) = path_result
+        && let Err(e) = validate_symlink(safe_link_path, target, dest, config)
+    {
+        issues.push(VerificationIssue::from_error(&e, Some(entry.path.clone())));
     }
 
     // Hardlink validation (similar to symlink)
     if let EntryType::Hardlink { ref target } = entry_type
-        && let Ok(safe_link_path) = validate_path(&entry.path, dest, config)
+        && let Ok(ref safe_link_path) = path_result
         && let Err(e) = validate_path(target, dest, config)
     {
         issues.push(VerificationIssue {


### PR DESCRIPTION
## Summary

- `verify_entry` called `validate_path` twice for symlink and hardlink entries: once at the top (result discarded) and again in the branch where the `SafePath` was needed
- Each call may invoke `canonicalize()` syscalls (5–50 µs); the second call was pure waste
- Cache the result in `path_result`, reuse it in both the error-reporting block and the symlink/hardlink branches

## Test plan

- [ ] All 826 existing tests pass (`cargo nextest run --workspace`)
- [ ] Clippy clean (`cargo clippy --workspace --all-targets --all-features -- -D warnings`)
- [ ] Formatted (`cargo +nightly fmt --all -- --check`)

Closes #236