### PR TITLE
refactor(archive): Archive::open returns Self instead of Result<Self>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SecurityConfig::allowed_extensions` filter is now enforced during extraction across all three format handlers (TAR, ZIP, 7z). When the list is non-empty, files whose extension is not in the allowlist are skipped and recorded in `ExtractionReport::files_skipped` with a warning (#230).
 - `create_archive` now rejects ZIP-family alias extensions (`.apk`, `.jar`, `.whl`, `.epub`, `.war`, `.ear`, `.aab`, `.ipa`, `.appx`, `.msix`, `.vsix`, `.nbm`) when the output format is inferred (i.e., `CreationConfig::format` is `None`). Set `CreationConfig::format = Some(ArchiveType::Zip)` to override (#231).
 
+### Breaking Changes
+
+- **`Archive::open`** now returns `Self` instead of `Result<Self>`. Callers must remove `?` or `.unwrap()` (#243).
+
 ### Changed
 
 - `verify_entry` in `exarch-core::inspection::verify` now calls `validate_path` once per entry and caches the result, eliminating a redundant second call (and the associated `canonicalize` syscalls) for symlink and hardlink entries (#236).

--- a/crates/exarch-core/src/archive.rs
+++ b/crates/exarch-core/src/archive.rs
@@ -17,16 +17,23 @@ pub struct Archive {
 impl Archive {
     /// Creates a new `Archive` from a file path.
     ///
-    /// # Errors
-    ///
     /// This constructor is infallible. I/O errors surface later when
     /// [`Archive::extract`] is called.
-    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self> {
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use exarch_core::Archive;
+    ///
+    /// let archive = Archive::open("archive.tar.gz");
+    /// ```
+    #[must_use]
+    pub fn open<P: AsRef<Path>>(path: P) -> Self {
         let path = path.as_ref().to_path_buf();
-        Ok(Self {
+        Self {
             path,
             config: SecurityConfig::default(),
-        })
+        }
     }
 
     /// Returns the path to the archive file.


### PR DESCRIPTION
## Summary

- `Archive::open` now returns `Self` directly instead of `Result<Self>`
- Adds `#[must_use]` attribute
- Removes misleading `# Errors` doc section, adds `# Examples` doctest
- Documents breaking change in `CHANGELOG.md`

## Breaking Change

`Archive::open` return type changed from `Result<Self>` to `Self`. Callers must remove `?` or `.unwrap()`.

## Test plan

- [x] `cargo nextest run --workspace --all-features` — 836 passed, 0 failed
- [x] `cargo test --doc --workspace --all-features` — 114 passed, 0 failed
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo +nightly fmt --all` — clean
- [x] `cargo deny check --all-features` — clean
- [x] Security audit: no unsafe code, no RUSTSEC advisories
- [x] Performance: zero-cost change (Result was already a tagged union, no heap allocation removed)

Closes #243