### PR TITLE
build(deps): upgrade zip 8.6.0 to 9.0.0-pre2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `verify_entry` in `exarch-core::inspection::verify` now calls `validate_path` once per entry and caches the result, eliminating a redundant second call (and the associated `canonicalize` syscalls) for symlink and hardlink entries (#236).
+- Upgraded `zip` dependency from 8.6.0 to 9.0.0-pre2; adapted `ZipFile::name()` call sites to propagate the new `Result<Cow<str>, ZipError>` return type (#238).
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2134,9 +2134,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "8.6.0"
+version = "9.0.0-pre2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+checksum = "cb30735adb9a33cbbb12950b940e1d105389e275ba8fa7118c385d9cffc4cec1"
 dependencies = [
  "bzip2",
  "crc32fast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ time = "0.3"
 tokio = "1.52"
 walkdir = "2.5"
 xz2 = { version = "0.1", features = ["static"] }
-zip = { version = "8.6", default-features = false }
+zip = { version = "9.0.0-pre2", default-features = false }
 zstd = "0.13"
 
 [workspace.lints.clippy]

--- a/crates/exarch-core/src/creation/zip.rs
+++ b/crates/exarch-core/src/creation/zip.rs
@@ -615,7 +615,7 @@ mod tests {
             if entry.is_dir() {
                 dir_entries += 1;
                 assert!(
-                    entry.name().ends_with('/'),
+                    entry.name().unwrap().ends_with('/'),
                     "Directory entry should end with /"
                 );
             }
@@ -650,7 +650,7 @@ mod tests {
 
         for i in 0..archive.len() {
             let entry = archive.by_index(i).unwrap();
-            if entry.name().contains("test.txt")
+            if entry.name().unwrap().contains("test.txt")
                 && let Some(mode) = entry.unix_mode()
             {
                 assert_eq!(mode & 0o777, 0o755, "Permissions should be preserved");
@@ -710,7 +710,7 @@ mod tests {
 
         for i in 0..archive.len() {
             let mut entry = archive.by_index(i).unwrap();
-            let outpath = extract_dir.path().join(entry.name());
+            let outpath = extract_dir.path().join(entry.name().unwrap().as_ref());
 
             if entry.is_dir() {
                 fs::create_dir_all(&outpath).unwrap();
@@ -753,7 +753,7 @@ mod tests {
 
         for i in 0..archive.len() {
             let entry = archive.by_index(i).unwrap();
-            let name = entry.name();
+            let name = entry.name().unwrap();
             // ZIP paths should never contain backslashes
             assert!(
                 !name.contains('\\'),

--- a/crates/exarch-core/src/formats/zip.rs
+++ b/crates/exarch-core/src/formats/zip.rs
@@ -276,12 +276,23 @@ impl<R: Read + Seek> ZipArchive<R> {
         })?;
 
         if zip_file.encrypted() {
+            let name = zip_file
+                .name()
+                .map_or_else(|_| format!("<entry {index}>"), std::borrow::Cow::into_owned);
             return Err(ExtractionError::SecurityViolation {
-                reason: format!("encrypted entry detected: {}", zip_file.name()),
+                reason: format!("encrypted entry detected: {name}"),
             });
         }
 
-        let path = PathBuf::from(zip_file.name());
+        let path = PathBuf::from(
+            zip_file
+                .name()
+                .map_err(|e| {
+                    ExtractionError::InvalidArchive(format!("invalid entry name at {index}: {e}"))
+                })?
+                .as_ref(),
+        );
+
         let (uncompressed_size, compressed_size) = ZipEntryAdapter::get_sizes(&zip_file);
         let mode = zip_file.unix_mode();
 
@@ -412,7 +423,15 @@ impl<R: Read + Seek> ArchiveFormat for ZipArchive<R> {
                 let zf = self.inner.by_index(i).map_err(|e| {
                     ExtractionError::InvalidArchive(format!("failed to open zip entry {i}: {e}"))
                 })?;
-                std::path::PathBuf::from(zf.name())
+                std::path::PathBuf::from(
+                    zf.name()
+                        .map_err(|e| {
+                            ExtractionError::InvalidArchive(format!(
+                                "invalid entry name at {i}: {e}"
+                            ))
+                        })?
+                        .as_ref(),
+                )
             };
             progress.on_entry_start(&entry_path, entry_count, i.saturating_add(1));
 

--- a/crates/exarch-core/src/inspection/list.rs
+++ b/crates/exarch-core/src/inspection/list.rs
@@ -290,10 +290,14 @@ pub(crate) fn list_zip_reader<R: Read + Seek>(
             });
         }
 
+        let raw_name = entry
+            .name()
+            .map_err(|e| ExtractionError::InvalidArchive(format!("invalid entry name: {e}")))?
+            .into_owned();
         let path = entry
             .enclosed_name()
             .ok_or_else(|| ExtractionError::PathTraversal {
-                path: PathBuf::from(entry.name()),
+                path: PathBuf::from(&raw_name),
             })?;
         let path = path.clone();
 


### PR DESCRIPTION
Closes #238.

## Summary

- Bumps `zip` from 8.6.0 to 9.0.0-pre2 in workspace `Cargo.toml`
- Adapts all `ZipFile::name()` call sites to the new `Result<Cow<str>, ZipError>` return type (the only breaking change that affects exarch)
- Production call sites use `?` / `map_err` for proper error propagation
- Test call sites use `.unwrap()` (acceptable in test context)

The other four breaking changes in zip v9 (`ExtraField` non-exhaustive, `ZipFileData` restructure, removed deprecated zip64 comment methods, macro export removal) have zero impact on this codebase.

## Test plan

- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` — 836 tests pass
- [x] `cargo test --doc --workspace --all-features` — 114 doctests pass
- [x] `cargo +nightly fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo deny check --all-features` — advisories/bans/licenses/sources all OK