### PR TITLE
fix(cli): fix CliProgress bar total and add --allowed-extensions flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `extract` subcommand now accepts `--allowed-extensions <EXT>` (repeatable; comma-separated values also accepted) and passes the parsed list to `SecurityConfig::with_allowed_extensions()`, exposing the core extension filter at the CLI level (#246).
+
 - Shell completion generation via `exarch completion <shell>` (bash, zsh, fish, powershell, elvish). Output goes to stdout for piping into the appropriate completions directory (#232).
 - `--verbose` flag now prints one line per extracted entry to stderr, including entry name, size, and type. `--quiet` takes precedence when both flags are provided (#233).
 - `SecurityConfig::allowed_extensions` filter is now enforced during extraction across all three format handlers (TAR, ZIP, 7z). When the list is non-empty, files whose extension is not in the allowlist are skipped and recorded in `ExtractionReport::files_skipped` with a warning (#230).
@@ -24,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded `zip` dependency from 8.6.0 to 9.0.0-pre2; adapted `ZipFile::name()` call sites to propagate the new `Result<Cow<str>, ZipError>` return type (#238).
 
 ### Fixed
+
+- `CliProgress` bar now receives the actual archive entry count instead of the hardcoded value of 100; byte throughput is shown via `set_message` so that the `{pos}/{len} files` counter tracks only entries and does not race with cumulative byte values (#245).
+- `CliProgress` entry count is pre-filtered when `--allowed-extensions` is active, so the progress bar reaches 100% even when a subset of entries is extracted (#245, #246).
 
 - `ArchiveBuilder::extract` now returns `ExtractionError::InvalidConfiguration` instead of `ExtractionError::SecurityViolation` when `archive_path` or `output_dir` are not set. The previous variant caused `error_code()` to return `"SECURITY_VIOLATION"` for what is a caller configuration mistake (#235).
 - Corrected the `Archive::open` doc-comment which incorrectly claimed the constructor validates file existence. The function is infallible; I/O errors surface on `extract()` (#237).

--- a/crates/exarch-cli/src/cli.rs
+++ b/crates/exarch-cli/src/cli.rs
@@ -104,6 +104,15 @@ pub struct ExtractArgs {
     /// exists.
     #[arg(long)]
     pub atomic: bool,
+
+    /// Only extract files whose extension is in this list.
+    ///
+    /// Can be repeated (`--allowed-extensions txt --allowed-extensions pdf`) or
+    /// comma-separated (`--allowed-extensions txt,pdf`). The leading dot is
+    /// optional and matching is case-insensitive. When omitted, all extensions
+    /// are allowed.
+    #[arg(long = "allowed-extensions", value_name = "EXT")]
+    pub allowed_extensions: Vec<String>,
 }
 
 #[derive(clap::Args)]

--- a/crates/exarch-cli/src/commands/extract.rs
+++ b/crates/exarch-cli/src/commands/extract.rs
@@ -33,6 +33,16 @@ fn run_extraction(
     )
 }
 
+/// Expands a list of extension tokens that may contain comma-separated values
+/// into individual lowercase extension strings without leading dots.
+fn parse_extensions(raw: &[String]) -> Vec<String> {
+    raw.iter()
+        .flat_map(|s| s.split(','))
+        .map(|ext| ext.trim().trim_start_matches('.').to_lowercase())
+        .filter(|ext| !ext.is_empty())
+        .collect()
+}
+
 pub fn execute(
     args: &ExtractArgs,
     formatter: &dyn OutputFormatter,
@@ -44,18 +54,19 @@ pub fn execute(
         None => env::current_dir().context("failed to get current directory")?,
     };
 
-    if !args.force && !args.atomic {
-        let manifest = list_archive(
-            &args.archive,
-            &SecurityConfig::default()
-                .with_max_file_count(args.max_files)
-                .with_max_total_size(args.max_total_size.unwrap_or(500 * 1024 * 1024))
-                .with_max_file_size(args.max_file_size.unwrap_or(50 * 1024 * 1024))
-                .with_max_compression_ratio(f64::from(args.max_compression_ratio))
-                .with_allow_solid_archives(args.allow_solid_archives),
-        )
+    let list_config = SecurityConfig::default()
+        .with_max_file_count(args.max_files)
+        .with_max_total_size(args.max_total_size.unwrap_or(500 * 1024 * 1024))
+        .with_max_file_size(args.max_file_size.unwrap_or(50 * 1024 * 1024))
+        .with_max_compression_ratio(f64::from(args.max_compression_ratio))
+        .with_allow_solid_archives(args.allow_solid_archives);
+
+    // Always list the archive: needed for conflict detection and for obtaining
+    // the real entry count that drives the progress bar.
+    let manifest = list_archive(&args.archive, &list_config)
         .with_context(|| format!("failed to list archive: {}", args.archive.display()))?;
 
+    if !args.force && !args.atomic {
         let conflicts: Vec<_> = manifest
             .entries
             .iter()
@@ -74,6 +85,8 @@ pub fn execute(
         }
     }
 
+    let allowed_extensions = parse_extensions(&args.allowed_extensions);
+
     let config = SecurityConfig::default()
         .with_max_file_count(args.max_files)
         .with_max_total_size(args.max_total_size.unwrap_or(500 * 1024 * 1024))
@@ -83,7 +96,22 @@ pub fn execute(
         .with_allow_hardlinks(args.allow_hardlinks)
         .with_allow_world_writable(args.allow_world_writable)
         .with_preserve_permissions(args.preserve_permissions)
-        .with_allow_solid_archives(args.allow_solid_archives);
+        .with_allow_solid_archives(args.allow_solid_archives)
+        .with_allowed_extensions(allowed_extensions);
+
+    let entry_count = if config.allowed_extensions.is_empty() {
+        manifest.entries.len()
+    } else {
+        manifest
+            .entries
+            .iter()
+            .filter(|e| e.entry_type == ManifestEntryType::File)
+            .filter(|e| {
+                let ext = e.path.extension().and_then(|s| s.to_str());
+                config.is_path_extension_allowed(ext)
+            })
+            .count()
+    };
 
     let options = ExtractionOptions::default()
         .with_atomic(args.atomic)
@@ -122,7 +150,7 @@ pub fn execute(
             &output_dir,
             &config,
             &options,
-            &mut CliProgress::new(100, "Extracting"),
+            &mut CliProgress::new(entry_count, "Extracting"),
             args.allow_symlinks,
         )?
     } else {
@@ -139,4 +167,50 @@ pub fn execute(
     formatter.format_extraction_result(&report)?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_extensions_comma_split() {
+        let raw = vec!["zip,tar,gz".to_string()];
+        assert_eq!(parse_extensions(&raw), vec!["zip", "tar", "gz"]);
+    }
+
+    #[test]
+    fn parse_extensions_strips_leading_dot() {
+        let raw = vec![".zip".to_string(), ".TAR".to_string()];
+        assert_eq!(parse_extensions(&raw), vec!["zip", "tar"]);
+    }
+
+    #[test]
+    fn parse_extensions_trims_whitespace() {
+        let raw = vec![" zip , tar ".to_string()];
+        assert_eq!(parse_extensions(&raw), vec!["zip", "tar"]);
+    }
+
+    #[test]
+    fn parse_extensions_lowercases() {
+        let raw = vec!["ZIP".to_string(), "TAR.GZ".to_string()];
+        assert_eq!(parse_extensions(&raw), vec!["zip", "tar.gz"]);
+    }
+
+    #[test]
+    fn parse_extensions_empty_input() {
+        assert_eq!(parse_extensions(&[]), Vec::<String>::new());
+    }
+
+    #[test]
+    fn parse_extensions_filters_empty_tokens() {
+        let raw = vec!["zip,,tar".to_string()];
+        assert_eq!(parse_extensions(&raw), vec!["zip", "tar"]);
+    }
+
+    #[test]
+    fn parse_extensions_mixed_repeatable_and_comma() {
+        let raw = vec!["zip,tar".to_string(), ".GZ".to_string()];
+        assert_eq!(parse_extensions(&raw), vec!["zip", "tar", "gz"]);
+    }
 }

--- a/crates/exarch-cli/src/progress.rs
+++ b/crates/exarch-cli/src/progress.rs
@@ -3,17 +3,18 @@
 use console::Term;
 use exarch_core::ProgressCallback;
 use indicatif::ProgressBar;
-use indicatif::ProgressState;
 use indicatif::ProgressStyle;
-use std::fmt::Write;
 use std::path::Path;
 
 /// CLI progress bar wrapper implementing `ProgressCallback`.
 ///
-/// Displays a progress bar with file count, bytes processed, speed, and ETA
-/// when running in a TTY. Automatically cleans up on drop.
+/// Displays a progress bar driven by entry count (`{pos}/{len} files`).
+/// Bytes written are shown in the message suffix and updated independently so
+/// that byte accumulation does not corrupt the entry counter. Automatically
+/// cleans up on drop.
 pub struct CliProgress {
     bar: ProgressBar,
+    label: String,
     bytes_written: u64,
 }
 
@@ -23,31 +24,17 @@ impl CliProgress {
     /// # Arguments
     ///
     /// * `total` - Total number of entries to process
-    /// * `message` - Message to display (e.g., "Extracting", "Creating")
+    /// * `message` - Label displayed before the bar (e.g., "Extracting")
     #[must_use]
     pub fn new(total: usize, message: &str) -> Self {
         let bar = ProgressBar::new(total as u64);
 
-        // Template: "Extracting [████████░░░░] 42/100 files (15.2 MB, 5.1 MB/s, 12s)"
+        // Template: "Extracting [████████░░░░] 42/100 files"
+        // Bytes are appended via set_message to keep pos/len as entry counts.
         bar.set_style(
             ProgressStyle::default_bar()
-                .template(
-                    "{msg} [{bar:40.cyan/blue}] {pos}/{len} files ({bytes}, {bytes_per_sec}, {eta})",
-                )
+                .template("{msg} [{bar:40.cyan/blue}] {pos}/{len} files")
                 .unwrap_or_else(|_| ProgressStyle::default_bar())
-                .with_key("bytes", |state: &ProgressState, w: &mut dyn Write| {
-                    write!(w, "{}", humanize_bytes(state.pos())).unwrap_or(());
-                })
-                .with_key("bytes_per_sec", |state: &ProgressState, w: &mut dyn Write| {
-                    let per_sec = state.per_sec();
-                    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-                    let bytes_per_sec = per_sec as u64;
-                    write!(w, "{}/s", humanize_bytes(bytes_per_sec)).unwrap_or(());
-                })
-                .with_key("eta", |state: &ProgressState, w: &mut dyn Write| {
-                    let eta = state.eta();
-                    write!(w, "{}", humanize_duration(eta)).unwrap_or(());
-                })
                 .progress_chars("█▓░"),
         );
 
@@ -55,6 +42,7 @@ impl CliProgress {
 
         Self {
             bar,
+            label: message.to_string(),
             bytes_written: 0,
         }
     }
@@ -73,13 +61,15 @@ impl Drop for CliProgress {
 }
 
 impl ProgressCallback for CliProgress {
-    fn on_entry_start(&mut self, _path: &Path, _total: usize, _current: usize) {
-        // Entry start is handled by on_entry_complete incrementing the counter
-    }
+    fn on_entry_start(&mut self, _path: &Path, _total: usize, _current: usize) {}
 
     fn on_bytes_written(&mut self, bytes: u64) {
         self.bytes_written += bytes;
-        self.bar.set_position(self.bytes_written);
+        self.bar.set_message(format!(
+            "{} ({})",
+            self.label,
+            humanize_bytes(self.bytes_written)
+        ));
     }
 
     fn on_entry_complete(&mut self, _path: &Path) {
@@ -151,18 +141,6 @@ fn humanize_bytes(bytes: u64) -> String {
     }
 }
 
-/// Converts duration to human-readable format.
-fn humanize_duration(duration: std::time::Duration) -> String {
-    let secs = duration.as_secs();
-    if secs >= 3600 {
-        format!("{}h{}m", secs / 3600, (secs % 3600) / 60)
-    } else if secs >= 60 {
-        format!("{}m{}s", secs / 60, secs % 60)
-    } else {
-        format!("{secs}s")
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -176,20 +154,6 @@ mod tests {
         assert_eq!(humanize_bytes(1024 * 1024), "1.0 MB");
         assert_eq!(humanize_bytes(1024 * 1024 * 1024), "1.0 GB");
         assert_eq!(humanize_bytes(1024_u64.pow(4)), "1.0 TB");
-    }
-
-    #[test]
-    fn test_humanize_duration() {
-        assert_eq!(humanize_duration(std::time::Duration::from_secs(0)), "0s");
-        assert_eq!(humanize_duration(std::time::Duration::from_secs(30)), "30s");
-        assert_eq!(
-            humanize_duration(std::time::Duration::from_secs(90)),
-            "1m30s"
-        );
-        assert_eq!(
-            humanize_duration(std::time::Duration::from_secs(3661)),
-            "1h1m"
-        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **#245** — `CliProgress` was initialized with a hardcoded total of 100 and conflated byte accumulation with entry counting on the same indicatif counter. Fixed by calling `list_archive()` before extraction to obtain the real entry count and routing bytes through `set_message()` so `{pos}/{len}` tracks only entries.
- **#246** — `SecurityConfig::with_allowed_extensions()` was only accessible via the Rust API. Added `--allowed-extensions <EXT>` to the `extract` subcommand (repeatable; comma-separated values accepted).
- **#245 + #246** — When `--allowed-extensions` is active the progress bar total is pre-filtered to count only entries that will actually be extracted, so the bar reaches 100%.

## Test plan

- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` — 842 passed, 3 skipped
- [x] `cargo test --doc --workspace --all-features --exclude exarch-python --exclude exarch-node` — 114 passed
- [x] `cargo +nightly fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] 7 new regression tests for `parse_extensions()` (comma-split, dot-stripping, whitespace trimming, lowercase normalization, empty input)

Closes #245, closes #246.