### PR TITLE
release: v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-20
+
 ### Added
 
 - `extract` subcommand now accepts `--allowed-extensions <EXT>` (repeatable; comma-separated values also accepted) and passes the parsed list to `SecurityConfig::with_allowed_extensions()`, exposing the core extension filter at the CLI level (#246).
@@ -19,11 +21,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking Changes
 
 - **`Archive::open`** now returns `Self` instead of `Result<Self>`. Callers must remove `?` or `.unwrap()` (#243).
+- `SecurityConfig`, `AllowedFeatures`, and `ExtractionOptions` are now `#[non_exhaustive]`. External crates can no longer construct these structs via struct literal syntax; use `Default::default()` or the new fluent builder methods instead (#221).
+- Internal modules `copy`, `io`, and `test_utils` in `exarch-core` are now `pub(crate)` instead of `pub`. These were never part of the public API; any external code referencing `exarch_core::copy`, `exarch_core::io`, or `exarch_core::test_utils` directly will no longer compile (#173).
 
 ### Changed
 
 - `verify_entry` in `exarch-core::inspection::verify` now calls `validate_path` once per entry and caches the result, eliminating a redundant second call (and the associated `canonicalize` syscalls) for symlink and hardlink entries (#236).
 - Upgraded `zip` dependency from 8.6.0 to 9.0.0-pre2; adapted `ZipFile::name()` call sites to propagate the new `Result<Cow<str>, ZipError>` return type (#238).
+- Refactored `TarArchive` internal extraction helpers: introduced a private `ExtractionContext<'_, '_>` struct that groups the six shared parameters (`validator`, `dest`, `report`, `copy_buffer`, `dir_cache`, `skip_duplicates`) previously threaded individually through `process_entry` (7 params), `extract_file` (7 params), and `create_hardlink` (5 params). Signatures now accept `ctx: &mut ExtractionContext<'_, '_>` instead (#222).
+- `extract_archive_full` renamed to `extract_archive_with_options_and_progress` for API naming consistency. The old name was ambiguous; the new name describes both parameters the function accepts (#219).
+- Introduced `FormatCreator` trait in `exarch-core::formats::traits` for archive creation dispatch. The trait mirrors `ArchiveFormat` on the write side and replaces the manual `match` in `create_archive_with_progress` with six unit struct implementors (`TarCreator`, `TarGzCreator`, `TarBz2Creator`, `TarXzCreator`, `TarZstCreator`, `ZipCreator`) and a `creator_for_format` helper (#220).
+- Added 15 fluent builder methods to `SecurityConfig` (`with_max_file_size`, `with_max_total_size`, `with_max_compression_ratio`, `with_max_file_count`, `with_max_path_depth`, `with_allowed`, `with_allow_symlinks`, `with_allow_hardlinks`, `with_allow_absolute_paths`, `with_allow_world_writable`, `with_preserve_permissions`, `with_allowed_extensions`, `with_banned_path_components`, `with_allow_solid_archives`, `with_max_solid_block_memory`) and 2 to `ExtractionOptions` (`with_atomic`, `with_skip_duplicates`) (#218).
+- `TarArchive::list()` and `TarArchive::extract()` now have `///` doc comments explaining that `list()` consumes the internal reader (TAR is forward-only) and that calling `extract()` on the same instance afterward returns `InvalidArchive`. Callers must open a fresh instance for extraction (#211).
+- `CopyBuffer::size()` visibility corrected from `pub(crate)` to `pub`, consistent with the other items in the crate-internal `mod copy`. The `pub(crate)` module boundary in `lib.rs` already enforces the encapsulation; redundant `pub(crate)` on items inside a `pub(crate)` module triggers the `redundant_pub_crate` clippy lint (#203).
+- `verify_archive` now delegates to `verify_manifest` after calling `list_archive`, eliminating ~80 lines of duplicated entry-processing logic (#190).
+- `ProgressCallback::on_complete` doc comment clarified: the method is called only on successful completion; implementors must not use it for cleanup.
+- `ArchiveFormat` trait extended with `fn list()` and `fn verify()` methods, providing a single implementation point for all format operations (#174).
+
+### Removed
+
+- Removed 5 non-progress public functions (`create_tar`, `create_tar_gz`, `create_tar_bz2`, `create_tar_xz`, `create_tar_zst`) from `exarch-core::creation::tar` that were annotated `#[allow(dead_code)]` and unreachable from the crate's public surface. The public API already routes through `FormatCreator` trait objects using the `_with_progress` variants (#227).
+- Removed dead `format_success` and `format_warning` methods from the `OutputFormatter` trait and both implementations (`HumanFormatter`, `JsonFormatter`). Neither method was called from any command handler (#208).
+- Removed dead constant `SEVENZ_MAGIC` and its `#[allow(dead_code)]` suppression from `formats/detect.rs`; the constant was unused in format detection logic (#175).
 
 ### Fixed
 
@@ -33,37 +52,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ArchiveBuilder::extract` now returns `ExtractionError::InvalidConfiguration` instead of `ExtractionError::SecurityViolation` when `archive_path` or `output_dir` are not set. The previous variant caused `error_code()` to return `"SECURITY_VIOLATION"` for what is a caller configuration mistake (#235).
 - Corrected the `Archive::open` doc-comment which incorrectly claimed the constructor validates file existence. The function is infallible; I/O errors surface on `extract()` (#237).
 - `create_tar_zst_with_progress` now calls `zstd::Encoder::finish()` explicitly and propagates any I/O error via `?`. Previously the encoder relied on `Drop` to call `try_finish()`, which silently discarded flush errors and could produce a truncated `.tar.zst` archive on disk-full or other I/O failure (#226).
-- CLI no longer emits `"HINT: Use --allow-symlinks"` when `--allow-symlinks` is already active and a symlink escape is blocked. The hint is now suppressed when the flag is set, since the escape is a genuine security violation rather than a configuration issue (#213).
-
-### Removed
-
-- Removed 5 non-progress public functions (`create_tar`, `create_tar_gz`, `create_tar_bz2`, `create_tar_xz`, `create_tar_zst`) from `exarch-core::creation::tar` that were annotated `#[allow(dead_code)]` and unreachable from the crate's public surface. The public API already routes through `FormatCreator` trait objects using the `_with_progress` variants (#227).
-
-### Changed
-
-- Refactored `TarArchive` internal extraction helpers: introduced a private `ExtractionContext<'_, '_>` struct that groups the six shared parameters (`validator`, `dest`, `report`, `copy_buffer`, `dir_cache`, `skip_duplicates`) previously threaded individually through `process_entry` (7 params), `extract_file` (7 params), and `create_hardlink` (5 params). Signatures now accept `ctx: &mut ExtractionContext<'_, '_>` instead (#222).
-
-### Breaking Changes
-
-- `SecurityConfig`, `AllowedFeatures`, and `ExtractionOptions` are now `#[non_exhaustive]`. External crates can no longer construct these structs via struct literal syntax; use `Default::default()` or the new fluent builder methods instead (#221).
-
-### Changed
-
-- `extract_archive_full` renamed to `extract_archive_with_options_and_progress` for API naming consistency. The old name was ambiguous; the new name describes both parameters the function accepts (#219).
-- Introduced `FormatCreator` trait in `exarch-core::formats::traits` for archive creation dispatch. The trait mirrors `ArchiveFormat` on the write side and replaces the manual `match` in `create_archive_with_progress` with six unit struct implementors (`TarCreator`, `TarGzCreator`, `TarBz2Creator`, `TarXzCreator`, `TarZstCreator`, `ZipCreator`) and a `creator_for_format` helper (#220).
-- Added 15 fluent builder methods to `SecurityConfig` (`with_max_file_size`, `with_max_total_size`, `with_max_compression_ratio`, `with_max_file_count`, `with_max_path_depth`, `with_allowed`, `with_allow_symlinks`, `with_allow_hardlinks`, `with_allow_absolute_paths`, `with_allow_world_writable`, `with_preserve_permissions`, `with_allowed_extensions`, `with_banned_path_components`, `with_allow_solid_archives`, `with_max_solid_block_memory`) and 2 to `ExtractionOptions` (`with_atomic`, `with_skip_duplicates`) (#218).
-- `TarArchive::list()` and `TarArchive::extract()` now have `///` doc comments explaining that `list()` consumes the internal reader (TAR is forward-only) and that calling `extract()` on the same instance afterward returns `InvalidArchive`. Callers must open a fresh instance for extraction (#211).
-- `CopyBuffer::size()` visibility corrected from `pub(crate)` to `pub`, consistent with the other items in the crate-internal `mod copy`. The `pub(crate)` module boundary in `lib.rs` already enforces the encapsulation; redundant `pub(crate)` on items inside a `pub(crate)` module triggers the `redundant_pub_crate` clippy lint (#203).
-
-- **BREAKING**: Internal modules `copy`, `io`, and `test_utils` in `exarch-core` are now `pub(crate)` instead of `pub`. These were never part of the public API; any external code referencing `exarch_core::copy`, `exarch_core::io`, or `exarch_core::test_utils` directly will no longer compile (#173).
-- `verify_archive` now delegates to `verify_manifest` after calling `list_archive`, eliminating ~80 lines of duplicated entry-processing logic (#190).
-- `ProgressCallback::on_complete` doc comment clarified: the method is called only on successful completion; implementors must not use it for cleanup.
-- Removed dead `format_success` and `format_warning` methods from the `OutputFormatter` trait and both implementations (`HumanFormatter`, `JsonFormatter`). Neither method was called from any command handler (#208).
-- Removed dead constant `SEVENZ_MAGIC` and its `#[allow(dead_code)]` suppression from `formats/detect.rs`; the constant was unused in format detection logic (#175).
-- `ArchiveFormat` trait extended with `fn list()` and `fn verify()` methods, providing a single implementation point for all format operations (#174).
-
-### Fixed
-
 - CLI no longer emits `"HINT: Use --allow-symlinks"` when `--allow-symlinks` is already active and a symlink escape is blocked. The hint is now suppressed when the flag is set, since the escape is a genuine security violation rather than a configuration issue (#213).
 - `verify_archive` no longer shares a static `/tmp/exarch-verify` directory across concurrent calls. Each invocation now uses an isolated `tempfile::TempDir` scoped to its lifetime, eliminating the TOCTOU race and persistent state pollution (#200).
 - 7z extraction callback now accumulates `bytes_written` via `checked_add` instead of unchecked `+=`, preventing silent integer wraparound in release builds and matching the project-wide convention established in `copy_with_buffer` (#201).
@@ -448,7 +436,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 64KB reusable copy buffers
 - LRU cache for symlink target resolution
 
-[Unreleased]: https://github.com/bug-ops/exarch/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/bug-ops/exarch/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/bug-ops/exarch/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/bug-ops/exarch/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/bug-ops/exarch/compare/v0.2.9...v0.3.0
 [0.2.9]: https://github.com/bug-ops/exarch/compare/v0.2.8...v0.2.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `extract` subcommand now accepts `--allowed-extensions <EXT>` (repeatable; comma-separated values also accepted) and passes the parsed list to `SecurityConfig::with_allowed_extensions()`, exposing the core extension filter at the CLI level (#246).
-
 - Shell completion generation via `exarch completion <shell>` (bash, zsh, fish, powershell, elvish). Output goes to stdout for piping into the appropriate completions directory (#232).
 - `--verbose` flag now prints one line per extracted entry to stderr, including entry name, size, and type. `--quiet` takes precedence when both flags are provided (#233).
 - `SecurityConfig::allowed_extensions` filter is now enforced during extraction across all three format handlers (TAR, ZIP, 7z). When the list is non-empty, files whose extension is not in the allowlist are skipped and recorded in `ExtractionReport::files_skipped` with a warning (#230).
+- `extract` subcommand now accepts `--allowed-extensions <EXT>` (repeatable; comma-separated values also accepted) and passes the parsed list to `SecurityConfig::with_allowed_extensions()`, exposing the core extension filter at the CLI level (#246).
 - `create_archive` now rejects ZIP-family alias extensions (`.apk`, `.jar`, `.whl`, `.epub`, `.war`, `.ear`, `.aab`, `.ipa`, `.appx`, `.msix`, `.vsix`, `.nbm`) when the output format is inferred (i.e., `CreationConfig::format` is `None`). Set `CreationConfig::format = Some(ArchiveType::Zip)` to override (#231).
 
 ### Breaking Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "exarch-cli"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "exarch-core"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "bzip2",
  "criterion",
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "exarch-node"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "exarch-core",
  "napi",
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "exarch-python"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "exarch-core",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.1"
+version = "0.4.0"
 authors = ["bug-ops"]
 edition = "2024"
 rust-version = "1.93.0"
@@ -19,7 +19,7 @@ keywords = ["archive", "extraction", "security", "tar", "zip"]
 categories = ["compression", "filesystem"]
 
 [workspace.dependencies]
-exarch-core = { path = "crates/exarch-core", version = "0.3.1" }
+exarch-core = { path = "crates/exarch-core", version = "0.4.0" }
 anyhow = "1.0"
 assert_cmd = "2.2"
 bzip2 = "0.6"

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Memory-safe archive extraction and creation library with Python and Node.js bind
 - **Extract, create, list, and verify archives** — Full support for TAR and ZIP (all operations), plus 7z extraction, listing, and verification
 - **Security-first design** — Default-deny security model with protection against path traversal, symlink attacks, zip bombs, and more
 - **Type-driven safety** — Rust's type system ensures validated paths can only be constructed through security checks
+- **Extension allowlists** — Optional `allowed_extensions` filter restricts extraction to a specific set of file extensions across TAR, ZIP, and 7z handlers
+- **Fluent configuration** — 15 `with_*` builder methods on `SecurityConfig` and 2 on `ExtractionOptions` for ergonomic setup
 - **Multi-language support** — Native bindings for Python (PyO3) and Node.js (napi-rs)
 - **Zero unsafe code** — Core library contains no unsafe Rust code
 - **High performance** — Optimized I/O with reusable buffers and streaming operations
@@ -29,7 +31,7 @@ Memory-safe archive extraction and creation library with Python and Node.js bind
 
 ```toml
 [dependencies]
-exarch-core = "0.3"
+exarch-core = "0.4"
 ```
 
 > [!IMPORTANT]
@@ -151,13 +153,15 @@ exarch provides defense-in-depth protection against common archive vulnerabiliti
 ```rust
 use exarch_core::SecurityConfig;
 
-let config = SecurityConfig {
-    max_file_size: 100 * 1024 * 1024,   // 100 MB
-    max_total_size: 1024 * 1024 * 1024, // 1 GB
-    max_compression_ratio: 50.0,         // 50x compression limit
-    ..Default::default()
-};
+let config = SecurityConfig::default()
+    .with_max_file_size(100 * 1024 * 1024)    // 100 MB
+    .with_max_total_size(1024 * 1024 * 1024)  // 1 GB
+    .with_max_compression_ratio(50.0)         // 50x compression limit
+    .with_allowed_extensions(vec![".tar".into(), ".gz".into()]); // optional allowlist
 ```
+
+> [!IMPORTANT]
+> `SecurityConfig`, `AllowedFeatures`, and `ExtractionOptions` are `#[non_exhaustive]` since v0.4.0. Use `Default::default()` plus the fluent `with_*` builder methods instead of struct literal syntax.
 
 ## Supported Formats
 

--- a/crates/exarch-cli/README.md
+++ b/crates/exarch-cli/README.md
@@ -127,6 +127,7 @@ exarch extract --allow-symlinks trusted-source.tar
 | `--max-total-size` | - | Maximum total extracted size (supports K/M/G/T suffixes) |
 | `--max-file-size` | - | Maximum single file size |
 | `--max-compression-ratio` | 100 | Maximum compression ratio (zip bomb protection) |
+| `--allowed-extensions` | — | Extract only entries whose extension is in the allowlist (repeatable; comma-separated values accepted; leading dots optional) |
 | `--allow-symlinks` | false | Allow symlinks (within extraction directory) |
 | `--allow-hardlinks` | false | Allow hardlinks (within extraction directory) |
 | `--preserve-permissions` | false | Preserve file permissions from archive |

--- a/crates/exarch-cli/README.md
+++ b/crates/exarch-cli/README.md
@@ -79,12 +79,13 @@ exarch [OPTIONS] <COMMAND>
 | `create` | Create a new archive |
 | `list` | List archive contents |
 | `verify` | Verify archive integrity |
+| `completion` | Generate shell completion script (bash, zsh, fish, powershell, elvish) |
 
 ### Global Options
 
 | Option | Short | Description |
 |--------|-------|-------------|
-| `--verbose` | `-v` | Enable verbose output |
+| `--verbose` | `-v` | Print one line per entry to stderr (name, size, type). Overridden by `--quiet`. |
 | `--quiet` | `-q` | Suppress non-error output |
 | `--json` | `-j` | Output results in JSON format |
 | `--help` | `-h` | Print help |
@@ -180,6 +181,30 @@ exarch create -f backup.tar.gz ./src
 > [!TIP]
 > Archive format is detected from the output file extension. Supported formats: `.tar`, `.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tar.zst`, `.zip`
 
+> [!CAUTION]
+> Since v0.4.0, `create` rejects ZIP-family alias extensions (`.apk`, `.jar`, `.whl`, `.epub`, `.war`, `.ear`, `.aab`, `.ipa`, `.appx`, `.msix`, `.vsix`, `.nbm`) when format inference is left to the file extension. These containers require extra structure (signing, manifests, ordering) that exarch doesn't produce.
+
+## Shell Completion
+
+Generate completion scripts for your shell:
+
+```bash
+# bash
+exarch completion bash > /usr/local/etc/bash_completion.d/exarch
+
+# zsh
+exarch completion zsh > ${fpath[1]}/_exarch
+
+# fish
+exarch completion fish > ~/.config/fish/completions/exarch.fish
+
+# PowerShell
+exarch completion powershell | Out-String | Invoke-Expression
+
+# elvish
+exarch completion elvish > ~/.config/elvish/lib/exarch.elv
+```
+
 ## Output Modes
 
 ### Human-readable (default)
@@ -262,7 +287,7 @@ cargo clippy -p exarch-cli -- -D warnings
 - [x] **Phase 1**: Foundation - CLI parsing, error handling, output formatting
 - [x] **Phase 2**: Archive creation functionality
 - [x] **Phase 3**: List and verify commands
-- [x] **Phase 4**: Progress bars, shell completions
+- [x] **Phase 4**: Progress bars, shell completions, per-entry verbose output
 - [ ] **Phase 5**: Distribution (Homebrew, apt, releases)
 
 ## Related Crates

--- a/crates/exarch-core/README.md
+++ b/crates/exarch-core/README.md
@@ -14,7 +14,7 @@ This crate is part of the [exarch](https://github.com/bug-ops/exarch) workspace.
 
 ```toml
 [dependencies]
-exarch-core = "0.3"
+exarch-core = "0.4"
 ```
 
 > [!IMPORTANT]
@@ -38,17 +38,21 @@ fn main() -> Result<(), exarch_core::ExtractionError> {
 
 ### Custom Security Configuration
 
+> [!IMPORTANT]
+> Since v0.4.0, `SecurityConfig`, `AllowedFeatures`, and `ExtractionOptions` are `#[non_exhaustive]`. Use `Default::default()` plus the fluent `with_*` builder methods instead of struct literal syntax.
+
 ```rust
 use exarch_core::SecurityConfig;
 
-let config = SecurityConfig {
-    max_file_size: 100 * 1024 * 1024,    // 100 MB per file
-    max_total_size: 1024 * 1024 * 1024,  // 1 GB total
-    max_file_count: 10_000,               // Max 10k files
-    max_compression_ratio: 50.0,          // 50x compression limit
-    ..Default::default()
-};
+let config = SecurityConfig::default()
+    .with_max_file_size(100 * 1024 * 1024)    // 100 MB per file
+    .with_max_total_size(1024 * 1024 * 1024)  // 1 GB total
+    .with_max_file_count(10_000)              // Max 10k files
+    .with_max_compression_ratio(50.0)         // 50x compression limit
+    .with_allowed_extensions(vec![".tar".into(), ".gz".into()]); // optional allowlist
 ```
+
+Available builders on `SecurityConfig`: `with_max_file_size`, `with_max_total_size`, `with_max_compression_ratio`, `with_max_file_count`, `with_max_path_depth`, `with_allowed`, `with_allow_symlinks`, `with_allow_hardlinks`, `with_allow_absolute_paths`, `with_allow_world_writable`, `with_preserve_permissions`, `with_allowed_extensions`, `with_banned_path_components`, `with_allow_solid_archives`, `with_max_solid_block_memory`. On `ExtractionOptions`: `with_atomic`, `with_skip_duplicates`.
 
 ### Builder Pattern
 
@@ -60,6 +64,9 @@ let report = ArchiveBuilder::new()
     .output_dir("/output/path")
     .extract()?;
 ```
+
+> [!WARNING]
+> **Breaking change in v0.4.0:** `Archive::open` now returns `Self` directly instead of `Result<Self>`. Drop the `?` or `.unwrap()` at call sites; I/O errors now surface on `extract()` instead.
 
 ## Security Features
 

--- a/crates/exarch-node/README.md
+++ b/crates/exarch-node/README.md
@@ -167,11 +167,13 @@ Builder-style security configuration.
 
 ```typescript
 const config = new SecurityConfig()
-  .maxFileSize(bytes)              // Max size per file
-  .maxTotalSize(bytes)             // Max total extraction size
-  .maxFileCount(count)             // Max number of files
-  .maxCompressionRatio(n)          // Max compression ratio (zip bomb detection)
-  .setAllowSolidArchives(true);    // Allow solid 7z archives (default: false)
+  .maxFileSize(bytes)                        // Max size per file
+  .maxTotalSize(bytes)                       // Max total extraction size
+  .maxFileCount(count)                       // Max number of files
+  .maxCompressionRatio(n)                    // Max compression ratio (zip bomb detection)
+  .allowedExtensions([".txt", ".md"])        // Restrict to a set of extensions
+  .bannedPathComponents(["__MACOSX"])        // Skip these path components
+  .setAllowSolidArchives(true);              // Allow solid 7z archives (default: false)
 ```
 
 ## Security Features
@@ -202,6 +204,8 @@ The library provides built-in protection against:
 | 7z | `.7z` | ✅ | — | ✅ | ✅ |
 
 **Note:** 7z creation is not yet supported. Solid and encrypted 7z archives are rejected for security reasons. Unix symlinks inside 7z archives are reported as regular files (sevenz-rust2 API limitation).
+
+**Note:** Since v0.4.0, partial extraction failures return the `ExtractionReport` accumulated up to the failure point without the inner error text being duplicated, and the report is now correctly delivered across the FFI boundary instead of being dropped early.
 
 ## Comparison with tar-fs
 

--- a/crates/exarch-node/package.json
+++ b/crates/exarch-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exarch-rs",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Memory-safe archive extraction library with built-in security validation",
   "main": "index.js",
   "types": "index.d.ts",

--- a/crates/exarch-python/README.md
+++ b/crates/exarch-python/README.md
@@ -31,7 +31,7 @@ pipenv install exarch
 
 ## Requirements
 
-- Python >= 3.9
+- Python >= 3.10
 
 ## Quick Start
 
@@ -148,16 +148,21 @@ Extract an archive to the specified directory with security validation.
 | `InvalidArchiveError` | Archive is corrupted |
 | `IOError` | I/O operation failed |
 
+**Note:** Since v0.4.0, `create_archive` raises `FileNotFoundError` for missing sources, `FileExistsError` when the output already exists without overwrite, and `ValueError` for invalid compression levels — matching standard Python conventions.
+
 ### `SecurityConfig`
 
 Builder-style security configuration.
 
 ```python
 config = exarch.SecurityConfig()
-config = config.max_file_size(100 * 1024 * 1024)    # 100 MB per file
-config = config.max_total_size(1024 * 1024 * 1024)  # 1 GB total
-config = config.max_file_count(10_000)               # Max 10k files
-config = config.allow_solid_archives(True)           # Allow solid 7z archives
+config = config.max_file_size(100 * 1024 * 1024)        # 100 MB per file
+config = config.max_total_size(1024 * 1024 * 1024)      # 1 GB total
+config = config.max_file_count(10_000)                   # Max 10k files
+config = config.max_compression_ratio(50.0)              # Zip bomb threshold
+config = config.allowed_extensions([".txt", ".md"])      # Extension allowlist
+config = config.banned_path_components(["__MACOSX"])     # Skip components
+config = config.allow_solid_archives(True)               # Allow solid 7z archives
 ```
 
 ## Security Features

--- a/crates/exarch-python/pyproject.toml
+++ b/crates/exarch-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exarch"
-version = "0.3.1"
+version = "0.4.0"
 description = "Memory-safe archive extraction library with built-in security validation"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/specs/001-exarch-system/spec.md
+++ b/specs/001-exarch-system/spec.md
@@ -18,7 +18,7 @@ related:
 # Feature: exarch System
 
 > [!info] Metadata
-> **Version**: 0.3.1
+> **Version**: 0.4.0
 > **MSRV**: Rust 1.93.0
 > **License**: MIT OR Apache-2.0
 > **Crates**: exarch-core, exarch-cli, exarch-python, exarch-node
@@ -181,7 +181,7 @@ THEN extraction runs on the libuv thread pool, files are extracted, and an Extra
 | FR-010 | WHEN a 7z archive is detected as solid and `allow_solid_archives` is false, THE SYSTEM SHALL reject extraction | must |
 | FR-011 | WHEN a 7z solid archive extraction is permitted, THE SYSTEM SHALL reject it if the total uncompressed size exceeds `max_solid_block_memory` | must |
 | FR-012 | WHEN the path depth of an entry exceeds `max_path_depth`, THE SYSTEM SHALL reject the entry | must |
-| FR-013 | WHEN `allowed_extensions` is non-empty and an entry's extension is not in the list, THE SYSTEM SHALL skip the entry | should |
+| FR-013 | WHEN `allowed_extensions` is non-empty and an entry's extension is not in the list, THE SYSTEM SHALL skip the entry and record it in `ExtractionReport::files_skipped` with a warning | must |
 
 ### 3.2 Format Support
 
@@ -198,11 +198,13 @@ THEN extraction runs on the libuv thread pool, files are extracted, and an Extra
 
 | ID | Requirement | Priority |
 |----|------------|----------|
-| FR-030 | `SecurityConfig` SHALL use a fluent builder API (`with_*` methods returning `Self`) and implement `Default` with secure deny-by-default settings | must |
-| FR-031 | `SecurityConfig::validate()` SHALL return an error if any limit field is zero or `max_compression_ratio` is not a positive finite number | must |
-| FR-032 | `CreationConfig` SHALL support: `follow_symlinks`, `include_hidden`, `max_file_size`, `exclude_patterns`, `strip_prefix`, `compression_level` (1-9), `preserve_permissions`, `format` override | must |
-| FR-033 | `ExtractionOptions` SHALL support: `atomic` (temp-dir + rename), `skip_duplicates` (default true) | must |
-| FR-034 | WHEN `ExtractionOptions::atomic` is true, THE SYSTEM SHALL extract to a temp dir in the same parent as the output directory and atomically rename on success; on failure it SHALL delete the temp dir | must |
+| FR-030 | `SecurityConfig` SHALL use a fluent builder API (15 `with_*` methods returning `Self`) and implement `Default` with secure deny-by-default settings | must |
+| FR-031 | `SecurityConfig` SHALL be annotated `#[non_exhaustive]`; external crates must use `Default::default()` or builder methods — struct literal construction is rejected at compile time | must |
+| FR-032 | `SecurityConfig::validate()` SHALL return an error if any limit field is zero (including `max_file_count` and `max_solid_block_memory`), `max_compression_ratio` is not a positive finite number, or any field contains an invalid value | must |
+| FR-033 | `CreationConfig` SHALL support: `follow_symlinks`, `include_hidden`, `max_file_size`, `exclude_patterns`, `strip_prefix`, `compression_level` (1-9), `preserve_permissions`, `format` override | must |
+| FR-034 | `ExtractionOptions` SHALL be annotated `#[non_exhaustive]` and SHALL support: `atomic` (temp-dir + rename), `skip_duplicates` (default true); fluent builders `with_atomic` and `with_skip_duplicates` are provided | must |
+| FR-035 | WHEN `ExtractionOptions::atomic` is true, THE SYSTEM SHALL extract to a temp dir in the same parent as the output directory and atomically rename on success; on failure it SHALL delete the temp dir | must |
+| FR-036 | `AllowedFeatures` SHALL be annotated `#[non_exhaustive]` so new flags do not break downstream struct literals | must |
 
 ### 3.4 Progress Reporting
 
@@ -230,7 +232,9 @@ THEN extraction runs on the libuv thread pool, files are extracted, and an Extra
 | FR-063 | `extract` SHALL support: `--max-files`, `--max-total-size` (with K/M/G/T suffixes), `--max-file-size`, `--max-compression-ratio`, `--allow-symlinks`, `--allow-hardlinks`, `--allow-solid-archives`, `--allow-world-writable`, `--preserve-permissions`, `--force`, `--atomic` | must |
 | FR-064 | `create` SHALL support: `--compression-level` (1-9), `--follow-symlinks`, `--include-hidden`, `--exclude` (repeatable glob), `--strip-prefix`, `--force` | must |
 | FR-065 | `list` and `verify` SHALL support: `--long`, `--human-readable`, `--max-files`, `--max-total-size`, `--allow-solid-archives` | must |
-| FR-066 | `completion` SHALL generate shell completion scripts for bash, zsh, fish, and PowerShell | should |
+| FR-066 | `completion <SHELL>` SHALL generate shell completion scripts for bash, zsh, fish, powershell, and elvish; output goes to stdout | must |
+| FR-067 | WHEN `--verbose` is set, THE CLI SHALL print one line per extracted entry to stderr including entry type, size, and path; `--quiet` takes precedence over `--verbose` | must |
+| FR-068 | WHEN `--allow-symlinks` is already active and a symlink escape is blocked, THE CLI SHALL NOT emit the `--allow-symlinks` hint (genuine security violation, not a configuration gap) | must |
 
 ### 3.7 Python Bindings
 
@@ -288,6 +292,9 @@ THEN extraction runs on the libuv thread pool, files are extracted, and an Extra
 | `VerificationReport` | Security and integrity check results | `status: VerificationStatus`, `issues: Vec<VerificationIssue>`, `total_entries` |
 | `VerificationIssue` | A single identified security or integrity issue | `severity: IssueSeverity`, `category: IssueCategory`, `message`, `path` |
 | `ArchiveType` | Enum of supported archive formats | `Tar`, `TarGz`, `TarBz2`, `TarXz`, `TarZst`, `Zip`, `SevenZ` |
+| `ArchiveFormat` | Trait for read-side format dispatch | Methods: `extract`, `list`, `verify`, `format_name` |
+| `FormatCreator` | Trait for write-side format dispatch | Methods: `create`, `format_name`; implemented by `TarCreator`, `TarGzCreator`, `TarBz2Creator`, `TarXzCreator`, `TarZstCreator`, `ZipCreator` via `creator_for_format()` helper |
+| `ExtractionContext` | Private TAR helper struct grouping six shared extraction parameters | `validator`, `dest`, `report`, `copy_buffer`, `dir_cache`, `skip_duplicates` |
 
 ## 6. Edge Cases and Error Handling
 
@@ -296,7 +303,7 @@ THEN extraction runs on the libuv thread pool, files are extracted, and an Extra
 | Archive path does not exist | `ExtractionError::Io` returned immediately |
 | Extension unrecognized or bare `.gz` without `.tar` stem | `ExtractionError::UnsupportedFormat` |
 | ZIP-family alias (`.apk`, `.whl`) extraction | Proceeds as ZIP |
-| ZIP-family alias creation without format override | `ExtractionError::InvalidArchive` with explanation |
+| ZIP-family alias creation without format override | `ExtractionError::InvalidArchive` with explanation naming the alias and referencing `CreationConfig::format` override |
 | 7z creation | `ExtractionError::UnsupportedFormat` |
 | Duplicate entry paths in archive | Logged as warning in `ExtractionReport.warnings` when `skip_duplicates` is true; error when false |
 | Atomic extraction to existing non-empty directory | `ExtractionError::OutputExists` on rename failure; temp dir cleaned up |
@@ -363,6 +370,12 @@ THEN extraction runs on the libuv thread pool, files are extracted, and an Extra
 - [NEEDS CLARIFICATION: Is there a plan to support 7z creation in a future version, or is read-only permanently by design?]
 - [NEEDS CLARIFICATION: Windows path separator handling in path validation — is there a CI job that runs the test suite on Windows?]
 - [NEEDS CLARIFICATION: Should `ProgressCallback` expose a cancellation mechanism (e.g., return bool to abort)?]
+
+> [!danger] Breaking Changes in v0.4.0
+> - **`Archive::open`** now returns `Self` (was `Result<Self>`). Remove `?` or `.unwrap()` at call sites (#243).
+> - **`SecurityConfig`**, **`AllowedFeatures`**, and **`ExtractionOptions`** are now `#[non_exhaustive]`. Struct literal construction no longer compiles; use `Default::default()` plus builder methods (#221).
+> - Internal modules `copy`, `io`, `test_utils` in `exarch-core` are now `pub(crate)`. External references to `exarch_core::copy`, `exarch_core::io`, or `exarch_core::test_utils` no longer compile (#173).
+> - `extract_archive_full` renamed to `extract_archive_with_options_and_progress` (#219).
 
 ## 10. See Also
 

--- a/specs/001-security-pipeline/spec.md
+++ b/specs/001-security-pipeline/spec.md
@@ -146,7 +146,7 @@ THEN the written file has those bits cleared; ValidatedEntry.mode reflects the s
 | FR-008 | WHEN a hardlink entry is encountered and `allowed.hardlinks` is true, THE SYSTEM SHALL validate that the hardlink target path is within `output_dir` and references a path previously seen in this archive | must |
 | FR-009 | WHEN extracting files on Unix, THE SYSTEM SHALL strip setuid (0o4000) and setgid (0o2000) bits from all file permissions | must |
 | FR-010 | WHEN the path depth of an entry exceeds `max_path_depth`, THE SYSTEM SHALL reject the entry with `ExtractionError::PathTraversal` | must |
-| FR-011 | WHEN `allowed_extensions` is non-empty and an entry's extension is not in the list, THE SYSTEM SHALL skip the entry | should |
+| FR-011 | WHEN `allowed_extensions` is non-empty and an entry's extension is not in the list, THE SYSTEM SHALL skip the entry and record it in `ExtractionReport::files_skipped` with a warning | must |
 | FR-012 | WHEN the file count across all entries exceeds `max_file_count`, THE SYSTEM SHALL reject further entries with `QuotaExceeded { resource: FileCount }` | must |
 | FR-013 | WHEN `allowed.world_writable` is false and a file entry has world-writable permissions (`mode & 0o002 != 0`), THE SYSTEM SHALL strip that bit or reject the entry | must |
 
@@ -194,7 +194,8 @@ THEN the written file has those bits cleared; ValidatedEntry.mode reflects the s
 | Hardlink with `allowed.hardlinks = false` | Entry skipped |
 | Hardlink to a path not previously seen | `ExtractionError::HardlinkEscape` |
 | setuid/setgid bits on Unix | Stripped silently; `ValidatedEntry.mode` reflects sanitized value |
-| `SecurityConfig` with zero limit | `SecurityConfig::validate()` returns `InvalidConfiguration` before extraction begins |
+| `SecurityConfig` with zero `max_file_size`, `max_total_size`, `max_path_depth`, `max_file_count`, or `max_solid_block_memory` | `SecurityConfig::validate()` returns `InvalidConfiguration` before extraction begins |
+| `SecurityConfig` with `max_compression_ratio` of 0.0, negative, or NaN | `SecurityConfig::validate()` returns `InvalidConfiguration` before extraction begins |
 
 ## 7. Success Criteria
 
@@ -230,7 +231,9 @@ THEN the written file has those bits cleared; ValidatedEntry.mode reflects the s
 
 - [NEEDS CLARIFICATION: Should `ProgressCallback` expose a cancellation mechanism (return bool) so callers can abort mid-stream from the security callback?]
 - [NEEDS CLARIFICATION: Windows path separator handling (`\` vs `/`) — is there a CI job covering Windows path validation edge cases?]
-- [NEEDS CLARIFICATION: Should world-writable entries be stripped or rejected? Current behavior unclear.]
+
+> [!note] Resolved in v0.4.0
+> World-writable entries: behavior clarified — the `allow_world_writable` bit is stripped (not rejection), matching setuid/setgid treatment. `allowed_extensions` filtering (FR-011) is now fully implemented across TAR, ZIP, and 7z in v0.4.0 (#230, #242). `SecurityConfig::validate()` now also rejects `max_file_count == 0` and `max_solid_block_memory == 0` in addition to the previously documented zero-limit fields (#181).
 
 ## 10. See Also
 

--- a/specs/001-security-pipeline/tasks.md
+++ b/specs/001-security-pipeline/tasks.md
@@ -7,7 +7,7 @@ tags:
   - security
   - rust
 created: 2026-05-20
-status: draft
+status: done
 related:
   - "[[spec]]"
   - "[[001-exarch-system/plan]]"
@@ -21,16 +21,16 @@ related:
 > **Plan**: [[001-exarch-system/plan]]
 > **Total tasks**: 2
 
-> [!warning] Scope
-> The security pipeline is substantially implemented. The only open gap is
-> FR-011 / FR-013: `allowed_extensions` is defined in `SecurityConfig` but
-> the `EntryValidator` never reads it, so extension filtering is silently
-> skipped during extraction. GitHub issue #230 tracks this.
+> [!note] Completed in v0.4.0
+> Both open tasks were resolved in v0.4.0. `allowed_extensions` filtering
+> (FR-011) is now enforced by `EntryValidator` across TAR, ZIP, and 7z
+> handlers (#230, #242). Skipped entries are recorded in
+> `ExtractionReport::files_skipped` with a warning.
 
 ## Progress
 
-- [ ] T001: Enforce `allowed_extensions` in `EntryValidator`
-- [ ] T002: Add integration tests for extension filtering
+- [x] T001: Enforce `allowed_extensions` in `EntryValidator`
+- [x] T002: Add integration tests for extension filtering
 
 ---
 

--- a/specs/002-format-handlers/spec.md
+++ b/specs/002-format-handlers/spec.md
@@ -22,6 +22,7 @@ related:
 > [!info] Metadata
 > **Subsystem**: exarch-core / formats
 > **MSRV**: Rust 1.93.0
+> **zip dependency**: 9.0.0-pre2
 > **Source**: extracted from [[001-exarch-system/spec]]
 
 ## 1. Overview
@@ -151,6 +152,8 @@ THEN ExtractionError::UnsupportedFormat is returned immediately
 | FR-027 | WHEN a 7z solid archive extraction is permitted, THE SYSTEM SHALL reject it if total uncompressed size exceeds `max_solid_block_memory` | must |
 | FR-028 | Every format handler SHALL route all entries through `EntryValidator` before writing to disk | must |
 | FR-029 | WHEN listing or verifying an archive, THE SYSTEM SHALL NOT write any files to disk | must |
+| FR-030 | WHEN `allowed_extensions` in `SecurityConfig` is non-empty, ALL three format handlers (TAR, ZIP, 7z) SHALL skip entries whose extension is not in the allowlist and record them in `ExtractionReport::files_skipped` | must |
+| FR-031 | `ArchiveFormat::extract` SHALL accept and invoke a `ProgressCallback` for every entry; ZIP-family alias creation without an explicit `CreationConfig::format` override SHALL be rejected with `ExtractionError::InvalidArchive` naming the alias | must |
 
 ## 4. Non-Functional Requirements
 
@@ -168,10 +171,11 @@ THEN ExtractionError::UnsupportedFormat is returned immediately
 |--------|-------------|----------------|
 | `ArchiveType` | Enum of supported archive formats | `Tar`, `TarGz`, `TarBz2`, `TarXz`, `TarZst`, `Zip`, `SevenZ` |
 | `ArchiveFormat` | Trait implemented by every format handler | Methods: `extract`, `list`, `verify`, `format_name` |
-| `FormatCreator` | Trait for archive creation; implemented by TAR variants and ZIP | Methods: `create`, `format_name` |
-| `TarArchive<R>` | TAR handler generic over decompressor type | Implements `ArchiveFormat` |
-| `ZipArchive` | ZIP handler | Implements `ArchiveFormat` and `FormatCreator` |
-| `SevenZArchive` | 7z handler (read-only) | Implements `ArchiveFormat` only |
+| `FormatCreator` | Trait for archive creation; implemented by six unit structs | `TarCreator`, `TarGzCreator`, `TarBz2Creator`, `TarXzCreator`, `TarZstCreator`, `ZipCreator`; dispatched via `creator_for_format()` |
+| `TarArchive<R>` | TAR handler generic over decompressor type | Implements `ArchiveFormat`; `list()` consumes the internal reader (TAR is forward-only); do not call `extract()` on the same instance |
+| `ZipArchive` | ZIP handler | Implements `ArchiveFormat` and `FormatCreator`; `ZipFile::name()` returns `Result<Cow<str>, ZipError>` in zip 9.x |
+| `SevenZArchive` | 7z handler (read-only) | Implements `ArchiveFormat` only; fires `on_entry_start`/`on_entry_complete` per-entry, interleaved with I/O |
+| `ExtractionContext<'_, '_>` | Private TAR helper struct reducing extraction helper arity | Groups `validator`, `dest`, `report`, `copy_buffer`, `dir_cache`, `skip_duplicates` |
 
 ### ArchiveType Detection Rules
 
@@ -203,6 +207,20 @@ FormatCreator:
   create(output, sources, config, progress) -> Result<CreationReport>
   format_name() -> &'static str
 ```
+
+> [!note] zip dependency
+> Upgraded from 8.6.0 to 9.0.0-pre2 in v0.4.0. `ZipFile::name()` now returns
+> `Result<Cow<str>, ZipError>` instead of `&str`; all call sites propagate the
+> new error via `?`.
+
+> [!note] TarArchive forward-only constraint
+> `TarArchive::list()` consumes the internal reader because TAR is forward-only.
+> Callers must open a fresh `TarArchive` instance to call `extract()` after `list()`.
+
+> [!note] 7z progress ordering fixed in v0.4.0
+> Prior to v0.4.0, `SevenZArchive::extract` batched all `on_entry_start` calls
+> before extraction and all `on_entry_complete` calls after. In v0.4.0, callbacks
+> fire per-entry, interleaved with actual I/O (#191).
 
 ## 6. Edge Cases and Error Handling
 

--- a/specs/002-format-handlers/tasks.md
+++ b/specs/002-format-handlers/tasks.md
@@ -7,7 +7,7 @@ tags:
   - archive
   - rust
 created: 2026-05-20
-status: draft
+status: done
 related:
   - "[[spec]]"
   - "[[001-exarch-system/plan]]"
@@ -21,16 +21,15 @@ related:
 > **Plan**: [[001-exarch-system/plan]]
 > **Total tasks**: 1
 
-> [!warning] Scope
-> Format handler extraction, listing, and verification are fully implemented
-> for TAR variants, ZIP, and 7z. The single open gap is FR-025: ZIP-family
-> alias creation rejection is implemented in `api.rs` but does not surface a
-> clear, user-facing error message containing the alias name and the available
-> override mechanism. GitHub issue #231 tracks this.
+> [!note] Completed in v0.4.0
+> All format handler work is complete. The ZIP-family alias creation error
+> message (FR-025 / #231) was improved in v0.4.0: the error now names the
+> detected alias extension and references the `CreationConfig::format` override
+> as the escape hatch.
 
 ## Progress
 
-- [ ] T001: Improve ZIP-family alias creation error message
+- [x] T001: Improve ZIP-family alias creation error message
 
 ---
 

--- a/specs/003-config-api/spec.md
+++ b/specs/003-config-api/spec.md
@@ -116,15 +116,16 @@ THEN no files are present in the output directory; the temp dir is cleaned up
 
 | ID | Requirement | Priority |
 |----|------------|----------|
-| FR-030 | `SecurityConfig` SHALL use a fluent builder API (`with_*` methods returning `Self`) and implement `Default` with secure deny-by-default settings | must |
-| FR-031 | `SecurityConfig` SHALL be annotated `#[non_exhaustive]` so new fields do not constitute a breaking change for struct literal construction | must |
-| FR-032 | `SecurityConfig::validate()` SHALL return an error if any limit field is zero or `max_compression_ratio` is not a positive finite number | must |
+| FR-030 | `SecurityConfig` SHALL expose 15 fluent builder methods: `with_max_file_size`, `with_max_total_size`, `with_max_compression_ratio`, `with_max_file_count`, `with_max_path_depth`, `with_allowed`, `with_allow_symlinks`, `with_allow_hardlinks`, `with_allow_absolute_paths`, `with_allow_world_writable`, `with_preserve_permissions`, `with_allowed_extensions`, `with_banned_path_components`, `with_allow_solid_archives`, `with_max_solid_block_memory`; each returns `Self` | must |
+| FR-031 | `SecurityConfig`, `AllowedFeatures`, and `ExtractionOptions` SHALL be annotated `#[non_exhaustive]`; external crates must use `Default::default()` plus builder methods — struct literal construction is a compile error | must |
+| FR-032 | `SecurityConfig::validate()` SHALL return `InvalidConfiguration` if: any numeric limit is zero (`max_file_size`, `max_total_size`, `max_file_count`, `max_path_depth`, `max_solid_block_memory`), or `max_compression_ratio` is zero, negative, or NaN | must |
 | FR-033 | `CreationConfig` SHALL support: `follow_symlinks`, `include_hidden`, `max_file_size`, `exclude_patterns` (glob), `strip_prefix`, `compression_level` (1–9), `preserve_permissions`, `format` override | must |
-| FR-034 | `ExtractionOptions` SHALL support: `atomic` (temp-dir + rename), `skip_duplicates` (default true) | must |
+| FR-034 | `ExtractionOptions` SHALL support: `atomic` (temp-dir + rename) via `with_atomic`, `skip_duplicates` (default true) via `with_skip_duplicates` | must |
 | FR-035 | WHEN `ExtractionOptions::atomic` is true, THE SYSTEM SHALL extract to a temp dir in the same parent as the output directory and atomically rename on success | must |
 | FR-036 | WHEN atomic extraction fails, THE SYSTEM SHALL delete the temp dir before returning the error | must |
 | FR-037 | All three config types SHALL implement `Default` with documented defaults | must |
 | FR-038 | `AllowedFeatures` SHALL be a separate struct with boolean flags: `symlinks`, `hardlinks`, `absolute_paths`, `world_writable`; all default to false | must |
+| FR-039 | `CreationConfig::validate()` SHALL be called inside `create_archive_with_progress` before any I/O; invalid configurations SHALL be rejected early | must |
 
 ## 4. Non-Functional Requirements
 
@@ -167,7 +168,7 @@ THEN no files are present in the output directory; the temp dir is cleaned up
 
 | Scenario | Expected Behavior |
 |----------|-------------------|
-| `SecurityConfig` with zero `max_file_size` | `validate()` returns `InvalidConfiguration` |
+| `SecurityConfig` with zero `max_file_size`, `max_total_size`, `max_path_depth`, `max_file_count`, or `max_solid_block_memory` | `validate()` returns `InvalidConfiguration` |
 | `SecurityConfig` with `max_compression_ratio` of 0.0, negative, or NaN | `validate()` returns `InvalidConfiguration` |
 | `compression_level` outside 1–9 | `CreationConfig` builder panics or returns error at construction |
 | `atomic = true` and output on a different filesystem than temp dir | `fs::rename` may fail; caller receives `ExtractionError::Io` |

--- a/specs/004-progress-tracking/spec.md
+++ b/specs/004-progress-tracking/spec.md
@@ -115,7 +115,7 @@ THEN on_entry_start and on_entry_complete are called for each source file added
 | FR-041 | THE SYSTEM SHALL provide a `NoopProgress` implementation that satisfies `ProgressCallback` with no runtime overhead | must |
 | FR-042 | `on_complete` SHALL NOT be called if extraction fails or is partial | must |
 | FR-043 | `ProgressCallback` SHALL be `Send` so it can be used across thread boundaries (Node.js, Python) | must |
-| FR-044 | Format handlers SHALL accept `&mut dyn ProgressCallback` and call it consistently for each entry | must |
+| FR-044 | Format handlers SHALL accept `&mut dyn ProgressCallback` and call it consistently for each entry; callbacks SHALL fire per-entry interleaved with actual I/O (not batched before or after) | must |
 | FR-045 | `on_bytes_written` SHALL be called with the number of bytes written in the current chunk, not a cumulative total | must |
 | FR-046 | `on_entry_start` SHALL receive the total number of entries (if known) and the current entry index | must |
 
@@ -144,8 +144,18 @@ ProgressCallback: Send
   on_entry_start(&mut self, path: &Path, total: usize, current: usize)
   on_bytes_written(&mut self, bytes: u64)
   on_entry_complete(&mut self, path: &Path)
-  on_complete(&mut self)  // NOT called on failure
+  on_complete(&mut self)  // NOT called on failure; called only on full success
 ```
+
+> [!note] v0.4.0 clarification
+> `on_complete` is called only on successful completion. Implementors must not
+> use it for cleanup — use the `Err` return path from `extract_archive` instead.
+
+> [!note] ExtractionContext
+> `ExtractionContext<'_, '_>` is a private TAR helper struct introduced in v0.4.0
+> that groups `validator`, `dest`, `report`, `copy_buffer`, `dir_cache`, and
+> `skip_duplicates` to reduce helper function arity. It is not part of the public
+> API but is documented here because `ProgressCallback` is passed through it.
 
 ## 6. Edge Cases and Error Handling
 
@@ -162,9 +172,9 @@ ProgressCallback: Send
 
 | ID | Metric | Target |
 |----|--------|--------|
-| SC-001 | `on_complete` not called on failure | Regression test (see issue #170) |
+| SC-001 | `on_complete` not called on failure | Regression test (issue #170, fixed in v0.4.0) |
 | SC-002 | Progress overhead vs no-progress | < 5% throughput penalty (measured in bench) |
-| SC-003 | All format handlers call progress callbacks | Integration test with a counting progress impl |
+| SC-003 | All format handlers (TAR, ZIP, 7z) call progress callbacks per-entry | Fixed in v0.4.0 (#170, #191) |
 
 ## 8. Agent Boundaries
 

--- a/specs/005-cli/spec.md
+++ b/specs/005-cli/spec.md
@@ -143,12 +143,14 @@ THEN stdout contains valid JSON with all report fields; stderr contains no progr
 | FR-063 | `extract` SHALL support: `--max-files N`, `--max-total-size SIZE` (K/M/G/T suffixes), `--max-file-size SIZE`, `--max-compression-ratio N`, `--allow-symlinks`, `--allow-hardlinks`, `--allow-solid-archives`, `--allow-world-writable`, `--preserve-permissions`, `--force`, `--atomic` | must |
 | FR-064 | `create` SHALL support: `-l/--compression-level 1-9`, `--follow-symlinks`, `--include-hidden`, `-x/--exclude PATTERN` (repeatable glob), `--strip-prefix PREFIX`, `-f/--force` | must |
 | FR-065 | `list` and `verify` SHALL support: `-l/--long`, `-H/--human-readable`, `--max-files N`, `--max-total-size SIZE`, `--allow-solid-archives` | must |
-| FR-066 | `completion` SHALL generate shell completion scripts for bash, zsh, fish, and PowerShell | should |
+| FR-066 | `completion <SHELL>` SHALL generate shell completion scripts for bash, zsh, fish, powershell, and elvish; output goes to stdout for piping into the appropriate completions directory | must |
 | FR-067 | WHEN extraction or creation fails, THE CLI SHALL exit with a non-zero exit code and print the error to stderr | must |
 | FR-068 | WHEN `--quiet` is set, THE CLI SHALL suppress progress bars and informational output; only errors go to stderr | must |
-| FR-069 | WHEN `--verbose` is set, THE CLI SHALL print per-entry details during extraction and creation | should |
+| FR-069 | WHEN `--verbose` is set, THE CLI SHALL print one line per extracted entry to stderr including entry type indicator (`f`/`d`/`l`), uncompressed size, and relative path; `--quiet` takes precedence when both are set | must |
 | FR-070 | THE CLI progress bar SHALL use `indicatif` in human mode and be suppressed in `--json` and `--quiet` modes | must |
 | FR-071 | Human-readable output SHALL use SI suffixes (K, M, G) for byte counts when `-H/--human-readable` is set | should |
+| FR-072 | WHEN `--allow-symlinks` is already active and a symlink escape is blocked, THE CLI SHALL NOT emit the `--allow-symlinks` hint; the hint is only relevant when symlinks are not yet enabled | must |
+| FR-073 | WHEN `--json` is used, the JSON `message` field for `PartialExtraction`, `PathTraversal`, `SymlinkEscape`, `HardlinkEscape`, `QuotaExceeded`, and `ZipBomb` errors SHALL NOT repeat inner error text that already appears in the structured fields | must |
 
 ## 4. Non-Functional Requirements
 
@@ -194,7 +196,7 @@ exarch list <ARCHIVE>
 exarch verify <ARCHIVE>
     [--max-files N] [--max-total-size SIZE] [--allow-solid-archives]
 
-exarch completion <SHELL>    # bash | zsh | fish | powershell | elvish
+exarch completion <SHELL>    # bash | zsh | fish | powershell | elvish  (output to stdout)
 ```
 
 ## 6. Edge Cases and Error Handling

--- a/specs/005-cli/tasks.md
+++ b/specs/005-cli/tasks.md
@@ -7,7 +7,7 @@ tags:
   - cli
   - rust
 created: 2026-05-20
-status: draft
+status: done
 related:
   - "[[spec]]"
   - "[[001-exarch-system/plan]]"
@@ -21,27 +21,22 @@ related:
 > **Plan**: [[001-exarch-system/plan]]
 > **Total tasks**: 2
 
-> [!warning] Scope
-> The core CLI (all subcommands, JSON output, progress bar, exit codes) is
-> fully implemented. Two `should`-priority requirements remain open:
+> [!note] Completed in v0.4.0
+> Both open CLI tasks were resolved in v0.4.0:
 >
-> - FR-066: `completion` subcommand — the command exists and generates valid
->   scripts, but the `CompletionArgs` struct does not appear in the CLI help
->   text with full shell option descriptions and the `--json` flag is accepted
->   but has no effect on completion output (correct behaviour, but untested).
->   Issue #232 tracks adding a CLI integration test that exercises the
->   `completion` subcommand end-to-end.
+> - **T001 (FR-066 / #232)**: `exarch completion <shell>` is fully implemented
+>   and tested for bash, zsh, fish, powershell, and elvish. Output goes to
+>   stdout for piping. Integration test added.
 >
-> - FR-069: `--verbose` per-entry output — the `verbose` flag is parsed and
->   stored in `HumanFormatter`, but the only verbose-gated output is two extra
->   summary lines after extraction (symlink count and duration). Per-entry
->   details (path, size, type) during active extraction or creation are not
->   printed. Issue #233 tracks implementing the per-entry verbose path.
+> - **T002 (FR-069 / #233)**: `--verbose` now prints one line per extracted
+>   entry to stderr including entry type (`f`/`d`/`l`), uncompressed size, and
+>   relative path. `--quiet` takes precedence when both flags are set. Verbose
+>   lines do not appear in `--json` mode.
 
 ## Progress
 
-- [ ] T001: Integration test for `completion` subcommand
-- [ ] T002: Per-entry verbose output during extraction and creation
+- [x] T001: Integration test for `completion` subcommand
+- [x] T002: Per-entry verbose output during extraction and creation
 
 ---
 
@@ -55,51 +50,47 @@ graph TD
 
 ---
 
-### T001: Integration test for `completion` subcommand
+### T001: Integration test for `completion` subcommand (done)
 
-**Context**: The `completion` command is implemented in
-`crates/exarch-cli/src/commands/completion.rs` with a unit test that verifies
-no panic occurs. There is no integration test confirming that the generated
-script is non-empty, written to stdout, and produces no stderr output. FR-066
-acceptance criteria require a verifiable completion script for each shell.
+**Context**: `exarch completion <shell>` generates completion scripts for bash,
+zsh, fish, powershell, and elvish. Output goes to stdout. Integration tests
+verify non-empty output containing `"exarch"` and zero stderr for each shell.
 **Spec reference**: [[spec#FR-066]], [[spec#US-005]]
-**GitHub issue**: #232
+**GitHub issue**: #232 (closed in v0.4.0)
 **Acceptance criteria**:
-- [ ] Integration test runs `exarch completion bash` and asserts stdout is non-empty and contains the string `"exarch"`
-- [ ] Same check for `zsh`, `fish`, and `powershell`
-- [ ] Test asserts stderr is empty and exit code is 0
-- [ ] Test for an unsupported shell name asserts exit code is non-zero
-- [ ] Tests pass under `cargo nextest run -p exarch-cli` (or the workspace nextest invocation)
+- [x] Integration test runs `exarch completion bash` and asserts stdout is non-empty and contains the string `"exarch"`
+- [x] Same check for `zsh`, `fish`, `powershell`, and `elvish`
+- [x] Test asserts stderr is empty and exit code is 0
+- [x] Test for an unsupported shell name asserts exit code is non-zero
+- [x] Tests pass under `cargo nextest run -p exarch-cli`
 **Dependencies**: none
 **Files**:
-- `crates/exarch-cli/tests/` — new integration test file `completion.rs` or extend existing CLI tests
+- `crates/exarch-cli/tests/` — `completion.rs` integration test
 **Complexity**: low
 
 ---
 
-### T002: Per-entry verbose output during extraction and creation
+### T002: Per-entry verbose output during extraction and creation (done)
 
-**Context**: FR-069 states: "WHEN `--verbose` is set, THE CLI SHALL print
-per-entry details during extraction and creation." Currently `HumanFormatter`
-gates only two extra lines on `self.verbose` (symlink count and duration in the
-post-extraction summary). No per-entry output is emitted during the extraction
-loop. The `ProgressCallback` path is the right place to hook verbose per-entry
-logging so it interleaves with the progress bar correctly.
+**Context**: `--verbose` now prints one line per extracted entry to stderr.
+Each line includes the entry type indicator (`f`/`d`/`l`), uncompressed size,
+and relative path. `--quiet` takes precedence. Verbose output is suppressed
+in `--json` mode.
 **Spec reference**: [[spec#FR-069]], [[spec#US-006]]
-**GitHub issue**: #233
+**GitHub issue**: #233 (closed in v0.4.0)
 **Acceptance criteria**:
-- [ ] When `--verbose` is active, each extracted entry path is printed to stderr during extraction (one line per entry)
-- [ ] Each verbose line includes: entry type indicator (`f`/`d`/`l`), uncompressed size, and relative path
-- [ ] Verbose lines go to stderr (not stdout), preserving `--json` stdout cleanliness
-- [ ] Verbose lines do not appear when `--quiet` or `--json` is set
-- [ ] During `create`, each added file path is printed to stderr when `--verbose` is set
-- [ ] Integration test: run `exarch extract <archive> --verbose 2>verbose.log` and assert `verbose.log` contains all entry paths
-- [ ] No changes to `ExtractionReport`, `CreationReport`, or `ProgressCallback` trait signatures
+- [x] When `--verbose` is active, each extracted entry path is printed to stderr during extraction (one line per entry)
+- [x] Each verbose line includes: entry type indicator (`f`/`d`/`l`), uncompressed size, and relative path
+- [x] Verbose lines go to stderr (not stdout), preserving `--json` stdout cleanliness
+- [x] Verbose lines do not appear when `--quiet` or `--json` is set
+- [x] During `create`, each added file path is printed to stderr when `--verbose` is set
+- [x] Integration test verifies verbose log contains all entry paths
+- [x] No changes to `ExtractionReport`, `CreationReport`, or `ProgressCallback` trait signatures
 **Dependencies**: none
 **Files**:
-- `crates/exarch-cli/src/progress.rs` — `CliProgress` implementation; add per-entry callback
-- `crates/exarch-cli/src/output/human.rs` — add `print_verbose_entry()` helper if needed
-- `crates/exarch-cli/tests/` — integration test for verbose output
+- `crates/exarch-cli/src/progress.rs` — `CliProgress` per-entry verbose callback
+- `crates/exarch-cli/src/output/human.rs` — `print_verbose_entry()` helper
+- `crates/exarch-cli/tests/` — verbose output integration test
 **Complexity**: medium
 
 ---

--- a/specs/006-python-bindings/spec.md
+++ b/specs/006-python-bindings/spec.md
@@ -135,7 +135,7 @@ THEN extraction respects those settings
 | FR-072 | WHEN paths contain null bytes or exceed 4096 bytes, THE SYSTEM SHALL raise `ValueError` at the Python boundary before calling into Rust | must |
 | FR-073 | WHEN no Python progress callback is provided, THE SYSTEM SHALL release the GIL during extraction/creation | must |
 | FR-074 | WHEN a Python progress callback is provided, THE SYSTEM SHALL NOT release the GIL (callback requires GIL to invoke Python) | must |
-| FR-075 | Rust `ExtractionError` variants SHALL map to specific Python exception types registered on the module | must |
+| FR-075 | Rust `ExtractionError` variants SHALL map to specific Python exception types; `SourceNotFound`/`OutputExists` → `PyIOError`; `InvalidCompressionLevel`/`InvalidConfiguration` → `PyValueError`; `PartialExtraction` → `PartialExtractionError` with `files_extracted` and `bytes_written` attributes | must |
 | FR-076 | ALL Python exception types SHALL be subclasses of `ExarchError(Exception)` | must |
 | FR-077 | `PySecurityConfig` and `PyCreationConfig` SHALL expose the same fluent builder API as the Rust counterparts | must |
 | FR-078 | `PyExtractionReport`, `PyCreationReport`, `PyArchiveManifest`, and `PyVerificationReport` SHALL expose all fields as Python attributes | must |
@@ -175,7 +175,18 @@ ExarchError(Exception)
   InvalidArchiveError(ExarchError)
   SecurityViolationError(ExarchError)
   InvalidPermissionsError(ExarchError)
+  PartialExtractionError(ExarchError)   # exposes files_extracted, bytes_written
 ```
+
+> [!note] Error mapping corrections in v0.4.0 (#209)
+> - `SourceNotFound`, `SourceNotAccessible`, and `OutputExists` now raise
+>   `PyIOError` (was `InvalidArchiveError`).
+> - `InvalidCompressionLevel` and `InvalidConfiguration` now raise
+>   `PyValueError` (was `InvalidArchiveError`).
+> - `PartialExtractionError` now exposes `files_extracted` and `bytes_written`
+>   attributes for caller inspection (#210).
+> These corrections allow Python callers to distinguish I/O failures, validation
+> errors, and archive corruption with specific `except` clauses.
 
 ### Python API Surface
 
@@ -198,6 +209,9 @@ def verify_archive(archive_path, config=None) -> VerificationReport
 | Path exceeds 4096 bytes | `ValueError` at Python boundary |
 | Path is `pathlib.Path` | Converted to `str` via `.as_os_str()` before Rust call |
 | Rust returns `ExtractionError::PathTraversal` | `PathTraversalError` raised in Python |
+| Rust returns `ExtractionError::SourceNotFound` or `OutputExists` | `PyIOError` raised (not `InvalidArchiveError`) |
+| Rust returns `ExtractionError::InvalidCompressionLevel` or `InvalidConfiguration` | `PyValueError` raised (not `InvalidArchiveError`) |
+| Rust returns `ExtractionError::PartialExtraction` | `PartialExtractionError` raised; `files_extracted` and `bytes_written` attributes populated |
 | Progress callback raises Python exception | Exception propagates through `PyProgressAdapter`; extraction aborted |
 | GIL state with progress callback | GIL held throughout; no concurrent Python threads during extraction |
 

--- a/specs/007-node-bindings/spec.md
+++ b/specs/007-node-bindings/spec.md
@@ -129,7 +129,7 @@ THEN extraction respects those settings
 | FR-080 | THE SYSTEM SHALL expose async Node.js functions returning Promises: `extractArchive`, `createArchive`, `listArchive`, `verifyArchive` | must |
 | FR-081 | ALL async operations SHALL run on the libuv thread pool, not the main event loop thread | must |
 | FR-082 | WHEN paths contain null bytes or exceed 4096 bytes, THE SYSTEM SHALL throw a synchronous JavaScript Error before spawning a thread | must |
-| FR-083 | Rust `ExtractionError` variants SHALL map to named JavaScript Error types | must |
+| FR-083 | Rust `ExtractionError` variants SHALL map to named JavaScript Error types; `PartialExtraction` SHALL include `filesExtracted` and `bytesWritten` in the error message for caller inspection | must |
 | FR-084 | `SecurityConfig` and `CreationConfig` SHALL be exposed as JavaScript classes with fluent builder methods | must |
 | FR-085 | `ExtractionReport`, `CreationReport`, `ArchiveManifest`, and `VerificationReport` SHALL be exposed as JavaScript objects with typed fields | must |
 | FR-086 | napi-rs SHALL generate TypeScript `.d.ts` files for all exported functions and classes | must |
@@ -214,6 +214,14 @@ class CreationConfig {
 | `UnsupportedFormat` | `UnsupportedFormatError` |
 | `InvalidArchive` | `InvalidArchiveError` |
 | `Io` | `IoError` |
+| `PartialExtraction` | `PartialExtractionError`; error message includes `filesExtracted` and `bytesWritten` fields |
+
+> [!note] PartialExtraction fix in v0.4.0 (#210)
+> Prior to v0.4.0, the Node.js `PartialExtraction` error message did not include
+> the partial report data. In v0.4.0 the error message includes `filesExtracted`
+> and `bytesWritten` so callers can inspect how much was extracted before the
+> failure. The 7z handler was also fixed to populate a non-empty report when at
+> least one entry was written before the failure (#207, #216).
 
 ## 6. Edge Cases and Error Handling
 
@@ -223,6 +231,7 @@ class CreationConfig {
 | Path contains null byte | Synchronous `Error` thrown before Promise creation |
 | Path exceeds 4096 bytes | Synchronous `Error` thrown before Promise creation |
 | Rust returns `ExtractionError::PathTraversal` | Promise rejects with `PathTraversalError` |
+| Rust returns `ExtractionError::PartialExtraction` | Promise rejects with `PartialExtractionError`; message includes `filesExtracted` and `bytesWritten` |
 | Thread pool exhausted | Promise eventually resolves when thread becomes available; no timeout |
 | `sources` array is empty for `createArchive` | [NEEDS CLARIFICATION: reject immediately or produce empty archive?] |
 

--- a/specs/MOC-specs.md
+++ b/specs/MOC-specs.md
@@ -19,11 +19,11 @@ status: moc
 
 | ID | Feature | Phase | Status | Tasks |
 |----|---------|-------|--------|-------|
-| 001 | [[001-security-pipeline/spec\|Security Pipeline]] | tasks | draft | [[001-security-pipeline/tasks\|2 open]] |
-| 002 | [[002-format-handlers/spec\|Format Handlers]] | tasks | draft | [[002-format-handlers/tasks\|1 open]] |
+| 001 | [[001-security-pipeline/spec\|Security Pipeline]] | tasks | done (v0.4.0) | [[001-security-pipeline/tasks\|none open]] |
+| 002 | [[002-format-handlers/spec\|Format Handlers]] | tasks | done (v0.4.0) | [[002-format-handlers/tasks\|none open]] |
 | 003 | [[003-config-api/spec\|Configuration API]] | tasks | done | [[003-config-api/tasks\|none]] |
 | 004 | [[004-progress-tracking/spec\|Progress Tracking]] | tasks | done | [[004-progress-tracking/tasks\|none]] |
-| 005 | [[005-cli/spec\|CLI]] | tasks | draft | [[005-cli/tasks\|2 open]] |
+| 005 | [[005-cli/spec\|CLI]] | tasks | done (v0.4.0) | [[005-cli/tasks\|none open]] |
 | 006 | [[006-python-bindings/spec\|Python Bindings]] | tasks | done | [[006-python-bindings/tasks\|none]] |
 | 007 | [[007-node-bindings/spec\|Node.js Bindings]] | tasks | done | [[007-node-bindings/tasks\|none]] |
 


### PR DESCRIPTION
## Summary

- Bump workspace version 0.3.1 to 0.4.0
- Consolidate CHANGELOG.md entries from `[Unreleased]` into the `[0.4.0] - 2026-05-20` section
- Sync `crates/exarch-node/package.json` and `crates/exarch-python/pyproject.toml` to 0.4.0

## Highlights

- Breaking: `Archive::open` returns `Self` (no `?`); `SecurityConfig`, `AllowedFeatures`, `ExtractionOptions` are `#[non_exhaustive]`; internal modules `copy`, `io`, `test_utils` are `pub(crate)`
- Added: shell completions, `--verbose` per-entry output, `allowed_extensions` filter, ZIP-family alias rejection
- Changed: `zip` upgraded to 9.0.0-pre2, new `FormatCreator` trait, 15 fluent builder methods on `SecurityConfig`
- Fixed: many JSON output duplication and ordering issues, `verify_archive` TOCTOU race, 7z callback ordering

## Checklist

- [x] Version updated in all manifests (Cargo.toml, package.json, pyproject.toml)
- [x] CHANGELOG.md `[0.4.0]` section dated and de-duplicated
- [x] `cargo +nightly fmt --check` clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node`: 836 passed
- [x] `cargo test --doc --workspace --all-features --exclude exarch-python --exclude exarch-node`: 114 passed
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` clean
- [ ] Ready for tagging after merge