### PR TITLE
fix(python,node): preserve specific exception type from partial extraction (#251)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- **Python**: `PartialExtractionError` has been removed from the public API. In 0.4.0 it was
+  always raised when extraction failed after some files were already written. Code written
+  against 0.4.0 that used `except PartialExtractionError` must be updated: catch the specific
+  exception type (`SymlinkEscapeError`, `QuotaExceededError`, etc.) or use `except
+  ExtractionError` as the catch-all. To detect whether output was partial, use
+  `getattr(e, "files_extracted", None) is not None` (#251).
+
+### Fixed
+
+- Python: `extract_archive` now raises the specific exception type (`SymlinkEscapeError`,
+  `HardlinkEscapeError`, `QuotaExceededError`, etc.) instead of the generic
+  `PartialExtractionError` when extraction fails after some files have been written to disk.
+  The `files_extracted` and `bytes_written` report attributes from #210 are attached directly
+  to the concrete exception (#251).
+- Node.js: `extract_archive` error messages now begin with the specific error code
+  (`SYMLINK_ESCAPE`, `QUOTA_EXCEEDED`, etc.) instead of always prefixing `PARTIAL_EXTRACTION`
+  when the error occurs after partial output has been written. The `filesExtracted` and
+  `bytesWritten` fields are still appended to the message (#251).
+
 ## [0.4.0] - 2026-05-20
 
 ### Added

--- a/crates/exarch-node/src/error.rs
+++ b/crates/exarch-node/src/error.rs
@@ -183,9 +183,12 @@ pub fn convert_error(err: CoreError) -> Error {
             Error::new(Status::GenericFailure, msg)
         }
         CoreError::PartialExtraction { source, report } => {
+            // Preserve the specific error code (SYMLINK_ESCAPE, QUOTA_EXCEEDED, etc.) from
+            // the inner source so JavaScript callers can distinguish the error type. The
+            // partial-extraction report fields from #210 are appended for caller
+            // inspection.
             let inner = convert_error(*source);
             let mut msg = String::with_capacity(inner.reason.len() + 64);
-            msg.push_str("PARTIAL_EXTRACTION: ");
             msg.push_str(&inner.reason);
             let _ = write!(
                 &mut msg,
@@ -361,10 +364,12 @@ mod tests {
         assert!(err_str.contains("file not found"));
     }
 
-    /// Regression test for #210: `convert_error` must embed `filesExtracted`
-    /// and `bytesWritten` in the error message for `PartialExtraction`.
+    /// Regression test for #251 + #210: `convert_error` must preserve the
+    /// specific error code from the inner source (e.g. `QUOTA_EXCEEDED`,
+    /// not `PARTIAL_EXTRACTION`), while still appending `filesExtracted`
+    /// and `bytesWritten` for caller inspection.
     #[test]
-    fn test_partial_extraction_node_message_format() {
+    fn test_partial_extraction_preserves_specific_code_with_report() {
         use exarch_core::ExtractionReport;
         use exarch_core::QuotaResource;
 
@@ -383,9 +388,11 @@ mod tests {
 
         let napi_err = convert_error(err);
         let msg = napi_err.reason.clone();
+        // Must carry the specific error code, not the generic PARTIAL_EXTRACTION
+        // prefix.
         assert!(
-            msg.contains("PARTIAL_EXTRACTION"),
-            "message must contain PARTIAL_EXTRACTION, got: {msg}"
+            msg.starts_with("QUOTA_EXCEEDED"),
+            "message must start with QUOTA_EXCEEDED, got: {msg}"
         );
         assert!(
             msg.contains("filesExtracted=3"),
@@ -395,5 +402,89 @@ mod tests {
             msg.contains("bytesWritten=1024"),
             "message must contain bytesWritten=1024, got: {msg}"
         );
+    }
+
+    // Regression tests for #251: security error variants must also preserve
+    // their specific error code and carry the #210 report fields.
+    //
+    // Helper that asserts the produced error reason starts with the given code
+    // and contains the expected report fields.
+    fn assert_partial_node_report(napi_err: &Error, expected_code: &str, files: usize, bytes: u64) {
+        let msg = &napi_err.reason;
+        assert!(
+            msg.starts_with(expected_code),
+            "message must start with {expected_code}, got: {msg}"
+        );
+        assert!(
+            msg.contains(&format!("filesExtracted={files}")),
+            "message must contain filesExtracted={files}, got: {msg}"
+        );
+        assert!(
+            msg.contains(&format!("bytesWritten={bytes}")),
+            "message must contain bytesWritten={bytes}, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_partial_extraction_symlink_escape_preserves_code_and_report() {
+        use exarch_core::ExtractionReport;
+
+        let report = ExtractionReport {
+            files_extracted: 2,
+            bytes_written: 512,
+            ..ExtractionReport::default()
+        };
+        let source = CoreError::SymlinkEscape {
+            path: PathBuf::from("/etc/passwd"),
+        };
+        let err = CoreError::PartialExtraction {
+            source: Box::new(source),
+            report,
+        };
+
+        let napi_err = convert_error(err);
+        assert_partial_node_report(&napi_err, "SYMLINK_ESCAPE", 2, 512);
+    }
+
+    #[test]
+    fn test_partial_extraction_hardlink_escape_preserves_code_and_report() {
+        use exarch_core::ExtractionReport;
+
+        let report = ExtractionReport {
+            files_extracted: 2,
+            bytes_written: 512,
+            ..ExtractionReport::default()
+        };
+        let source = CoreError::HardlinkEscape {
+            path: PathBuf::from("/etc/shadow"),
+        };
+        let err = CoreError::PartialExtraction {
+            source: Box::new(source),
+            report,
+        };
+
+        let napi_err = convert_error(err);
+        assert_partial_node_report(&napi_err, "HARDLINK_ESCAPE", 2, 512);
+    }
+
+    #[test]
+    fn test_partial_extraction_security_violation_preserves_code_and_report() {
+        use exarch_core::ExtractionReport;
+
+        let report = ExtractionReport {
+            files_extracted: 2,
+            bytes_written: 512,
+            ..ExtractionReport::default()
+        };
+        let source = CoreError::SecurityViolation {
+            reason: "test policy violation".to_string(),
+        };
+        let err = CoreError::PartialExtraction {
+            source: Box::new(source),
+            report,
+        };
+
+        let napi_err = convert_error(err);
+        assert_partial_node_report(&napi_err, "SECURITY_VIOLATION", 2, 512);
     }
 }

--- a/crates/exarch-python/exarch.pyi
+++ b/crates/exarch-python/exarch.pyi
@@ -677,4 +677,3 @@ class InvalidArchiveError(ExtractionError):
     """Archive is corrupted."""
 
     ...
-

--- a/crates/exarch-python/exarch.pyi
+++ b/crates/exarch-python/exarch.pyi
@@ -451,6 +451,12 @@ def extract_archive(
         UnsupportedFormatError: Archive format not supported
         InvalidArchiveError: Archive is corrupted
         IOError: I/O operation failed
+
+    Note:
+        When extraction fails after some files have already been written to disk,
+        the specific exception (e.g. ``SymlinkEscapeError``) is raised with
+        ``files_extracted`` and ``bytes_written`` attributes attached. Detect a
+        partial extraction via ``hasattr(e, "files_extracted")``.
     """
     ...
 
@@ -552,47 +558,123 @@ def verify_archive(
     """
     ...
 
-class PathTraversalError(ValueError):
-    """Path traversal attempt detected."""
+class ExtractionError(Exception):
+    """Base exception for all extraction errors."""
 
     ...
 
-class SymlinkEscapeError(ValueError):
-    """Symlink points outside extraction directory."""
+class PathTraversalError(ExtractionError):
+    """
+    Path traversal attempt detected.
 
-    ...
+    When raised during ``extract_archive``, the following attributes are
+    available if some files were already written before the error occurred:
 
-class HardlinkEscapeError(ValueError):
-    """Hardlink target outside extraction directory."""
+    Attributes:
+        files_extracted: Number of files successfully extracted before the error.
+        bytes_written: Total bytes written to disk before the error.
+    """
 
-    ...
+    files_extracted: int
+    bytes_written: int
 
-class ZipBombError(ValueError):
-    """Potential zip bomb detected."""
+class SymlinkEscapeError(ExtractionError):
+    """
+    Symlink points outside extraction directory.
 
-    ...
+    When raised during ``extract_archive``, the following attributes are
+    available if some files were already written before the error occurred:
 
-class InvalidPermissionsError(ValueError):
-    """File permissions are invalid or unsafe."""
+    Attributes:
+        files_extracted: Number of files successfully extracted before the error.
+        bytes_written: Total bytes written to disk before the error.
+    """
 
-    ...
+    files_extracted: int
+    bytes_written: int
 
-class QuotaExceededError(ValueError):
-    """Resource quota exceeded."""
+class HardlinkEscapeError(ExtractionError):
+    """
+    Hardlink target outside extraction directory.
 
-    ...
+    When raised during ``extract_archive``, the following attributes are
+    available if some files were already written before the error occurred:
 
-class SecurityViolationError(ValueError):
-    """Security policy violation."""
+    Attributes:
+        files_extracted: Number of files successfully extracted before the error.
+        bytes_written: Total bytes written to disk before the error.
+    """
 
-    ...
+    files_extracted: int
+    bytes_written: int
 
-class UnsupportedFormatError(ValueError):
+class ZipBombError(ExtractionError):
+    """
+    Potential zip bomb detected.
+
+    When raised during ``extract_archive``, the following attributes are
+    available if some files were already written before the error occurred:
+
+    Attributes:
+        files_extracted: Number of files successfully extracted before the error.
+        bytes_written: Total bytes written to disk before the error.
+    """
+
+    files_extracted: int
+    bytes_written: int
+
+class InvalidPermissionsError(ExtractionError):
+    """
+    File permissions are invalid or unsafe.
+
+    When raised during ``extract_archive``, the following attributes are
+    available if some files were already written before the error occurred:
+
+    Attributes:
+        files_extracted: Number of files successfully extracted before the error.
+        bytes_written: Total bytes written to disk before the error.
+    """
+
+    files_extracted: int
+    bytes_written: int
+
+class QuotaExceededError(ExtractionError):
+    """
+    Resource quota exceeded.
+
+    When raised during ``extract_archive``, the following attributes are
+    available if some files were already written before the error occurred:
+
+    Attributes:
+        files_extracted: Number of files successfully extracted before the error.
+        bytes_written: Total bytes written to disk before the error.
+    """
+
+    files_extracted: int
+    bytes_written: int
+
+class SecurityViolationError(ExtractionError):
+    """
+    Security policy violation.
+
+    When raised during ``extract_archive``, the following attributes are
+    available if some files were already written before the error occurred:
+
+    Attributes:
+        files_extracted: Number of files successfully extracted before the error.
+        bytes_written: Total bytes written to disk before the error.
+    """
+
+    files_extracted: int
+    bytes_written: int
+
+class UnsupportedFormatError(ExtractionError):
     """Archive format not supported."""
 
     ...
 
-class InvalidArchiveError(ValueError):
+class InvalidArchiveError(ExtractionError):
     """Archive is corrupted."""
 
     ...
+

--- a/crates/exarch-python/src/error.rs
+++ b/crates/exarch-python/src/error.rs
@@ -21,7 +21,6 @@ create_exception!(exarch, QuotaExceededError, ExtractionError);
 create_exception!(exarch, SecurityViolationError, ExtractionError);
 create_exception!(exarch, UnsupportedFormatError, ExtractionError);
 create_exception!(exarch, InvalidArchiveError, ExtractionError);
-create_exception!(exarch, PartialExtractionError, ExtractionError);
 
 /// Converts Rust extraction errors to Python exceptions.
 ///
@@ -102,19 +101,17 @@ pub fn convert_error(err: CoreError) -> PyErr {
             PyValueError::new_err(format!("invalid configuration: {reason}"))
         }
         CoreError::PartialExtraction { source, report } => {
+            // Recover the specific exception type (SymlinkEscapeError, HardlinkEscapeError,
+            // etc.) so callers can catch the precise error. The partial-extraction report
+            // attributes from #210 are attached to that concrete exception instead.
             let source_err = convert_error(*source);
             Python::attach(|py| {
-                let msg = source_err.value(py).str().map_or_else(
-                    |_| "partial extraction failed".to_string(),
-                    |s| s.to_string_lossy().into_owned(),
-                );
-                let err = PartialExtractionError::new_err(msg);
-                let exc_value = err.value(py);
-                // setattr with a u64 value cannot fail in practice; silencing the result
-                // to preserve the `PyErr → PyErr` conversion signature.
+                let exc_value = source_err.value(py);
+                // setattr failures are silenced to preserve the `PyErr → PyErr` signature;
+                // the workspace forbids unwrap/expect outside tests.
                 let _ = exc_value.setattr("files_extracted", report.files_extracted);
                 let _ = exc_value.setattr("bytes_written", report.bytes_written);
-                err
+                source_err
             })
         }
     }
@@ -155,10 +152,6 @@ pub fn register_exceptions(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add(
         "InvalidArchiveError",
         m.py().get_type::<InvalidArchiveError>(),
-    )?;
-    m.add(
-        "PartialExtractionError",
-        m.py().get_type::<PartialExtractionError>(),
     )?;
     Ok(())
 }
@@ -473,11 +466,12 @@ mod tests {
         });
     }
 
-    /// Regression test for #210: `convert_error` must produce a
-    /// `PartialExtractionError` (not a bare `QuotaExceededError`) when the
-    /// source error is wrapped in `CoreError::PartialExtraction`.
+    /// Regression test for #251 + #210: `convert_error` must surface the
+    /// specific exception type from the inner source and attach
+    /// `files_extracted` and `bytes_written` attributes for the
+    /// partial-extraction report.
     #[test]
-    fn test_partial_extraction_python_exposes_report() {
+    fn test_partial_extraction_preserves_specific_type_with_report() {
         use exarch_core::ExtractionReport;
         use exarch_core::QuotaResource;
 
@@ -496,11 +490,121 @@ mod tests {
 
         let py_err = convert_error(err);
         Python::attach(|py| {
+            // Must be the specific concrete type.
             assert!(
-                py_err.is_instance_of::<PartialExtractionError>(py),
-                "expected PartialExtractionError, got: {}",
+                py_err.is_instance_of::<QuotaExceededError>(py),
+                "expected QuotaExceededError, got: {}",
                 py_err
             );
+            // Report attributes must be present on the concrete exception.
+            let exc_value = py_err.value(py);
+            let files: u64 = exc_value
+                .getattr("files_extracted")
+                .expect("files_extracted missing")
+                .extract()
+                .expect("files_extracted not u64");
+            let bytes: u64 = exc_value
+                .getattr("bytes_written")
+                .expect("bytes_written missing")
+                .extract()
+                .expect("bytes_written not u64");
+            assert_eq!(files, 3);
+            assert_eq!(bytes, 1024);
         });
+    }
+
+    // Regression tests for #251: security error variants must surface their
+    // specific type and carry the #210 report attributes.
+    //
+    // Helper that verifies the given `py_err` from a PartialExtraction is
+    // the expected specific type and has the expected report attributes.
+    fn assert_partial_extraction_report<T: pyo3::PyTypeInfo>(
+        py_err: &PyErr,
+        expected_files: usize,
+        expected_bytes: u64,
+    ) {
+        Python::attach(|py| {
+            assert!(
+                py_err.is_instance_of::<T>(py),
+                "expected specific error type, got: {}",
+                py_err
+            );
+            let exc_value = py_err.value(py);
+            let files: usize = exc_value
+                .getattr("files_extracted")
+                .expect("files_extracted missing")
+                .extract()
+                .expect("files_extracted extraction failed");
+            let bytes: u64 = exc_value
+                .getattr("bytes_written")
+                .expect("bytes_written missing")
+                .extract()
+                .expect("bytes_written extraction failed");
+            assert_eq!(files, expected_files, "files_extracted mismatch");
+            assert_eq!(bytes, expected_bytes, "bytes_written mismatch");
+        });
+    }
+
+    #[test]
+    fn test_partial_extraction_symlink_escape_preserves_type_and_report() {
+        use exarch_core::ExtractionReport;
+
+        let report = ExtractionReport {
+            files_extracted: 2,
+            bytes_written: 512,
+            ..ExtractionReport::default()
+        };
+        let source = CoreError::SymlinkEscape {
+            path: PathBuf::from("/etc/passwd"),
+        };
+        let err = CoreError::PartialExtraction {
+            source: Box::new(source),
+            report,
+        };
+
+        let py_err = convert_error(err);
+        assert_partial_extraction_report::<SymlinkEscapeError>(&py_err, 2, 512);
+    }
+
+    #[test]
+    fn test_partial_extraction_hardlink_escape_preserves_type_and_report() {
+        use exarch_core::ExtractionReport;
+
+        let report = ExtractionReport {
+            files_extracted: 2,
+            bytes_written: 512,
+            ..ExtractionReport::default()
+        };
+        let source = CoreError::HardlinkEscape {
+            path: PathBuf::from("/etc/shadow"),
+        };
+        let err = CoreError::PartialExtraction {
+            source: Box::new(source),
+            report,
+        };
+
+        let py_err = convert_error(err);
+        assert_partial_extraction_report::<HardlinkEscapeError>(&py_err, 2, 512);
+    }
+
+    #[test]
+    fn test_partial_extraction_security_violation_preserves_type_and_report() {
+        use exarch_core::ExtractionReport;
+
+        let report = ExtractionReport {
+            files_extracted: 2,
+            bytes_written: 512,
+            ..ExtractionReport::default()
+        };
+        let source = CoreError::SecurityViolation {
+            reason: "test policy violation".to_string(),
+        };
+        let err = CoreError::PartialExtraction {
+            source: Box::new(source),
+            report,
+        };
+
+        let py_err = convert_error(err);
+        assert_partial_extraction_report::<SecurityViolationError>(&py_err, 2, 512);
     }
 }

--- a/crates/exarch-python/tests/test_cve_regression.py
+++ b/crates/exarch-python/tests/test_cve_regression.py
@@ -190,3 +190,76 @@ def test_hardlink_escape(malicious_hardlink_escape, temp_dir):
 
     # Verify no hardlinks were created
     assert not (output_dir2 / "evil_hardlink").exists()
+
+
+def _make_tar_gz(path, entries):
+    """Build a .tar.gz at `path` from (TarInfo, data-or-None) entries."""
+    import io
+    import tarfile
+
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        for info, data in entries:
+            if data is None:
+                tar.addfile(info)
+            else:
+                info.size = len(data)
+                tar.addfile(info, io.BytesIO(data))
+    path.write_bytes(buf.getvalue())
+
+
+def test_partial_extraction_preserves_symlink_escape_type(temp_dir):
+    """
+    Regression test for #251.
+
+    When a security error occurs after a regular file has already been written,
+    the core wraps it in PartialExtraction. The binding must still raise the
+    specific exception type (not a generic one) and expose the partial report
+    via `files_extracted` / `bytes_written` attributes (the #210 capability).
+    """
+    import tarfile
+
+    archive = temp_dir / "partial_symlink.tar.gz"
+    regular = tarfile.TarInfo("dist/file.txt")
+    regular.type = tarfile.REGTYPE
+    link = tarfile.TarInfo("dist/link")
+    link.type = tarfile.SYMTYPE
+    link.linkname = "../../outside.txt"
+    _make_tar_gz(archive, [(regular, b"ok"), (link, None)])
+
+    output_dir = temp_dir / "out"
+    output_dir.mkdir()
+    config = exarch.SecurityConfig().allow_symlinks(True).allow_hardlinks(False)
+
+    with pytest.raises(exarch.SymlinkEscapeError) as exc_info:
+        exarch.extract_archive(archive, output_dir, config)
+
+    # #210 report attributes are attached to the specific exception.
+    err = exc_info.value
+    assert getattr(err, "files_extracted", None) is not None
+    assert err.files_extracted >= 1
+    assert err.bytes_written >= len(b"ok")
+
+
+def test_partial_extraction_preserves_hardlink_escape_type(temp_dir):
+    """Regression test for #251 (hardlink variant)."""
+    import tarfile
+
+    archive = temp_dir / "partial_hardlink.tar.gz"
+    regular = tarfile.TarInfo("dist/file.txt")
+    regular.type = tarfile.REGTYPE
+    hard = tarfile.TarInfo("dist/hard")
+    hard.type = tarfile.LNKTYPE
+    hard.linkname = "../../outside.txt"
+    _make_tar_gz(archive, [(regular, b"ok"), (hard, None)])
+
+    output_dir = temp_dir / "out"
+    output_dir.mkdir()
+    config = exarch.SecurityConfig().allow_hardlinks(True)
+
+    with pytest.raises(exarch.HardlinkEscapeError) as exc_info:
+        exarch.extract_archive(archive, output_dir, config)
+
+    err = exc_info.value
+    assert getattr(err, "files_extracted", None) is not None
+    assert err.files_extracted >= 1

--- a/specs/006-python-bindings/spec.md
+++ b/specs/006-python-bindings/spec.md
@@ -135,7 +135,7 @@ THEN extraction respects those settings
 | FR-072 | WHEN paths contain null bytes or exceed 4096 bytes, THE SYSTEM SHALL raise `ValueError` at the Python boundary before calling into Rust | must |
 | FR-073 | WHEN no Python progress callback is provided, THE SYSTEM SHALL release the GIL during extraction/creation | must |
 | FR-074 | WHEN a Python progress callback is provided, THE SYSTEM SHALL NOT release the GIL (callback requires GIL to invoke Python) | must |
-| FR-075 | Rust `ExtractionError` variants SHALL map to specific Python exception types; `SourceNotFound`/`OutputExists` → `PyIOError`; `InvalidCompressionLevel`/`InvalidConfiguration` → `PyValueError`; `PartialExtraction` → `PartialExtractionError` with `files_extracted` and `bytes_written` attributes | must |
+| FR-075 | Rust `ExtractionError` variants SHALL map to specific Python exception types; `SourceNotFound`/`OutputExists` → `PyIOError`; `InvalidCompressionLevel`/`InvalidConfiguration` → `PyValueError`; `PartialExtraction` → the specific inner exception type (e.g. `SymlinkEscapeError`, `QuotaExceededError`) with `files_extracted` and `bytes_written` attributes attached to that exception | must |
 | FR-076 | ALL Python exception types SHALL be subclasses of `ExarchError(Exception)` | must |
 | FR-077 | `PySecurityConfig` and `PyCreationConfig` SHALL expose the same fluent builder API as the Rust counterparts | must |
 | FR-078 | `PyExtractionReport`, `PyCreationReport`, `PyArchiveManifest`, and `PyVerificationReport` SHALL expose all fields as Python attributes | must |
@@ -166,25 +166,33 @@ THEN extraction respects those settings
 
 ```
 ExarchError(Exception)
-  PathTraversalError(ExarchError)
-  SymlinkEscapeError(ExarchError)
-  HardlinkEscapeError(ExarchError)
-  ZipBombError(ExarchError)
-  QuotaExceededError(ExarchError)
+  PathTraversalError(ExarchError)      # may carry files_extracted, bytes_written
+  SymlinkEscapeError(ExarchError)      # may carry files_extracted, bytes_written
+  HardlinkEscapeError(ExarchError)     # may carry files_extracted, bytes_written
+  ZipBombError(ExarchError)            # may carry files_extracted, bytes_written
+  QuotaExceededError(ExarchError)      # may carry files_extracted, bytes_written
+  SecurityViolationError(ExarchError)  # may carry files_extracted, bytes_written
+  InvalidPermissionsError(ExarchError) # may carry files_extracted, bytes_written
   UnsupportedFormatError(ExarchError)
   InvalidArchiveError(ExarchError)
-  SecurityViolationError(ExarchError)
-  InvalidPermissionsError(ExarchError)
-  PartialExtractionError(ExarchError)   # exposes files_extracted, bytes_written
 ```
 
-> [!note] Error mapping corrections in v0.4.0 (#209)
+The `files_extracted` and `bytes_written` attributes are present on the raised
+exception when `exarch-core` wraps the inner error in `CoreError::PartialExtraction`
+(i.e. when at least one file was written to disk before the security check failed).
+Use `hasattr(e, "files_extracted")` to detect whether a partial extraction occurred.
+`ExarchError` is the catch-all base for any extraction failure.
+
+> [!note] Error mapping corrections (#209, #210, #251)
 > - `SourceNotFound`, `SourceNotAccessible`, and `OutputExists` now raise
 >   `PyIOError` (was `InvalidArchiveError`).
 > - `InvalidCompressionLevel` and `InvalidConfiguration` now raise
 >   `PyValueError` (was `InvalidArchiveError`).
-> - `PartialExtractionError` now exposes `files_extracted` and `bytes_written`
->   attributes for caller inspection (#210).
+> - In v0.4.0, `PartialExtraction` incorrectly collapsed all partial-extraction
+>   failures into a generic `PartialExtractionError` (#216). Fixed in v0.4.1
+>   (#251): the specific inner exception type is raised (e.g. `SymlinkEscapeError`)
+>   with `files_extracted` and `bytes_written` attached directly to it (#210).
+>   `PartialExtractionError` has been removed from the public API.
 > These corrections allow Python callers to distinguish I/O failures, validation
 > errors, and archive corruption with specific `except` clauses.
 
@@ -211,7 +219,7 @@ def verify_archive(archive_path, config=None) -> VerificationReport
 | Rust returns `ExtractionError::PathTraversal` | `PathTraversalError` raised in Python |
 | Rust returns `ExtractionError::SourceNotFound` or `OutputExists` | `PyIOError` raised (not `InvalidArchiveError`) |
 | Rust returns `ExtractionError::InvalidCompressionLevel` or `InvalidConfiguration` | `PyValueError` raised (not `InvalidArchiveError`) |
-| Rust returns `ExtractionError::PartialExtraction` | `PartialExtractionError` raised; `files_extracted` and `bytes_written` attributes populated |
+| Rust returns `ExtractionError::PartialExtraction` | The specific inner exception (e.g. `SymlinkEscapeError`) is raised; `files_extracted` and `bytes_written` attributes are attached; detect partiality via `hasattr(e, "files_extracted")` |
 | Progress callback raises Python exception | Exception propagates through `PyProgressAdapter`; extraction aborted |
 | GIL state with progress callback | GIL held throughout; no concurrent Python threads during extraction |
 

--- a/specs/007-node-bindings/spec.md
+++ b/specs/007-node-bindings/spec.md
@@ -129,7 +129,7 @@ THEN extraction respects those settings
 | FR-080 | THE SYSTEM SHALL expose async Node.js functions returning Promises: `extractArchive`, `createArchive`, `listArchive`, `verifyArchive` | must |
 | FR-081 | ALL async operations SHALL run on the libuv thread pool, not the main event loop thread | must |
 | FR-082 | WHEN paths contain null bytes or exceed 4096 bytes, THE SYSTEM SHALL throw a synchronous JavaScript Error before spawning a thread | must |
-| FR-083 | Rust `ExtractionError` variants SHALL map to named JavaScript Error types; `PartialExtraction` SHALL include `filesExtracted` and `bytesWritten` in the error message for caller inspection | must |
+| FR-083 | Rust `ExtractionError` variants SHALL map to named JavaScript Error types; when `PartialExtraction` wraps an inner error, the error message SHALL begin with the specific inner error code (e.g. `SYMLINK_ESCAPE`, `QUOTA_EXCEEDED`) and SHALL append `filesExtracted` and `bytesWritten` fields for caller inspection | must |
 | FR-084 | `SecurityConfig` and `CreationConfig` SHALL be exposed as JavaScript classes with fluent builder methods | must |
 | FR-085 | `ExtractionReport`, `CreationReport`, `ArchiveManifest`, and `VerificationReport` SHALL be exposed as JavaScript objects with typed fields | must |
 | FR-086 | napi-rs SHALL generate TypeScript `.d.ts` files for all exported functions and classes | must |
@@ -214,14 +214,17 @@ class CreationConfig {
 | `UnsupportedFormat` | `UnsupportedFormatError` |
 | `InvalidArchive` | `InvalidArchiveError` |
 | `Io` | `IoError` |
-| `PartialExtraction` | `PartialExtractionError`; error message includes `filesExtracted` and `bytesWritten` fields |
+| `PartialExtraction` | The specific inner error code (e.g. `SYMLINK_ESCAPE: ...`) is preserved; `filesExtracted` and `bytesWritten` are appended to the message |
 
-> [!note] PartialExtraction fix in v0.4.0 (#210)
-> Prior to v0.4.0, the Node.js `PartialExtraction` error message did not include
-> the partial report data. In v0.4.0 the error message includes `filesExtracted`
-> and `bytesWritten` so callers can inspect how much was extracted before the
-> failure. The 7z handler was also fixed to populate a non-empty report when at
-> least one entry was written before the failure (#207, #216).
+> [!note] PartialExtraction fix in v0.4.0 and v0.4.1 (#210, #251)
+> In v0.4.0 the error message for `PartialExtraction` was extended to include
+> `filesExtracted` and `bytesWritten` for caller inspection (#210). However the
+> message prefix was incorrectly changed to always read `PARTIAL_EXTRACTION:`
+> regardless of the actual inner error type (#216). Fixed in v0.4.1 (#251): the
+> message now begins with the specific error code (`SYMLINK_ESCAPE`, `QUOTA_EXCEEDED`,
+> etc.) and appends the report fields, so callers can distinguish the error type
+> by inspecting the message prefix. The 7z handler was also fixed to populate a
+> non-empty report when at least one entry was written before the failure (#207).
 
 ## 6. Edge Cases and Error Handling
 
@@ -231,7 +234,7 @@ class CreationConfig {
 | Path contains null byte | Synchronous `Error` thrown before Promise creation |
 | Path exceeds 4096 bytes | Synchronous `Error` thrown before Promise creation |
 | Rust returns `ExtractionError::PathTraversal` | Promise rejects with `PathTraversalError` |
-| Rust returns `ExtractionError::PartialExtraction` | Promise rejects with `PartialExtractionError`; message includes `filesExtracted` and `bytesWritten` |
+| Rust returns `ExtractionError::PartialExtraction` | Promise rejects with the specific inner error code as prefix (e.g. `SYMLINK_ESCAPE: ...`); message appends `filesExtracted` and `bytesWritten` |
 | Thread pool exhausted | Promise eventually resolves when thread becomes available; no timeout |
 | `sources` array is empty for `createArchive` | [NEEDS CLARIFICATION: reject immediately or produce empty archive?] |
 


### PR DESCRIPTION
## Summary

Fixes #251. Since 0.4.0 the bindings collapsed `SymlinkEscapeError`, `HardlinkEscapeError`, and `SecurityViolationError` into a generic `PartialExtractionError` (Python) / `PARTIAL_EXTRACTION` message prefix (Node) whenever a security error occurred after some files had already been written to disk.

### Root cause

`exarch-core` wraps such errors in `ExtractionError::PartialExtraction { source, report }` once `report.total_items() > 0`. Prior to 0.4.0 the Python binding unwrapped this transparently (`convert_error(*source)`), surfacing the specific type. PR #216 (issue #210) reworked the mapping to always build the wrapper type so it could expose the partial report — which silently dropped the inner type. The `.pyi` and specs still advertised the specific types, confirming it was unintentional. Node inherited the same change.

### Fix

`convert_error` now unwraps `PartialExtraction` to the specific inner error and attaches the partial-extraction report onto that concrete error:

- **Python**: `files_extracted` / `bytes_written` attributes set on the concrete exception.
- **Node**: `filesExtracted` / `bytesWritten` appended to the specific-coded message.

Both the #251 type contract and the #210 report-inspection capability hold simultaneously.

`PartialExtractionError` is **removed** from the Python public API: with the unwrap it is never raised, and making the concrete types inherit from it would be semantically wrong (those errors also occur non-partially, on the very first entry). Callers detect partial output via the report attributes.

### Spec conformance

A spec-conformance check found the fix contradicted **FR-075** (006-python-bindings) and **FR-083** (007-node-bindings), which had codified the buggy "always `PartialExtractionError`" behavior under #210. Both specs, their acceptance tables, and the #210/#216 notes are updated so the documented contract matches the corrected behavior.

### Tests

Regression tests added for `SymlinkEscape`, `HardlinkEscape`, and `SecurityViolation` sources wrapped in `PartialExtraction`, for both bindings — asserting the specific type/code **and** the report attributes. This closes the coverage gap that let #216 regress in the first place (the prior test only covered a `QuotaExceeded` source).

## Breaking change

Python `PartialExtractionError` is removed. Code using `except PartialExtractionError` must catch the specific exception type (or `ExtractionError` as the catch-all) and detect partial output via `getattr(e, "files_extracted", None) is not None`. Documented in CHANGELOG.

## Verification

- `cargo +nightly fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` — 842 passed, 3 skipped
- `cargo test --doc --workspace --all-features --exclude exarch-python --exclude exarch-node` — 114 passed

Note: the new binding unit tests execute in the dedicated `pytest` / `npm test` CI jobs; the Rust job type-checks them (cdylib extension modules cannot link as standalone test binaries — pre-existing project pattern).

Closes #251