### PR TITLE
refactor(core): consolidate error variants, fix re-export, panic→Result (#255, #256, #257)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `ValidationReport` is now re-exported at the crate root as `exarch_core::ValidationReport`
+  (was only accessible as `exarch_core::security::ValidationReport`) (#256).
+
 ### Breaking Changes
 
+- **`ExtractionError::UnsupportedFormat`** has been removed. All format-detection failures now
+  return `ExtractionError::UnknownFormat { path }`, which carries the path that could not be
+  identified. Match arms on `UnsupportedFormat` must be updated to `UnknownFormat { .. }` (#255).
+- **7z archive creation** now returns `ExtractionError::InvalidConfiguration` instead of
+  `ExtractionError::UnsupportedFormat` when the output path has a `.7z` extension, since the
+  format is recognised but creation is unsupported (#255).
+- **`CreationConfig::with_compression_level`** now returns `Result<Self, ExtractionError>` instead
+  of `Self`. Call sites must handle the error with `?` or `.unwrap()`; the method no longer panics
+  on out-of-range input (#257). The real validation gate is `CreationConfig::validate()`, which is
+  invoked by the creation pipeline; this change removes the panic from the public builder surface.
 - **Python**: `PartialExtractionError` has been removed from the public API. In 0.4.0 it was
   always raised when extraction failed after some files were already written. Code written
   against 0.4.0 that used `except PartialExtractionError` must be updated: catch the specific

--- a/crates/exarch-cli/src/error.rs
+++ b/crates/exarch-cli/src/error.rs
@@ -102,10 +102,10 @@ pub fn convert_extraction_error(
                 io_err
             )
         }
-        ExtractionError::UnsupportedFormat => format!(
-            "Archive format not supported: {}\n\
+        ExtractionError::UnknownFormat { path } => format!(
+            "Cannot determine archive format: {}\n\
              HINT: Supported formats: tar, tar.gz, tar.bz2, tar.xz, tar.zstd, zip",
-            archive.display()
+            path.display()
         ),
         ExtractionError::InvalidArchive(reason) => format!(
             "Invalid archive '{}': {}\n\

--- a/crates/exarch-cli/src/output/json.rs
+++ b/crates/exarch-cli/src/output/json.rs
@@ -18,7 +18,6 @@ use std::path::Path;
 fn extraction_error_kind(err: &ExtractionError) -> String {
     match err {
         ExtractionError::Io(_) => "IoError",
-        ExtractionError::UnsupportedFormat => "UnsupportedFormat",
         ExtractionError::InvalidArchive(_) => "InvalidArchive",
         ExtractionError::PathTraversal { .. } => "PathTraversal",
         ExtractionError::SymlinkEscape { .. } => "SymlinkEscape",
@@ -359,9 +358,11 @@ mod tests {
     }
 
     #[test]
-    fn test_extraction_error_kind_unsupported_format() {
-        let err = ExtractionError::UnsupportedFormat;
-        assert_eq!(error_kind(&err), "UnsupportedFormat");
+    fn test_extraction_error_kind_unknown_format() {
+        let err = ExtractionError::UnknownFormat {
+            path: std::path::PathBuf::from("archive.rar"),
+        };
+        assert_eq!(error_kind(&err), "UnknownFormat");
     }
 
     #[test]

--- a/crates/exarch-core/benches/creation.rs
+++ b/crates/exarch-core/benches/creation.rs
@@ -197,7 +197,8 @@ fn benchmark_compression_levels(c: &mut Criterion) {
                     let output = temp.path().join("output.tar.gz");
                     let config = CreationConfig::default()
                         .with_format(Some(ArchiveType::TarGz))
-                        .with_compression_level(*level);
+                        .with_compression_level(*level)
+                        .unwrap();
                     let _ = create_archive(
                         black_box(&output),
                         black_box(&[&source_dir]),

--- a/crates/exarch-core/src/api.rs
+++ b/crates/exarch-core/src/api.rs
@@ -508,7 +508,9 @@ fn creator_for_format(
         ArchiveType::TarXz => Ok(Box::new(crate::creation::TarXzCreator)),
         ArchiveType::TarZst => Ok(Box::new(crate::creation::TarZstCreator)),
         ArchiveType::Zip => Ok(Box::new(crate::creation::ZipCreator)),
-        ArchiveType::SevenZ => Err(ExtractionError::UnsupportedFormat),
+        ArchiveType::SevenZ => Err(ExtractionError::InvalidConfiguration {
+            reason: "7z archive creation is not supported".into(),
+        }),
     }
 }
 
@@ -794,7 +796,7 @@ mod tests {
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
-            ExtractionError::UnsupportedFormat
+            ExtractionError::InvalidConfiguration { .. }
         ));
     }
 

--- a/crates/exarch-core/src/creation/config.rs
+++ b/crates/exarch-core/src/creation/config.rs
@@ -15,13 +15,16 @@ use std::path::PathBuf;
 /// ```
 /// use exarch_core::creation::CreationConfig;
 ///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// // Use secure defaults
 /// let config = CreationConfig::default();
 ///
 /// // Customize for specific needs
 /// let custom = CreationConfig::default()
 ///     .with_follow_symlinks(true)
-///     .with_compression_level(9);
+///     .with_compression_level(9)?;
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Debug, Clone)]
 pub struct CreationConfig {
@@ -158,15 +161,16 @@ impl CreationConfig {
 
     /// Sets the compression level.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if the compression level is not in the range 1-9.
-    /// Use `validate()` for non-panicking validation.
-    #[must_use]
-    pub fn with_compression_level(mut self, level: u8) -> Self {
-        assert!((1..=9).contains(&level), "compression level must be 1-9");
+    /// Returns [`ExtractionError::InvalidCompressionLevel`] if `level` is not
+    /// in the range 1–9.
+    pub fn with_compression_level(mut self, level: u8) -> Result<Self> {
+        if !(1..=9).contains(&level) {
+            return Err(ExtractionError::InvalidCompressionLevel { level });
+        }
         self.compression_level = Some(level);
-        self
+        Ok(self)
     }
 
     /// Sets whether to preserve permissions.
@@ -220,6 +224,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::unwrap_used)]
     fn test_creation_config_builder() {
         let config = CreationConfig::default()
             .with_follow_symlinks(true)
@@ -228,6 +233,7 @@ mod tests {
             .with_exclude_patterns(vec!["*.log".to_string()])
             .with_strip_prefix(Some(PathBuf::from("/base")))
             .with_compression_level(9)
+            .unwrap()
             .with_preserve_permissions(false)
             .with_format(Some(ArchiveType::TarGz));
 
@@ -242,14 +248,15 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::unwrap_used)]
     fn test_creation_config_validate_valid() {
         let config = CreationConfig::default();
         assert!(config.validate().is_ok());
 
-        let config = CreationConfig::default().with_compression_level(1);
+        let config = CreationConfig::default().with_compression_level(1).unwrap();
         assert!(config.validate().is_ok());
 
-        let config = CreationConfig::default().with_compression_level(9);
+        let config = CreationConfig::default().with_compression_level(9).unwrap();
         assert!(config.validate().is_ok());
 
         let config = CreationConfig {
@@ -286,9 +293,15 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "compression level must be 1-9")]
     fn test_creation_config_builder_invalid_compression() {
-        let _config = CreationConfig::default().with_compression_level(0);
+        assert!(matches!(
+            CreationConfig::default().with_compression_level(0),
+            Err(ExtractionError::InvalidCompressionLevel { level: 0 })
+        ));
+        assert!(matches!(
+            CreationConfig::default().with_compression_level(10),
+            Err(ExtractionError::InvalidCompressionLevel { level: 10 })
+        ));
     }
 
     #[test]

--- a/crates/exarch-core/src/creation/creator.rs
+++ b/crates/exarch-core/src/creation/creator.rs
@@ -402,7 +402,8 @@ mod tests {
     fn test_builder_full_config() {
         let config = CreationConfig::default()
             .with_follow_symlinks(true)
-            .with_compression_level(9);
+            .with_compression_level(9)
+            .unwrap();
 
         let creator = ArchiveCreator::new()
             .output("test.tar.gz")

--- a/crates/exarch-core/src/creation/tar.rs
+++ b/crates/exarch-core/src/creation/tar.rs
@@ -549,6 +549,7 @@ mod tests {
         let config = CreationConfig::default()
             .with_exclude_patterns(vec![])
             .with_compression_level(9)
+            .unwrap()
             .with_format(Some(ArchiveType::TarGz));
 
         let report = create_archive(&output, &[source_dir.path()], &config).unwrap();
@@ -636,6 +637,7 @@ mod tests {
             let config = CreationConfig::default()
                 .with_exclude_patterns(vec![])
                 .with_compression_level(level)
+                .unwrap()
                 .with_format(Some(ArchiveType::TarGz));
 
             let report = create_archive(&output, &[source_dir.path()], &config).unwrap();

--- a/crates/exarch-core/src/creation/zip.rs
+++ b/crates/exarch-core/src/creation/zip.rs
@@ -552,7 +552,8 @@ mod tests {
 
         let config = CreationConfig::default()
             .with_exclude_patterns(vec![])
-            .with_compression_level(9);
+            .with_compression_level(9)
+            .unwrap();
 
         let report = create_zip(&output, &[source_dir.path()], &config).unwrap();
 
@@ -577,7 +578,8 @@ mod tests {
             let output = temp.path().join(format!("output_{level}.zip"));
             let config = CreationConfig::default()
                 .with_exclude_patterns(vec![])
-                .with_compression_level(level);
+                .with_compression_level(level)
+                .unwrap();
 
             let report = create_zip(&output, &[source_dir.path()], &config).unwrap();
             assert_eq!(report.files_added, 1);

--- a/crates/exarch-core/src/error/messages.rs
+++ b/crates/exarch-core/src/error/messages.rs
@@ -101,12 +101,6 @@ impl ExtractionError {
                 context: None,
             },
 
-            Self::UnsupportedFormat => FfiErrorMessage {
-                code: "UNSUPPORTED_FORMAT",
-                description: "unsupported archive format".into(),
-                context: None,
-            },
-
             Self::InvalidArchive(reason) => FfiErrorMessage {
                 code: "INVALID_ARCHIVE",
                 description: format!("invalid archive: {reason}"),
@@ -192,7 +186,6 @@ impl ExtractionError {
             Self::ZipBomb { .. } => "ZIP_BOMB",
             Self::QuotaExceeded { .. } => "QUOTA_EXCEEDED",
             Self::SecurityViolation { .. } => "SECURITY_VIOLATION",
-            Self::UnsupportedFormat => "UNSUPPORTED_FORMAT",
             Self::InvalidArchive(_) => "INVALID_ARCHIVE",
             Self::Io(_) => "IO_ERROR",
             Self::InvalidPermissions { .. } => "INVALID_PERMISSIONS",
@@ -299,7 +292,9 @@ mod tests {
             ExtractionError::SecurityViolation {
                 reason: "test".into(),
             },
-            ExtractionError::UnsupportedFormat,
+            ExtractionError::UnknownFormat {
+                path: PathBuf::from("test.rar"),
+            },
             ExtractionError::InvalidArchive("test".into()),
             ExtractionError::Io(std::io::Error::other("test")),
             ExtractionError::InvalidPermissions {

--- a/crates/exarch-core/src/error/types.rs
+++ b/crates/exarch-core/src/error/types.rs
@@ -60,10 +60,6 @@ pub enum ExtractionError {
     #[error("I/O error: {0}")]
     Io(std::io::Error),
 
-    /// Archive format is unsupported or unrecognized.
-    #[error("unsupported archive format")]
-    UnsupportedFormat,
-
     /// Archive is corrupted or invalid.
     #[error("invalid archive: {0}")]
     InvalidArchive(String),
@@ -207,7 +203,7 @@ impl ExtractionError {
     /// };
     /// assert!(err.is_security_violation());
     ///
-    /// let err = ExtractionError::UnsupportedFormat;
+    /// let err = ExtractionError::InvalidArchive("corrupted header".to_string());
     /// assert!(!err.is_security_violation());
     /// ```
     #[must_use]
@@ -271,11 +267,14 @@ impl ExtractionError {
     ///
     /// ```
     /// use exarch_core::ExtractionError;
+    /// use std::path::PathBuf;
     ///
     /// let err = ExtractionError::InvalidArchive("bad header".to_string());
     /// assert_eq!(err.context(), Some("bad header"));
     ///
-    /// let err = ExtractionError::UnsupportedFormat;
+    /// let err = ExtractionError::UnknownFormat {
+    ///     path: PathBuf::from("archive.rar"),
+    /// };
     /// assert_eq!(err.context(), None);
     /// ```
     #[must_use]
@@ -305,8 +304,13 @@ mod tests {
 
     #[test]
     fn test_error_display() {
-        let err = ExtractionError::UnsupportedFormat;
-        assert_eq!(err.to_string(), "unsupported archive format");
+        let err = ExtractionError::UnknownFormat {
+            path: PathBuf::from("archive.rar"),
+        };
+        assert_eq!(
+            err.to_string(),
+            "cannot determine archive format from: archive.rar"
+        );
     }
 
     #[test]
@@ -362,7 +366,9 @@ mod tests {
         assert!(err.is_security_violation());
 
         // Not security violations
-        let err = ExtractionError::UnsupportedFormat;
+        let err = ExtractionError::UnknownFormat {
+            path: PathBuf::from("archive.rar"),
+        };
         assert!(!err.is_security_violation());
 
         let err = ExtractionError::InvalidArchive("bad".into());
@@ -386,7 +392,9 @@ mod tests {
         let err = ExtractionError::InvalidArchive("corrupted".into());
         assert!(!err.is_recoverable());
 
-        let err = ExtractionError::UnsupportedFormat;
+        let err = ExtractionError::UnknownFormat {
+            path: PathBuf::from("archive.rar"),
+        };
         assert!(!err.is_recoverable());
 
         let err = ExtractionError::ZipBomb {
@@ -407,7 +415,9 @@ mod tests {
         };
         assert_eq!(err.context(), Some("not allowed"));
 
-        let err = ExtractionError::UnsupportedFormat;
+        let err = ExtractionError::UnknownFormat {
+            path: PathBuf::from("archive.rar"),
+        };
         assert_eq!(err.context(), None);
 
         let err = ExtractionError::PathTraversal {

--- a/crates/exarch-core/src/formats/detect.rs
+++ b/crates/exarch-core/src/formats/detect.rs
@@ -48,17 +48,18 @@ pub enum ArchiveType {
 ///
 /// `.gz` files are only accepted when the stem ends with `.tar`
 /// (i.e. `archive.tar.gz`). A bare `archive.gz` returns
-/// [`ExtractionError::UnsupportedFormat`].
+/// [`ExtractionError::UnknownFormat`].
 ///
 /// # Errors
 ///
-/// Returns [`ExtractionError::UnsupportedFormat`] if the extension is
+/// Returns [`ExtractionError::UnknownFormat`] if the extension is
 /// unrecognised or if a `.gz` file has no `.tar` stem.
 pub fn detect_format(path: &Path) -> Result<ArchiveType> {
-    let extension = path
-        .extension()
-        .and_then(|e| e.to_str())
-        .ok_or(ExtractionError::UnsupportedFormat)?;
+    let extension = path.extension().and_then(|e| e.to_str()).ok_or_else(|| {
+        ExtractionError::UnknownFormat {
+            path: path.to_path_buf(),
+        }
+    })?;
 
     let ext_lower = extension.to_ascii_lowercase();
     match ext_lower.as_str() {
@@ -70,7 +71,9 @@ pub fn detect_format(path: &Path) -> Result<ArchiveType> {
             {
                 Ok(ArchiveType::TarGz)
             } else {
-                Err(ExtractionError::UnsupportedFormat)
+                Err(ExtractionError::UnknownFormat {
+                    path: path.to_path_buf(),
+                })
             }
         }
         "bz2" | "tbz" | "tbz2" => Ok(ArchiveType::TarBz2),
@@ -82,7 +85,9 @@ pub fn detect_format(path: &Path) -> Result<ArchiveType> {
         // extensions, EPUBs - all ZIP under the hood, so they extract
         // through the same path. See `ZIP_FAMILY_ALIASES` for the list.
         ext if is_zip_family_alias(ext) => Ok(ArchiveType::Zip),
-        _ => Err(ExtractionError::UnsupportedFormat),
+        _ => Err(ExtractionError::UnknownFormat {
+            path: path.to_path_buf(),
+        }),
     }
 }
 
@@ -108,11 +113,21 @@ mod tests {
     }
 
     #[test]
-    fn test_detect_bare_gz_returns_unsupported() {
+    fn test_detect_bare_gz_returns_unknown_format() {
         let path = PathBuf::from("archive.gz");
         assert!(matches!(
             detect_format(&path),
-            Err(ExtractionError::UnsupportedFormat)
+            Err(ExtractionError::UnknownFormat { .. })
+        ));
+    }
+
+    #[test]
+    fn test_detect_bare_gz_error_carries_path() {
+        let path = PathBuf::from("archive.gz");
+        let err = detect_format(&path).unwrap_err();
+        assert!(matches!(
+            err,
+            ExtractionError::UnknownFormat { path: ref p } if p == &PathBuf::from("archive.gz")
         ));
     }
 
@@ -191,11 +206,21 @@ mod tests {
     }
 
     #[test]
-    fn test_detect_unsupported() {
+    fn test_detect_unknown_format() {
         let path = PathBuf::from("archive.rar");
         assert!(matches!(
             detect_format(&path),
-            Err(ExtractionError::UnsupportedFormat)
+            Err(ExtractionError::UnknownFormat { .. })
+        ));
+    }
+
+    #[test]
+    fn test_detect_unknown_format_error_carries_path() {
+        let path = PathBuf::from("archive.rar");
+        let err = detect_format(&path).unwrap_err();
+        assert!(matches!(
+            err,
+            ExtractionError::UnknownFormat { path: ref p } if p == &PathBuf::from("archive.rar")
         ));
     }
 

--- a/crates/exarch-core/src/inspection/report.rs
+++ b/crates/exarch-core/src/inspection/report.rs
@@ -205,11 +205,6 @@ impl VerificationIssue {
                 IssueCategory::InvalidArchive,
                 format!("I/O error: {io_err}"),
             ),
-            ExtractionError::UnsupportedFormat => (
-                IssueSeverity::High,
-                IssueCategory::InvalidArchive,
-                "Unsupported archive format".to_string(),
-            ),
             ExtractionError::InvalidArchive(msg) => (
                 IssueSeverity::High,
                 IssueCategory::InvalidArchive,
@@ -506,15 +501,6 @@ mod tests {
         assert_eq!(issue.severity, IssueSeverity::Medium);
         assert_eq!(issue.category, IssueCategory::InvalidPermissions);
         assert!(issue.message.contains("Invalid permissions"));
-    }
-
-    #[test]
-    fn test_verification_issue_from_unsupported_format() {
-        let error = ExtractionError::UnsupportedFormat;
-        let issue = VerificationIssue::from_error(&error, None);
-        assert_eq!(issue.severity, IssueSeverity::High);
-        assert_eq!(issue.category, IssueCategory::InvalidArchive);
-        assert!(issue.message.contains("Unsupported archive format"));
     }
 
     #[test]

--- a/crates/exarch-core/src/lib.rs
+++ b/crates/exarch-core/src/lib.rs
@@ -73,6 +73,11 @@ pub use inspection::VerificationIssue;
 pub use inspection::VerificationReport;
 pub use inspection::VerificationStatus;
 
+// Re-export security types
+/// Summary statistics produced by the validation pipeline; see
+/// [`security::ValidationReport`].
+pub use security::ValidationReport;
+
 // Re-export types module for easier access
 pub use types::DestDir;
 pub use types::EntryType;

--- a/crates/exarch-node/src/error.rs
+++ b/crates/exarch-node/src/error.rs
@@ -123,10 +123,6 @@ pub fn convert_error(err: CoreError) -> Error {
             msg.push_str(&reason);
             Error::new(Status::GenericFailure, msg)
         }
-        CoreError::UnsupportedFormat => Error::new(
-            Status::GenericFailure,
-            "UNSUPPORTED_FORMAT: unsupported archive format",
-        ),
         CoreError::InvalidArchive(archive_msg) => {
             let mut msg = String::with_capacity(30 + archive_msg.len());
             msg.push_str("INVALID_ARCHIVE: invalid archive: ");
@@ -336,12 +332,14 @@ mod tests {
     }
 
     #[test]
-    fn test_unsupported_format_conversion() {
-        let err = CoreError::UnsupportedFormat;
+    fn test_unknown_format_conversion() {
+        let err = CoreError::UnknownFormat {
+            path: std::path::PathBuf::from("archive.rar"),
+        };
         let napi_err = convert_error(err);
         let err_str = napi_err.to_string();
-        assert!(err_str.contains("UNSUPPORTED_FORMAT"));
-        assert!(err_str.contains("unsupported archive format"));
+        assert!(err_str.contains("UNKNOWN_FORMAT"));
+        assert!(err_str.contains("cannot determine archive format"));
     }
 
     #[test]

--- a/crates/exarch-python/src/error.rs
+++ b/crates/exarch-python/src/error.rs
@@ -74,9 +74,6 @@ pub fn convert_error(err: CoreError) -> PyErr {
         CoreError::SecurityViolation { reason } => SecurityViolationError::new_err(format!(
             "operation denied by security policy: {reason}"
         )),
-        CoreError::UnsupportedFormat => {
-            UnsupportedFormatError::new_err("unsupported archive format")
-        }
         CoreError::InvalidArchive(msg) => {
             InvalidArchiveError::new_err(format!("invalid archive: {msg}"))
         }
@@ -374,13 +371,20 @@ mod tests {
     }
 
     #[test]
-    fn test_unsupported_format_conversion() {
-        let err = CoreError::UnsupportedFormat;
+    fn test_unknown_format_conversion() {
+        let err = CoreError::UnknownFormat {
+            path: PathBuf::from("archive.rar"),
+        };
         let py_err = convert_error(err);
         let err_str = py_err.to_string();
         assert!(
-            err_str.contains("unsupported archive format"),
-            "Expected 'unsupported archive format' in error message, got: {}",
+            err_str.contains("cannot determine archive format"),
+            "Expected 'cannot determine archive format' in error message, got: {}",
+            err_str
+        );
+        assert!(
+            err_str.contains("archive.rar"),
+            "Expected path in error message, got: {}",
             err_str
         );
     }


### PR DESCRIPTION
## Summary

- **#255** — Remove `ExtractionError::UnsupportedFormat`; merge into `UnknownFormat { path: PathBuf }`. Format detection now carries the actual archive path in the error. The 7z creation case uses `InvalidConfiguration` (semantically distinct: format is known but creation is unsupported). All callers updated across core, CLI, Python, and Node bindings.
- **#256** — Re-export `ValidationReport` from `exarch_core::ValidationReport` to match every other public report type. Was only accessible via `exarch_core::security::ValidationReport`.
- **#257** — `CreationConfig::with_compression_level` returns `Result<Self, ExtractionError>` instead of panicking on invalid input. `CreationConfig::validate()` retains its check as the runtime gate; the builder now surfaces `InvalidCompressionLevel` at the API boundary.

## Breaking changes

- `ExtractionError::UnsupportedFormat` removed — match arms must use `UnknownFormat { path }` instead
- `with_compression_level` return type changed from `Self` to `Result<Self, ExtractionError>`

## Test plan

- [x] `cargo +nightly fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` — 843/843 pass
- [x] `cargo test --doc --workspace --all-features` — 114/114 pass
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace` — clean
- [x] `cargo check -p exarch-python -p exarch-node --all-features` — clean

## Follow-up

Issue #264 / #265 tracks stale `UnsupportedFormat` references in `specs/` — out of scope for this PR, to be addressed in a docs pass.

Closes #255, #256, #257