### PR TITLE
feat(exarch-node): add catch_unwind to async ops and getAllowSolidArchives getter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ExtractionError` as the catch-all. To detect whether output was partial, use
   `getattr(e, "files_extracted", None) is not None` (#251).
 
+### Added
+
+- Node.js: `SecurityConfig` now exposes `allowSolidArchives` getter, consistent with all other
+  boolean permission getters (`allowSymlinks`, `allowHardlinks`, `allowAbsolutePaths`,
+  `allowWorldWritable`) (#261).
+
 ### Fixed
 
+- Node.js: async operations (`extractArchive`, `createArchive`, `listArchive`, `verifyArchive`)
+  now wrap the core call with `catch_unwind` inside `spawn_blocking`, preventing panics in
+  `exarch-core` from crossing the FFI boundary and aborting the Node.js process. Panics are
+  converted to JavaScript errors with a descriptive message (#262).
 - Python: `extract_archive` now raises the specific exception type (`SymlinkEscapeError`,
   `HardlinkEscapeError`, `QuotaExceededError`, etc.) instead of the generic
   `PartialExtractionError` when extraction fails after some files have been written to disk.

--- a/crates/exarch-node/package-lock.json
+++ b/crates/exarch-node/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "exarch-rs",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "exarch-rs",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
-        "@biomejs/biome": "^2.0",
-        "@napi-rs/cli": "^3.5"
+        "@biomejs/biome": "^2.4.15",
+        "@napi-rs/cli": "^3.6.2"
       },
       "engines": {
         "node": ">= 18"

--- a/crates/exarch-node/src/config.rs
+++ b/crates/exarch-node/src/config.rs
@@ -313,6 +313,12 @@ impl SecurityConfig {
         self.inner.allowed.world_writable
     }
 
+    /// Whether solid 7z archives are allowed.
+    #[napi(getter)]
+    pub fn get_allow_solid_archives(&self) -> bool {
+        self.inner.allow_solid_archives
+    }
+
     /// List of allowed file extensions.
     ///
     /// Note: This getter clones the underlying data. For performance-critical
@@ -826,6 +832,22 @@ mod tests {
         assert!(
             config.get_preserve_permissions(),
             "preserve_permissions getter should return set value"
+        );
+    }
+
+    #[test]
+    fn test_allow_solid_archives_default_and_round_trip() {
+        let config = SecurityConfig::new();
+        assert!(
+            !config.get_allow_solid_archives(),
+            "allow_solid_archives should default to false"
+        );
+
+        let mut config = SecurityConfig::new();
+        config.set_allow_solid_archives(Some(true));
+        assert!(
+            config.get_allow_solid_archives(),
+            "allow_solid_archives getter should reflect setter value"
         );
     }
 

--- a/crates/exarch-node/src/lib.rs
+++ b/crates/exarch-node/src/lib.rs
@@ -150,11 +150,16 @@ pub async fn extract_archive(
     // For maximum security with untrusted archives, use extractArchiveSync()
     // or ensure exclusive file access (e.g., flock) during extraction.
     let report = tokio::task::spawn_blocking(move || {
-        exarch_core::extract_archive(&archive_path, &output_dir, &config_owned)
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            exarch_core::extract_archive(&archive_path, &output_dir, &config_owned)
+                .map_err(convert_error)
+        }))
+        .map_err(|_| Error::from_reason("Internal panic during archive extraction"))
+        .flatten()
     })
     .await
-    .map_err(|e| Error::from_reason(format!("task execution failed: {e}")))?
-    .map_err(convert_error)?;
+    .map_err(|e| Error::from_reason(format!("task join error: {e}")))
+    .flatten()?;
 
     Ok(ExtractionReport::from(report))
 }
@@ -264,12 +269,17 @@ pub async fn create_archive(
         config.map(|c| c.as_core().clone()).unwrap_or_default();
 
     let report = tokio::task::spawn_blocking(move || {
-        let sources_refs: Vec<&str> = sources.iter().map(String::as_str).collect();
-        exarch_core::create_archive(&output_path, &sources_refs, &config_owned)
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let sources_refs: Vec<&str> = sources.iter().map(String::as_str).collect();
+            exarch_core::create_archive(&output_path, &sources_refs, &config_owned)
+                .map_err(convert_error)
+        }))
+        .map_err(|_| Error::from_reason("Internal panic during archive creation"))
+        .flatten()
     })
     .await
-    .map_err(|e| Error::from_reason(format!("task execution failed: {e}")))?
-    .map_err(convert_error)?;
+    .map_err(|e| Error::from_reason(format!("task join error: {e}")))
+    .flatten()?;
 
     Ok(CreationReport::from(report))
 }
@@ -364,11 +374,15 @@ pub async fn list_archive(
         config.map(|c| c.as_core().clone()).unwrap_or_default();
 
     let manifest = tokio::task::spawn_blocking(move || {
-        exarch_core::list_archive(&archive_path, &config_owned)
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            exarch_core::list_archive(&archive_path, &config_owned).map_err(convert_error)
+        }))
+        .map_err(|_| Error::from_reason("Internal panic during archive listing"))
+        .flatten()
     })
     .await
-    .map_err(|e| Error::from_reason(format!("task execution failed: {e}")))?
-    .map_err(convert_error)?;
+    .map_err(|e| Error::from_reason(format!("task join error: {e}")))
+    .flatten()?;
 
     Ok(ArchiveManifest::from(manifest))
 }
@@ -461,11 +475,15 @@ pub async fn verify_archive(
         config.map(|c| c.as_core().clone()).unwrap_or_default();
 
     let report = tokio::task::spawn_blocking(move || {
-        exarch_core::verify_archive(&archive_path, &config_owned)
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            exarch_core::verify_archive(&archive_path, &config_owned).map_err(convert_error)
+        }))
+        .map_err(|_| Error::from_reason("Internal panic during archive verification"))
+        .flatten()
     })
     .await
-    .map_err(|e| Error::from_reason(format!("task execution failed: {e}")))?
-    .map_err(convert_error)?;
+    .map_err(|e| Error::from_reason(format!("task join error: {e}")))
+    .flatten()?;
 
     Ok(VerificationReport::from(report))
 }

--- a/crates/exarch-node/tests/security-config.test.js
+++ b/crates/exarch-node/tests/security-config.test.js
@@ -112,6 +112,19 @@ describe('SecurityConfig', () => {
       assert.strictEqual(config.allowWorldWritable, true);
     });
 
+    it('should default allowSolidArchives to false', () => {
+      const config = new SecurityConfig();
+
+      assert.strictEqual(config.allowSolidArchives, false);
+    });
+
+    it('should set allow solid archives', () => {
+      const config = new SecurityConfig();
+      config.setAllowSolidArchives(true);
+
+      assert.strictEqual(config.allowSolidArchives, true);
+    });
+
     it('should set preserve permissions', () => {
       const config = new SecurityConfig();
       config.setPreservePermissions(true);


### PR DESCRIPTION
## Summary

- Add explicit `catch_unwind(AssertUnwindSafe(...))` inside `spawn_blocking` for all four async Node.js operations (`extractArchive`, `createArchive`, `listArchive`, `verifyArchive`), making them consistent with the existing sync variants. Panics in `exarch-core` are now converted to JavaScript errors instead of aborting the process. Closes #262.
- Add `getAllowSolidArchives()` getter to `SecurityConfig`, matching the pattern of all other boolean permission getters. Closes #261.

## Changes

- `crates/exarch-node/src/lib.rs` — wrap core call with `catch_unwind` in all 4 async ops; use `Result::flatten()` to collapse `Result<Result<T, E>, E>`
- `crates/exarch-node/src/config.rs` — add `get_allow_solid_archives` getter with `#[napi(getter)]` and `///` doc comment
- `crates/exarch-node/tests/security-config.test.js` — 2 new JS tests for default value and setter/getter round-trip
- `CHANGELOG.md` — `[Unreleased]` entries for both changes

## Test plan

- [ ] `cargo +nightly fmt --all -- --check` — pass
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — pass (0 warnings)
- [ ] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` — 686 passed
- [ ] `cargo test --doc --workspace --all-features` — 114 passed
- [ ] `cd crates/exarch-node && npm run build` — release build clean