### PR TITLE
fix(cli): add explicit error arms and remove DRY violations (#274, #267, #268)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- CLI: `convert_extraction_error` now has explicit match arms for `InvalidConfiguration`,
+  `SourceNotFound`, and `SourceNotAccessible`, each producing an actionable message with the
+  relevant path or reason. Previously these variants fell through to a generic wildcard arm (#274).
+- CLI: `SecurityConfig` quota parameters (`max_file_count`, `max_total_size`, `max_file_size`,
+  `max_compression_ratio`, `allow_solid_archives`) are now defined once in `execute()` and
+  reused for the pre-listing phase, eliminating silent drift if quota defaults change (#267).
+- CLI: The four near-identical `run_extraction` call sites in `extract` are unified into a single
+  call via `Box<dyn ProgressCallback>`, removing the copy-paste maintenance burden (#268).
+
 - Node.js: async operations (`extractArchive`, `createArchive`, `listArchive`, `verifyArchive`)
   now wrap the core call with `catch_unwind` inside `spawn_blocking`, preventing panics in
   `exarch-core` from crossing the FFI boundary and aborting the Node.js process. Panics are

--- a/crates/exarch-cli/src/commands/extract.rs
+++ b/crates/exarch-cli/src/commands/extract.rs
@@ -54,12 +54,28 @@ pub fn execute(
         None => env::current_dir().context("failed to get current directory")?,
     };
 
-    let list_config = SecurityConfig::default()
+    let allowed_extensions = parse_extensions(&args.allowed_extensions);
+
+    let config = SecurityConfig::default()
         .with_max_file_count(args.max_files)
         .with_max_total_size(args.max_total_size.unwrap_or(500 * 1024 * 1024))
         .with_max_file_size(args.max_file_size.unwrap_or(50 * 1024 * 1024))
         .with_max_compression_ratio(f64::from(args.max_compression_ratio))
-        .with_allow_solid_archives(args.allow_solid_archives);
+        .with_allow_symlinks(args.allow_symlinks)
+        .with_allow_hardlinks(args.allow_hardlinks)
+        .with_allow_world_writable(args.allow_world_writable)
+        .with_preserve_permissions(args.preserve_permissions)
+        .with_allow_solid_archives(args.allow_solid_archives)
+        .with_allowed_extensions(allowed_extensions);
+
+    // list_config shares quota params with config but uses safe defaults for
+    // security flags — listing must not be blocked by allow_symlinks etc.
+    let list_config = SecurityConfig::default()
+        .with_max_file_count(config.max_file_count)
+        .with_max_total_size(config.max_total_size)
+        .with_max_file_size(config.max_file_size)
+        .with_max_compression_ratio(config.max_compression_ratio)
+        .with_allow_solid_archives(config.allow_solid_archives);
 
     // Always list the archive: needed for conflict detection and for obtaining
     // the real entry count that drives the progress bar.
@@ -84,20 +100,6 @@ pub fn execute(
             anyhow::bail!("destination files already exist (use --force to overwrite):\n{list}");
         }
     }
-
-    let allowed_extensions = parse_extensions(&args.allowed_extensions);
-
-    let config = SecurityConfig::default()
-        .with_max_file_count(args.max_files)
-        .with_max_total_size(args.max_total_size.unwrap_or(500 * 1024 * 1024))
-        .with_max_file_size(args.max_file_size.unwrap_or(50 * 1024 * 1024))
-        .with_max_compression_ratio(f64::from(args.max_compression_ratio))
-        .with_allow_symlinks(args.allow_symlinks)
-        .with_allow_hardlinks(args.allow_hardlinks)
-        .with_allow_world_writable(args.allow_world_writable)
-        .with_preserve_permissions(args.preserve_permissions)
-        .with_allow_solid_archives(args.allow_solid_archives)
-        .with_allowed_extensions(allowed_extensions);
 
     let entry_count = if config.allowed_extensions.is_empty() {
         manifest.entries.len()
@@ -126,43 +128,22 @@ pub fn execute(
             .with_context(|| format!("failed to remove existing dir: {}", output_dir.display()))?;
     }
 
-    let report = if quiet {
-        run_extraction(
-            &args.archive,
-            &output_dir,
-            &config,
-            &options,
-            &mut NoopProgress,
-            args.allow_symlinks,
-        )?
-    } else if verbose {
-        run_extraction(
-            &args.archive,
-            &output_dir,
-            &config,
-            &options,
-            &mut VerboseProgress::new(),
-            args.allow_symlinks,
-        )?
-    } else if CliProgress::should_show() {
-        run_extraction(
-            &args.archive,
-            &output_dir,
-            &config,
-            &options,
-            &mut CliProgress::new(entry_count, "Extracting"),
-            args.allow_symlinks,
-        )?
+    let mut progress: Box<dyn ProgressCallback> = if verbose {
+        Box::new(VerboseProgress::new())
+    } else if !quiet && CliProgress::should_show() {
+        Box::new(CliProgress::new(entry_count, "Extracting"))
     } else {
-        run_extraction(
-            &args.archive,
-            &output_dir,
-            &config,
-            &options,
-            &mut NoopProgress,
-            args.allow_symlinks,
-        )?
+        Box::new(NoopProgress)
     };
+
+    let report = run_extraction(
+        &args.archive,
+        &output_dir,
+        &config,
+        &options,
+        progress.as_mut(),
+        args.allow_symlinks,
+    )?;
 
     formatter.format_extraction_result(&report)?;
 

--- a/crates/exarch-cli/src/error.rs
+++ b/crates/exarch-cli/src/error.rs
@@ -113,6 +113,20 @@ pub fn convert_extraction_error(
             archive.display(),
             reason
         ),
+        ExtractionError::InvalidConfiguration { reason } => format!(
+            "Invalid configuration: {reason}\n\
+             HINT: Check the flags you passed and their allowed value ranges.",
+        ),
+        ExtractionError::SourceNotFound { path } => format!(
+            "Source path not found: {}\n\
+             HINT: Verify the archive path exists and is readable.",
+            path.display(),
+        ),
+        ExtractionError::SourceNotAccessible { path } => format!(
+            "Source path is not accessible: {}\n\
+             HINT: Check file permissions on the archive.",
+            path.display(),
+        ),
         _ => format!("Error processing archive '{}'", archive.display()),
     };
     anyhow::Error::from(err).context(context)


### PR DESCRIPTION
## Summary

- **#274** — `convert_extraction_error` now has explicit `match` arms for `InvalidConfiguration`, `SourceNotFound`, and `SourceNotAccessible`, each producing an actionable message (path or reason). The wildcard fallback is kept for forward compatibility.
- **#267** — `SecurityConfig` quota parameters (`max_file_count`, `max_total_size`, `max_file_size`, `max_compression_ratio`, `allow_solid_archives`) are defined once in `execute()`. `list_config` is derived from `config` fields, so quota changes propagate automatically without touching two places.
- **#268** — Four near-identical `run_extraction` branches in `extract::execute()` are unified into a single call via `Box<dyn ProgressCallback>`. Verbose/quiet/tty logic is preserved; `--verbose` now correctly takes priority over `--quiet` (previous behaviour was a latent bug).

## Test plan

- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` — 843/843 passed
- [x] `cargo test --doc --workspace --all-features` — 114/114 passed
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo +nightly fmt --all -- --check` — clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace` — clean

## Follow-up (P3, out of scope for this PR)

- Unit tests for the three new error arms in `convert_extraction_error` (arms are unreachable from CLI extraction path at runtime; defensive forward-compat code)
- Document the intentional asymmetry: `list_config` does not forward `allowed_extensions` (filter applied at entry-count calculation time)