### PR TITLE
feat(python,node): add UnknownFormatError subclass and extract_archive_with_progress (#260, #263)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Node.js: `SecurityConfig` now exposes `allowSolidArchives` getter, consistent with all other
   boolean permission getters (`allowSymlinks`, `allowHardlinks`, `allowAbsolutePaths`,
   `allowWorldWritable`) (#261).
+- Python: `UnknownFormatError` is now a distinct exception subclass of `UnsupportedFormatError`,
+  raised when an archive format cannot be determined from the file path or magic bytes
+  (`CoreError::UnknownFormat`). Callers catching `UnsupportedFormatError` continue to work
+  unchanged; callers that need to distinguish "format unknown" from "format known but unsupported"
+  can now catch the narrower type (#260).
+- Python: `extract_archive_with_progress(archive_path, output_dir, config, progress)` binding
+  added, mirroring `create_archive_with_progress`. The GIL is held when a callback is provided
+  and released otherwise. `exarch.pyi` and the stub are updated (#263).
+- Node.js: `extractArchiveWithProgress(archivePath, outputDir, config?, progress?)` async binding
+  added, accepting an optional `ThreadsafeFunction` progress callback with signature
+  `(path: string, total: bigint, current: bigint, bytesWritten: bigint) => void` (#263).
 
 ### Fixed
 

--- a/crates/exarch-node/src/lib.rs
+++ b/crates/exarch-node/src/lib.rs
@@ -44,6 +44,8 @@
 #![allow(clippy::trailing_empty_array)]
 
 use napi::bindgen_prelude::*;
+use napi::threadsafe_function::ThreadsafeFunction;
+use napi::threadsafe_function::ThreadsafeFunctionCallMode;
 use napi_derive::napi;
 
 mod config;
@@ -535,10 +537,144 @@ pub fn verify_archive_sync(
     Ok(VerificationReport::from(report))
 }
 
-// NOTE: Progress callback support (createArchiveWithProgress) is planned for
-// a future release. The napi-rs 3.x ThreadsafeFunction API requires additional
-// work to properly bridge Rust ProgressCallback trait to JavaScript callbacks.
-// For now, use createArchive/createArchiveSync without progress tracking.
+/// Extract an archive to the specified directory with a progress callback
+/// (async).
+///
+/// The `progress` callback is called once per entry with
+/// `(path, total, current, bytesWritten)` where:
+/// - `path` — entry path inside the archive
+/// - `total` — total number of entries as `bigint` (0 for TAR-family formats
+///   because the entry count is unknown until the stream is fully read)
+/// - `current` — 1-based index of the current entry as `bigint`
+/// - `bytesWritten` — cumulative bytes written to disk so far as `bigint`
+///   (always 0 during extraction because the core library does not emit
+///   byte-level progress events for extraction; only entry-level events fire)
+///
+/// Extraction runs on the tokio blocking thread pool. The progress callback is
+/// dispatched back to the JavaScript thread via a threadsafe function.
+///
+/// # Arguments
+///
+/// * `archive_path` - Path to the archive file
+/// * `output_dir` - Directory where files will be extracted
+/// * `config` - Optional `SecurityConfig` (uses secure defaults if omitted)
+/// * `progress` - Optional progress callback `(path: string, total: bigint,
+///   current: bigint, bytesWritten: bigint) => void`
+///
+/// # Returns
+///
+/// Promise resolving to `ExtractionReport` with extraction statistics
+///
+/// # Errors
+///
+/// Returns error for security violations or I/O errors. Error messages are
+/// prefixed with error codes for discrimination in JavaScript. See
+/// `extractArchive` for the full list of error codes.
+///
+/// # Examples
+///
+/// ```javascript
+/// const report = await extractArchiveWithProgress(
+///   'archive.tar.gz',
+///   '/tmp/output',
+///   null,
+///   (path, total, current, bytesWritten) => {
+///     console.log(`${current}/${total}: ${path}`);
+///   },
+/// );
+/// console.log(`Extracted ${report.filesExtracted} files`);
+/// ```
+#[napi]
+#[allow(clippy::needless_pass_by_value, clippy::trailing_empty_array)]
+pub async fn extract_archive_with_progress(
+    archive_path: String,
+    output_dir: String,
+    config: Option<&SecurityConfig>,
+    progress: Option<ThreadsafeFunction<(String, i64, i64, i64)>>,
+) -> Result<ExtractionReport> {
+    validate_path(&archive_path)?;
+    validate_path(&output_dir)?;
+
+    let config_owned: exarch_core::SecurityConfig =
+        config.map(|c| c.as_core().clone()).unwrap_or_default();
+
+    let report = tokio::task::spawn_blocking(move || {
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            run_extract_with_optional_progress(&archive_path, &output_dir, &config_owned, progress)
+                .map_err(convert_error)
+        }))
+        .map_err(|_| Error::from_reason("Internal panic during archive extraction with progress"))
+        .flatten()
+    })
+    .await
+    .map_err(|e| Error::from_reason(format!("task join error: {e}")))
+    .flatten()?;
+
+    Ok(ExtractionReport::from(report))
+}
+
+/// Runs `extract_archive_with_progress` routing to the JS callback when present
+/// or to [`exarch_core::NoopProgress`] when absent.
+fn run_extract_with_optional_progress(
+    archive_path: &str,
+    output_dir: &str,
+    config: &exarch_core::SecurityConfig,
+    progress: Option<ThreadsafeFunction<(String, i64, i64, i64)>>,
+) -> exarch_core::Result<exarch_core::ExtractionReport> {
+    progress.map_or_else(
+        || {
+            let mut noop = exarch_core::NoopProgress;
+            exarch_core::extract_archive_with_progress(archive_path, output_dir, config, &mut noop)
+        },
+        |tsfn| {
+            let mut callback = NodeProgressAdapter::new(tsfn);
+            exarch_core::extract_archive_with_progress(
+                archive_path,
+                output_dir,
+                config,
+                &mut callback,
+            )
+        },
+    )
+}
+
+/// Adapter that calls a JavaScript progress callback from a Rust worker thread.
+struct NodeProgressAdapter {
+    tsfn: ThreadsafeFunction<(String, i64, i64, i64)>,
+    accumulated_bytes: i64,
+    total: usize,
+}
+
+impl NodeProgressAdapter {
+    fn new(tsfn: ThreadsafeFunction<(String, i64, i64, i64)>) -> Self {
+        Self {
+            tsfn,
+            accumulated_bytes: 0,
+            total: 0,
+        }
+    }
+}
+
+impl exarch_core::ProgressCallback for NodeProgressAdapter {
+    fn on_entry_start(&mut self, path: &std::path::Path, total: usize, current: usize) {
+        self.total = total;
+        let path_str = path.to_string_lossy().into_owned();
+        let total_i64 = i64::try_from(total).unwrap_or(i64::MAX);
+        let current_i64 = i64::try_from(current).unwrap_or(i64::MAX);
+        self.tsfn.call(
+            Ok((path_str, total_i64, current_i64, self.accumulated_bytes)),
+            ThreadsafeFunctionCallMode::NonBlocking,
+        );
+    }
+
+    fn on_bytes_written(&mut self, bytes: u64) {
+        self.accumulated_bytes = self.accumulated_bytes.saturating_add(bytes.cast_signed());
+    }
+
+    fn on_entry_complete(&mut self, _path: &std::path::Path) {}
+
+    fn on_complete(&mut self) {}
+}
 
 #[cfg(test)]
 #[allow(

--- a/crates/exarch-python/exarch.pyi
+++ b/crates/exarch-python/exarch.pyi
@@ -418,6 +418,9 @@ class VerificationReport:
         """Returns true if there are any critical severity issues."""
         ...
 
+ProgressCallbackFn = Callable[[str, int, int, int], None]
+"""Progress callback: (path, total, current, bytes_written) -> None."""
+
 def extract_archive(
     archive_path: str | Path,
     output_dir: str | Path,
@@ -460,6 +463,63 @@ def extract_archive(
     """
     ...
 
+def extract_archive_with_progress(
+    archive_path: str | Path,
+    output_dir: str | Path,
+    config: SecurityConfig | None = None,
+    progress: ProgressCallbackFn | None = None,
+) -> ExtractionReport:
+    """
+    Extract an archive to the specified directory with progress reporting.
+
+    Args:
+        archive_path: Path to the archive file (str or pathlib.Path)
+        output_dir: Directory where files will be extracted (str or pathlib.Path)
+        config: Optional SecurityConfig (uses secure defaults if None)
+        progress: Optional callback function for progress updates
+
+    Returns:
+        ExtractionReport with extraction statistics
+
+    Raises:
+        ValueError: Invalid argument type, null bytes in path, or path too long
+        PathTraversalError: Path traversal attempt detected
+        SymlinkEscapeError: Symlink points outside extraction directory
+        HardlinkEscapeError: Hardlink target outside extraction directory
+        ZipBombError: Potential zip bomb detected
+        InvalidPermissionsError: File permissions are invalid or unsafe
+        QuotaExceededError: Resource quota exceeded
+        SecurityViolationError: Security policy violation
+        UnsupportedFormatError: Archive format not supported
+        InvalidArchiveError: Archive is corrupted
+        IOError: I/O operation failed
+
+    Note:
+        When a progress callback is provided, the GIL is held during extraction
+        so that the callback can safely call into Python. Without a callback,
+        the GIL is released for performance.
+
+        Progress callback limitations:
+
+        - The ``bytes_written`` argument reflects ``on_bytes_written`` events
+          from the core library. Extraction does not emit byte-level progress,
+          only entry-level events, so ``bytes_written`` will always be 0 during
+          extraction.
+        - For TAR-family formats (tar, tar.gz, tar.bz2, tar.xz, tar.zst) the
+          ``total`` argument is 0 because the entry count is unknown until the
+          stream is fully read.
+
+        When extraction fails after some files have already been written to disk,
+        the specific exception (e.g. ``SymlinkEscapeError``) is raised with
+        ``files_extracted`` and ``bytes_written`` attributes attached.
+
+    Example:
+        >>> def progress(path: str, total: int, current: int, bytes: int):
+        ...     print(f"{current}/{total}: {path} ({bytes} bytes)")
+        >>> report = extract_archive_with_progress("archive.tar.gz", "/tmp/out", None, progress)
+    """
+    ...
+
 def create_archive(
     output_path: str | Path,
     sources: list[str | Path],
@@ -482,9 +542,6 @@ def create_archive(
         UnsupportedFormatError: Archive format not supported
     """
     ...
-
-ProgressCallbackFn = Callable[[str, int, int, int], None]
-"""Progress callback: (path, total, current, bytes_written) -> None."""
 
 def create_archive_with_progress(
     output_path: str | Path,
@@ -670,6 +727,18 @@ class SecurityViolationError(ExtractionError):
 
 class UnsupportedFormatError(ExtractionError):
     """Archive format not supported."""
+
+    ...
+
+class UnknownFormatError(UnsupportedFormatError):
+    """
+    Archive format cannot be determined from the file path or magic bytes.
+
+    This is a subclass of ``UnsupportedFormatError`` so existing callers that
+    catch the parent continue to work, while callers that need to distinguish
+    "we know the format but don't support it" from "we cannot identify the
+    format at all" can catch this narrower type.
+    """
 
     ...
 

--- a/crates/exarch-python/src/error.rs
+++ b/crates/exarch-python/src/error.rs
@@ -20,6 +20,10 @@ create_exception!(exarch, InvalidPermissionsError, ExtractionError);
 create_exception!(exarch, QuotaExceededError, ExtractionError);
 create_exception!(exarch, SecurityViolationError, ExtractionError);
 create_exception!(exarch, UnsupportedFormatError, ExtractionError);
+// Subclass of UnsupportedFormatError: raised when the format cannot be
+// identified at all (as opposed to being known but unsupported). Callers
+// catching the parent still work.
+create_exception!(exarch, UnknownFormatError, UnsupportedFormatError);
 create_exception!(exarch, InvalidArchiveError, ExtractionError);
 
 /// Converts Rust extraction errors to Python exceptions.
@@ -90,7 +94,7 @@ pub fn convert_error(err: CoreError) -> PyErr {
         CoreError::InvalidCompressionLevel { level } => {
             PyValueError::new_err(format!("invalid compression level {level}, must be 1-9"))
         }
-        CoreError::UnknownFormat { path } => UnsupportedFormatError::new_err(format!(
+        CoreError::UnknownFormat { path } => UnknownFormatError::new_err(format!(
             "cannot determine archive format from: {}",
             path.display()
         )),
@@ -145,6 +149,10 @@ pub fn register_exceptions(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add(
         "UnsupportedFormatError",
         m.py().get_type::<UnsupportedFormatError>(),
+    )?;
+    m.add(
+        "UnknownFormatError",
+        m.py().get_type::<UnknownFormatError>(),
     )?;
     m.add(
         "InvalidArchiveError",
@@ -387,6 +395,20 @@ mod tests {
             "Expected path in error message, got: {}",
             err_str
         );
+        // UnknownFormatError must be the concrete type
+        Python::attach(|py| {
+            assert!(
+                py_err.is_instance_of::<UnknownFormatError>(py),
+                "expected UnknownFormatError, got: {}",
+                py_err
+            );
+            // Must also be catchable as UnsupportedFormatError (subclass)
+            assert!(
+                py_err.is_instance_of::<UnsupportedFormatError>(py),
+                "expected UnsupportedFormatError (parent), got: {}",
+                py_err
+            );
+        });
     }
 
     #[test]
@@ -462,6 +484,10 @@ mod tests {
             assert!(
                 module.getattr("UnsupportedFormatError").is_ok(),
                 "UnsupportedFormatError not registered"
+            );
+            assert!(
+                module.getattr("UnknownFormatError").is_ok(),
+                "UnknownFormatError not registered"
             );
             assert!(
                 module.getattr("InvalidArchiveError").is_ok(),

--- a/crates/exarch-python/src/lib.rs
+++ b/crates/exarch-python/src/lib.rs
@@ -425,6 +425,111 @@ fn create_archive_with_progress(
     }
 }
 
+/// Extract an archive with progress callback.
+///
+/// # Arguments
+///
+/// * `archive_path` - Path to the archive file (str or pathlib.Path)
+/// * `output_dir` - Directory where files will be extracted (str or
+///   pathlib.Path)
+/// * `config` - Optional `SecurityConfig` (uses secure defaults if None)
+/// * `progress` - Optional progress callback function
+///
+/// Progress callback signature: `(path: str, total: int, current: int,
+/// bytes_written: int) -> None`
+///
+/// # Returns
+///
+/// `ExtractionReport` with extraction statistics
+///
+/// # Raises
+///
+/// * `ValueError` - Invalid arguments
+/// * `PathTraversalError` - Path traversal attempt detected
+/// * `SymlinkEscapeError` - Symlink points outside extraction directory
+/// * `HardlinkEscapeError` - Hardlink target outside extraction directory
+/// * `ZipBombError` - Potential zip bomb detected
+/// * `InvalidPermissionsError` - File permissions are invalid or unsafe
+/// * `QuotaExceededError` - Resource quota exceeded
+/// * `SecurityViolationError` - Security policy violation
+/// * `UnsupportedFormatError` - Archive format not supported
+/// * `InvalidArchiveError` - Archive is corrupted
+/// * `IOError` - I/O operation failed
+///
+/// # Security Considerations
+///
+/// ## GIL Release and TOCTOU
+///
+/// When a progress callback is provided the GIL is held during extraction so
+/// that the callback can safely call into Python. Without a callback the GIL
+/// is released for performance, but the TOCTOU caveat from `extract_archive`
+/// still applies.
+///
+/// # Examples
+///
+/// ```python
+/// from exarch import extract_archive_with_progress
+///
+/// def progress(path: str, total: int, current: int, bytes: int):
+///     print(f"{current}/{total}: {path} ({bytes} bytes)")
+///
+/// report = extract_archive_with_progress(
+///     "archive.tar.gz", "/tmp/output", None, progress
+/// )
+/// ```
+#[pyfunction]
+#[pyo3(signature = (archive_path, output_dir, config=None, progress=None))]
+fn extract_archive_with_progress(
+    py: Python<'_>,
+    archive_path: &Bound<'_, PyAny>,
+    output_dir: &Bound<'_, PyAny>,
+    config: Option<&PySecurityConfig>,
+    progress: Option<Py<PyAny>>,
+) -> PyResult<PyExtractionReport> {
+    let archive_path = path_to_string(py, archive_path)?;
+    let output_dir = path_to_string(py, output_dir)?;
+
+    let default_config = exarch_core::SecurityConfig::default();
+    let config_ref = config.map_or(&default_config, |c| c.as_core());
+
+    if let Some(py_callback) = progress {
+        let mut callback = PyProgressAdapter::new(py_callback);
+
+        // CRITICAL: Do NOT release GIL when using Python callback!
+        // Python callback requires GIL to call into Python.
+        let report = exarch_core::extract_archive_with_progress(
+            &archive_path,
+            &output_dir,
+            config_ref,
+            &mut callback,
+        )
+        .map_err(convert_error)?;
+
+        Ok(PyExtractionReport::from(report))
+    } else {
+        // No progress callback - can release GIL
+        let mut noop = exarch_core::NoopProgress;
+        let report = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            py.detach(|| {
+                exarch_core::extract_archive_with_progress(
+                    &archive_path,
+                    &output_dir,
+                    config_ref,
+                    &mut noop,
+                )
+            })
+        }))
+        .map_err(|_| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
+                "Internal panic during archive extraction with progress",
+            )
+        })?
+        .map_err(convert_error)?;
+
+        Ok(PyExtractionReport::from(report))
+    }
+}
+
 /// Adapter that calls Python callback from Rust.
 struct PyProgressAdapter {
     callback: Py<PyAny>,
@@ -481,6 +586,7 @@ fn exarch(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     // Top-level functions
     m.add_function(wrap_pyfunction!(extract_archive, m)?)?;
+    m.add_function(wrap_pyfunction!(extract_archive_with_progress, m)?)?;
     m.add_function(wrap_pyfunction!(create_archive, m)?)?;
     m.add_function(wrap_pyfunction!(create_archive_with_progress, m)?)?;
     m.add_function(wrap_pyfunction!(list_archive, m)?)?;


### PR DESCRIPTION
## Summary

- **#260** — Python: introduce `UnknownFormatError(UnsupportedFormatError)` for `CoreError::UnknownFormat`. Previously both error variants mapped to the same `UnsupportedFormatError`, preventing programmatic discrimination. Mirrors the distinction already present in the Node.js binding.
- **#263** — Python: add `extract_archive_with_progress` mirroring the existing `create_archive_with_progress`. Node.js: add `extractArchiveWithProgress` with optional `ThreadsafeFunction` progress callback.

## Changes

| File | Change |
|------|--------|
| `crates/exarch-python/src/error.rs` | Add `UnknownFormatError` exception, remap `CoreError::UnknownFormat` |
| `crates/exarch-python/src/lib.rs` | Add `extract_archive_with_progress` pyfunction |
| `crates/exarch-python/exarch.pyi` | Add `UnknownFormatError` class, `extract_archive_with_progress` stub |
| `crates/exarch-node/src/lib.rs` | Add `extractArchiveWithProgress` with `catch_unwind` + `ThreadsafeFunction` |
| `CHANGELOG.md` | Add entries for #260 and #263 under `[Unreleased]` |

## Progress limitations

Both bindings document that `bytes_written`/`bytesWritten` is always 0 during extraction (the core does not emit byte-level events on extraction paths), and `total` is 0 for TAR-family formats (entry count is unknown until streaming completes).

## Test plan

- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` — 843/843 passed
- [x] `cargo nextest run -p exarch-node --all-features --lib` — 131/131 passed
- [x] `cargo test --doc --workspace --all-features --exclude exarch-python --exclude exarch-node` — 114 passed
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo +nightly fmt --all -- --check` — clean
- [ ] Python integration tests for `UnknownFormatError` and `extract_archive_with_progress` — tracked as follow-up (require native build environment with CPython dev headers)
- [ ] Node.js JS integration tests for `extractArchiveWithProgress` — tracked as follow-up (require `npm run build`)

Closes #260, closes #263