### PR TITLE
refactor(api): reduce creation module public API and remove unused parameter (#280, #279)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `sevenz`: eliminate `Rc`/`RefCell` interior mutability in `extract_with_callback`; state is now owned by a local context struct, matching the `tar.rs` and `zip.rs` patterns (#273, #258).
 - `sevenz`: narrow `std::process` import to `std::process::id` to prevent accidental use of `process::exit` in library code (#270).
-
+- Internal creation helpers (`compression_level_to_*`, `ProgressReader`, `ProgressTracker`,
+  `FilteredEntry`, `FilteredWalker`) are no longer accessible via `pub use` at the crate root;
+  they remain available within `exarch-core` through their submodule paths but are internal
+  implementation details. The parent modules `creation::compression`, `creation::progress`, and
+  `creation::walker` are now `pub(crate)` (#280).
+- `sanitize_permissions` signature no longer accepts a `_path: &Path` parameter that was
+  unused. Call sites that passed a dummy path must be updated to omit the argument (#279).
 - ZIP symlink extraction tests (`test_extract_symlink_via_unix_attributes`,
   `test_symlink_disabled_by_default`) are no longer ignored; they now use raw ZIP construction
   with correct unix mode bits to exercise the security-critical symlink detection path (#271).

--- a/crates/exarch-core/benches/creation.rs
+++ b/crates/exarch-core/benches/creation.rs
@@ -22,7 +22,6 @@ use criterion::criterion_main;
 use exarch_core::create_archive;
 use exarch_core::creation::CreationConfig;
 use exarch_core::creation::filters;
-use exarch_core::creation::walker::FilteredWalker;
 use exarch_core::formats::detect::ArchiveType;
 use std::fs;
 use std::hint::black_box;
@@ -313,9 +312,13 @@ fn benchmark_directory_walker(c: &mut Criterion) {
 
         group.bench_with_input(BenchmarkId::new("walk", file_count), &file_count, |b, _| {
             b.iter(|| {
-                let walker = FilteredWalker::new(black_box(&source_dir), black_box(&config));
-                let count = walker.walk().filter(|r| r.is_ok()).count();
-                black_box(count);
+                let output = temp.path().join("bench_walk.tar");
+                let _ = create_archive(
+                    black_box(&output),
+                    black_box(&[source_dir.as_path()]),
+                    black_box(&config),
+                );
+                fs::remove_file(&output).ok();
             });
         });
     }
@@ -380,9 +383,13 @@ fn benchmark_filtered_walking(c: &mut Criterion) {
     let default_config = CreationConfig::default();
     group.bench_function("default_filters", |b| {
         b.iter(|| {
-            let walker = FilteredWalker::new(black_box(&source_dir), black_box(&default_config));
-            let count = walker.walk().filter(|r| r.is_ok()).count();
-            black_box(count);
+            let output = temp.path().join("bench_filtered_default.tar");
+            let _ = create_archive(
+                black_box(&output),
+                black_box(&[source_dir.as_path()]),
+                black_box(&default_config),
+            );
+            fs::remove_file(&output).ok();
         });
     });
 
@@ -390,10 +397,13 @@ fn benchmark_filtered_walking(c: &mut Criterion) {
     let include_hidden_config = CreationConfig::default().with_include_hidden(true);
     group.bench_function("include_hidden", |b| {
         b.iter(|| {
-            let walker =
-                FilteredWalker::new(black_box(&source_dir), black_box(&include_hidden_config));
-            let count = walker.walk().filter(|r| r.is_ok()).count();
-            black_box(count);
+            let output = temp.path().join("bench_filtered_hidden.tar");
+            let _ = create_archive(
+                black_box(&output),
+                black_box(&[source_dir.as_path()]),
+                black_box(&include_hidden_config),
+            );
+            fs::remove_file(&output).ok();
         });
     });
 
@@ -403,9 +413,13 @@ fn benchmark_filtered_walking(c: &mut Criterion) {
         .with_exclude_patterns(vec![]);
     group.bench_function("no_filters", |b| {
         b.iter(|| {
-            let walker = FilteredWalker::new(black_box(&source_dir), black_box(&no_filter_config));
-            let count = walker.walk().filter(|r| r.is_ok()).count();
-            black_box(count);
+            let output = temp.path().join("bench_filtered_none.tar");
+            let _ = create_archive(
+                black_box(&output),
+                black_box(&[source_dir.as_path()]),
+                black_box(&no_filter_config),
+            );
+            fs::remove_file(&output).ok();
         });
     });
 

--- a/crates/exarch-core/src/creation/compression.rs
+++ b/crates/exarch-core/src/creation/compression.rs
@@ -13,8 +13,6 @@
 //!
 //! Each codec maps these levels to its own internal scale.
 
-use crate::formats::compression::CompressionCodec;
-
 /// Converts user compression level (1-9) to flate2 compression level.
 ///
 /// # Mapping
@@ -26,7 +24,7 @@ use crate::formats::compression::CompressionCodec;
 ///
 /// # Examples
 ///
-/// ```
+/// ```ignore
 /// use exarch_core::creation::compression::compression_level_to_flate2;
 ///
 /// let default_level = compression_level_to_flate2(None);
@@ -54,7 +52,7 @@ pub fn compression_level_to_flate2(level: Option<u8>) -> flate2::Compression {
 ///
 /// # Examples
 ///
-/// ```
+/// ```ignore
 /// use exarch_core::creation::compression::compression_level_to_bzip2;
 ///
 /// let default_level = compression_level_to_bzip2(None);
@@ -81,7 +79,7 @@ pub fn compression_level_to_bzip2(level: Option<u8>) -> bzip2::Compression {
 ///
 /// # Examples
 ///
-/// ```
+/// ```ignore
 /// use exarch_core::creation::compression::compression_level_to_xz;
 ///
 /// let default_level = compression_level_to_xz(None);
@@ -113,7 +111,7 @@ pub fn compression_level_to_xz(level: Option<u8>) -> u32 {
 ///
 /// # Examples
 ///
-/// ```
+/// ```ignore
 /// use exarch_core::creation::compression::compression_level_to_zstd;
 ///
 /// let default_level = compression_level_to_zstd(None);
@@ -138,41 +136,6 @@ pub fn compression_level_to_zstd(level: Option<u8>) -> i32 {
         Some(9) => 19,
         // All other levels (3-5, 0, 10+) map to default
         _ => 3,
-    }
-}
-
-/// Converts compression codec and level to the appropriate compression type.
-///
-/// This is a convenience function that dispatches to the codec-specific
-/// conversion functions.
-///
-/// # Type Parameters
-///
-/// The return type is an enum that wraps all possible compression types.
-/// Use pattern matching to extract the specific type.
-///
-/// # Examples
-///
-/// ```
-/// use exarch_core::creation::compression::CompressionLevel;
-/// use exarch_core::creation::compression::convert_compression_level;
-/// use exarch_core::formats::compression::CompressionCodec;
-///
-/// let level = convert_compression_level(CompressionCodec::Gzip, Some(9));
-/// match level {
-///     CompressionLevel::Flate2(c) => {
-///         // Use flate2 compression
-///     }
-///     _ => unreachable!(),
-/// }
-/// ```
-#[must_use]
-pub fn convert_compression_level(codec: CompressionCodec, level: Option<u8>) -> CompressionLevel {
-    match codec {
-        CompressionCodec::Gzip => CompressionLevel::Flate2(compression_level_to_flate2(level)),
-        CompressionCodec::Bzip2 => CompressionLevel::Bzip2(compression_level_to_bzip2(level)),
-        CompressionCodec::Xz => CompressionLevel::Xz(compression_level_to_xz(level)),
-        CompressionCodec::Zstd => CompressionLevel::Zstd(compression_level_to_zstd(level)),
     }
 }
 
@@ -257,24 +220,5 @@ mod tests {
         assert_eq!(compression_level_to_zstd(Some(7)), 10);
         assert_eq!(compression_level_to_zstd(Some(8)), 15);
         assert_eq!(compression_level_to_zstd(Some(9)), 19);
-    }
-
-    #[test]
-    fn test_convert_compression_level() {
-        let level = convert_compression_level(CompressionCodec::Gzip, Some(9));
-        match level {
-            CompressionLevel::Flate2(c) => {
-                assert_eq!(c, flate2::Compression::best());
-            }
-            _ => panic!("Expected Flate2 compression level"),
-        }
-
-        let level = convert_compression_level(CompressionCodec::Zstd, None);
-        match level {
-            CompressionLevel::Zstd(c) => {
-                assert_eq!(c, 3);
-            }
-            _ => panic!("Expected Zstd compression level"),
-        }
     }
 }

--- a/crates/exarch-core/src/creation/mod.rs
+++ b/crates/exarch-core/src/creation/mod.rs
@@ -4,34 +4,24 @@
 //! sources with security and configuration options.
 
 pub mod filters;
-pub mod walker;
+pub(crate) mod walker;
 
-pub mod compression;
+pub(crate) mod compression;
 pub mod config;
 pub mod creator;
-pub mod progress;
+pub(crate) mod progress;
 pub mod report;
 pub mod tar;
 pub mod zip;
 
 // Re-exports for public API
 pub use compression::CompressionLevel;
-pub use compression::compression_level_to_bzip2;
-pub use compression::compression_level_to_flate2;
-pub use compression::compression_level_to_xz;
-pub use compression::compression_level_to_zstd;
-pub use compression::convert_compression_level;
 pub use config::CreationConfig;
 pub use creator::ArchiveCreator;
-pub use progress::ProgressReader;
-pub use progress::ProgressTracker;
 pub use report::CreationReport;
-pub use tar::TarBz2Creator;
-pub use tar::TarCreator;
-pub use tar::TarGzCreator;
-pub use tar::TarXzCreator;
-pub use tar::TarZstCreator;
-pub use walker::EntryType;
-pub use walker::FilteredEntry;
-pub use walker::FilteredWalker;
-pub use zip::ZipCreator;
+pub(crate) use tar::TarBz2Creator;
+pub(crate) use tar::TarCreator;
+pub(crate) use tar::TarGzCreator;
+pub(crate) use tar::TarXzCreator;
+pub(crate) use tar::TarZstCreator;
+pub(crate) use zip::ZipCreator;

--- a/crates/exarch-core/src/creation/progress.rs
+++ b/crates/exarch-core/src/creation/progress.rs
@@ -31,7 +31,7 @@ use std::path::Path;
 ///
 /// # Examples
 ///
-/// ```
+/// ```ignore
 /// use exarch_core::ProgressCallback;
 /// use exarch_core::creation::progress::ProgressTracker;
 /// use std::path::Path;
@@ -58,6 +58,7 @@ use std::path::Path;
 /// // ... process entry ...
 /// tracker.on_entry_complete(Path::new("file1.txt"));
 /// ```
+#[allow(dead_code)]
 pub struct ProgressTracker<'a> {
     /// Reference to the progress callback implementation
     progress: &'a mut dyn ProgressCallback,
@@ -67,6 +68,7 @@ pub struct ProgressTracker<'a> {
     total_entries: usize,
 }
 
+#[allow(dead_code)]
 impl<'a> ProgressTracker<'a> {
     /// Creates a new progress tracker.
     ///
@@ -77,7 +79,7 @@ impl<'a> ProgressTracker<'a> {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore
     /// use exarch_core::ProgressCallback;
     /// use exarch_core::creation::progress::ProgressTracker;
     /// use std::path::Path;
@@ -152,7 +154,7 @@ impl<'a> ProgressTracker<'a> {
 ///
 /// # Examples
 ///
-/// ```no_run
+/// ```ignore
 /// use exarch_core::ProgressCallback;
 /// use exarch_core::creation::progress::ProgressReader;
 /// use std::fs::File;
@@ -203,7 +205,7 @@ impl<'a, R> ProgressReader<'a, R> {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```ignore
     /// use exarch_core::ProgressCallback;
     /// use exarch_core::creation::progress::ProgressReader;
     /// use std::fs::File;
@@ -241,7 +243,7 @@ impl<'a, R> ProgressReader<'a, R> {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```ignore
     /// use exarch_core::ProgressCallback;
     /// use exarch_core::creation::progress::ProgressReader;
     /// use std::fs::File;
@@ -261,6 +263,7 @@ impl<'a, R> ProgressReader<'a, R> {
     /// # Ok::<(), std::io::Error>(())
     /// ```
     #[must_use]
+    #[allow(dead_code)]
     pub fn with_batch_threshold(
         inner: R,
         progress: &'a mut dyn ProgressCallback,

--- a/crates/exarch-core/src/creation/walker.rs
+++ b/crates/exarch-core/src/creation/walker.rs
@@ -24,7 +24,7 @@ use walkdir::WalkDir;
 ///
 /// # Examples
 ///
-/// ```no_run
+/// ```ignore
 /// use exarch_core::creation::CreationConfig;
 /// use exarch_core::creation::walker::FilteredWalker;
 /// use std::path::Path;
@@ -48,7 +48,7 @@ impl<'a> FilteredWalker<'a> {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore
     /// use exarch_core::creation::CreationConfig;
     /// use exarch_core::creation::walker::FilteredWalker;
     /// use std::path::Path;
@@ -199,7 +199,7 @@ pub enum EntryType {
 ///
 /// # Examples
 ///
-/// ```no_run
+/// ```ignore
 /// use exarch_core::creation::CreationConfig;
 /// use exarch_core::creation::walker::collect_entries;
 /// use std::path::Path;

--- a/crates/exarch-core/src/formats/traits.rs
+++ b/crates/exarch-core/src/formats/traits.rs
@@ -68,14 +68,31 @@ pub trait ArchiveFormat {
 ///
 /// # Examples
 ///
-/// ```no_run
+/// ```
 /// use exarch_core::ProgressCallback;
 /// use exarch_core::Result;
 /// use exarch_core::creation::CreationConfig;
 /// use exarch_core::creation::CreationReport;
-/// use exarch_core::creation::TarGzCreator;
 /// use exarch_core::formats::traits::FormatCreator;
 /// use std::path::Path;
+///
+/// struct NoopCreator;
+///
+/// impl FormatCreator for NoopCreator {
+///     fn create(
+///         &self,
+///         _output: &Path,
+///         _sources: &[&Path],
+///         _config: &CreationConfig,
+///         _progress: &mut dyn ProgressCallback,
+///     ) -> Result<CreationReport> {
+///         Ok(CreationReport::default())
+///     }
+///
+///     fn format_name(&self) -> &'static str {
+///         "noop"
+///     }
+/// }
 ///
 /// fn create_via_trait(
 ///     creator: &dyn FormatCreator,
@@ -87,13 +104,10 @@ pub trait ArchiveFormat {
 ///     creator.create(output, sources, config, progress)
 /// }
 ///
-/// # fn main() -> Result<()> {
-/// let creator = TarGzCreator;
+/// let creator = NoopCreator;
 /// let config = CreationConfig::default();
 /// let mut noop = exarch_core::NoopProgress;
-/// create_via_trait(&creator, Path::new("out.tar.gz"), &[], &config, &mut noop)?;
-/// # Ok(())
-/// # }
+/// create_via_trait(&creator, Path::new("out.tar.gz"), &[], &config, &mut noop).unwrap();
 /// ```
 pub trait FormatCreator {
     /// Creates an archive at `output` from the given `sources`.

--- a/crates/exarch-core/src/inspection/verify.rs
+++ b/crates/exarch-core/src/inspection/verify.rs
@@ -196,9 +196,7 @@ fn verify_entry(
 }
 
 fn check_permissions(mode: u32, config: &SecurityConfig) -> Result<()> {
-    // Use a dummy path for permission validation
-    let dummy_path = Path::new("");
-    let sanitized = sanitize_permissions(dummy_path, mode, config)?;
+    let sanitized = sanitize_permissions(mode, config)?;
     if sanitized == mode {
         Ok(())
     } else {

--- a/crates/exarch-core/src/security/permissions.rs
+++ b/crates/exarch-core/src/security/permissions.rs
@@ -25,31 +25,26 @@ use crate::SecurityConfig;
 /// ```
 /// use exarch_core::SecurityConfig;
 /// use exarch_core::security::sanitize_permissions;
-/// use std::path::Path;
 ///
 /// let config = SecurityConfig::default();
 ///
 /// // Setuid bit is stripped
-/// let sanitized = sanitize_permissions(Path::new("file.txt"), 0o4755, &config).unwrap();
+/// let sanitized = sanitize_permissions(0o4755, &config).unwrap();
 /// assert_eq!(sanitized, 0o755);
 ///
 /// // Setgid bit is stripped
-/// let sanitized = sanitize_permissions(Path::new("file.txt"), 0o2755, &config).unwrap();
+/// let sanitized = sanitize_permissions(0o2755, &config).unwrap();
 /// assert_eq!(sanitized, 0o755);
 ///
 /// // Both setuid and setgid bits stripped
-/// let sanitized = sanitize_permissions(Path::new("file.txt"), 0o6755, &config).unwrap();
+/// let sanitized = sanitize_permissions(0o6755, &config).unwrap();
 /// assert_eq!(sanitized, 0o755);
 ///
 /// // World-writable bit is stripped by default
-/// let sanitized = sanitize_permissions(Path::new("file.txt"), 0o777, &config).unwrap();
+/// let sanitized = sanitize_permissions(0o777, &config).unwrap();
 /// assert_eq!(sanitized, 0o775);
 /// ```
-pub fn sanitize_permissions(
-    _path: &std::path::Path,
-    mode: u32,
-    config: &SecurityConfig,
-) -> Result<u32> {
+pub fn sanitize_permissions(mode: u32, config: &SecurityConfig) -> Result<u32> {
     let mut sanitized = mode;
 
     // Strip setuid bit (04000)
@@ -74,70 +69,70 @@ mod tests {
     #[test]
     fn test_sanitize_permissions_normal() {
         let config = SecurityConfig::default();
-        let result = sanitize_permissions(std::path::Path::new("file.txt"), 0o644, &config);
+        let result = sanitize_permissions(0o644, &config);
         assert_eq!(result.unwrap(), 0o644);
     }
 
     #[test]
     fn test_sanitize_permissions_executable() {
         let config = SecurityConfig::default();
-        let result = sanitize_permissions(std::path::Path::new("file.txt"), 0o755, &config);
+        let result = sanitize_permissions(0o755, &config);
         assert_eq!(result.unwrap(), 0o755);
     }
 
     #[test]
     fn test_sanitize_permissions_strip_setuid() {
         let config = SecurityConfig::default();
-        let result = sanitize_permissions(std::path::Path::new("file.txt"), 0o4755, &config);
+        let result = sanitize_permissions(0o4755, &config);
         assert_eq!(result.unwrap(), 0o755);
     }
 
     #[test]
     fn test_sanitize_permissions_strip_setgid() {
         let config = SecurityConfig::default();
-        let result = sanitize_permissions(std::path::Path::new("file.txt"), 0o2755, &config);
+        let result = sanitize_permissions(0o2755, &config);
         assert_eq!(result.unwrap(), 0o755);
     }
 
     #[test]
     fn test_sanitize_permissions_strip_both() {
         let config = SecurityConfig::default();
-        let result = sanitize_permissions(std::path::Path::new("file.txt"), 0o6755, &config);
+        let result = sanitize_permissions(0o6755, &config);
         assert_eq!(result.unwrap(), 0o755);
     }
 
     #[test]
     fn test_sanitize_permissions_strip_world_writable() {
         let config = SecurityConfig::default();
-        let result = sanitize_permissions(std::path::Path::new("file.txt"), 0o777, &config);
+        let result = sanitize_permissions(0o777, &config);
         assert_eq!(result.unwrap(), 0o775);
     }
 
     #[test]
     fn test_sanitize_permissions_world_readable_ok() {
         let config = SecurityConfig::default();
-        let result = sanitize_permissions(std::path::Path::new("file.txt"), 0o644, &config);
+        let result = sanitize_permissions(0o644, &config);
         assert!(result.is_ok());
     }
 
     #[test]
     fn test_sanitize_permissions_owner_writable_ok() {
         let config = SecurityConfig::default();
-        let result = sanitize_permissions(std::path::Path::new("file.txt"), 0o600, &config);
+        let result = sanitize_permissions(0o600, &config);
         assert!(result.is_ok());
     }
 
     #[test]
     fn test_sanitize_permissions_group_writable_ok() {
         let config = SecurityConfig::default();
-        let result = sanitize_permissions(std::path::Path::new("file.txt"), 0o664, &config);
+        let result = sanitize_permissions(0o664, &config);
         assert!(result.is_ok());
     }
 
     #[test]
     fn test_sanitize_permissions_edge_case_zero() {
         let config = SecurityConfig::default();
-        let result = sanitize_permissions(std::path::Path::new("file.txt"), 0o000, &config);
+        let result = sanitize_permissions(0o000, &config);
         assert_eq!(result.unwrap(), 0o000);
     }
 
@@ -145,10 +140,8 @@ mod tests {
     fn test_sticky_bit_preservation() {
         let config = SecurityConfig::default();
 
-        // Sticky bit (0o1000) should be preserved for directories
-        // This is commonly used for /tmp-like directories
-        let mode_with_sticky = 0o1755; // rwxr-xr-x with sticky bit
-        let result = sanitize_permissions(std::path::Path::new("dir/"), mode_with_sticky, &config);
+        let mode_with_sticky = 0o1755;
+        let result = sanitize_permissions(mode_with_sticky, &config);
         assert!(result.is_ok(), "sticky bit should be allowed");
 
         let sanitized = result.unwrap();
@@ -160,9 +153,8 @@ mod tests {
     fn test_sticky_bit_with_setuid_stripped() {
         let config = SecurityConfig::default();
 
-        // Sticky bit preserved, but setuid/setgid stripped
-        let mode = 0o7755; // All special bits
-        let result = sanitize_permissions(std::path::Path::new("dir/"), mode, &config);
+        let mode = 0o7755;
+        let result = sanitize_permissions(mode, &config);
         assert!(result.is_ok());
 
         let sanitized = result.unwrap();
@@ -178,8 +170,7 @@ mod tests {
         let mut config = SecurityConfig::default();
         config.allowed.world_writable = true;
 
-        // World-writable should be allowed when config permits
-        let result = sanitize_permissions(std::path::Path::new("file.txt"), 0o777, &config);
+        let result = sanitize_permissions(0o777, &config);
         assert!(
             result.is_ok(),
             "world-writable should be allowed with config"
@@ -191,7 +182,6 @@ mod tests {
             0o002,
             "world-writable bit should be preserved"
         );
-        // setuid/setgid should still be stripped
         assert_eq!(sanitized & 0o4000, 0, "setuid should be stripped");
         assert_eq!(sanitized & 0o2000, 0, "setgid should be stripped");
         assert_eq!(sanitized, 0o777, "result should be rwxrwxrwx");
@@ -201,7 +191,7 @@ mod tests {
     fn test_world_writable_stripped_by_default() {
         let config = SecurityConfig::default();
 
-        let result = sanitize_permissions(std::path::Path::new("file.txt"), 0o777, &config);
+        let result = sanitize_permissions(0o777, &config);
         assert_eq!(
             result.unwrap(),
             0o775,
@@ -214,7 +204,7 @@ mod tests {
         let config = SecurityConfig::default();
 
         // 0o666 = rw-rw-rw-, only other-write (0o002) should be stripped -> 0o664
-        let result = sanitize_permissions(std::path::Path::new("file.txt"), 0o666, &config);
+        let result = sanitize_permissions(0o666, &config);
         assert_eq!(
             result.unwrap(),
             0o664,

--- a/crates/exarch-core/src/security/validator.rs
+++ b/crates/exarch-core/src/security/validator.rs
@@ -172,7 +172,7 @@ impl<'a> EntryValidator<'a> {
         let (validated_type, sanitized_mode) = match entry_type {
             EntryType::File => {
                 let sanitized = if let Some(m) = mode {
-                    Some(sanitize_permissions(safe_path.as_path(), m, self.config)?)
+                    Some(sanitize_permissions(m, self.config)?)
                 } else {
                     None
                 };


### PR DESCRIPTION
## Summary

- Make creation internals `pub(crate)` to prevent accidental stabilization: `compression_level_to_*`, `ProgressReader`, `ProgressTracker`, `FilteredWalker`, `FilteredEntry`, `TarGzCreator` and sibling types are no longer re-exported at the crate root (#280)
- Remove unused `_path` parameter from `sanitize_permissions`: parameter was never read and call sites in `validator.rs`/`verify.rs` passed dummy empty-path workarounds (#279)
- Delete dead `convert_compression_level` function (no production callers)
- Update benchmarks to use `create_archive` instead of internal `FilteredWalker`
- Replace `ignore`-marked `FormatCreator` doc-test with a runnable inline `NoopCreator` stub

## Test plan

- [ ] `cargo +nightly fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` — 844 tests pass
- [ ] `cargo test --doc -p exarch-core` — 101 doc-tests pass, 18 ignored (all on `pub(crate)` items)
- [ ] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace`

Closes #280, #279