### PR TITLE
docs(specs): replace UnsupportedFormat with UnknownFormat/InvalidConfiguration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Specifications in `specs/` updated to replace stale `UnsupportedFormat` references with
+  `UnknownFormat { path }` (format-detection failures) and `InvalidConfiguration` (7z creation),
+  matching the post-#255 Rust API. Python exception hierarchy updated to include
+  `UnknownFormatError(UnsupportedFormatError)` (#265, #264).
+
 ### Added
 
 - `ValidationReport` is now re-exported at the crate root as `exarch_core::ValidationReport`

--- a/specs/001-exarch-system/plan.md
+++ b/specs/001-exarch-system/plan.md
@@ -83,7 +83,7 @@ graph TD
 | Security pipeline ordering | path → quota → compression ratio → type-specific | Cheap checks first; fail fast before I/O | Post-write validation (rejected: leaves partial output) |
 | `SafePath` as newtype | Cannot be constructed without passing validation | Type-safe guarantee that a path is safe | Runtime flag on `PathBuf` (rejected: not statically enforced) |
 | `EntryValidator` holds references | `&SecurityConfig`, `&DestDir` | No cloning per entry; measurable perf benefit | Clone per entry (rejected: measurable overhead at 10k+ files) |
-| 7z creation unsupported | Return `UnsupportedFormat` | `sevenz-rust2` write support is experimental | Expose write path (deferred: correctness risk) |
+| 7z creation unsupported | Return `InvalidConfiguration` | `sevenz-rust2` write support is experimental | Expose write path (deferred: correctness risk) |
 | ZIP-family aliases rejected for creation | Return `InvalidArchive` with explanation | Silently producing a bare ZIP with `.apk` extension is misleading | Allow it silently (rejected: would confuse callers expecting valid APK structure) |
 | Atomic extraction via temp-dir + rename | `ExtractionOptions::atomic` | All-or-nothing semantics on same filesystem | Copy-then-delete (rejected: not atomic) |
 | Deny-by-default for symlinks/hardlinks | `AllowedFeatures` all false | Defense in depth; explicit opt-in | Allow-by-default (rejected: too many CVE-pattern escapes) |
@@ -255,8 +255,8 @@ pub enum ValidatedEntryType {
 | `.zip` | `Zip` |
 | `.jar`, `.war`, `.ear`, `.nar`, `.nbm`, `.apk`, `.aab`, `.ipa`, `.appx`, `.msix`, `.whl`, `.vsix`, `.xpi`, `.epub` | `Zip` (extraction) / error (creation) |
 | `.7z` | `SevenZ` |
-| `.gz` (no `.tar` stem) | Error: `UnsupportedFormat` |
-| anything else | Error: `UnsupportedFormat` |
+| `.gz` (no `.tar` stem) | Error: `UnknownFormat { path }` |
+| anything else | Error: `UnknownFormat { path }` |
 
 > [!note]
 > Detection is extension-based, case-insensitive. Magic byte detection is NOT currently implemented — format is inferred from the file extension only.
@@ -377,6 +377,7 @@ ExarchError(Exception)
   ZipBombError(ExarchError)
   QuotaExceededError(ExarchError)
   UnsupportedFormatError(ExarchError)
+    UnknownFormatError(UnsupportedFormatError)
   InvalidArchiveError(ExarchError)
   SecurityViolationError(ExarchError)
   InvalidPermissionsError(ExarchError)

--- a/specs/001-exarch-system/spec.md
+++ b/specs/001-exarch-system/spec.md
@@ -90,7 +90,7 @@ THEN an archive is produced containing all source files, and CreationReport.file
 ```
 GIVEN a 7z output path
 WHEN I call create_archive()
-THEN the call fails with ExtractionError::UnsupportedFormat
+THEN the call fails with ExtractionError::InvalidConfiguration
 ```
 
 ### US-003: Archive Inspection
@@ -190,8 +190,8 @@ THEN extraction runs on the libuv thread pool, files are extracted, and an Extra
 | FR-020 | WHEN an archive path has extension `.tar`, `.tgz`, `.tar.gz`, `.tar.bz2`, `.tbz`, `.tbz2`, `.tar.xz`, `.txz`, `.tar.zst`, `.tzst`, THE SYSTEM SHALL extract it as a TAR archive with the appropriate decompressor | must |
 | FR-021 | WHEN an archive path has extension `.zip` or any ZIP-family alias (`.jar`, `.war`, `.apk`, `.whl`, etc.), THE SYSTEM SHALL extract it as a ZIP archive | must |
 | FR-022 | WHEN an archive path has extension `.7z`, THE SYSTEM SHALL extract it using the 7z handler (extraction only) | must |
-| FR-023 | WHEN format detection is ambiguous or the extension is unrecognized, THE SYSTEM SHALL return `ExtractionError::UnsupportedFormat` | must |
-| FR-024 | WHEN creating archives, THE SYSTEM SHALL support TAR (all compression variants) and ZIP; 7z creation SHALL return `UnsupportedFormat` | must |
+| FR-023 | WHEN format detection is ambiguous or the extension is unrecognized, THE SYSTEM SHALL return `ExtractionError::UnknownFormat { path }` | must |
+| FR-024 | WHEN creating archives, THE SYSTEM SHALL support TAR (all compression variants) and ZIP; 7z creation SHALL return `InvalidConfiguration` | must |
 | FR-025 | WHEN creating archives for ZIP-family aliases without an explicit `CreationConfig::format` override, THE SYSTEM SHALL return an error explaining that the format requires extra structure | should |
 
 ### 3.3 Configuration API
@@ -301,10 +301,10 @@ THEN extraction runs on the libuv thread pool, files are extracted, and an Extra
 | Scenario | Expected Behavior |
 |----------|-------------------|
 | Archive path does not exist | `ExtractionError::Io` returned immediately |
-| Extension unrecognized or bare `.gz` without `.tar` stem | `ExtractionError::UnsupportedFormat` |
+| Extension unrecognized or bare `.gz` without `.tar` stem | `ExtractionError::UnknownFormat { path }` |
 | ZIP-family alias (`.apk`, `.whl`) extraction | Proceeds as ZIP |
 | ZIP-family alias creation without format override | `ExtractionError::InvalidArchive` with explanation naming the alias and referencing `CreationConfig::format` override |
-| 7z creation | `ExtractionError::UnsupportedFormat` |
+| 7z creation | `ExtractionError::InvalidConfiguration` |
 | Duplicate entry paths in archive | Logged as warning in `ExtractionReport.warnings` when `skip_duplicates` is true; error when false |
 | Atomic extraction to existing non-empty directory | `ExtractionError::OutputExists` on rename failure; temp dir cleaned up |
 | Path traversal `../` or absolute path | `ExtractionError::PathTraversal` |

--- a/specs/002-format-handlers/spec.md
+++ b/specs/002-format-handlers/spec.md
@@ -109,7 +109,7 @@ THEN extraction proceeds through the security pipeline and files are written to 
 ```
 GIVEN a .7z output path
 WHEN create_archive() is called
-THEN the call fails with ExtractionError::UnsupportedFormat
+THEN the call fails with ExtractionError::InvalidConfiguration
 ```
 
 ### US-005: Solid 7z Rejection by Default
@@ -135,7 +135,7 @@ SO THAT I do not need to specify the format explicitly
 ```
 GIVEN an archive path with an unrecognized extension
 WHEN any archive operation is called
-THEN ExtractionError::UnsupportedFormat is returned immediately
+THEN ExtractionError::UnknownFormat { path } is returned immediately
 ```
 
 ## 3. Functional Requirements
@@ -145,8 +145,8 @@ THEN ExtractionError::UnsupportedFormat is returned immediately
 | FR-020 | WHEN an archive path has extension `.tar`, `.tgz`, `.tar.gz`, `.tar.bz2`, `.tbz`, `.tbz2`, `.tar.xz`, `.txz`, `.tar.zst`, `.tzst`, THE SYSTEM SHALL extract it as a TAR archive with the appropriate decompressor | must |
 | FR-021 | WHEN an archive path has extension `.zip` or any ZIP-family alias, THE SYSTEM SHALL extract it as a ZIP archive | must |
 | FR-022 | WHEN an archive path has extension `.7z`, THE SYSTEM SHALL extract it using the 7z handler | must |
-| FR-023 | WHEN format detection finds an unrecognized or ambiguous extension (e.g. bare `.gz` without `.tar` stem), THE SYSTEM SHALL return `ExtractionError::UnsupportedFormat` | must |
-| FR-024 | WHEN creating archives, THE SYSTEM SHALL support TAR (all compression variants) and ZIP; 7z creation SHALL return `UnsupportedFormat` | must |
+| FR-023 | WHEN format detection finds an unrecognized or ambiguous extension (e.g. bare `.gz` without `.tar` stem), THE SYSTEM SHALL return `ExtractionError::UnknownFormat { path }` | must |
+| FR-024 | WHEN creating archives, THE SYSTEM SHALL support TAR (all compression variants) and ZIP; 7z creation SHALL return `InvalidConfiguration` | must |
 | FR-025 | WHEN creating archives for ZIP-family aliases without an explicit `CreationConfig::format` override, THE SYSTEM SHALL return `ExtractionError::InvalidArchive` with an explanation | should |
 | FR-026 | WHEN a 7z archive is solid and `allow_solid_archives` is false, THE SYSTEM SHALL reject extraction before decompressing the solid block | must |
 | FR-027 | WHEN a 7z solid archive extraction is permitted, THE SYSTEM SHALL reject it if total uncompressed size exceeds `max_solid_block_memory` | must |
@@ -189,7 +189,7 @@ THEN ExtractionError::UnsupportedFormat is returned immediately
 | `.zip` | `Zip` |
 | `.jar`, `.war`, `.ear`, `.nar`, `.nbm`, `.apk`, `.aab`, `.ipa`, `.appx`, `.msix`, `.whl`, `.vsix`, `.xpi`, `.epub` | `Zip` (extraction) / error (creation) |
 | `.7z` | `SevenZ` |
-| `.gz` (no `.tar` stem), anything else | `UnsupportedFormat` |
+| `.gz` (no `.tar` stem), anything else | `UnknownFormat { path }` |
 
 > [!note]
 > Format detection is extension-based, case-insensitive. Magic byte detection is NOT currently implemented.
@@ -227,10 +227,10 @@ FormatCreator:
 | Scenario | Expected Behavior |
 |----------|-------------------|
 | Archive path does not exist | `ExtractionError::Io` returned immediately |
-| Extension unrecognized or bare `.gz` without `.tar` stem | `ExtractionError::UnsupportedFormat` |
+| Extension unrecognized or bare `.gz` without `.tar` stem | `ExtractionError::UnknownFormat { path }` |
 | ZIP-family alias extraction | Proceeds as ZIP |
 | ZIP-family alias creation without format override | `ExtractionError::InvalidArchive` with explanation |
-| 7z creation | `ExtractionError::UnsupportedFormat` |
+| 7z creation | `ExtractionError::InvalidConfiguration` |
 | Solid 7z with `allow_solid_archives = false` | Extraction rejected before decompressing |
 | Solid 7z with total uncompressed size > `max_solid_block_memory` | `ExtractionError::QuotaExceeded` or format-specific rejection |
 | Corrupt archive (unreadable headers) | `ExtractionError::InvalidArchive`; `verify_archive` returns `VerificationReport` with issues |

--- a/specs/006-python-bindings/spec.md
+++ b/specs/006-python-bindings/spec.md
@@ -174,6 +174,7 @@ ExarchError(Exception)
   SecurityViolationError(ExarchError)  # may carry files_extracted, bytes_written
   InvalidPermissionsError(ExarchError) # may carry files_extracted, bytes_written
   UnsupportedFormatError(ExarchError)
+    UnknownFormatError(UnsupportedFormatError)
   InvalidArchiveError(ExarchError)
 ```
 

--- a/specs/007-node-bindings/spec.md
+++ b/specs/007-node-bindings/spec.md
@@ -211,7 +211,8 @@ class CreationConfig {
 | `HardlinkEscape` | `HardlinkEscapeError` |
 | `ZipBomb` | `ZipBombError` |
 | `QuotaExceeded` | `QuotaExceededError` |
-| `UnsupportedFormat` | `UnsupportedFormatError` |
+| `UnknownFormat` | `UnknownFormatError` |
+| `InvalidConfiguration` | `InvalidConfigurationError` |
 | `InvalidArchive` | `InvalidArchiveError` |
 | `Io` | `IoError` |
 | `PartialExtraction` | The specific inner error code (e.g. `SYMLINK_ESCAPE: ...`) is preserved; `filesExtracted` and `bytesWritten` are appended to the message |

--- a/specs/constitution.md
+++ b/specs/constitution.md
@@ -67,7 +67,7 @@ status: permanent
 
 - Before v1.0.0: implement only the minimum necessary functionality; avoid additional abstractions and premature optimization
 - Before v1.0.0: no backward-compatibility guarantees — document breaking changes in `CHANGELOG.md`
-- 7z creation is not supported (read-only); callers receive `UnsupportedFormat`
+- 7z creation is not supported (read-only); callers receive `InvalidConfiguration`
 - ZIP-family aliases (`.jar`, `.apk`, `.whl`, etc.) are extracted as ZIP but creation is rejected unless the caller explicitly overrides `CreationConfig::format`
 
 ## VIII. Git Workflow


### PR DESCRIPTION
## Summary

- Replace 17 stale `UnsupportedFormat` references in `specs/` with the correct post-#255 variants
- Format-detection failures (`UnknownFormat { path }`) and 7z creation (`InvalidConfiguration`) are now distinct in all BDD scenarios, FR tables, and edge-case tables
- Python exception hierarchy updated to include `UnknownFormatError(UnsupportedFormatError)` in `plan.md` and `006-python-bindings/spec.md`
- Node.js error mapping table updated: `UnsupportedFormat → UnsupportedFormatError` replaced with `UnknownFormat → UnknownFormatError` and a new `InvalidConfiguration → InvalidConfigurationError` row

Closes #265, closes #264

## Test plan

- [ ] All 844 Rust tests pass (`cargo nextest run`)
- [ ] 101 doc tests pass (excluding Python/Node bindings)
- [ ] `cargo clippy` clean with `-D warnings`
- [ ] `cargo +nightly fmt --check` passes
- [ ] Docs build clean (`RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`)
- [ ] No remaining `ExtractionError::UnsupportedFormat` in `specs/` (grep confirms)