### PR TITLE
fix(python,node): reset bytes_written per entry in progress adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `PyProgressAdapter` and `NodeProgressAdapter` now reset `bytes_written` to 0 at the start of each entry, eliminating stale values from previous entries (#285).
+
 ### Changed
 
 - Specifications in `specs/` updated to replace stale `UnsupportedFormat` references with

--- a/crates/exarch-node/src/lib.rs
+++ b/crates/exarch-node/src/lib.rs
@@ -639,9 +639,15 @@ fn run_extract_with_optional_progress(
 }
 
 /// Adapter that calls a JavaScript progress callback from a Rust worker thread.
+///
+/// The JavaScript callback receives `(path: string, total: number, current:
+/// number, bytesWritten: number)` where `bytesWritten` is the number of bytes
+/// written **for the current entry so far** (starts at 0 when the entry begins,
+/// grows as chunks are flushed to disk; always 0 during extraction because the
+/// core library does not emit byte-level progress events for extraction).
 struct NodeProgressAdapter {
     tsfn: ThreadsafeFunction<(String, i64, i64, i64)>,
-    accumulated_bytes: i64,
+    current_entry_bytes: i64,
     total: usize,
 }
 
@@ -649,7 +655,7 @@ impl NodeProgressAdapter {
     fn new(tsfn: ThreadsafeFunction<(String, i64, i64, i64)>) -> Self {
         Self {
             tsfn,
-            accumulated_bytes: 0,
+            current_entry_bytes: 0,
             total: 0,
         }
     }
@@ -657,18 +663,19 @@ impl NodeProgressAdapter {
 
 impl exarch_core::ProgressCallback for NodeProgressAdapter {
     fn on_entry_start(&mut self, path: &std::path::Path, total: usize, current: usize) {
+        self.current_entry_bytes = 0;
         self.total = total;
         let path_str = path.to_string_lossy().into_owned();
         let total_i64 = i64::try_from(total).unwrap_or(i64::MAX);
         let current_i64 = i64::try_from(current).unwrap_or(i64::MAX);
         self.tsfn.call(
-            Ok((path_str, total_i64, current_i64, self.accumulated_bytes)),
+            Ok((path_str, total_i64, current_i64, self.current_entry_bytes)),
             ThreadsafeFunctionCallMode::NonBlocking,
         );
     }
 
     fn on_bytes_written(&mut self, bytes: u64) {
-        self.accumulated_bytes = self.accumulated_bytes.saturating_add(bytes.cast_signed());
+        self.current_entry_bytes = self.current_entry_bytes.saturating_add(bytes.cast_signed());
     }
 
     fn on_entry_complete(&mut self, _path: &std::path::Path) {}

--- a/crates/exarch-python/src/lib.rs
+++ b/crates/exarch-python/src/lib.rs
@@ -531,32 +531,38 @@ fn extract_archive_with_progress(
 }
 
 /// Adapter that calls Python callback from Rust.
+///
+/// The Python callback receives `(path: str, total: int, current: int,
+/// bytes_written: int)` where `bytes_written` is the number of bytes written
+/// **for the current entry so far** (starts at 0 when the entry begins, grows
+/// as chunks are flushed to disk).
 struct PyProgressAdapter {
     callback: Py<PyAny>,
-    accumulated_bytes: u64,
+    current_entry_bytes: u64,
 }
 
 impl PyProgressAdapter {
     fn new(callback: Py<PyAny>) -> Self {
         Self {
             callback,
-            accumulated_bytes: 0,
+            current_entry_bytes: 0,
         }
     }
 }
 
 impl exarch_core::ProgressCallback for PyProgressAdapter {
     fn on_entry_start(&mut self, path: &std::path::Path, total: usize, current: usize) {
+        self.current_entry_bytes = 0;
         Python::attach(|py| {
             let path_str = path.to_string_lossy().into_owned();
             let _ = self
                 .callback
-                .call1(py, (path_str, total, current, self.accumulated_bytes));
+                .call1(py, (path_str, total, current, self.current_entry_bytes));
         });
     }
 
     fn on_bytes_written(&mut self, bytes: u64) {
-        self.accumulated_bytes += bytes;
+        self.current_entry_bytes += bytes;
     }
 
     fn on_entry_complete(&mut self, _path: &std::path::Path) {

--- a/crates/exarch-python/tests/test_cve_regression.py
+++ b/crates/exarch-python/tests/test_cve_regression.py
@@ -270,49 +270,42 @@ def test_progress_bytes_written_not_stale(temp_dir):
     Regression test for #285.
 
     PyProgressAdapter was passing stale `bytes_written` (accumulated from all
-    previous entries) to the Python callback at `on_entry_start`.  The fix
-    resets `current_entry_bytes` to 0 at the start of each entry, so the very
-    first callback invocation for every entry always receives 0 regardless of
-    how large the preceding entries were.
+    previous entries) to the Python callback at `on_entry_start`. The bug only
+    manifests through `create_archive_with_progress` because `on_bytes_written`
+    is only called during creation, not extraction.
 
-    Failure signature of the original bug: entry 2's on_entry_start call would
-    report bytes_written == 1024 (entry 1's total) instead of 0.
+    The fix resets `current_entry_bytes` to 0 at the start of each entry, so
+    `bytes_written` at `on_entry_start` is always 0 regardless of how many
+    bytes the preceding entries wrote.
+
+    Failure signature of the original bug: file2's on_entry_start call would
+    report bytes_written == len(SMALL) (stale from file1) instead of 0.
     """
-    import io
-    import tarfile
-
     SMALL = b"x" * 1024          # 1 KB
     LARGE = b"y" * (100 * 1024)  # 100 KB
 
+    src_dir = temp_dir / "src"
+    src_dir.mkdir()
+    (src_dir / "small.txt").write_bytes(SMALL)
+    (src_dir / "large.txt").write_bytes(LARGE)
+
     archive = temp_dir / "two_files.tar.gz"
-    buf = io.BytesIO()
-    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
-        for name, data in [("small.txt", SMALL), ("large.txt", LARGE)]:
-            info = tarfile.TarInfo(name=name)
-            info.size = len(data)
-            tar.addfile(info, io.BytesIO(data))
-    archive.write_bytes(buf.getvalue())
 
-    output_dir = temp_dir / "out"
-    output_dir.mkdir()
-
-    # entry_start_bytes[name] = bytes_written value received at on_entry_start
+    # entry_start_bytes[name] = bytes_written received at on_entry_start
     entry_start_bytes: dict = {}
 
     def callback(path: str, total: int, current: int, bytes_written: int) -> None:
-        # Record only the first call per entry (on_entry_start fires once per
-        # entry before any bytes are written, so bytes_written must be 0).
         name = path.split("/")[-1].split("\\")[-1]
         if name not in entry_start_bytes:
             entry_start_bytes[name] = bytes_written
 
-    exarch.extract_archive_with_progress(archive, output_dir, None, callback)
+    exarch.create_archive_with_progress(archive, [src_dir], None, callback)
 
     assert "small.txt" in entry_start_bytes, "callback never fired for small.txt"
     assert "large.txt" in entry_start_bytes, "callback never fired for large.txt"
 
     # Both entries must start with bytes_written == 0.
-    # The original bug: large.txt would receive bytes_written == 1024 (stale from small.txt).
+    # The original bug: large.txt received bytes_written == 1024 (stale from small.txt).
     assert entry_start_bytes["small.txt"] == 0, (
         f"small.txt: expected bytes_written=0 at entry start, got {entry_start_bytes['small.txt']}"
     )

--- a/crates/exarch-python/tests/test_cve_regression.py
+++ b/crates/exarch-python/tests/test_cve_regression.py
@@ -279,15 +279,15 @@ def test_progress_bytes_written_not_stale(temp_dir):
     bytes the preceding entries wrote.
 
     Failure signature of the original bug: file2's on_entry_start call would
-    report bytes_written == len(SMALL) (stale from file1) instead of 0.
+    report bytes_written == 1024 (stale from file1) instead of 0.
     """
-    SMALL = b"x" * 1024  # 1 KB
-    LARGE = b"y" * (100 * 1024)  # 100 KB
+    small = b"x" * 1024  # 1 KB
+    large = b"y" * (100 * 1024)  # 100 KB
 
     src_dir = temp_dir / "src"
     src_dir.mkdir()
-    (src_dir / "small.txt").write_bytes(SMALL)
-    (src_dir / "large.txt").write_bytes(LARGE)
+    (src_dir / "small.txt").write_bytes(small)
+    (src_dir / "large.txt").write_bytes(large)
 
     archive = temp_dir / "two_files.tar.gz"
 

--- a/crates/exarch-python/tests/test_cve_regression.py
+++ b/crates/exarch-python/tests/test_cve_regression.py
@@ -263,3 +263,60 @@ def test_partial_extraction_preserves_hardlink_escape_type(temp_dir):
     err = exc_info.value
     assert getattr(err, "files_extracted", None) is not None
     assert err.files_extracted >= 1
+
+
+def test_progress_bytes_written_not_stale(temp_dir):
+    """
+    Regression test for #285.
+
+    PyProgressAdapter was passing stale `bytes_written` (accumulated from all
+    previous entries) to the Python callback at `on_entry_start`.  The fix
+    resets `current_entry_bytes` to 0 at the start of each entry, so the very
+    first callback invocation for every entry always receives 0 regardless of
+    how large the preceding entries were.
+
+    Failure signature of the original bug: entry 2's on_entry_start call would
+    report bytes_written == 1024 (entry 1's total) instead of 0.
+    """
+    import io
+    import tarfile
+
+    SMALL = b"x" * 1024          # 1 KB
+    LARGE = b"y" * (100 * 1024)  # 100 KB
+
+    archive = temp_dir / "two_files.tar.gz"
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        for name, data in [("small.txt", SMALL), ("large.txt", LARGE)]:
+            info = tarfile.TarInfo(name=name)
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+    archive.write_bytes(buf.getvalue())
+
+    output_dir = temp_dir / "out"
+    output_dir.mkdir()
+
+    # entry_start_bytes[name] = bytes_written value received at on_entry_start
+    entry_start_bytes: dict = {}
+
+    def callback(path: str, total: int, current: int, bytes_written: int) -> None:
+        # Record only the first call per entry (on_entry_start fires once per
+        # entry before any bytes are written, so bytes_written must be 0).
+        name = path.split("/")[-1].split("\\")[-1]
+        if name not in entry_start_bytes:
+            entry_start_bytes[name] = bytes_written
+
+    exarch.extract_archive_with_progress(archive, output_dir, None, callback)
+
+    assert "small.txt" in entry_start_bytes, "callback never fired for small.txt"
+    assert "large.txt" in entry_start_bytes, "callback never fired for large.txt"
+
+    # Both entries must start with bytes_written == 0.
+    # The original bug: large.txt would receive bytes_written == 1024 (stale from small.txt).
+    assert entry_start_bytes["small.txt"] == 0, (
+        f"small.txt: expected bytes_written=0 at entry start, got {entry_start_bytes['small.txt']}"
+    )
+    assert entry_start_bytes["large.txt"] == 0, (
+        f"large.txt: expected bytes_written=0 at entry start, "
+        f"got {entry_start_bytes['large.txt']} (stale value — original #285 bug)"
+    )

--- a/crates/exarch-python/tests/test_cve_regression.py
+++ b/crates/exarch-python/tests/test_cve_regression.py
@@ -281,7 +281,7 @@ def test_progress_bytes_written_not_stale(temp_dir):
     Failure signature of the original bug: file2's on_entry_start call would
     report bytes_written == len(SMALL) (stale from file1) instead of 0.
     """
-    SMALL = b"x" * 1024          # 1 KB
+    SMALL = b"x" * 1024  # 1 KB
     LARGE = b"y" * (100 * 1024)  # 100 KB
 
     src_dir = temp_dir / "src"


### PR DESCRIPTION
## Summary

- `PyProgressAdapter` was passing a stale cumulative byte total from all previous entries as `bytes_written` to the Python callback at `on_entry_start`; the bug only manifests on the creation path (`create_archive_with_progress`) where `on_bytes_written` actually fires.
- Renamed `accumulated_bytes` → `current_entry_bytes` in both `PyProgressAdapter` and `NodeProgressAdapter`; reset to `0` at `on_entry_start` so the callback receives per-entry bytes starting at `0`.
- Updated doc comments in both adapters to describe the per-entry semantics.
- Added regression test `test_progress_bytes_written_not_stale` using `create_archive_with_progress` — fails on the unfixed code.

## Test plan

- [x] `cargo +nightly fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` — 844/844 passed
- [x] `cargo check -p exarch-python --all-features` — clean
- [x] `cargo check -p exarch-node --all-features` — clean

Fixes #285