### PR TITLE
refactor(creation,api): wire ProgressTracker and DRY extract_tar* (#284, #254)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `creation/tar`: replace manual entry counter with `ProgressTracker`; add `ProgressTracker::callback()` accessor to enable byte-level progress in nested helpers without lifetime conflicts (#284).
+- `creation/zip`: same `ProgressTracker` wiring as tar, removing manual `idx + 1` counter (#284).
+- `api`: collapse five identical `extract_tar*` private functions into a single generic `extract_tar_with_decoder` helper parametrised by a decoder closure; eliminates ~80 lines of structural duplication (#254).
 - `sevenz`: eliminate `Rc`/`RefCell` interior mutability in `extract_with_callback`; state is now owned by a local context struct, matching the `tar.rs` and `zip.rs` patterns (#273, #258).
 - `sevenz`: narrow `std::process` import to `std::process::id` to prevent accidental use of `process::exit` in library code (#270).
 - Internal creation helpers (`compression_level_to_*`, `ProgressReader`, `ProgressTracker`,

--- a/crates/exarch-core/src/api.rs
+++ b/crates/exarch-core/src/api.rs
@@ -121,11 +121,29 @@ fn extract_impl<P: AsRef<Path>, Q: AsRef<Path>>(
 
     // Dispatch to format-specific extraction
     match format {
-        ArchiveType::Tar => extract_tar(archive_path, output_dir, config, options, progress),
-        ArchiveType::TarGz => extract_tar_gz(archive_path, output_dir, config, options, progress),
-        ArchiveType::TarBz2 => extract_tar_bz2(archive_path, output_dir, config, options, progress),
-        ArchiveType::TarXz => extract_tar_xz(archive_path, output_dir, config, options, progress),
-        ArchiveType::TarZst => extract_tar_zst(archive_path, output_dir, config, options, progress),
+        ArchiveType::Tar => {
+            extract_tar_with_decoder(archive_path, output_dir, config, options, progress, Ok)
+        }
+        ArchiveType::TarGz => {
+            extract_tar_with_decoder(archive_path, output_dir, config, options, progress, |r| {
+                Ok(flate2::read::GzDecoder::new(r))
+            })
+        }
+        ArchiveType::TarBz2 => {
+            extract_tar_with_decoder(archive_path, output_dir, config, options, progress, |r| {
+                Ok(bzip2::read::BzDecoder::new(r))
+            })
+        }
+        ArchiveType::TarXz => {
+            extract_tar_with_decoder(archive_path, output_dir, config, options, progress, |r| {
+                Ok(xz2::read::XzDecoder::new(r))
+            })
+        }
+        ArchiveType::TarZst => {
+            extract_tar_with_decoder(archive_path, output_dir, config, options, progress, |r| {
+                Ok(zstd::stream::read::Decoder::new(r)?)
+            })
+        }
         ArchiveType::Zip => extract_zip(archive_path, output_dir, config, options, progress),
         ArchiveType::SevenZ => extract_7z(archive_path, output_dir, config, options, progress),
     }
@@ -257,100 +275,31 @@ fn extract_atomic<P: AsRef<Path>, Q: AsRef<Path>>(
     }
 }
 
-fn extract_tar(
+/// Opens `archive_path`, wraps it in a `BufReader`, passes it to
+/// `make_decoder`, and extracts the resulting TAR stream.
+///
+/// `make_decoder` builds a decoder (e.g. `GzDecoder`, `XzDecoder`) from the
+/// buffered file reader. For uncompressed TAR pass `Ok` as the identity
+/// closure. The closure may be fallible (e.g. zstd requires a constructor call
+/// that can fail with an I/O error).
+fn extract_tar_with_decoder<R, F>(
     archive_path: &Path,
     output_dir: &Path,
     config: &SecurityConfig,
     options: &ExtractionOptions,
     progress: &mut dyn ProgressCallback,
-) -> Result<ExtractionReport> {
+    make_decoder: F,
+) -> Result<ExtractionReport>
+where
+    R: std::io::Read,
+    F: FnOnce(std::io::BufReader<std::fs::File>) -> Result<R>,
+{
     use crate::formats::TarArchive;
     use crate::formats::traits::ArchiveFormat;
-    use std::fs::File;
-    use std::io::BufReader;
 
-    let file = File::open(archive_path)?;
-    let reader = BufReader::new(file);
-    let mut archive = TarArchive::new(reader);
-    archive.extract(output_dir, config, options, progress)
-}
-
-fn extract_tar_gz(
-    archive_path: &Path,
-    output_dir: &Path,
-    config: &SecurityConfig,
-    options: &ExtractionOptions,
-    progress: &mut dyn ProgressCallback,
-) -> Result<ExtractionReport> {
-    use crate::formats::TarArchive;
-    use crate::formats::traits::ArchiveFormat;
-    use flate2::read::GzDecoder;
-    use std::fs::File;
-    use std::io::BufReader;
-
-    let file = File::open(archive_path)?;
-    let reader = BufReader::new(file);
-    let decoder = GzDecoder::new(reader);
-    let mut archive = TarArchive::new(decoder);
-    archive.extract(output_dir, config, options, progress)
-}
-
-fn extract_tar_bz2(
-    archive_path: &Path,
-    output_dir: &Path,
-    config: &SecurityConfig,
-    options: &ExtractionOptions,
-    progress: &mut dyn ProgressCallback,
-) -> Result<ExtractionReport> {
-    use crate::formats::TarArchive;
-    use crate::formats::traits::ArchiveFormat;
-    use bzip2::read::BzDecoder;
-    use std::fs::File;
-    use std::io::BufReader;
-
-    let file = File::open(archive_path)?;
-    let reader = BufReader::new(file);
-    let decoder = BzDecoder::new(reader);
-    let mut archive = TarArchive::new(decoder);
-    archive.extract(output_dir, config, options, progress)
-}
-
-fn extract_tar_xz(
-    archive_path: &Path,
-    output_dir: &Path,
-    config: &SecurityConfig,
-    options: &ExtractionOptions,
-    progress: &mut dyn ProgressCallback,
-) -> Result<ExtractionReport> {
-    use crate::formats::TarArchive;
-    use crate::formats::traits::ArchiveFormat;
-    use std::fs::File;
-    use std::io::BufReader;
-    use xz2::read::XzDecoder;
-
-    let file = File::open(archive_path)?;
-    let reader = BufReader::new(file);
-    let decoder = XzDecoder::new(reader);
-    let mut archive = TarArchive::new(decoder);
-    archive.extract(output_dir, config, options, progress)
-}
-
-fn extract_tar_zst(
-    archive_path: &Path,
-    output_dir: &Path,
-    config: &SecurityConfig,
-    options: &ExtractionOptions,
-    progress: &mut dyn ProgressCallback,
-) -> Result<ExtractionReport> {
-    use crate::formats::TarArchive;
-    use crate::formats::traits::ArchiveFormat;
-    use std::fs::File;
-    use std::io::BufReader;
-    use zstd::stream::read::Decoder as ZstdDecoder;
-
-    let file = File::open(archive_path)?;
-    let reader = BufReader::new(file);
-    let decoder = ZstdDecoder::new(reader)?;
+    let file = std::fs::File::open(archive_path)?;
+    let reader = std::io::BufReader::new(file);
+    let decoder = make_decoder(reader)?;
     let mut archive = TarArchive::new(decoder);
     archive.extract(output_dir, config, options, progress)
 }

--- a/crates/exarch-core/src/creation/progress.rs
+++ b/crates/exarch-core/src/creation/progress.rs
@@ -58,7 +58,6 @@ use std::path::Path;
 /// // ... process entry ...
 /// tracker.on_entry_complete(Path::new("file1.txt"));
 /// ```
-#[allow(dead_code)]
 pub struct ProgressTracker<'a> {
     /// Reference to the progress callback implementation
     progress: &'a mut dyn ProgressCallback,
@@ -68,7 +67,6 @@ pub struct ProgressTracker<'a> {
     total_entries: usize,
 }
 
-#[allow(dead_code)]
 impl<'a> ProgressTracker<'a> {
     /// Creates a new progress tracker.
     ///
@@ -132,6 +130,16 @@ impl<'a> ProgressTracker<'a> {
     /// processed.
     pub fn on_complete(&mut self) {
         self.progress.on_complete();
+    }
+
+    /// Returns a mutable reference to the underlying progress callback.
+    ///
+    /// Use this to pass the callback into nested helpers that perform
+    /// byte-level progress reporting, while keeping the tracker in scope
+    /// for entry-level accounting. The borrow is sequential — call this
+    /// only between `on_entry_start` and the next tracker call.
+    pub fn callback(&mut self) -> &mut dyn ProgressCallback {
+        self.progress
     }
 }
 

--- a/crates/exarch-core/src/creation/tar.rs
+++ b/crates/exarch-core/src/creation/tar.rs
@@ -11,6 +11,7 @@ use crate::creation::compression::compression_level_to_xz;
 use crate::creation::compression::compression_level_to_zstd;
 use crate::creation::config::CreationConfig;
 use crate::creation::progress::ProgressReader;
+use crate::creation::progress::ProgressTracker;
 use crate::creation::report::CreationReport;
 use crate::creation::walker::EntryType;
 use crate::creation::walker::collect_entries;
@@ -220,37 +221,33 @@ fn create_tar_internal_with_progress<W: Write, P: AsRef<Path>>(
     let entries = collect_entries(sources, config)?;
     let total_entries = entries.len();
 
-    // Manual entry counting (we can't use ProgressTracker because we need to
-    // pass progress to nested functions for byte-level progress)
-    let mut current_entry = 0usize;
+    let mut tracker = ProgressTracker::new(progress, total_entries);
 
     // Reusable buffer for file copying (fixes HIGH #2)
     let mut buffer = vec![0u8; 64 * 1024]; // 64 KB
 
     for entry in &entries {
-        current_entry += 1;
-
         match &entry.entry_type {
             EntryType::File => {
-                progress.on_entry_start(&entry.archive_path, total_entries, current_entry);
+                tracker.on_entry_start(&entry.archive_path);
                 add_file_to_tar_with_progress_impl(
                     &mut builder,
                     &entry.path,
                     &entry.archive_path,
                     config,
                     &mut report,
-                    progress,
+                    tracker.callback(),
                     &mut buffer,
                 )?;
-                progress.on_entry_complete(&entry.archive_path);
+                tracker.on_entry_complete(&entry.archive_path);
             }
             EntryType::Directory => {
-                progress.on_entry_start(&entry.archive_path, total_entries, current_entry);
+                tracker.on_entry_start(&entry.archive_path);
                 report.directories_added += 1;
-                progress.on_entry_complete(&entry.archive_path);
+                tracker.on_entry_complete(&entry.archive_path);
             }
             EntryType::Symlink { target } => {
-                progress.on_entry_start(&entry.archive_path, total_entries, current_entry);
+                tracker.on_entry_start(&entry.archive_path);
                 if config.follow_symlinks {
                     add_file_to_tar_with_progress_impl(
                         &mut builder,
@@ -258,13 +255,13 @@ fn create_tar_internal_with_progress<W: Write, P: AsRef<Path>>(
                         &entry.archive_path,
                         config,
                         &mut report,
-                        progress,
+                        tracker.callback(),
                         &mut buffer,
                     )?;
                 } else {
                     add_symlink_to_tar(&mut builder, &entry.archive_path, target, &mut report)?;
                 }
-                progress.on_entry_complete(&entry.archive_path);
+                tracker.on_entry_complete(&entry.archive_path);
             }
         }
     }
@@ -278,7 +275,7 @@ fn create_tar_internal_with_progress<W: Write, P: AsRef<Path>>(
     report.bytes_compressed = counting_writer.total_bytes();
     report.duration = start.elapsed();
 
-    progress.on_complete();
+    tracker.on_complete();
 
     Ok((report, counting_writer.into_inner()))
 }

--- a/crates/exarch-core/src/creation/zip.rs
+++ b/crates/exarch-core/src/creation/zip.rs
@@ -8,6 +8,7 @@ use crate::ProgressCallback;
 use crate::Result;
 use crate::creation::config::CreationConfig;
 use crate::creation::filters;
+use crate::creation::progress::ProgressTracker;
 use crate::creation::report::CreationReport;
 use crate::creation::walker::EntryType;
 use crate::creation::walker::FilteredWalker;
@@ -42,7 +43,6 @@ use zip::write::SimpleFileOptions;
 /// - Source path does not exist
 /// - Output file cannot be created
 /// - I/O error during archive creation
-#[allow(dead_code)] // Will be used by CLI
 pub fn create_zip<P: AsRef<Path>, Q: AsRef<Path>>(
     output: P,
     sources: &[Q],
@@ -125,7 +125,6 @@ pub fn create_zip<P: AsRef<Path>, Q: AsRef<Path>>(
 /// - Output file cannot be created
 /// - I/O error during archive creation
 /// - File metadata cannot be read
-#[allow(dead_code)] // Will be used by CLI
 pub fn create_zip_with_progress<P: AsRef<Path>, Q: AsRef<Path>>(
     output: P,
     sources: &[Q],
@@ -161,15 +160,15 @@ fn create_zip_internal_with_progress<W: Write + Seek, P: AsRef<Path>>(
     let entries = collect_entries(sources, config)?;
     let total_entries = entries.len();
 
+    let mut tracker = ProgressTracker::new(progress, total_entries);
+
     // Reusable buffer for file copying (fixes HIGH #2)
     let mut buffer = vec![0u8; 64 * 1024]; // 64 KB
 
-    for (idx, entry) in entries.iter().enumerate() {
-        let current_entry = idx + 1;
-
+    for entry in &entries {
         match &entry.entry_type {
             EntryType::File => {
-                progress.on_entry_start(&entry.archive_path, total_entries, current_entry);
+                tracker.on_entry_start(&entry.archive_path);
                 add_file_to_zip_with_progress_and_buffer(
                     &mut zip,
                     &entry.path,
@@ -177,13 +176,13 @@ fn create_zip_internal_with_progress<W: Write + Seek, P: AsRef<Path>>(
                     config,
                     &mut report,
                     &options,
-                    progress,
+                    tracker.callback(),
                     &mut buffer,
                 )?;
-                progress.on_entry_complete(&entry.archive_path);
+                tracker.on_entry_complete(&entry.archive_path);
             }
             EntryType::Directory => {
-                progress.on_entry_start(&entry.archive_path, total_entries, current_entry);
+                tracker.on_entry_start(&entry.archive_path);
                 // Skip root directory entry (empty path becomes "/" which is invalid)
                 if !entry.archive_path.as_os_str().is_empty() {
                     let dir_path = format!("{}/", normalize_zip_path(&entry.archive_path)?);
@@ -192,15 +191,15 @@ fn create_zip_internal_with_progress<W: Write + Seek, P: AsRef<Path>>(
                     })?;
                     report.directories_added += 1;
                 }
-                progress.on_entry_complete(&entry.archive_path);
+                tracker.on_entry_complete(&entry.archive_path);
             }
             EntryType::Symlink { .. } => {
-                progress.on_entry_start(&entry.archive_path, total_entries, current_entry);
+                tracker.on_entry_start(&entry.archive_path);
                 if !config.follow_symlinks {
                     report.files_skipped += 1;
                     report.add_warning(format!("Skipped symlink: {}", entry.path.display()));
                 }
-                progress.on_entry_complete(&entry.archive_path);
+                tracker.on_entry_complete(&entry.archive_path);
             }
         }
     }
@@ -211,7 +210,7 @@ fn create_zip_internal_with_progress<W: Write + Seek, P: AsRef<Path>>(
 
     report.duration = start.elapsed();
 
-    progress.on_complete();
+    tracker.on_complete();
 
     Ok(report)
 }


### PR DESCRIPTION
## Summary

- **#284**: `ProgressTracker` was dead code; `tar.rs` and `zip.rs` each had manual entry counters and called `progress.on_entry_start/complete` directly. Add a `ProgressTracker::callback()` accessor to resolve the borrow blocker and wire the tracker into both creation pipelines. Remove both `#[allow(dead_code)]` attributes.
- **#254**: Five near-identical `extract_tar*` functions in `api.rs` collapsed into a single generic `extract_tar_with_decoder<R, F>` helper; each former function becomes a one-line closure at the call site.
- **bonus**: Remove stale `#[allow(dead_code)]` from `create_zip` and `create_zip_with_progress` in `zip.rs` (both functions are actively called).

## Changes

| File | What changed |
|------|-------------|
| `creation/progress.rs` | Add `callback()` accessor; remove `#[allow(dead_code)]` |
| `creation/tar.rs` | Replace manual counter with `ProgressTracker` |
| `creation/zip.rs` | Same + remove stale `#[allow(dead_code)]` |
| `api.rs` | Five `extract_tar*` → one `extract_tar_with_decoder<R, F>` |
| `CHANGELOG.md` | Updated `[Unreleased]` section |

## Test plan

- [ ] `cargo +nightly fmt --all -- --check` — clean
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [ ] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` — 844 passed
- [ ] `cargo test --doc --workspace --all-features` — 101 passed

Closes #284
Closes #254