### PR TITLE
refactor(security,api): restrict security primitives to pub(crate) and fix check_permissions path (#286, #281)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `PyProgressAdapter` and `NodeProgressAdapter` now reset `bytes_written` to 0 at the start of each entry, eliminating stale values from previous entries (#285).
+- `check_permissions` in `inspection/verify.rs` now passes the actual entry path to
+  `InvalidPermissions` instead of an empty `PathBuf`, so error messages include the
+  offending archive entry (#286).
 
 ### Breaking Changes
 
@@ -25,6 +28,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (the canonical implementation) instead of calling the internal `extract_impl` directly.
   All four `extract_archive*` convenience wrappers now form a clean delegation chain through the
   single canonical function (#259).
+- Security primitives `validate_path`, `validate_symlink`, `sanitize_permissions`,
+  `validate_compression_ratio`, `QuotaTracker`, and `HardlinkTracker` are now `pub(crate)`
+  and no longer part of the public API. External benchmarks and integration tests that
+  reference these directly must add `--features testing` (#281).
+- `sanitize_permissions` return type changed from `Result<u32>` to `u32` — the function
+  never fails; callers no longer need `?` or `.unwrap()`.
 - Specifications in `specs/` updated to replace stale `UnsupportedFormat` references with
   `UnknownFormat { path }` (format-detection failures) and `InvalidConfiguration` (7z creation),
   matching the post-#255 Rust API. Python exception hierarchy updated to include

--- a/crates/exarch-core/Cargo.toml
+++ b/crates/exarch-core/Cargo.toml
@@ -34,8 +34,17 @@ criterion.workspace = true
 dhat.workspace = true
 proptest.workspace = true
 
+[features]
+# Exposes security primitives as `pub` for external benchmarks and integration
+# tests that cannot access pub(crate) items. Not intended for production use.
+testing = []
+
 [lints]
 workspace = true
+
+[[test]]
+name = "property_tests"
+required-features = ["testing"]
 
 [[bench]]
 name = "creation"
@@ -48,6 +57,7 @@ harness = false
 [[bench]]
 name = "validation"
 harness = false
+required-features = ["testing"]
 
 [[bench]]
 name = "progress"

--- a/crates/exarch-core/src/inspection/verify.rs
+++ b/crates/exarch-core/src/inspection/verify.rs
@@ -1,7 +1,6 @@
 //! Archive verification implementation.
 
 use std::path::Path;
-use std::path::PathBuf;
 
 use crate::ArchiveError;
 use crate::Result;
@@ -187,7 +186,7 @@ fn verify_entry(
 
     // Permission validation
     if let Some(mode) = entry.mode
-        && let Err(e) = check_permissions(mode, config)
+        && let Err(e) = check_permissions(&entry.path, mode, config)
     {
         issues.push(VerificationIssue::from_error(&e, Some(entry.path.clone())));
     }
@@ -195,13 +194,13 @@ fn verify_entry(
     issues
 }
 
-fn check_permissions(mode: u32, config: &SecurityConfig) -> Result<()> {
-    let sanitized = sanitize_permissions(mode, config)?;
+fn check_permissions(path: &Path, mode: u32, config: &SecurityConfig) -> Result<()> {
+    let sanitized = sanitize_permissions(mode, config);
     if sanitized == mode {
         Ok(())
     } else {
         Err(ArchiveError::InvalidPermissions {
-            path: PathBuf::new(),
+            path: path.to_path_buf(),
             mode,
         })
     }
@@ -295,6 +294,7 @@ fn determine_security_status(issues: &[VerificationIssue]) -> CheckStatus {
 mod tests {
     use super::*;
     use std::io::Write;
+    use std::path::PathBuf;
     use tempfile::NamedTempFile;
 
     #[test]

--- a/crates/exarch-core/src/security/hardlink.rs
+++ b/crates/exarch-core/src/security/hardlink.rs
@@ -169,7 +169,6 @@ impl HardlinkTracker {
     pub fn count(&self) -> usize {
         self.seen_targets.len()
     }
-
 }
 
 #[cfg(test)]

--- a/crates/exarch-core/src/security/hardlink.rs
+++ b/crates/exarch-core/src/security/hardlink.rs
@@ -170,10 +170,11 @@ impl HardlinkTracker {
         self.seen_targets.len()
     }
 
-    /// Checks if a target path has been seen before.
-    #[must_use]
-    #[allow(dead_code)]
-    pub fn has_target(&self, target: &Path) -> bool {
+}
+
+#[cfg(test)]
+impl HardlinkTracker {
+    pub(crate) fn has_target(&self, target: &Path) -> bool {
         self.seen_targets.contains_key(target)
     }
 }

--- a/crates/exarch-core/src/security/hardlink.rs
+++ b/crates/exarch-core/src/security/hardlink.rs
@@ -35,7 +35,7 @@ use crate::types::safe_symlink::resolve_through_symlinks;
 ///
 /// # Examples
 ///
-/// ```no_run
+/// ```ignore
 /// use exarch_core::SecurityConfig;
 /// use exarch_core::security::HardlinkTracker;
 /// use exarch_core::types::DestDir;
@@ -86,7 +86,7 @@ impl HardlinkTracker {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```ignore
     /// use exarch_core::SecurityConfig;
     /// use exarch_core::security::HardlinkTracker;
     /// use exarch_core::types::DestDir;
@@ -172,6 +172,7 @@ impl HardlinkTracker {
 
     /// Checks if a target path has been seen before.
     #[must_use]
+    #[allow(dead_code)]
     pub fn has_target(&self, target: &Path) -> bool {
         self.seen_targets.contains_key(target)
     }

--- a/crates/exarch-core/src/security/mod.rs
+++ b/crates/exarch-core/src/security/mod.rs
@@ -1,22 +1,31 @@
 //! Security validation modules.
 
 pub(crate) mod context;
-pub mod hardlink;
-pub mod path;
-pub mod permissions;
-pub mod quota;
-pub mod symlink;
+pub(crate) mod hardlink;
+pub(crate) mod path;
+pub(crate) mod permissions;
+pub(crate) mod quota;
+pub(crate) mod symlink;
 pub mod validator;
-pub mod zipbomb;
+pub(crate) mod zipbomb;
 
-// Re-export public types and functions
-pub use hardlink::HardlinkTracker;
-pub use path::validate_path;
-pub use permissions::sanitize_permissions;
-pub use quota::QuotaTracker;
-pub use symlink::validate_symlink;
+// Re-export public API types
 pub use validator::EntryValidator;
 pub use validator::ValidatedEntry;
 pub use validator::ValidatedEntryType;
 pub use validator::ValidationReport;
+
+// Security primitives exposed under the `testing` feature for external
+// benchmarks and integration tests that cannot access pub(crate) items.
+#[cfg(feature = "testing")]
+pub use hardlink::HardlinkTracker;
+#[cfg(feature = "testing")]
+pub use path::validate_path;
+#[cfg(feature = "testing")]
+pub use permissions::sanitize_permissions;
+#[cfg(feature = "testing")]
+pub use quota::QuotaTracker;
+#[cfg(feature = "testing")]
+pub use symlink::validate_symlink;
+#[cfg(feature = "testing")]
 pub use zipbomb::validate_compression_ratio;

--- a/crates/exarch-core/src/security/path.rs
+++ b/crates/exarch-core/src/security/path.rs
@@ -32,7 +32,7 @@ use crate::types::SafePath;
 ///
 /// # Examples
 ///
-/// ```no_run
+/// ```ignore
 /// use exarch_core::SecurityConfig;
 /// use exarch_core::security::validate_path;
 /// use exarch_core::types::DestDir;

--- a/crates/exarch-core/src/security/permissions.rs
+++ b/crates/exarch-core/src/security/permissions.rs
@@ -1,6 +1,5 @@
 //! File permission validation and sanitization.
 
-use crate::Result;
 use crate::SecurityConfig;
 
 /// Sanitizes file permissions by stripping dangerous bits.
@@ -16,35 +15,32 @@ use crate::SecurityConfig;
 ///
 /// This is a pure computation with no I/O. Typical execution time: <10 ns.
 ///
-/// # Errors
-///
-/// Returns `ArchiveError::InvalidPermissions` only for truly invalid modes.
-///
 /// # Examples
 ///
-/// ```
+/// ```ignore
 /// use exarch_core::SecurityConfig;
 /// use exarch_core::security::sanitize_permissions;
 ///
 /// let config = SecurityConfig::default();
 ///
 /// // Setuid bit is stripped
-/// let sanitized = sanitize_permissions(0o4755, &config).unwrap();
+/// let sanitized = sanitize_permissions(0o4755, &config);
 /// assert_eq!(sanitized, 0o755);
 ///
 /// // Setgid bit is stripped
-/// let sanitized = sanitize_permissions(0o2755, &config).unwrap();
+/// let sanitized = sanitize_permissions(0o2755, &config);
 /// assert_eq!(sanitized, 0o755);
 ///
 /// // Both setuid and setgid bits stripped
-/// let sanitized = sanitize_permissions(0o6755, &config).unwrap();
+/// let sanitized = sanitize_permissions(0o6755, &config);
 /// assert_eq!(sanitized, 0o755);
 ///
 /// // World-writable bit is stripped by default
-/// let sanitized = sanitize_permissions(0o777, &config).unwrap();
+/// let sanitized = sanitize_permissions(0o777, &config);
 /// assert_eq!(sanitized, 0o775);
 /// ```
-pub fn sanitize_permissions(mode: u32, config: &SecurityConfig) -> Result<u32> {
+#[must_use]
+pub fn sanitize_permissions(mode: u32, config: &SecurityConfig) -> u32 {
     let mut sanitized = mode;
 
     // Strip setuid bit (04000)
@@ -58,93 +54,77 @@ pub fn sanitize_permissions(mode: u32, config: &SecurityConfig) -> Result<u32> {
         sanitized &= !0o002;
     }
 
-    Ok(sanitized)
+    sanitized
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
 
     #[test]
     fn test_sanitize_permissions_normal() {
         let config = SecurityConfig::default();
-        let result = sanitize_permissions(0o644, &config);
-        assert_eq!(result.unwrap(), 0o644);
+        assert_eq!(sanitize_permissions(0o644, &config), 0o644);
     }
 
     #[test]
     fn test_sanitize_permissions_executable() {
         let config = SecurityConfig::default();
-        let result = sanitize_permissions(0o755, &config);
-        assert_eq!(result.unwrap(), 0o755);
+        assert_eq!(sanitize_permissions(0o755, &config), 0o755);
     }
 
     #[test]
     fn test_sanitize_permissions_strip_setuid() {
         let config = SecurityConfig::default();
-        let result = sanitize_permissions(0o4755, &config);
-        assert_eq!(result.unwrap(), 0o755);
+        assert_eq!(sanitize_permissions(0o4755, &config), 0o755);
     }
 
     #[test]
     fn test_sanitize_permissions_strip_setgid() {
         let config = SecurityConfig::default();
-        let result = sanitize_permissions(0o2755, &config);
-        assert_eq!(result.unwrap(), 0o755);
+        assert_eq!(sanitize_permissions(0o2755, &config), 0o755);
     }
 
     #[test]
     fn test_sanitize_permissions_strip_both() {
         let config = SecurityConfig::default();
-        let result = sanitize_permissions(0o6755, &config);
-        assert_eq!(result.unwrap(), 0o755);
+        assert_eq!(sanitize_permissions(0o6755, &config), 0o755);
     }
 
     #[test]
     fn test_sanitize_permissions_strip_world_writable() {
         let config = SecurityConfig::default();
-        let result = sanitize_permissions(0o777, &config);
-        assert_eq!(result.unwrap(), 0o775);
+        assert_eq!(sanitize_permissions(0o777, &config), 0o775);
     }
 
     #[test]
     fn test_sanitize_permissions_world_readable_ok() {
         let config = SecurityConfig::default();
-        let result = sanitize_permissions(0o644, &config);
-        assert!(result.is_ok());
+        assert_eq!(sanitize_permissions(0o644, &config), 0o644);
     }
 
     #[test]
     fn test_sanitize_permissions_owner_writable_ok() {
         let config = SecurityConfig::default();
-        let result = sanitize_permissions(0o600, &config);
-        assert!(result.is_ok());
+        assert_eq!(sanitize_permissions(0o600, &config), 0o600);
     }
 
     #[test]
     fn test_sanitize_permissions_group_writable_ok() {
         let config = SecurityConfig::default();
-        let result = sanitize_permissions(0o664, &config);
-        assert!(result.is_ok());
+        assert_eq!(sanitize_permissions(0o664, &config), 0o664);
     }
 
     #[test]
     fn test_sanitize_permissions_edge_case_zero() {
         let config = SecurityConfig::default();
-        let result = sanitize_permissions(0o000, &config);
-        assert_eq!(result.unwrap(), 0o000);
+        assert_eq!(sanitize_permissions(0o000, &config), 0o000);
     }
 
     #[test]
     fn test_sticky_bit_preservation() {
         let config = SecurityConfig::default();
-
-        let mode_with_sticky = 0o1755;
-        let result = sanitize_permissions(mode_with_sticky, &config);
-        assert!(result.is_ok(), "sticky bit should be allowed");
-
-        let sanitized = result.unwrap();
+        let sanitized = sanitize_permissions(0o1755, &config);
         assert_eq!(sanitized & 0o1000, 0o1000, "sticky bit should be preserved");
         assert_eq!(sanitized, 0o1755, "full mode should be preserved");
     }
@@ -152,12 +132,7 @@ mod tests {
     #[test]
     fn test_sticky_bit_with_setuid_stripped() {
         let config = SecurityConfig::default();
-
-        let mode = 0o7755;
-        let result = sanitize_permissions(mode, &config);
-        assert!(result.is_ok());
-
-        let sanitized = result.unwrap();
+        let sanitized = sanitize_permissions(0o7755, &config);
         assert_eq!(sanitized & 0o1000, 0o1000, "sticky bit should remain");
         assert_eq!(sanitized & 0o4000, 0, "setuid should be stripped");
         assert_eq!(sanitized & 0o2000, 0, "setgid should be stripped");
@@ -169,14 +144,7 @@ mod tests {
     fn test_world_writable_allowed_with_config() {
         let mut config = SecurityConfig::default();
         config.allowed.world_writable = true;
-
-        let result = sanitize_permissions(0o777, &config);
-        assert!(
-            result.is_ok(),
-            "world-writable should be allowed with config"
-        );
-
-        let sanitized = result.unwrap();
+        let sanitized = sanitize_permissions(0o777, &config);
         assert_eq!(
             sanitized & 0o002,
             0o002,
@@ -190,10 +158,8 @@ mod tests {
     #[test]
     fn test_world_writable_stripped_by_default() {
         let config = SecurityConfig::default();
-
-        let result = sanitize_permissions(0o777, &config);
         assert_eq!(
-            result.unwrap(),
+            sanitize_permissions(0o777, &config),
             0o775,
             "world-writable bit should be stripped by default"
         );
@@ -202,11 +168,9 @@ mod tests {
     #[test]
     fn test_world_writable_bit_only_stripped() {
         let config = SecurityConfig::default();
-
         // 0o666 = rw-rw-rw-, only other-write (0o002) should be stripped -> 0o664
-        let result = sanitize_permissions(0o666, &config);
         assert_eq!(
-            result.unwrap(),
+            sanitize_permissions(0o666, &config),
             0o664,
             "only world-writable bit should be stripped, not group-write"
         );

--- a/crates/exarch-core/src/security/symlink.rs
+++ b/crates/exarch-core/src/security/symlink.rs
@@ -30,7 +30,7 @@ use crate::types::SafeSymlink;
 ///
 /// # Examples
 ///
-/// ```no_run
+/// ```ignore
 /// use exarch_core::SecurityConfig;
 /// use exarch_core::security::validate_symlink;
 /// use exarch_core::types::DestDir;

--- a/crates/exarch-core/src/security/validator.rs
+++ b/crates/exarch-core/src/security/validator.rs
@@ -171,11 +171,7 @@ impl<'a> EntryValidator<'a> {
 
         let (validated_type, sanitized_mode) = match entry_type {
             EntryType::File => {
-                let sanitized = if let Some(m) = mode {
-                    Some(sanitize_permissions(m, self.config)?)
-                } else {
-                    None
-                };
+                let sanitized = mode.map(|m| sanitize_permissions(m, self.config));
                 (ValidatedEntryType::File, sanitized)
             }
 


### PR DESCRIPTION
## Summary

- `check_permissions` in `inspection/verify.rs` now accepts `path: &Path` and constructs `InvalidPermissions` with the real entry path instead of `PathBuf::new()` — fixes empty path in FFI error messages (#286)
- Six internal security primitives (`validate_path`, `validate_symlink`, `sanitize_permissions`, `validate_compression_ratio`, `QuotaTracker`, `HardlinkTracker`) changed from `pub` to `pub(crate)` — narrows public API surface, prevents accidental stabilization (#281)
- `sanitize_permissions` return type changed from `Result<u32>` to `u32` (function is infallible)
- Added `testing` Cargo feature to re-expose security primitives for `tests/property_tests.rs` and `benches/validation.rs`
- Five doctests on now-private symbols changed to `ignore` (symbols inaccessible outside crate under default features)

## Test plan

- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` — 844/844 passed
- [x] `cargo test --doc --workspace --all-features --exclude exarch-python --exclude exarch-node` — 96 passed, 23 ignored
- [x] `cargo test --doc -p exarch-core` (no `--all-features`) — 96 passed, 0 failed, 23 ignored
- [x] `cargo nextest run -p exarch-core --features testing --test property_tests` — 22/22 passed
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy -p exarch-core --all-targets -- -D warnings` (without features) — clean
- [x] `cargo +nightly fmt --all -- --check` — clean

Closes #286, closes #281