### PR TITLE
refactor(api)!: rename ExtractionError to ArchiveError and consolidate extraction API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `PyProgressAdapter` and `NodeProgressAdapter` now reset `bytes_written` to 0 at the start of each entry, eliminating stale values from previous entries (#285).
 
+### Breaking Changes
+
+- **`ExtractionError` renamed to `ArchiveError`** across the entire public API (#253). The error
+  type now covers all archive operations (extraction, creation, listing, verification), not just
+  extraction. Update all match arms, `use` imports, and type aliases:
+  `use exarch_core::ArchiveError;`. The Python base exception is now `exarch.ArchiveError`
+  (was `exarch.ExtractionError`).
+
 ### Changed
 
+- `extract_archive_with_progress` now delegates to `extract_archive_with_options_and_progress`
+  (the canonical implementation) instead of calling the internal `extract_impl` directly.
+  All four `extract_archive*` convenience wrappers now form a clean delegation chain through the
+  single canonical function (#259).
 - Specifications in `specs/` updated to replace stale `UnsupportedFormat` references with
   `UnknownFormat { path }` (format-detection failures) and `InvalidConfiguration` (7z creation),
   matching the post-#255 Rust API. Python exception hierarchy updated to include

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ npm install exarch-rs
 ```rust
 use exarch_core::{extract_archive, SecurityConfig};
 
-fn main() -> Result<(), exarch_core::ExtractionError> {
+fn main() -> Result<(), exarch_core::ArchiveError> {
     let config = SecurityConfig::default();
     let report = extract_archive("archive.tar.gz", "/output/path", &config)?;
 
@@ -102,7 +102,7 @@ console.log(`Extracted ${result.filesExtracted} files`);
 ```rust
 use exarch_core::{create_archive, CreationConfig};
 
-fn main() -> Result<(), exarch_core::ExtractionError> {
+fn main() -> Result<(), exarch_core::ArchiveError> {
     let config = CreationConfig::default();
     let report = create_archive("output.tar.gz", &["src/", "Cargo.toml"], &config)?;
 

--- a/crates/exarch-cli/src/error.rs
+++ b/crates/exarch-cli/src/error.rs
@@ -4,14 +4,14 @@
 //! contextual errors (anyhow) with actionable guidance.
 
 use anyhow::Result;
-use exarch_core::ExtractionError;
+use exarch_core::ArchiveError;
 use exarch_core::ExtractionReport;
 use std::fmt;
 use std::path::Path;
 
 /// Carrier for partial-extraction progress embedded in the anyhow error chain.
 ///
-/// `ExtractionError::PartialExtraction` uses `#[error("{source}")]` with
+/// `ArchiveError::PartialExtraction` uses `#[error("{source}")]` with
 /// `#[source]`, so placing it directly in an anyhow chain causes the inner
 /// error text to appear twice in `{:#}` output (once via Display, once via the
 /// source chain).  This type carries the report without re-emitting the inner
@@ -37,9 +37,9 @@ impl fmt::Display for PartialExtractionContext {
 
 impl std::error::Error for PartialExtractionContext {}
 
-/// Converts `ExtractionError` to user-friendly anyhow error with context.
+/// Converts `ArchiveError` to user-friendly anyhow error with context.
 ///
-/// The original `ExtractionError` is preserved as the error source so that
+/// The original `ArchiveError` is preserved as the error source so that
 /// callers can downcast via the anyhow chain (used by JSON error output).
 ///
 /// `allow_symlinks` suppresses the `--allow-symlinks` hint for `SymlinkEscape`
@@ -47,7 +47,7 @@ impl std::error::Error for PartialExtractionContext {}
 /// genuine security violation, not a configuration issue.
 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 pub fn convert_extraction_error(
-    err: ExtractionError,
+    err: ArchiveError,
     archive: &Path,
     allow_symlinks: bool,
 ) -> anyhow::Error {
@@ -58,28 +58,28 @@ pub fn convert_extraction_error(
     // twice in `{:#}` output.  Instead, we extract the inner error and wrap
     // it with `PartialExtractionContext`, which carries the partial report
     // without duplicating the inner Display text.
-    if let ExtractionError::PartialExtraction { source, report } = err {
+    if let ArchiveError::PartialExtraction { source, report } = err {
         return anyhow::Error::from(*source).context(PartialExtractionContext { report });
     }
 
     let context = match &err {
-        ExtractionError::PartialExtraction { .. } => unreachable!(),
-        ExtractionError::PathTraversal { .. } => format!(
+        ArchiveError::PartialExtraction { .. } => unreachable!(),
+        ArchiveError::PathTraversal { .. } => format!(
             "Security violation: Archive '{}' attempted path traversal\n\
              HINT: This archive may be malicious. Do not extract from untrusted sources.",
             archive.display(),
         ),
-        ExtractionError::ZipBomb { .. } => format!(
+        ArchiveError::ZipBomb { .. } => format!(
             "Security violation: Archive '{}' appears to be a zip bomb\n\
              HINT: Use --max-compression-ratio to allow higher ratios if legitimate.",
             archive.display(),
         ),
-        ExtractionError::QuotaExceeded { .. } => format!(
+        ArchiveError::QuotaExceeded { .. } => format!(
             "Extraction limit exceeded for '{}'\n\
              HINT: Use --max-files, --max-total-size, or --max-file-size to increase limits.",
             archive.display(),
         ),
-        ExtractionError::SymlinkEscape { .. } => {
+        ArchiveError::SymlinkEscape { .. } => {
             if allow_symlinks {
                 format!("Symlink escape blocked in '{}'", archive.display())
             } else {
@@ -90,39 +90,39 @@ pub fn convert_extraction_error(
                 )
             }
         }
-        ExtractionError::HardlinkEscape { .. } => format!(
+        ArchiveError::HardlinkEscape { .. } => format!(
             "Hardlink rejected in '{}'\n\
              HINT: Use --allow-hardlinks to extract hardlinks (only if trusted source).",
             archive.display(),
         ),
-        ExtractionError::Io(io_err) => {
+        ArchiveError::Io(io_err) => {
             format!(
                 "I/O error while processing '{}': {}",
                 archive.display(),
                 io_err
             )
         }
-        ExtractionError::UnknownFormat { path } => format!(
+        ArchiveError::UnknownFormat { path } => format!(
             "Cannot determine archive format: {}\n\
              HINT: Supported formats: tar, tar.gz, tar.bz2, tar.xz, tar.zstd, zip",
             path.display()
         ),
-        ExtractionError::InvalidArchive(reason) => format!(
+        ArchiveError::InvalidArchive(reason) => format!(
             "Invalid archive '{}': {}\n\
              HINT: The archive may be corrupted or malformed.",
             archive.display(),
             reason
         ),
-        ExtractionError::InvalidConfiguration { reason } => format!(
+        ArchiveError::InvalidConfiguration { reason } => format!(
             "Invalid configuration: {reason}\n\
              HINT: Check the flags you passed and their allowed value ranges.",
         ),
-        ExtractionError::SourceNotFound { path } => format!(
+        ArchiveError::SourceNotFound { path } => format!(
             "Source path not found: {}\n\
              HINT: Verify the archive path exists and is readable.",
             path.display(),
         ),
-        ExtractionError::SourceNotAccessible { path } => format!(
+        ArchiveError::SourceNotAccessible { path } => format!(
             "Source path is not accessible: {}\n\
              HINT: Check file permissions on the archive.",
             path.display(),
@@ -137,7 +137,7 @@ pub fn convert_extraction_error(
 /// `allow_symlinks` is forwarded to [`convert_extraction_error`] to suppress
 /// the `--allow-symlinks` hint when the flag is already active.
 pub fn add_archive_context<T>(
-    result: Result<T, ExtractionError>,
+    result: Result<T, ArchiveError>,
     archive: &Path,
     allow_symlinks: bool,
 ) -> anyhow::Result<T> {
@@ -152,7 +152,7 @@ mod tests {
 
     #[test]
     fn test_convert_path_traversal_error() {
-        let err = ExtractionError::PathTraversal {
+        let err = ArchiveError::PathTraversal {
             path: PathBuf::from("../../../etc/passwd"),
         };
         let converted = convert_extraction_error(err, Path::new("malicious.zip"), false);
@@ -164,7 +164,7 @@ mod tests {
 
     #[test]
     fn test_convert_zip_bomb_error() {
-        let err = ExtractionError::ZipBomb {
+        let err = ArchiveError::ZipBomb {
             compressed: 1024,
             uncompressed: 1024 * 1024 * 150,
             ratio: 150.0,
@@ -178,7 +178,7 @@ mod tests {
     #[test]
     fn test_path_traversal_path_appears_once() {
         let path = PathBuf::from("../../../etc/passwd");
-        let err = ExtractionError::PathTraversal { path };
+        let err = ArchiveError::PathTraversal { path };
         let converted = convert_extraction_error(err, Path::new("archive.tar.gz"), false);
         let msg = format!("{converted:#}");
         assert_eq!(
@@ -191,7 +191,7 @@ mod tests {
     #[test]
     fn test_symlink_escape_path_appears_once() {
         let path = PathBuf::from("link/to/escape");
-        let err = ExtractionError::SymlinkEscape { path };
+        let err = ArchiveError::SymlinkEscape { path };
         let converted = convert_extraction_error(err, Path::new("archive.tar.gz"), false);
         let msg = format!("{converted:#}");
         assert_eq!(
@@ -204,7 +204,7 @@ mod tests {
     #[test]
     fn test_symlink_escape_hint_suppressed_when_flag_active() {
         let path = PathBuf::from("link/to/escape");
-        let err = ExtractionError::SymlinkEscape { path };
+        let err = ArchiveError::SymlinkEscape { path };
         let converted = convert_extraction_error(err, Path::new("archive.tar.gz"), true);
         let msg = format!("{converted:#}");
         assert!(
@@ -216,7 +216,7 @@ mod tests {
     #[test]
     fn test_symlink_escape_hint_shown_when_flag_inactive() {
         let path = PathBuf::from("link/to/escape");
-        let err = ExtractionError::SymlinkEscape { path };
+        let err = ArchiveError::SymlinkEscape { path };
         let converted = convert_extraction_error(err, Path::new("archive.tar.gz"), false);
         let msg = format!("{converted:#}");
         assert!(
@@ -228,7 +228,7 @@ mod tests {
     #[test]
     fn test_hardlink_escape_path_appears_once() {
         let path = PathBuf::from("hard/link/escape");
-        let err = ExtractionError::HardlinkEscape { path };
+        let err = ArchiveError::HardlinkEscape { path };
         let converted = convert_extraction_error(err, Path::new("archive.tar.gz"), false);
         let msg = format!("{converted:#}");
         assert_eq!(
@@ -241,7 +241,7 @@ mod tests {
     #[test]
     fn test_convert_io_error() {
         let io_err = io::Error::new(io::ErrorKind::NotFound, "file not found");
-        let err = ExtractionError::Io(io_err);
+        let err = ArchiveError::Io(io_err);
         let converted = convert_extraction_error(err, Path::new("archive.tar.gz"), false);
         let msg = format!("{converted:?}");
         assert!(msg.contains("I/O error"));
@@ -255,7 +255,7 @@ mod tests {
         use exarch_core::ExtractionReport;
         use std::time::Duration;
 
-        let inner = ExtractionError::HardlinkEscape {
+        let inner = ArchiveError::HardlinkEscape {
             path: PathBuf::from("hardlink_escape_path"),
         };
         let report = ExtractionReport {
@@ -267,7 +267,7 @@ mod tests {
             files_skipped: 0,
             warnings: vec![],
         };
-        let err = ExtractionError::PartialExtraction {
+        let err = ArchiveError::PartialExtraction {
             source: Box::new(inner),
             report,
         };
@@ -285,7 +285,7 @@ mod tests {
         use exarch_core::ExtractionReport;
         use std::time::Duration;
 
-        let inner = ExtractionError::SymlinkEscape {
+        let inner = ArchiveError::SymlinkEscape {
             path: PathBuf::from("symlink_escape_path"),
         };
         let report = ExtractionReport {
@@ -297,7 +297,7 @@ mod tests {
             files_skipped: 0,
             warnings: vec![],
         };
-        let err = ExtractionError::PartialExtraction {
+        let err = ArchiveError::PartialExtraction {
             source: Box::new(inner),
             report,
         };

--- a/crates/exarch-cli/src/output/human.rs
+++ b/crates/exarch-cli/src/output/human.rs
@@ -399,7 +399,7 @@ mod tests {
     #[test]
     fn test_human_format_error_does_not_panic() {
         let formatter = HumanFormatter::new(false, false);
-        let err = anyhow::anyhow!(exarch_core::ExtractionError::ZipBomb {
+        let err = anyhow::anyhow!(exarch_core::ArchiveError::ZipBomb {
             compressed: 1000,
             uncompressed: 1_000_000,
             ratio: 1000.0,
@@ -410,11 +410,11 @@ mod tests {
 
     #[test]
     fn test_human_format_error_plain_text_not_json() {
-        use exarch_core::ExtractionError;
+        use exarch_core::ArchiveError;
         use std::path::PathBuf;
 
         let formatter = HumanFormatter::new(false, false);
-        let err = anyhow::anyhow!(ExtractionError::PathTraversal {
+        let err = anyhow::anyhow!(ArchiveError::PathTraversal {
             path: PathBuf::from("../etc/passwd"),
         });
         // format_error does not return a value; verify it completes without panic.

--- a/crates/exarch-cli/src/output/json.rs
+++ b/crates/exarch-cli/src/output/json.rs
@@ -5,9 +5,9 @@ use super::formatter::JsonPartialReport;
 use super::formatter::OutputFormatter;
 use crate::error::PartialExtractionContext;
 use anyhow::Result;
+use exarch_core::ArchiveError;
 use exarch_core::ArchiveManifest;
 use exarch_core::CreationReport;
-use exarch_core::ExtractionError;
 use exarch_core::ExtractionReport;
 use exarch_core::VerificationReport;
 use serde::Serialize;
@@ -15,24 +15,24 @@ use std::io::Write;
 use std::io::{self};
 use std::path::Path;
 
-fn extraction_error_kind(err: &ExtractionError) -> String {
+fn extraction_error_kind(err: &ArchiveError) -> String {
     match err {
-        ExtractionError::Io(_) => "IoError",
-        ExtractionError::InvalidArchive(_) => "InvalidArchive",
-        ExtractionError::PathTraversal { .. } => "PathTraversal",
-        ExtractionError::SymlinkEscape { .. } => "SymlinkEscape",
-        ExtractionError::HardlinkEscape { .. } => "HardlinkEscape",
-        ExtractionError::ZipBomb { .. } => "ZipBomb",
-        ExtractionError::InvalidPermissions { .. } => "InvalidPermissions",
-        ExtractionError::QuotaExceeded { .. } => "QuotaExceeded",
-        ExtractionError::SecurityViolation { .. } => "SecurityViolation",
-        ExtractionError::SourceNotFound { .. } => "SourceNotFound",
-        ExtractionError::SourceNotAccessible { .. } => "SourceNotAccessible",
-        ExtractionError::OutputExists { .. } => "OutputExists",
-        ExtractionError::InvalidCompressionLevel { .. } => "InvalidCompressionLevel",
-        ExtractionError::UnknownFormat { .. } => "UnknownFormat",
-        ExtractionError::InvalidConfiguration { .. } => "InvalidConfiguration",
-        ExtractionError::PartialExtraction { source, .. } => return extraction_error_kind(source),
+        ArchiveError::Io(_) => "IoError",
+        ArchiveError::InvalidArchive(_) => "InvalidArchive",
+        ArchiveError::PathTraversal { .. } => "PathTraversal",
+        ArchiveError::SymlinkEscape { .. } => "SymlinkEscape",
+        ArchiveError::HardlinkEscape { .. } => "HardlinkEscape",
+        ArchiveError::ZipBomb { .. } => "ZipBomb",
+        ArchiveError::InvalidPermissions { .. } => "InvalidPermissions",
+        ArchiveError::QuotaExceeded { .. } => "QuotaExceeded",
+        ArchiveError::SecurityViolation { .. } => "SecurityViolation",
+        ArchiveError::SourceNotFound { .. } => "SourceNotFound",
+        ArchiveError::SourceNotAccessible { .. } => "SourceNotAccessible",
+        ArchiveError::OutputExists { .. } => "OutputExists",
+        ArchiveError::InvalidCompressionLevel { .. } => "InvalidCompressionLevel",
+        ArchiveError::UnknownFormat { .. } => "UnknownFormat",
+        ArchiveError::InvalidConfiguration { .. } => "InvalidConfiguration",
+        ArchiveError::PartialExtraction { source, .. } => return extraction_error_kind(source),
     }
     .to_string()
 }
@@ -105,16 +105,14 @@ impl OutputFormatter for JsonFormatter {
     }
 
     fn format_error(&self, operation: &str, error: &anyhow::Error) {
-        let extraction_err = error
-            .chain()
-            .find_map(|e| e.downcast_ref::<ExtractionError>());
+        let extraction_err = error.chain().find_map(|e| e.downcast_ref::<ArchiveError>());
 
         let kind = extraction_err.map_or_else(|| "Error".to_string(), extraction_error_kind);
         let message = format!("{error:#}");
 
         // PartialExtraction is converted by convert_extraction_error into a chain
-        // of PartialExtractionContext → inner ExtractionError, so the partial
-        // report is carried by PartialExtractionContext, not by ExtractionError.
+        // of PartialExtractionContext → inner ArchiveError, so the partial
+        // report is carried by PartialExtractionContext, not by ArchiveError.
         let partial_report = error
             .chain()
             .find_map(|e| e.downcast_ref::<PartialExtractionContext>())
@@ -272,7 +270,7 @@ mod tests {
     use exarch_core::QuotaResource;
     use std::path::PathBuf;
 
-    fn error_kind(err: &ExtractionError) -> String {
+    fn error_kind(err: &ArchiveError) -> String {
         extraction_error_kind(err)
     }
 
@@ -299,7 +297,7 @@ mod tests {
 
     #[test]
     fn test_extraction_error_kind_zip_bomb() {
-        let err = ExtractionError::ZipBomb {
+        let err = ArchiveError::ZipBomb {
             compressed: 1000,
             uncompressed: 1_000_000,
             ratio: 1000.0,
@@ -309,7 +307,7 @@ mod tests {
 
     #[test]
     fn test_extraction_error_kind_path_traversal() {
-        let err = ExtractionError::PathTraversal {
+        let err = ArchiveError::PathTraversal {
             path: PathBuf::from("../etc/passwd"),
         };
         assert_eq!(error_kind(&err), "PathTraversal");
@@ -317,7 +315,7 @@ mod tests {
 
     #[test]
     fn test_extraction_error_kind_symlink_escape() {
-        let err = ExtractionError::SymlinkEscape {
+        let err = ArchiveError::SymlinkEscape {
             path: PathBuf::from("link"),
         };
         assert_eq!(error_kind(&err), "SymlinkEscape");
@@ -325,7 +323,7 @@ mod tests {
 
     #[test]
     fn test_extraction_error_kind_hardlink_escape() {
-        let err = ExtractionError::HardlinkEscape {
+        let err = ArchiveError::HardlinkEscape {
             path: PathBuf::from("hardlink"),
         };
         assert_eq!(error_kind(&err), "HardlinkEscape");
@@ -333,7 +331,7 @@ mod tests {
 
     #[test]
     fn test_extraction_error_kind_quota_exceeded() {
-        let err = ExtractionError::QuotaExceeded {
+        let err = ArchiveError::QuotaExceeded {
             resource: QuotaResource::FileCount {
                 current: 11,
                 max: 10,
@@ -344,13 +342,13 @@ mod tests {
 
     #[test]
     fn test_extraction_error_kind_invalid_archive() {
-        let err = ExtractionError::InvalidArchive("corrupted header".to_string());
+        let err = ArchiveError::InvalidArchive("corrupted header".to_string());
         assert_eq!(error_kind(&err), "InvalidArchive");
     }
 
     #[test]
     fn test_extraction_error_kind_io_error() {
-        let err = ExtractionError::Io(std::io::Error::new(
+        let err = ArchiveError::Io(std::io::Error::new(
             std::io::ErrorKind::NotFound,
             "file not found",
         ));
@@ -359,7 +357,7 @@ mod tests {
 
     #[test]
     fn test_extraction_error_kind_unknown_format() {
-        let err = ExtractionError::UnknownFormat {
+        let err = ArchiveError::UnknownFormat {
             path: std::path::PathBuf::from("archive.rar"),
         };
         assert_eq!(error_kind(&err), "UnknownFormat");
@@ -367,7 +365,7 @@ mod tests {
 
     #[test]
     fn test_extraction_error_kind_security_violation() {
-        let err = ExtractionError::SecurityViolation {
+        let err = ArchiveError::SecurityViolation {
             reason: "denied".to_string(),
         };
         assert_eq!(error_kind(&err), "SecurityViolation");
@@ -376,8 +374,8 @@ mod tests {
     #[test]
     fn test_format_error_downcasts_extraction_error() {
         // Verify that format_error correctly resolves the kind from an anyhow chain
-        // containing an ExtractionError.
-        let extraction_err = ExtractionError::ZipBomb {
+        // containing an ArchiveError.
+        let extraction_err = ArchiveError::ZipBomb {
             compressed: 100,
             uncompressed: 100_000,
             ratio: 1000.0,
@@ -387,7 +385,7 @@ mod tests {
         // Downcast manually, same logic as format_error uses
         let kind = anyhow_err
             .chain()
-            .find_map(|e| e.downcast_ref::<ExtractionError>())
+            .find_map(|e| e.downcast_ref::<ArchiveError>())
             .map_or_else(|| "Error".to_string(), extraction_error_kind);
 
         assert_eq!(kind, "ZipBomb");
@@ -395,20 +393,20 @@ mod tests {
 
     #[test]
     fn test_format_error_unknown_error_uses_generic_kind() {
-        // A plain anyhow error with no ExtractionError in chain should use "Error" as
+        // A plain anyhow error with no ArchiveError in chain should use "Error" as
         // kind
         let anyhow_err = anyhow::anyhow!("something went wrong");
 
         let kind = anyhow_err
             .chain()
-            .find_map(|e| e.downcast_ref::<ExtractionError>())
+            .find_map(|e| e.downcast_ref::<ArchiveError>())
             .map_or_else(|| "Error".to_string(), extraction_error_kind);
 
         assert_eq!(kind, "Error");
     }
 
     // Regression tests for issue #192: JSON error message must not duplicate text
-    // that ExtractionError::Display already emits.
+    // that ArchiveError::Display already emits.
 
     #[test]
     fn test_json_message_quota_exceeded_no_duplication() {
@@ -416,13 +414,13 @@ mod tests {
         use exarch_core::QuotaResource;
         use std::path::Path;
 
-        let err = ExtractionError::QuotaExceeded {
+        let err = ArchiveError::QuotaExceeded {
             resource: QuotaResource::FileCount {
                 current: 11,
                 max: 10,
             },
         };
-        // ExtractionError::Display emits "quota exceeded: file count (11 > 10)"
+        // ArchiveError::Display emits "quota exceeded: file count (11 > 10)"
         let display_text = err.to_string();
         let anyhow_err = convert_extraction_error(err, Path::new("archive.tar.gz"), false);
         let message = format!("{anyhow_err:#}");
@@ -431,7 +429,7 @@ mod tests {
         let display_occurrences = message.matches(&display_text).count();
         assert!(
             display_occurrences <= 1,
-            "JSON message duplicates ExtractionError display text ({display_occurrences} occurrences): {message}"
+            "JSON message duplicates ArchiveError display text ({display_occurrences} occurrences): {message}"
         );
     }
 
@@ -443,12 +441,12 @@ mod tests {
         let compressed = 1_024_u64;
         let uncompressed = 1_024 * 1_024 * 150_u64;
         let ratio = 150.0_f64;
-        let err = ExtractionError::ZipBomb {
+        let err = ArchiveError::ZipBomb {
             compressed,
             uncompressed,
             ratio,
         };
-        // ExtractionError::Display emits the ratio info
+        // ArchiveError::Display emits the ratio info
         let display_text = err.to_string();
         let anyhow_err = convert_extraction_error(err, Path::new("bomb.zip"), false);
         let message = format!("{anyhow_err:#}");
@@ -456,7 +454,7 @@ mod tests {
         let display_occurrences = message.matches(&display_text).count();
         assert!(
             display_occurrences <= 1,
-            "JSON message duplicates ExtractionError display text ({display_occurrences} occurrences): {message}"
+            "JSON message duplicates ArchiveError display text ({display_occurrences} occurrences): {message}"
         );
     }
 }

--- a/crates/exarch-core/README.md
+++ b/crates/exarch-core/README.md
@@ -25,7 +25,7 @@ exarch-core = "0.4"
 ```rust
 use exarch_core::{extract_archive, SecurityConfig};
 
-fn main() -> Result<(), exarch_core::ExtractionError> {
+fn main() -> Result<(), exarch_core::ArchiveError> {
     let config = SecurityConfig::default();
     let report = extract_archive("archive.tar.gz", "/output/dir", &config)?;
 
@@ -156,19 +156,19 @@ let report = ArchiveCreator::new()
 | [`CreationConfig`](https://docs.rs/exarch-core/latest/exarch_core/struct.CreationConfig.html) | Configuration for archive creation |
 | [`ExtractionReport`](https://docs.rs/exarch-core/latest/exarch_core/struct.ExtractionReport.html) | Extraction statistics, warnings, and skipped-entry counts |
 | [`CreationReport`](https://docs.rs/exarch-core/latest/exarch_core/struct.CreationReport.html) | Creation statistics and results |
-| [`ExtractionError`](https://docs.rs/exarch-core/latest/exarch_core/enum.ExtractionError.html) | Error types for all operations |
+| [`ArchiveError`](https://docs.rs/exarch-core/latest/exarch_core/enum.ArchiveError.html) | Error types for all operations |
 
 ### Error Handling
 
 ```rust
-use exarch_core::{extract_archive, ExtractionError, SecurityConfig};
+use exarch_core::{extract_archive, ArchiveError, SecurityConfig};
 
 match extract_archive("archive.tar.gz", "/output", &SecurityConfig::default()) {
     Ok(report) => println!("Extracted {} files", report.files_extracted),
-    Err(ExtractionError::PathTraversal { path, .. }) => {
+    Err(ArchiveError::PathTraversal { path, .. }) => {
         eprintln!("Blocked path traversal: {}", path.display());
     }
-    Err(ExtractionError::QuotaExceeded { resource }) => {
+    Err(ArchiveError::QuotaExceeded { resource }) => {
         eprintln!("Resource limit exceeded: {:?}", resource);
     }
     Err(e) => eprintln!("Extraction failed: {}", e),

--- a/crates/exarch-core/src/api.rs
+++ b/crates/exarch-core/src/api.rs
@@ -2,7 +2,7 @@
 
 use std::path::Path;
 
-use crate::ExtractionError;
+use crate::ArchiveError;
 use crate::ExtractionReport;
 use crate::NoopProgress;
 use crate::ProgressCallback;
@@ -101,7 +101,7 @@ pub fn extract_archive_with_progress<P: AsRef<Path>, Q: AsRef<Path>>(
     progress: &mut dyn ProgressCallback,
 ) -> Result<ExtractionReport> {
     let options = ExtractionOptions::default();
-    extract_impl(archive_path, output_dir, config, &options, progress)
+    extract_archive_with_options_and_progress(archive_path, output_dir, config, &options, progress)
 }
 
 fn extract_impl<P: AsRef<Path>, Q: AsRef<Path>>(
@@ -151,8 +151,10 @@ fn extract_impl<P: AsRef<Path>, Q: AsRef<Path>>(
 
 /// Extracts an archive with extraction options and optional progress reporting.
 ///
-/// This is the most flexible extraction API. Use this when you need both
-/// `ExtractionOptions` (e.g., atomic mode) and progress reporting.
+/// This is the canonical extraction implementation. All other
+/// `extract_archive*` functions are thin wrappers that delegate here. Use this
+/// directly when you need both [`ExtractionOptions`] (e.g., atomic mode) and a
+/// progress callback.
 ///
 /// # Arguments
 ///
@@ -170,6 +172,30 @@ fn extract_impl<P: AsRef<Path>, Q: AsRef<Path>>(
 /// - Security validation fails
 /// - I/O operations fail
 /// - Atomic temp dir creation or rename fails
+///
+/// # Examples
+///
+/// ```no_run
+/// use exarch_core::ExtractionOptions;
+/// use exarch_core::NoopProgress;
+/// use exarch_core::SecurityConfig;
+/// use exarch_core::extract_archive_with_options_and_progress;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let config = SecurityConfig::default();
+/// let options = ExtractionOptions::default().with_atomic(true);
+/// let mut progress = NoopProgress;
+/// let report = extract_archive_with_options_and_progress(
+///     "archive.tar.gz",
+///     "/tmp/output",
+///     &config,
+///     &options,
+///     &mut progress,
+/// )?;
+/// println!("Extracted {} files", report.files_extracted);
+/// # Ok(())
+/// # }
+/// ```
 pub fn extract_archive_with_options_and_progress<P: AsRef<Path>, Q: AsRef<Path>>(
     archive_path: P,
     output_dir: Q,
@@ -186,8 +212,9 @@ pub fn extract_archive_with_options_and_progress<P: AsRef<Path>, Q: AsRef<Path>>
 
 /// Extracts an archive with extraction options (no progress reporting).
 ///
-/// Same as `extract_archive_with_options_and_progress` but uses a no-op
-/// progress callback.
+/// Convenience wrapper around [`extract_archive_with_options_and_progress`]
+/// that passes a no-op progress callback. Use this when you need
+/// [`ExtractionOptions`] but do not require progress updates.
 ///
 /// # Errors
 ///
@@ -197,6 +224,22 @@ pub fn extract_archive_with_options_and_progress<P: AsRef<Path>, Q: AsRef<Path>>
 /// - Security validation fails
 /// - I/O operations fail
 /// - Atomic temp dir creation or rename fails
+///
+/// # Examples
+///
+/// ```no_run
+/// use exarch_core::ExtractionOptions;
+/// use exarch_core::SecurityConfig;
+/// use exarch_core::extract_archive_with_options;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let config = SecurityConfig::default();
+/// let options = ExtractionOptions::default().with_atomic(true);
+/// let report = extract_archive_with_options("archive.tar.gz", "/tmp/output", &config, &options)?;
+/// println!("Extracted {} files", report.files_extracted);
+/// # Ok(())
+/// # }
+/// ```
 pub fn extract_archive_with_options<P: AsRef<Path>, Q: AsRef<Path>>(
     archive_path: P,
     output_dir: Q,
@@ -220,22 +263,21 @@ fn extract_atomic<P: AsRef<Path>, Q: AsRef<Path>>(
     // computing the parent, so temp dir lands on the same filesystem.
     // If output_dir doesn't exist yet, use its lexical parent.
     let canonical_output = if output_dir.exists() {
-        output_dir.canonicalize().map_err(ExtractionError::Io)?
+        output_dir.canonicalize().map_err(ArchiveError::Io)?
     } else {
         output_dir.to_path_buf()
     };
 
-    let parent =
-        canonical_output
-            .parent()
-            .ok_or_else(|| ExtractionError::InvalidConfiguration {
-                reason: "output directory has no parent".into(),
-            })?;
+    let parent = canonical_output
+        .parent()
+        .ok_or_else(|| ArchiveError::InvalidConfiguration {
+            reason: "output directory has no parent".into(),
+        })?;
 
-    std::fs::create_dir_all(parent).map_err(ExtractionError::Io)?;
+    std::fs::create_dir_all(parent).map_err(ArchiveError::Io)?;
 
     let temp_dir = tempfile::tempdir_in(parent).map_err(|e| {
-        ExtractionError::Io(std::io::Error::new(
+        ArchiveError::Io(std::io::Error::new(
             e.kind(),
             format!(
                 "failed to create temp directory in {}: {e}",
@@ -255,11 +297,11 @@ fn extract_atomic<P: AsRef<Path>, Q: AsRef<Path>>(
                 let _ = std::fs::remove_dir_all(&temp_path);
                 // Map AlreadyExists to OutputExists for caller clarity
                 if e.kind() == std::io::ErrorKind::AlreadyExists {
-                    ExtractionError::OutputExists {
+                    ArchiveError::OutputExists {
                         path: output_dir.to_path_buf(),
                     }
                 } else {
-                    ExtractionError::Io(std::io::Error::new(
+                    ArchiveError::Io(std::io::Error::new(
                         e.kind(),
                         format!("failed to rename temp dir to {}: {e}", output_dir.display()),
                     ))
@@ -457,7 +499,7 @@ fn creator_for_format(
         ArchiveType::TarXz => Ok(Box::new(crate::creation::TarXzCreator)),
         ArchiveType::TarZst => Ok(Box::new(crate::creation::TarZstCreator)),
         ArchiveType::Zip => Ok(Box::new(crate::creation::ZipCreator)),
-        ArchiveType::SevenZ => Err(ExtractionError::InvalidConfiguration {
+        ArchiveType::SevenZ => Err(ArchiveError::InvalidConfiguration {
             reason: "7z archive creation is not supported".into(),
         }),
     }
@@ -565,7 +607,7 @@ fn reject_zip_family_creation(output: &Path) -> Result<()> {
     };
     if is_zip_family_alias(ext) {
         let ext_lower = ext.to_ascii_lowercase();
-        return Err(ExtractionError::InvalidArchive(format!(
+        return Err(ArchiveError::InvalidArchive(format!(
             "creation for .{ext_lower} isn't supported: the format is ZIP-based but \
              requires extra structure (signing, manifests, ordering) that exarch \
              doesn't produce. Use .zip, or set CreationConfig::format = Some(\
@@ -694,7 +736,7 @@ mod tests {
         assert!(
             matches!(
                 result,
-                Err(ExtractionError::InvalidCompressionLevel { level: 15 })
+                Err(ArchiveError::InvalidCompressionLevel { level: 15 })
             ),
             "expected InvalidCompressionLevel, got {result:?}",
         );
@@ -712,7 +754,7 @@ mod tests {
             let archive_path = dest.path().join(format!("output.{ext}"));
             let result = create_archive(&archive_path, &[] as &[&str], &CreationConfig::default());
             assert!(
-                matches!(result, Err(ExtractionError::InvalidArchive(_))),
+                matches!(result, Err(ArchiveError::InvalidArchive(_))),
                 ".{ext} should be rejected, got {result:?}",
             );
         }
@@ -745,7 +787,7 @@ mod tests {
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
-            ExtractionError::InvalidConfiguration { .. }
+            ArchiveError::InvalidConfiguration { .. }
         ));
     }
 

--- a/crates/exarch-core/src/archive.rs
+++ b/crates/exarch-core/src/archive.rs
@@ -119,13 +119,13 @@ impl ArchiveBuilder {
     pub fn extract(self) -> Result<ExtractionReport> {
         let archive_path =
             self.archive_path
-                .ok_or_else(|| crate::ExtractionError::InvalidConfiguration {
+                .ok_or_else(|| crate::ArchiveError::InvalidConfiguration {
                     reason: "archive path not set".to_string(),
                 })?;
 
         let output_dir =
             self.output_dir
-                .ok_or_else(|| crate::ExtractionError::InvalidConfiguration {
+                .ok_or_else(|| crate::ArchiveError::InvalidConfiguration {
                     reason: "output directory not set".to_string(),
                 })?;
 
@@ -155,7 +155,7 @@ mod tests {
         let result = builder.extract();
         assert!(matches!(
             result,
-            Err(crate::ExtractionError::InvalidConfiguration { .. })
+            Err(crate::ArchiveError::InvalidConfiguration { .. })
         ));
     }
 
@@ -165,7 +165,7 @@ mod tests {
         let result = builder.extract();
         assert!(matches!(
             result,
-            Err(crate::ExtractionError::InvalidConfiguration { .. })
+            Err(crate::ArchiveError::InvalidConfiguration { .. })
         ));
     }
 }

--- a/crates/exarch-core/src/config.rs
+++ b/crates/exarch-core/src/config.rs
@@ -199,7 +199,7 @@ impl SecurityConfig {
     ///
     /// # Errors
     ///
-    /// Returns `ExtractionError::InvalidConfiguration` if:
+    /// Returns `ArchiveError::InvalidConfiguration` if:
     /// - `max_compression_ratio` is not positive
     /// - `max_file_size` is zero
     /// - `max_total_size` is zero
@@ -220,32 +220,32 @@ impl SecurityConfig {
     /// ```
     pub fn validate(&self) -> crate::Result<()> {
         if !self.max_compression_ratio.is_finite() || self.max_compression_ratio <= 0.0 {
-            return Err(crate::ExtractionError::InvalidConfiguration {
+            return Err(crate::ArchiveError::InvalidConfiguration {
                 reason: "max_compression_ratio must be positive".into(),
             });
         }
         if self.max_file_size == 0 {
-            return Err(crate::ExtractionError::InvalidConfiguration {
+            return Err(crate::ArchiveError::InvalidConfiguration {
                 reason: "max_file_size must not be zero".into(),
             });
         }
         if self.max_total_size == 0 {
-            return Err(crate::ExtractionError::InvalidConfiguration {
+            return Err(crate::ArchiveError::InvalidConfiguration {
                 reason: "max_total_size must not be zero".into(),
             });
         }
         if self.max_path_depth == 0 {
-            return Err(crate::ExtractionError::InvalidConfiguration {
+            return Err(crate::ArchiveError::InvalidConfiguration {
                 reason: "max_path_depth must not be zero".into(),
             });
         }
         if self.max_file_count == 0 {
-            return Err(crate::ExtractionError::InvalidConfiguration {
+            return Err(crate::ArchiveError::InvalidConfiguration {
                 reason: "max_file_count must not be zero".into(),
             });
         }
         if self.max_solid_block_memory == 0 {
-            return Err(crate::ExtractionError::InvalidConfiguration {
+            return Err(crate::ArchiveError::InvalidConfiguration {
                 reason: "max_solid_block_memory must not be zero".into(),
             });
         }

--- a/crates/exarch-core/src/copy.rs
+++ b/crates/exarch-core/src/copy.rs
@@ -15,7 +15,7 @@ use std::io::Read;
 use std::io::Write;
 use std::io::{self};
 
-use crate::ExtractionError;
+use crate::ArchiveError;
 
 /// Optimal buffer size for I/O operations (64KB).
 ///
@@ -82,7 +82,7 @@ pub fn copy_with_buffer<R: Read, W: Write>(
     reader: &mut R,
     writer: &mut W,
     buffer: &mut CopyBuffer,
-) -> Result<u64, ExtractionError> {
+) -> Result<u64, ArchiveError> {
     let mut total: u64 = 0;
 
     loop {
@@ -90,17 +90,17 @@ pub fn copy_with_buffer<R: Read, W: Write>(
             Ok(0) => break,
             Ok(n) => n,
             Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
-            Err(e) => return Err(ExtractionError::Io(e)),
+            Err(e) => return Err(ArchiveError::Io(e)),
         };
 
         writer
             .write_all(&buffer.buf[..bytes_read])
-            .map_err(ExtractionError::Io)?;
+            .map_err(ArchiveError::Io)?;
 
         // SECURITY: Detect overflow to prevent quota bypass
         total = total
             .checked_add(bytes_read as u64)
-            .ok_or(ExtractionError::QuotaExceeded {
+            .ok_or(ArchiveError::QuotaExceeded {
                 resource: crate::QuotaResource::IntegerOverflow,
             })?;
     }
@@ -323,7 +323,7 @@ mod tests {
 
         assert!(result.is_err(), "copy should propagate write errors");
         match result {
-            Err(ExtractionError::Io(e)) => {
+            Err(ArchiveError::Io(e)) => {
                 assert_eq!(e.kind(), ErrorKind::Other);
             }
             _ => panic!("expected IO error"),

--- a/crates/exarch-core/src/creation/config.rs
+++ b/crates/exarch-core/src/creation/config.rs
@@ -1,6 +1,6 @@
 //! Configuration for archive creation operations.
 
-use crate::ExtractionError;
+use crate::ArchiveError;
 use crate::Result;
 use crate::formats::detect::ArchiveType;
 use std::path::PathBuf;
@@ -163,11 +163,11 @@ impl CreationConfig {
     ///
     /// # Errors
     ///
-    /// Returns [`ExtractionError::InvalidCompressionLevel`] if `level` is not
+    /// Returns [`ArchiveError::InvalidCompressionLevel`] if `level` is not
     /// in the range 1–9.
     pub fn with_compression_level(mut self, level: u8) -> Result<Self> {
         if !(1..=9).contains(&level) {
-            return Err(ExtractionError::InvalidCompressionLevel { level });
+            return Err(ArchiveError::InvalidCompressionLevel { level });
         }
         self.compression_level = Some(level);
         Ok(self)
@@ -197,7 +197,7 @@ impl CreationConfig {
         if let Some(level) = self.compression_level
             && !(1..=9).contains(&level)
         {
-            return Err(ExtractionError::InvalidCompressionLevel { level });
+            return Err(ArchiveError::InvalidCompressionLevel { level });
         }
         Ok(())
     }
@@ -277,7 +277,7 @@ mod tests {
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
-            ExtractionError::InvalidCompressionLevel { level: 0 }
+            ArchiveError::InvalidCompressionLevel { level: 0 }
         ));
 
         let config = CreationConfig {
@@ -288,7 +288,7 @@ mod tests {
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
-            ExtractionError::InvalidCompressionLevel { level: 10 }
+            ArchiveError::InvalidCompressionLevel { level: 10 }
         ));
     }
 
@@ -296,11 +296,11 @@ mod tests {
     fn test_creation_config_builder_invalid_compression() {
         assert!(matches!(
             CreationConfig::default().with_compression_level(0),
-            Err(ExtractionError::InvalidCompressionLevel { level: 0 })
+            Err(ArchiveError::InvalidCompressionLevel { level: 0 })
         ));
         assert!(matches!(
             CreationConfig::default().with_compression_level(10),
-            Err(ExtractionError::InvalidCompressionLevel { level: 10 })
+            Err(ArchiveError::InvalidCompressionLevel { level: 10 })
         ));
     }
 

--- a/crates/exarch-core/src/creation/creator.rs
+++ b/crates/exarch-core/src/creation/creator.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 
 use crate::creation::config::CreationConfig;
 use crate::creation::report::CreationReport;
-use crate::error::ExtractionError;
+use crate::error::ArchiveError;
 use crate::error::Result;
 use crate::formats::detect::ArchiveType;
 
@@ -27,7 +27,7 @@ use crate::formats::detect::ArchiveType;
 ///     .create()?;
 ///
 /// println!("Created archive with {} files", report.files_added);
-/// # Ok::<(), exarch_core::ExtractionError>(())
+/// # Ok::<(), exarch_core::ArchiveError>(())
 /// ```
 #[derive(Debug, Default)]
 pub struct ArchiveCreator {
@@ -243,17 +243,17 @@ impl ArchiveCreator {
     ///     .output("backup.tar.gz")
     ///     .add_source("src/")
     ///     .create()?;
-    /// # Ok::<(), exarch_core::ExtractionError>(())
+    /// # Ok::<(), exarch_core::ArchiveError>(())
     /// ```
     pub fn create(self) -> Result<CreationReport> {
-        let output_path =
-            self.output_path
-                .ok_or_else(|| ExtractionError::InvalidConfiguration {
-                    reason: "output path not set".to_string(),
-                })?;
+        let output_path = self
+            .output_path
+            .ok_or_else(|| ArchiveError::InvalidConfiguration {
+                reason: "output path not set".to_string(),
+            })?;
 
         if self.sources.is_empty() {
-            return Err(ExtractionError::InvalidConfiguration {
+            return Err(ArchiveError::InvalidConfiguration {
                 reason: "no source paths provided".to_string(),
             });
         }
@@ -340,7 +340,7 @@ mod tests {
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
-            ExtractionError::InvalidConfiguration { .. }
+            ArchiveError::InvalidConfiguration { .. }
         ));
     }
 
@@ -352,7 +352,7 @@ mod tests {
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
-            ExtractionError::InvalidConfiguration { .. }
+            ArchiveError::InvalidConfiguration { .. }
         ));
     }
 

--- a/crates/exarch-core/src/creation/filters.rs
+++ b/crates/exarch-core/src/creation/filters.rs
@@ -3,7 +3,7 @@
 //! This module provides utilities for filtering files during archive creation
 //! based on patterns, hidden file rules, and size constraints.
 
-use crate::ExtractionError;
+use crate::ArchiveError;
 use crate::Result;
 use crate::creation::config::CreationConfig;
 use std::path::Path;
@@ -170,16 +170,15 @@ pub fn compute_archive_path(
     config: &CreationConfig,
 ) -> Result<PathBuf> {
     // Compute relative path from root
-    let relative =
-        source_path
-            .strip_prefix(root)
-            .map_err(|_| ExtractionError::SecurityViolation {
-                reason: format!(
-                    "path {} is not under root directory: {}",
-                    source_path.display(),
-                    root.display()
-                ),
-            })?;
+    let relative = source_path
+        .strip_prefix(root)
+        .map_err(|_| ArchiveError::SecurityViolation {
+            reason: format!(
+                "path {} is not under root directory: {}",
+                source_path.display(),
+                root.display()
+            ),
+        })?;
 
     // Apply strip_prefix if configured
     if let Some(strip) = &config.strip_prefix

--- a/crates/exarch-core/src/creation/tar.rs
+++ b/crates/exarch-core/src/creation/tar.rs
@@ -85,7 +85,7 @@ use tar::Header;
 ///     &config,
 ///     &mut progress,
 /// )?;
-/// # Ok::<(), exarch_core::ExtractionError>(())
+/// # Ok::<(), exarch_core::ArchiveError>(())
 /// ```
 ///
 /// # Errors
@@ -479,7 +479,7 @@ impl crate::formats::traits::FormatCreator for TarZstCreator {
 #[allow(clippy::unwrap_used)] // Allow unwrap in tests for brevity
 mod tests {
     use super::*;
-    use crate::ExtractionError;
+    use crate::ArchiveError;
     use crate::SecurityConfig;
     use crate::api::create_archive;
     use crate::api::extract_archive;
@@ -738,7 +738,7 @@ mod tests {
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
-            ExtractionError::SourceNotFound { .. }
+            ArchiveError::SourceNotFound { .. }
         ));
     }
 

--- a/crates/exarch-core/src/creation/walker.rs
+++ b/crates/exarch-core/src/creation/walker.rs
@@ -4,7 +4,7 @@
 //! based on configuration options like hidden files, exclude patterns, and size
 //! limits.
 
-use crate::ExtractionError;
+use crate::ArchiveError;
 use crate::Result;
 use crate::creation::config::CreationConfig;
 use crate::creation::filters;
@@ -98,8 +98,8 @@ impl<'a> FilteredWalker<'a> {
                     }
                 }
                 Err(e) => {
-                    // Convert walkdir error to ExtractionError
-                    Some(Err(ExtractionError::Io(std::io::Error::other(format!(
+                    // Convert walkdir error to ArchiveError
+                    Some(Err(ArchiveError::Io(std::io::Error::other(format!(
                         "walkdir error: {e}"
                     )))))
                 }
@@ -114,7 +114,7 @@ impl<'a> FilteredWalker<'a> {
     fn build_filtered_entry(&self, entry: &walkdir::DirEntry) -> Result<Option<FilteredEntry>> {
         let path = entry.path().to_path_buf();
         let metadata = entry.metadata().map_err(|e| {
-            ExtractionError::Io(std::io::Error::other(format!(
+            ArchiveError::Io(std::io::Error::other(format!(
                 "cannot read metadata for {}: {e}",
                 path.display()
             )))
@@ -123,7 +123,7 @@ impl<'a> FilteredWalker<'a> {
         // Determine entry type
         let entry_type = if metadata.is_symlink() {
             let target = std::fs::read_link(&path).map_err(|e| {
-                ExtractionError::Io(std::io::Error::other(format!(
+                ArchiveError::Io(std::io::Error::other(format!(
                     "cannot read symlink target for {}: {e}",
                     path.display()
                 )))
@@ -208,7 +208,7 @@ pub enum EntryType {
 /// let sources = [Path::new("./src")];
 /// let entries = collect_entries(&sources, &config)?;
 /// println!("Total entries: {}", entries.len());
-/// # Ok::<(), exarch_core::ExtractionError>(())
+/// # Ok::<(), exarch_core::ArchiveError>(())
 /// ```
 ///
 /// # Errors
@@ -227,7 +227,7 @@ pub fn collect_entries<P: AsRef<Path>>(
         let path = source.as_ref();
 
         if !path.exists() {
-            return Err(ExtractionError::SourceNotFound {
+            return Err(ArchiveError::SourceNotFound {
                 path: path.to_path_buf(),
             });
         }
@@ -260,7 +260,7 @@ pub fn collect_entries<P: AsRef<Path>>(
             } else {
                 path.file_name()
                     .ok_or_else(|| {
-                        ExtractionError::Io(std::io::Error::other(format!(
+                        ArchiveError::Io(std::io::Error::other(format!(
                             "cannot determine filename for {}",
                             path.display()
                         )))
@@ -615,7 +615,7 @@ mod tests {
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
-            ExtractionError::SourceNotFound { .. }
+            ArchiveError::SourceNotFound { .. }
         ));
     }
 

--- a/crates/exarch-core/src/creation/zip.rs
+++ b/crates/exarch-core/src/creation/zip.rs
@@ -3,7 +3,7 @@
 //! This module provides functions for creating ZIP archives with configurable
 //! compression levels and security options.
 
-use crate::ExtractionError;
+use crate::ArchiveError;
 use crate::ProgressCallback;
 use crate::Result;
 use crate::creation::config::CreationConfig;
@@ -34,7 +34,7 @@ use zip::write::SimpleFileOptions;
 /// let config = CreationConfig::default();
 /// let report = create_zip(Path::new("output.zip"), &[Path::new("src")], &config)?;
 /// println!("Added {} files", report.files_added);
-/// # Ok::<(), exarch_core::ExtractionError>(())
+/// # Ok::<(), exarch_core::ArchiveError>(())
 /// ```
 ///
 /// # Errors
@@ -115,7 +115,7 @@ pub fn create_zip<P: AsRef<Path>, Q: AsRef<Path>>(
 ///     &config,
 ///     &mut progress,
 /// )?;
-/// # Ok::<(), exarch_core::ExtractionError>(())
+/// # Ok::<(), exarch_core::ArchiveError>(())
 /// ```
 ///
 /// # Errors
@@ -243,7 +243,7 @@ fn create_zip_internal<W: Write + Seek, P: AsRef<Path>>(
 
         // Validate source exists
         if !path.exists() {
-            return Err(ExtractionError::SourceNotFound {
+            return Err(ArchiveError::SourceNotFound {
                 path: path.to_path_buf(),
             });
         }
@@ -453,7 +453,7 @@ fn add_file_to_zip_with_progress_and_buffer<W: Write + Seek>(
 fn normalize_zip_path(path: &Path) -> Result<String> {
     // Convert to string
     let path_str = path.to_str().ok_or_else(|| {
-        ExtractionError::Io(std::io::Error::other(format!(
+        ArchiveError::Io(std::io::Error::other(format!(
             "path is not valid UTF-8: {}",
             path.display()
         )))
@@ -778,7 +778,7 @@ mod tests {
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
-            ExtractionError::SourceNotFound { .. }
+            ArchiveError::SourceNotFound { .. }
         ));
     }
 

--- a/crates/exarch-core/src/error/messages.rs
+++ b/crates/exarch-core/src/error/messages.rs
@@ -5,7 +5,7 @@
 
 use std::path::Path;
 
-use super::types::ExtractionError;
+use super::types::ArchiveError;
 
 /// Error message for FFI consumption.
 ///
@@ -23,7 +23,7 @@ pub struct FfiErrorMessage {
     pub context: Option<String>,
 }
 
-impl ExtractionError {
+impl ArchiveError {
     /// Formats error for FFI consumption.
     ///
     /// # Arguments
@@ -35,10 +35,10 @@ impl ExtractionError {
     /// # Examples
     ///
     /// ```
-    /// use exarch_core::ExtractionError;
+    /// use exarch_core::ArchiveError;
     /// use std::path::PathBuf;
     ///
-    /// let error = ExtractionError::PathTraversal {
+    /// let error = ArchiveError::PathTraversal {
     ///     path: PathBuf::from("/etc/passwd"),
     /// };
     ///
@@ -222,7 +222,7 @@ mod tests {
 
     #[test]
     fn test_path_sanitization() {
-        let error = ExtractionError::PathTraversal {
+        let error = ArchiveError::PathTraversal {
             path: PathBuf::from("/etc/passwd"),
         };
 
@@ -240,19 +240,19 @@ mod tests {
     fn test_error_codes_match() {
         let test_cases = vec![
             (
-                ExtractionError::PathTraversal {
+                ArchiveError::PathTraversal {
                     path: PathBuf::from("test"),
                 },
                 "PATH_TRAVERSAL",
             ),
             (
-                ExtractionError::SymlinkEscape {
+                ArchiveError::SymlinkEscape {
                     path: PathBuf::from("test"),
                 },
                 "SYMLINK_ESCAPE",
             ),
             (
-                ExtractionError::ZipBomb {
+                ArchiveError::ZipBomb {
                     compressed: 100,
                     uncompressed: 10000,
                     ratio: 100.0,
@@ -272,49 +272,49 @@ mod tests {
         use super::super::types::QuotaResource;
 
         let errors = vec![
-            ExtractionError::PathTraversal {
+            ArchiveError::PathTraversal {
                 path: PathBuf::from("test"),
             },
-            ExtractionError::SymlinkEscape {
+            ArchiveError::SymlinkEscape {
                 path: PathBuf::from("test"),
             },
-            ExtractionError::HardlinkEscape {
+            ArchiveError::HardlinkEscape {
                 path: PathBuf::from("test"),
             },
-            ExtractionError::ZipBomb {
+            ArchiveError::ZipBomb {
                 compressed: 100,
                 uncompressed: 10000,
                 ratio: 100.0,
             },
-            ExtractionError::QuotaExceeded {
+            ArchiveError::QuotaExceeded {
                 resource: QuotaResource::IntegerOverflow,
             },
-            ExtractionError::SecurityViolation {
+            ArchiveError::SecurityViolation {
                 reason: "test".into(),
             },
-            ExtractionError::UnknownFormat {
+            ArchiveError::UnknownFormat {
                 path: PathBuf::from("test.rar"),
             },
-            ExtractionError::InvalidArchive("test".into()),
-            ExtractionError::Io(std::io::Error::other("test")),
-            ExtractionError::InvalidPermissions {
+            ArchiveError::InvalidArchive("test".into()),
+            ArchiveError::Io(std::io::Error::other("test")),
+            ArchiveError::InvalidPermissions {
                 path: PathBuf::from("test"),
                 mode: 0o777,
             },
-            ExtractionError::SourceNotFound {
+            ArchiveError::SourceNotFound {
                 path: PathBuf::from("test"),
             },
-            ExtractionError::SourceNotAccessible {
+            ArchiveError::SourceNotAccessible {
                 path: PathBuf::from("test"),
             },
-            ExtractionError::OutputExists {
+            ArchiveError::OutputExists {
                 path: PathBuf::from("test"),
             },
-            ExtractionError::InvalidCompressionLevel { level: 10 },
-            ExtractionError::UnknownFormat {
+            ArchiveError::InvalidCompressionLevel { level: 10 },
+            ArchiveError::UnknownFormat {
                 path: PathBuf::from("test"),
             },
-            ExtractionError::InvalidConfiguration {
+            ArchiveError::InvalidConfiguration {
                 reason: "test".into(),
             },
         ];

--- a/crates/exarch-core/src/error/mod.rs
+++ b/crates/exarch-core/src/error/mod.rs
@@ -1,9 +1,9 @@
-//! Error types for archive extraction operations.
+//! Error types for archive operations.
 
 pub mod messages;
 pub mod types;
 
 pub use messages::FfiErrorMessage;
-pub use types::ExtractionError;
+pub use types::ArchiveError;
 pub use types::QuotaResource;
 pub use types::Result;

--- a/crates/exarch-core/src/error/types.rs
+++ b/crates/exarch-core/src/error/types.rs
@@ -1,10 +1,10 @@
-//! Core error types for archive extraction operations.
+//! Core error types for archive operations.
 
 use std::path::PathBuf;
 use thiserror::Error;
 
-/// Result type alias using `ExtractionError`.
-pub type Result<T> = std::result::Result<T, ExtractionError>;
+/// Result type alias using [`ArchiveError`].
+pub type Result<T> = std::result::Result<T, ArchiveError>;
 
 /// Represents a specific quota resource that was exceeded.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -53,9 +53,10 @@ impl std::fmt::Display for QuotaResource {
     }
 }
 
-/// Errors that can occur during archive extraction.
+/// Errors that can occur during archive operations (extraction, creation,
+/// listing, verification).
 #[derive(Error, Debug)]
-pub enum ExtractionError {
+pub enum ArchiveError {
     /// I/O operation failed.
     #[error("I/O error: {0}")]
     Io(std::io::Error),
@@ -174,13 +175,13 @@ pub enum ExtractionError {
     },
 }
 
-impl From<std::io::Error> for ExtractionError {
+impl From<std::io::Error> for ArchiveError {
     fn from(e: std::io::Error) -> Self {
         Self::Io(e)
     }
 }
 
-impl ExtractionError {
+impl ArchiveError {
     /// Returns `true` if this error represents a security violation.
     ///
     /// Security violations include:
@@ -195,15 +196,15 @@ impl ExtractionError {
     /// # Examples
     ///
     /// ```
-    /// use exarch_core::ExtractionError;
+    /// use exarch_core::ArchiveError;
     /// use std::path::PathBuf;
     ///
-    /// let err = ExtractionError::PathTraversal {
+    /// let err = ArchiveError::PathTraversal {
     ///     path: PathBuf::from("../etc/passwd"),
     /// };
     /// assert!(err.is_security_violation());
     ///
-    /// let err = ExtractionError::InvalidArchive("corrupted header".to_string());
+    /// let err = ArchiveError::InvalidArchive("corrupted header".to_string());
     /// assert!(!err.is_security_violation());
     /// ```
     #[must_use]
@@ -232,15 +233,15 @@ impl ExtractionError {
     /// # Examples
     ///
     /// ```
-    /// use exarch_core::ExtractionError;
+    /// use exarch_core::ArchiveError;
     /// use std::path::PathBuf;
     ///
-    /// let err = ExtractionError::PathTraversal {
+    /// let err = ArchiveError::PathTraversal {
     ///     path: PathBuf::from("../etc/passwd"),
     /// };
     /// assert!(err.is_recoverable()); // Could skip this entry
     ///
-    /// let err = ExtractionError::InvalidArchive("corrupted header".to_string());
+    /// let err = ArchiveError::InvalidArchive("corrupted header".to_string());
     /// assert!(!err.is_recoverable()); // Cannot continue
     /// ```
     #[must_use]
@@ -266,13 +267,13 @@ impl ExtractionError {
     /// # Examples
     ///
     /// ```
-    /// use exarch_core::ExtractionError;
+    /// use exarch_core::ArchiveError;
     /// use std::path::PathBuf;
     ///
-    /// let err = ExtractionError::InvalidArchive("bad header".to_string());
+    /// let err = ArchiveError::InvalidArchive("bad header".to_string());
     /// assert_eq!(err.context(), Some("bad header"));
     ///
-    /// let err = ExtractionError::UnknownFormat {
+    /// let err = ArchiveError::UnknownFormat {
     ///     path: PathBuf::from("archive.rar"),
     /// };
     /// assert_eq!(err.context(), None);
@@ -304,7 +305,7 @@ mod tests {
 
     #[test]
     fn test_error_display() {
-        let err = ExtractionError::UnknownFormat {
+        let err = ArchiveError::UnknownFormat {
             path: PathBuf::from("archive.rar"),
         };
         assert_eq!(
@@ -315,7 +316,7 @@ mod tests {
 
     #[test]
     fn test_path_traversal_error() {
-        let err = ExtractionError::PathTraversal {
+        let err = ArchiveError::PathTraversal {
             path: PathBuf::from("../etc/passwd"),
         };
         assert!(err.to_string().contains("path traversal"));
@@ -324,7 +325,7 @@ mod tests {
 
     #[test]
     fn test_zip_bomb_error() {
-        let err = ExtractionError::ZipBomb {
+        let err = ArchiveError::ZipBomb {
             compressed: 1000,
             uncompressed: 1_000_000,
             ratio: 1000.0,
@@ -336,68 +337,68 @@ mod tests {
     #[test]
     fn test_io_error_conversion() {
         let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "file not found");
-        let err: ExtractionError = io_err.into();
-        assert!(matches!(err, ExtractionError::Io(_)));
+        let err: ArchiveError = io_err.into();
+        assert!(matches!(err, ArchiveError::Io(_)));
     }
 
     #[test]
     fn test_is_security_violation() {
         // Security violations
-        let err = ExtractionError::PathTraversal {
+        let err = ArchiveError::PathTraversal {
             path: PathBuf::from("../etc/passwd"),
         };
         assert!(err.is_security_violation());
 
-        let err = ExtractionError::SymlinkEscape {
+        let err = ArchiveError::SymlinkEscape {
             path: PathBuf::from("link"),
         };
         assert!(err.is_security_violation());
 
-        let err = ExtractionError::ZipBomb {
+        let err = ArchiveError::ZipBomb {
             compressed: 1000,
             uncompressed: 1_000_000,
             ratio: 1000.0,
         };
         assert!(err.is_security_violation());
 
-        let err = ExtractionError::SecurityViolation {
+        let err = ArchiveError::SecurityViolation {
             reason: "test".into(),
         };
         assert!(err.is_security_violation());
 
         // Not security violations
-        let err = ExtractionError::UnknownFormat {
+        let err = ArchiveError::UnknownFormat {
             path: PathBuf::from("archive.rar"),
         };
         assert!(!err.is_security_violation());
 
-        let err = ExtractionError::InvalidArchive("bad".into());
+        let err = ArchiveError::InvalidArchive("bad".into());
         assert!(!err.is_security_violation());
     }
 
     #[test]
     fn test_is_recoverable() {
         // Recoverable errors
-        let err = ExtractionError::PathTraversal {
+        let err = ArchiveError::PathTraversal {
             path: PathBuf::from("../etc/passwd"),
         };
         assert!(err.is_recoverable());
 
-        let err = ExtractionError::SecurityViolation {
+        let err = ArchiveError::SecurityViolation {
             reason: "test".into(),
         };
         assert!(err.is_recoverable());
 
         // Non-recoverable errors
-        let err = ExtractionError::InvalidArchive("corrupted".into());
+        let err = ArchiveError::InvalidArchive("corrupted".into());
         assert!(!err.is_recoverable());
 
-        let err = ExtractionError::UnknownFormat {
+        let err = ArchiveError::UnknownFormat {
             path: PathBuf::from("archive.rar"),
         };
         assert!(!err.is_recoverable());
 
-        let err = ExtractionError::ZipBomb {
+        let err = ArchiveError::ZipBomb {
             compressed: 1000,
             uncompressed: 1_000_000,
             ratio: 1000.0,
@@ -407,20 +408,20 @@ mod tests {
 
     #[test]
     fn test_context() {
-        let err = ExtractionError::InvalidArchive("bad header".into());
+        let err = ArchiveError::InvalidArchive("bad header".into());
         assert_eq!(err.context(), Some("bad header"));
 
-        let err = ExtractionError::SecurityViolation {
+        let err = ArchiveError::SecurityViolation {
             reason: "not allowed".into(),
         };
         assert_eq!(err.context(), Some("not allowed"));
 
-        let err = ExtractionError::UnknownFormat {
+        let err = ArchiveError::UnknownFormat {
             path: PathBuf::from("archive.rar"),
         };
         assert_eq!(err.context(), None);
 
-        let err = ExtractionError::PathTraversal {
+        let err = ArchiveError::PathTraversal {
             path: PathBuf::from("../etc/passwd"),
         };
         assert_eq!(err.context(), None);
@@ -428,7 +429,7 @@ mod tests {
 
     #[test]
     fn test_symlink_escape_error() {
-        let err = ExtractionError::SymlinkEscape {
+        let err = ArchiveError::SymlinkEscape {
             path: PathBuf::from("malicious/link"),
         };
         let display = err.to_string();
@@ -439,7 +440,7 @@ mod tests {
 
     #[test]
     fn test_hardlink_escape_error() {
-        let err = ExtractionError::HardlinkEscape {
+        let err = ArchiveError::HardlinkEscape {
             path: PathBuf::from("malicious/hardlink"),
         };
         let display = err.to_string();
@@ -450,7 +451,7 @@ mod tests {
 
     #[test]
     fn test_invalid_permissions_error() {
-        let err = ExtractionError::InvalidPermissions {
+        let err = ArchiveError::InvalidPermissions {
             path: PathBuf::from("file.txt"),
             mode: 0o777,
         };
@@ -463,7 +464,7 @@ mod tests {
 
     #[test]
     fn test_quota_exceeded_error() {
-        let err = ExtractionError::QuotaExceeded {
+        let err = ArchiveError::QuotaExceeded {
             resource: QuotaResource::FileCount {
                 current: 11,
                 max: 10,
@@ -494,26 +495,26 @@ mod tests {
         use std::error::Error;
 
         let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "inner error");
-        let err: ExtractionError = io_err.into();
+        let err: ArchiveError = io_err.into();
 
         // Verify source chain works
-        if let ExtractionError::Io(ref inner) = err {
+        if let ArchiveError::Io(ref inner) = err {
             // IO error may or may not have a source
             let _source = inner.source();
         }
     }
 
-    // Regression test for #177: ExtractionError::Io must not expose the inner
+    // Regression test for #177: ArchiveError::Io must not expose the inner
     // std::io::Error as an error source. The manual From impl intentionally omits
     // #[source] so callers building error chains (anyhow, thiserror) do not append
-    // the OS message a second time after ExtractionError::Io's own Display.
+    // the OS message a second time after ArchiveError::Io's own Display.
     #[test]
     fn test_io_error_no_source_chain() {
         use std::error::Error;
 
         let os_message = "permission denied";
         let io_err = std::io::Error::new(std::io::ErrorKind::PermissionDenied, os_message);
-        let err: ExtractionError = io_err.into();
+        let err: ArchiveError = io_err.into();
 
         // Display must contain the OS message exactly once.
         let display = err.to_string();
@@ -527,7 +528,7 @@ mod tests {
         // message.
         assert!(
             err.source().is_none(),
-            "ExtractionError::Io must not expose inner io::Error as source"
+            "ArchiveError::Io must not expose inner io::Error as source"
         );
     }
 
@@ -535,7 +536,7 @@ mod tests {
     #[test]
     fn test_zip_bomb_edge_cases() {
         // Zero compressed size (would cause division by zero in ratio calc)
-        let err = ExtractionError::ZipBomb {
+        let err = ArchiveError::ZipBomb {
             compressed: 0,
             uncompressed: 1000,
             ratio: f64::INFINITY,
@@ -545,7 +546,7 @@ mod tests {
         assert!(display.contains("zip bomb"));
 
         // Equal sizes (ratio = 1.0)
-        let err = ExtractionError::ZipBomb {
+        let err = ArchiveError::ZipBomb {
             compressed: 1000,
             uncompressed: 1000,
             ratio: 1.0,
@@ -556,7 +557,7 @@ mod tests {
 
     #[test]
     fn test_source_not_found_error() {
-        let err = ExtractionError::SourceNotFound {
+        let err = ArchiveError::SourceNotFound {
             path: PathBuf::from("/nonexistent/path"),
         };
         let display = err.to_string();
@@ -567,7 +568,7 @@ mod tests {
 
     #[test]
     fn test_source_not_accessible_error() {
-        let err = ExtractionError::SourceNotAccessible {
+        let err = ArchiveError::SourceNotAccessible {
             path: PathBuf::from("/restricted/path"),
         };
         let display = err.to_string();
@@ -578,7 +579,7 @@ mod tests {
 
     #[test]
     fn test_output_exists_error() {
-        let err = ExtractionError::OutputExists {
+        let err = ArchiveError::OutputExists {
             path: PathBuf::from("output.tar.gz"),
         };
         let display = err.to_string();
@@ -589,21 +590,21 @@ mod tests {
 
     #[test]
     fn test_invalid_compression_level_error() {
-        let err = ExtractionError::InvalidCompressionLevel { level: 0 };
+        let err = ArchiveError::InvalidCompressionLevel { level: 0 };
         let display = err.to_string();
         assert!(display.contains("invalid compression level"));
         assert!(display.contains('0'));
         assert!(display.contains("must be 1-9"));
         assert!(!err.is_security_violation());
 
-        let err = ExtractionError::InvalidCompressionLevel { level: 10 };
+        let err = ArchiveError::InvalidCompressionLevel { level: 10 };
         let display = err.to_string();
         assert!(display.contains("10"));
     }
 
     #[test]
     fn test_unknown_format_error() {
-        let err = ExtractionError::UnknownFormat {
+        let err = ArchiveError::UnknownFormat {
             path: PathBuf::from("archive.rar"),
         };
         let display = err.to_string();
@@ -614,7 +615,7 @@ mod tests {
 
     #[test]
     fn test_invalid_configuration_error() {
-        let err = ExtractionError::InvalidConfiguration {
+        let err = ArchiveError::InvalidConfiguration {
             reason: "output path not set".to_string(),
         };
         let display = err.to_string();
@@ -626,13 +627,13 @@ mod tests {
     #[test]
     fn test_partial_extraction_display_shows_source() {
         use crate::ExtractionReport;
-        let source = ExtractionError::QuotaExceeded {
+        let source = ArchiveError::QuotaExceeded {
             resource: QuotaResource::FileCount {
                 current: 11,
                 max: 10,
             },
         };
-        let err = ExtractionError::PartialExtraction {
+        let err = ArchiveError::PartialExtraction {
             source: Box::new(source),
             report: ExtractionReport::new(),
         };
@@ -643,17 +644,17 @@ mod tests {
     #[test]
     fn test_partial_extraction_delegates_is_security_violation() {
         use crate::ExtractionReport;
-        let security_err = ExtractionError::PathTraversal {
+        let security_err = ArchiveError::PathTraversal {
             path: PathBuf::from("../etc/passwd"),
         };
-        let err = ExtractionError::PartialExtraction {
+        let err = ArchiveError::PartialExtraction {
             source: Box::new(security_err),
             report: ExtractionReport::new(),
         };
         assert!(err.is_security_violation());
 
-        let non_security_err = ExtractionError::InvalidArchive("bad".into());
-        let err2 = ExtractionError::PartialExtraction {
+        let non_security_err = ArchiveError::InvalidArchive("bad".into());
+        let err2 = ArchiveError::PartialExtraction {
             source: Box::new(non_security_err),
             report: ExtractionReport::new(),
         };
@@ -663,10 +664,10 @@ mod tests {
     #[test]
     fn test_partial_extraction_delegates_is_recoverable() {
         use crate::ExtractionReport;
-        let recoverable = ExtractionError::PathTraversal {
+        let recoverable = ArchiveError::PathTraversal {
             path: PathBuf::from("../etc/passwd"),
         };
-        let err = ExtractionError::PartialExtraction {
+        let err = ArchiveError::PartialExtraction {
             source: Box::new(recoverable),
             report: ExtractionReport::new(),
         };
@@ -676,12 +677,12 @@ mod tests {
     #[test]
     fn test_partial_extraction_delegates_error_code() {
         use crate::ExtractionReport;
-        let source = ExtractionError::ZipBomb {
+        let source = ArchiveError::ZipBomb {
             compressed: 100,
             uncompressed: 100_000,
             ratio: 1000.0,
         };
-        let err = ExtractionError::PartialExtraction {
+        let err = ArchiveError::PartialExtraction {
             source: Box::new(source),
             report: ExtractionReport::new(),
         };

--- a/crates/exarch-core/src/formats/common.rs
+++ b/crates/exarch-core/src/formats/common.rs
@@ -19,7 +19,7 @@ use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
 
-use crate::ExtractionError;
+use crate::ArchiveError;
 use crate::ExtractionReport;
 use crate::Result;
 use crate::copy::CopyBuffer;
@@ -407,7 +407,7 @@ pub fn extract_file_generic<R: Read>(
         report
             .bytes_written
             .checked_add(size)
-            .ok_or(ExtractionError::QuotaExceeded {
+            .ok_or(ArchiveError::QuotaExceeded {
                 resource: QuotaResource::IntegerOverflow,
             })?;
     }
@@ -424,7 +424,7 @@ pub fn extract_file_generic<R: Read>(
         report
             .bytes_written
             .checked_add(bytes_written)
-            .ok_or(ExtractionError::QuotaExceeded {
+            .ok_or(ArchiveError::QuotaExceeded {
                 resource: QuotaResource::IntegerOverflow,
             })?;
 
@@ -543,7 +543,7 @@ pub fn create_symlink(
 
     #[cfg(not(unix))]
     {
-        Err(ExtractionError::SecurityViolation {
+        Err(ArchiveError::SecurityViolation {
             reason: "symlinks are not supported on this platform".into(),
         })
     }
@@ -553,7 +553,7 @@ pub fn create_symlink(
 #[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use crate::ExtractionError;
+    use crate::ArchiveError;
     use crate::ExtractionReport;
     use crate::SecurityConfig;
     use crate::copy::CopyBuffer;
@@ -603,7 +603,7 @@ mod tests {
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
-            ExtractionError::QuotaExceeded {
+            ArchiveError::QuotaExceeded {
                 resource: QuotaResource::IntegerOverflow
             }
         ));

--- a/crates/exarch-core/src/formats/detect.rs
+++ b/crates/exarch-core/src/formats/detect.rs
@@ -2,7 +2,7 @@
 
 use std::path::Path;
 
-use crate::ExtractionError;
+use crate::ArchiveError;
 use crate::Result;
 
 /// File extensions that wrap a ZIP container with extra structure.
@@ -48,18 +48,19 @@ pub enum ArchiveType {
 ///
 /// `.gz` files are only accepted when the stem ends with `.tar`
 /// (i.e. `archive.tar.gz`). A bare `archive.gz` returns
-/// [`ExtractionError::UnknownFormat`].
+/// [`ArchiveError::UnknownFormat`].
 ///
 /// # Errors
 ///
-/// Returns [`ExtractionError::UnknownFormat`] if the extension is
+/// Returns [`ArchiveError::UnknownFormat`] if the extension is
 /// unrecognised or if a `.gz` file has no `.tar` stem.
 pub fn detect_format(path: &Path) -> Result<ArchiveType> {
-    let extension = path.extension().and_then(|e| e.to_str()).ok_or_else(|| {
-        ExtractionError::UnknownFormat {
-            path: path.to_path_buf(),
-        }
-    })?;
+    let extension =
+        path.extension()
+            .and_then(|e| e.to_str())
+            .ok_or_else(|| ArchiveError::UnknownFormat {
+                path: path.to_path_buf(),
+            })?;
 
     let ext_lower = extension.to_ascii_lowercase();
     match ext_lower.as_str() {
@@ -71,7 +72,7 @@ pub fn detect_format(path: &Path) -> Result<ArchiveType> {
             {
                 Ok(ArchiveType::TarGz)
             } else {
-                Err(ExtractionError::UnknownFormat {
+                Err(ArchiveError::UnknownFormat {
                     path: path.to_path_buf(),
                 })
             }
@@ -85,7 +86,7 @@ pub fn detect_format(path: &Path) -> Result<ArchiveType> {
         // extensions, EPUBs - all ZIP under the hood, so they extract
         // through the same path. See `ZIP_FAMILY_ALIASES` for the list.
         ext if is_zip_family_alias(ext) => Ok(ArchiveType::Zip),
-        _ => Err(ExtractionError::UnknownFormat {
+        _ => Err(ArchiveError::UnknownFormat {
             path: path.to_path_buf(),
         }),
     }
@@ -117,7 +118,7 @@ mod tests {
         let path = PathBuf::from("archive.gz");
         assert!(matches!(
             detect_format(&path),
-            Err(ExtractionError::UnknownFormat { .. })
+            Err(ArchiveError::UnknownFormat { .. })
         ));
     }
 
@@ -127,7 +128,7 @@ mod tests {
         let err = detect_format(&path).unwrap_err();
         assert!(matches!(
             err,
-            ExtractionError::UnknownFormat { path: ref p } if p == &PathBuf::from("archive.gz")
+            ArchiveError::UnknownFormat { path: ref p } if p == &PathBuf::from("archive.gz")
         ));
     }
 
@@ -210,7 +211,7 @@ mod tests {
         let path = PathBuf::from("archive.rar");
         assert!(matches!(
             detect_format(&path),
-            Err(ExtractionError::UnknownFormat { .. })
+            Err(ArchiveError::UnknownFormat { .. })
         ));
     }
 
@@ -220,7 +221,7 @@ mod tests {
         let err = detect_format(&path).unwrap_err();
         assert!(matches!(
             err,
-            ExtractionError::UnknownFormat { path: ref p } if p == &PathBuf::from("archive.rar")
+            ArchiveError::UnknownFormat { path: ref p } if p == &PathBuf::from("archive.rar")
         ));
     }
 

--- a/crates/exarch-core/src/formats/sevenz.rs
+++ b/crates/exarch-core/src/formats/sevenz.rs
@@ -63,7 +63,7 @@
 //! use std::fs::File;
 //! use std::path::Path;
 //!
-//! # fn main() -> Result<(), exarch_core::ExtractionError> {
+//! # fn main() -> Result<(), exarch_core::ArchiveError> {
 //! let file = File::open("archive.7z")?;
 //! let mut archive = SevenZArchive::new(file)?;
 //! let report = archive.extract(
@@ -104,7 +104,7 @@ use sevenz_rust2::Password;
 // Atomic counter for generating unique temporary file names
 static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
-use crate::ExtractionError;
+use crate::ArchiveError;
 use crate::ExtractionOptions;
 use crate::ExtractionReport;
 use crate::ProgressCallback;
@@ -196,7 +196,7 @@ struct CachedEntry {
 ///     &mut exarch_core::NoopProgress,
 /// )?;
 /// println!("Extracted {} files", report.files_extracted);
-/// # Ok::<(), exarch_core::ExtractionError>(())
+/// # Ok::<(), exarch_core::ArchiveError>(())
 /// ```
 #[derive(Debug)]
 pub struct SevenZArchive<R: Read + Seek> {
@@ -229,7 +229,7 @@ impl<R: Read + Seek> SevenZArchive<R> {
     ///
     /// let file = File::open("archive.7z")?;
     /// let archive = SevenZArchive::new(file)?;
-    /// # Ok::<(), exarch_core::ExtractionError>(())
+    /// # Ok::<(), exarch_core::ArchiveError>(())
     /// ```
     pub fn new(mut source: R) -> Result<Self> {
         // Step 1: Verify it's a valid 7z archive by reading metadata
@@ -240,7 +240,7 @@ impl<R: Read + Seek> SevenZArchive<R> {
                 // SECURITY: Check if error indicates encryption
                 let err_str = e.to_string().to_lowercase();
                 if err_str.contains("encrypt") || err_str.contains("password") {
-                    return Err(ExtractionError::SecurityViolation {
+                    return Err(ArchiveError::SecurityViolation {
                         reason: "encrypted 7z archive detected. Password-protected archives are not supported. \
                                  Decrypt the archive externally and try again.".into(),
                     });
@@ -255,7 +255,7 @@ impl<R: Read + Seek> SevenZArchive<R> {
                         is_solid: false,
                     });
                 }
-                return Err(ExtractionError::InvalidArchive(format!(
+                return Err(ArchiveError::InvalidArchive(format!(
                     "failed to open 7z archive: {e}"
                 )));
             }
@@ -277,7 +277,7 @@ impl<R: Read + Seek> SevenZArchive<R> {
             .collect();
 
         // Step 4: Rewind for actual extraction
-        source.rewind().map_err(ExtractionError::Io)?;
+        source.rewind().map_err(ArchiveError::Io)?;
 
         Ok(Self {
             source,
@@ -444,10 +444,10 @@ impl<R: Read + Seek> SevenZArchive<R> {
 
         let e = match result {
             Ok(()) => return Ok(accumulated),
-            Err(e) => ExtractionError::from(e),
+            Err(e) => ArchiveError::from(e),
         };
         if accumulated.total_items() > 0 {
-            Err(ExtractionError::PartialExtraction {
+            Err(ArchiveError::PartialExtraction {
                 source: Box::new(e),
                 report: accumulated,
             })
@@ -468,7 +468,7 @@ impl<R: Read + Seek> ArchiveFormat for SevenZArchive<R> {
         // Step 0: Validate solid archive policy
         if self.is_solid {
             if !config.allow_solid_archives {
-                return Err(ExtractionError::SecurityViolation {
+                return Err(ArchiveError::SecurityViolation {
                     reason: "solid 7z archives are not allowed (enable allow_solid_archives)"
                         .into(),
                 });
@@ -482,14 +482,14 @@ impl<R: Read + Seek> ArchiveFormat for SevenZArchive<R> {
                 .entries
                 .iter()
                 .try_fold(0u64, |acc, e| acc.checked_add(e.size))
-                .ok_or(ExtractionError::QuotaExceeded {
+                .ok_or(ArchiveError::QuotaExceeded {
                     resource: QuotaResource::TotalSize {
                         current: u64::MAX,
                         max: config.max_solid_block_memory,
                     },
                 })?;
             if total_uncompressed > config.max_solid_block_memory {
-                return Err(ExtractionError::QuotaExceeded {
+                return Err(ArchiveError::QuotaExceeded {
                     resource: QuotaResource::TotalSize {
                         current: total_uncompressed,
                         max: config.max_solid_block_memory,
@@ -534,7 +534,7 @@ impl<R: Read + Seek> ArchiveFormat for SevenZArchive<R> {
                 _ => {
                     // KNOWN LIMITATION: sevenz-rust2 doesn't expose symlink/hardlink detection.
                     // If entry type detection improves, this will catch them.
-                    return Err(ExtractionError::SecurityViolation {
+                    return Err(ArchiveError::SecurityViolation {
                         reason: "symlinks/hardlinks not yet supported for 7z".into(),
                     });
                 }
@@ -570,7 +570,7 @@ impl<R: Read + Seek> ArchiveFormat for SevenZArchive<R> {
 
     fn list(&mut self, config: &SecurityConfig) -> Result<crate::inspection::ArchiveManifest> {
         use crate::inspection::list::list_sevenz_reader;
-        self.source.rewind().map_err(ExtractionError::Io)?;
+        self.source.rewind().map_err(ArchiveError::Io)?;
         list_sevenz_reader(&mut self.source, config)
     }
 
@@ -644,7 +644,7 @@ impl SevenZEntryAdapter {
         // SECURITY: Check Windows attributes for reparse points FIRST
         // This applies to BOTH files AND directories (e.g., directory junctions)
         if Self::is_windows_reparse_point(entry) {
-            return Err(ExtractionError::SecurityViolation {
+            return Err(ArchiveError::SecurityViolation {
                 reason: format!(
                     "symlink detected in 7z archive: {} \
                      (Windows reparse point attribute set). \
@@ -715,8 +715,8 @@ fn is_empty_sevenz_archive<R: Read + Seek>(err: &sevenz_rust2::Error, source: &m
     source.read_exact(&mut magic).is_ok() && magic == SEVENZ_MAGIC
 }
 
-/// Converts sevenz-rust2 errors to our `ExtractionError` type.
-impl From<sevenz_rust2::Error> for ExtractionError {
+/// Converts sevenz-rust2 errors to our `ArchiveError` type.
+impl From<sevenz_rust2::Error> for ArchiveError {
     fn from(err: sevenz_rust2::Error) -> Self {
         let err_str = err.to_string();
         let err_lower = err_str.to_lowercase();
@@ -783,7 +783,7 @@ mod tests {
         assert!(result.is_err(), "invalid archive should fail to parse");
 
         // Verify the error is InvalidArchive (not security violation)
-        assert!(matches!(result, Err(ExtractionError::InvalidArchive(_))));
+        assert!(matches!(result, Err(ArchiveError::InvalidArchive(_))));
     }
 
     /// Test that invalid magic bytes are rejected.
@@ -794,7 +794,7 @@ mod tests {
 
         let result = SevenZArchive::new(cursor);
         assert!(result.is_err());
-        assert!(matches!(result, Err(ExtractionError::InvalidArchive(_))));
+        assert!(matches!(result, Err(ArchiveError::InvalidArchive(_))));
     }
 
     #[test]
@@ -874,7 +874,7 @@ mod tests {
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
-            ExtractionError::SecurityViolation { .. }
+            ArchiveError::SecurityViolation { .. }
         ));
     }
 
@@ -888,7 +888,7 @@ mod tests {
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
-            ExtractionError::SecurityViolation { .. }
+            ArchiveError::SecurityViolation { .. }
         ));
     }
 
@@ -956,7 +956,7 @@ mod tests {
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
-            ExtractionError::QuotaExceeded { .. }
+            ArchiveError::QuotaExceeded { .. }
         ));
     }
 
@@ -1050,7 +1050,7 @@ mod tests {
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
-            ExtractionError::SecurityViolation { .. }
+            ArchiveError::SecurityViolation { .. }
         ));
     }
 
@@ -1077,7 +1077,7 @@ mod tests {
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
-            ExtractionError::QuotaExceeded { .. }
+            ArchiveError::QuotaExceeded { .. }
         ));
     }
 
@@ -1185,7 +1185,7 @@ mod tests {
         assert!(result.is_err(), "one byte under limit should reject");
         assert!(matches!(
             result.unwrap_err(),
-            ExtractionError::QuotaExceeded { .. }
+            ArchiveError::QuotaExceeded { .. }
         ));
     }
 
@@ -1206,7 +1206,7 @@ mod tests {
 
         assert!(result.is_err());
         match result.unwrap_err() {
-            ExtractionError::SecurityViolation { reason } => {
+            ArchiveError::SecurityViolation { reason } => {
                 assert!(
                     reason.contains("solid") && reason.contains("allow_solid_archives"),
                     "error should mention 'solid' and 'allow_solid_archives', got: {reason}"
@@ -1235,10 +1235,7 @@ mod tests {
         let result = SevenZEntryAdapter::to_entry_type(&entry);
         assert!(result.is_err(), "should return error for reparse point");
         assert!(
-            matches!(
-                result.unwrap_err(),
-                ExtractionError::SecurityViolation { .. }
-            ),
+            matches!(result.unwrap_err(), ArchiveError::SecurityViolation { .. }),
             "should be SecurityViolation error"
         );
     }
@@ -1307,7 +1304,7 @@ mod tests {
         assert!(result.is_err(), "directory junction should be rejected");
         assert!(matches!(
             result.unwrap_err(),
-            ExtractionError::SecurityViolation { .. }
+            ArchiveError::SecurityViolation { .. }
         ));
     }
 
@@ -1322,7 +1319,7 @@ mod tests {
         assert!(result.is_err());
 
         match result.unwrap_err() {
-            ExtractionError::SecurityViolation { reason } => {
+            ArchiveError::SecurityViolation { reason } => {
                 assert!(
                     reason.contains("symlink") && reason.contains("link.txt"),
                     "error should mention 'symlink' and entry name, got: {reason}"

--- a/crates/exarch-core/src/formats/tar.rs
+++ b/crates/exarch-core/src/formats/tar.rs
@@ -78,7 +78,7 @@
 //!     &mut exarch_core::NoopProgress,
 //! )?;
 //! println!("Extracted {} files", report.files_extracted);
-//! # Ok::<(), exarch_core::ExtractionError>(())
+//! # Ok::<(), exarch_core::ArchiveError>(())
 //! ```
 //!
 //! Gzip-compressed TAR:
@@ -101,7 +101,7 @@
 //!     &ExtractionOptions::default(),
 //!     &mut exarch_core::NoopProgress,
 //! )?;
-//! # Ok::<(), exarch_core::ExtractionError>(())
+//! # Ok::<(), exarch_core::ArchiveError>(())
 //! ```
 
 use std::fs::File;
@@ -113,7 +113,7 @@ use std::time::Instant;
 use smallvec::SmallVec;
 use tar::Archive;
 
-use crate::ExtractionError;
+use crate::ArchiveError;
 use crate::ExtractionOptions;
 use crate::ExtractionReport;
 use crate::ProgressCallback;
@@ -158,7 +158,7 @@ use super::traits::ArchiveFormat;
 ///     &ExtractionOptions::default(),
 ///     &mut exarch_core::NoopProgress,
 /// )?;
-/// # Ok::<(), exarch_core::ExtractionError>(())
+/// # Ok::<(), exarch_core::ArchiveError>(())
 /// ```
 pub struct TarArchive<R: Read> {
     /// Underlying `tar::Archive` reader; `None` after `list()` consumes it.
@@ -209,7 +209,7 @@ impl<R: Read> TarArchive<R> {
 
         let path = entry
             .path()
-            .map_err(|e| ExtractionError::InvalidArchive(format!("invalid path: {e}")))?
+            .map_err(|e| ArchiveError::InvalidArchive(format!("invalid path: {e}")))?
             .into_owned();
 
         let entry_type = TarEntryAdapter::to_entry_type(&entry)?;
@@ -299,7 +299,7 @@ impl<R: Read> TarArchive<R> {
         let target_path = ctx.dest.join(&info.target_path);
 
         if !target_path.exists() {
-            return Err(ExtractionError::InvalidArchive(format!(
+            return Err(ArchiveError::InvalidArchive(format!(
                 "hardlink target does not exist: {}",
                 info.target_path.as_path().display()
             )));
@@ -317,7 +317,7 @@ impl<R: Read> TarArchive<R> {
                 ));
                 return Ok(());
             }
-            return Err(ExtractionError::InvalidArchive(format!(
+            return Err(ArchiveError::InvalidArchive(format!(
                 "duplicate entry: {}",
                 info.link_path.as_path().display()
             )));
@@ -339,7 +339,7 @@ impl<R: Read> ArchiveFormat for TarArchive<R> {
     ///
     /// # Errors
     ///
-    /// Returns [`ExtractionError::InvalidArchive`] if [`list`](Self::list) was
+    /// Returns [`ArchiveError::InvalidArchive`] if [`list`](Self::list) was
     /// called on this instance before `extract`. Because TAR is a forward-only
     /// stream, `list` consumes the internal reader; calling `extract` afterward
     /// is not possible. Open a fresh [`TarArchive`] instance instead.
@@ -368,11 +368,11 @@ impl<R: Read> ArchiveFormat for TarArchive<R> {
         let mut current_entry: usize = 0;
 
         let inner = self.inner.as_mut().ok_or_else(|| {
-            ExtractionError::InvalidArchive("archive reader already consumed by list()".into())
+            ArchiveError::InvalidArchive("archive reader already consumed by list()".into())
         })?;
         let entries = inner
             .entries()
-            .map_err(|e| ExtractionError::InvalidArchive(format!("failed to read entries: {e}")))?;
+            .map_err(|e| ArchiveError::InvalidArchive(format!("failed to read entries: {e}")))?;
 
         let mut ctx = ExtractionContext {
             validator: &mut validator,
@@ -386,9 +386,9 @@ impl<R: Read> ArchiveFormat for TarArchive<R> {
 
         for entry_result in entries {
             let entry = entry_result.map_err(|e| {
-                let raw = ExtractionError::InvalidArchive(format!("failed to read entry: {e}"));
+                let raw = ArchiveError::InvalidArchive(format!("failed to read entry: {e}"));
                 if ctx.report.total_items() > 0 {
-                    ExtractionError::PartialExtraction {
+                    ArchiveError::PartialExtraction {
                         source: Box::new(raw),
                         report: std::mem::take(ctx.report),
                     }
@@ -416,7 +416,7 @@ impl<R: Read> ArchiveFormat for TarArchive<R> {
                 }
                 Err(e) => {
                     return Err(if ctx.report.total_items() > 0 {
-                        ExtractionError::PartialExtraction {
+                        ArchiveError::PartialExtraction {
                             source: Box::new(e),
                             report: std::mem::take(ctx.report),
                         }
@@ -431,7 +431,7 @@ impl<R: Read> ArchiveFormat for TarArchive<R> {
         for hardlink_info in &hardlinks {
             if let Err(e) = Self::create_hardlink(hardlink_info, &mut ctx) {
                 return Err(if ctx.report.total_items() > 0 {
-                    ExtractionError::PartialExtraction {
+                    ArchiveError::PartialExtraction {
                         source: Box::new(e),
                         report: std::mem::take(ctx.report),
                     }
@@ -454,7 +454,7 @@ impl<R: Read> ArchiveFormat for TarArchive<R> {
     /// TAR is a forward-only stream format. This method consumes the internal
     /// reader via `self.inner.take()`. After `list()` returns, the reader is
     /// gone and any subsequent call to [`extract`](Self::extract) on **the same
-    /// instance** will return `Err(ExtractionError::InvalidArchive(...))`.
+    /// instance** will return `Err(ArchiveError::InvalidArchive(...))`.
     ///
     /// To extract after listing, open a **new** [`TarArchive`] from the
     /// original source:
@@ -474,9 +474,7 @@ impl<R: Read> ArchiveFormat for TarArchive<R> {
         // Consume the inner archive — TAR readers are forward-only streams.
         // After list() returns, extract() will return an error if called.
         let inner = self.inner.take().ok_or_else(|| {
-            crate::ExtractionError::InvalidArchive(
-                "archive reader already consumed by list()".into(),
-            )
+            crate::ArchiveError::InvalidArchive("archive reader already consumed by list()".into())
         })?;
         list_tar_reader(inner.into_inner(), ArchiveType::Tar, config)
     }
@@ -540,11 +538,9 @@ impl TarEntryAdapter {
                 let target = tar_entry
                     .link_name()
                     .map_err(|e| {
-                        ExtractionError::InvalidArchive(format!("failed to read symlink name: {e}"))
+                        ArchiveError::InvalidArchive(format!("failed to read symlink name: {e}"))
                     })?
-                    .ok_or_else(|| {
-                        ExtractionError::InvalidArchive("symlink missing target".into())
-                    })?
+                    .ok_or_else(|| ArchiveError::InvalidArchive("symlink missing target".into()))?
                     .into_owned();
                 Ok(EntryType::Symlink { target })
             }
@@ -553,30 +549,26 @@ impl TarEntryAdapter {
                 let target = tar_entry
                     .link_name()
                     .map_err(|e| {
-                        ExtractionError::InvalidArchive(format!(
-                            "failed to read hardlink name: {e}"
-                        ))
+                        ArchiveError::InvalidArchive(format!("failed to read hardlink name: {e}"))
                     })?
-                    .ok_or_else(|| {
-                        ExtractionError::InvalidArchive("hardlink missing target".into())
-                    })?
+                    .ok_or_else(|| ArchiveError::InvalidArchive("hardlink missing target".into()))?
                     .into_owned();
                 Ok(EntryType::Hardlink { target })
             }
 
-            TarType::Char => Err(ExtractionError::SecurityViolation {
+            TarType::Char => Err(ArchiveError::SecurityViolation {
                 reason: "character device entries not supported".into(),
             }),
 
-            TarType::Block => Err(ExtractionError::SecurityViolation {
+            TarType::Block => Err(ArchiveError::SecurityViolation {
                 reason: "block device entries not supported".into(),
             }),
 
-            TarType::Fifo => Err(ExtractionError::SecurityViolation {
+            TarType::Fifo => Err(ArchiveError::SecurityViolation {
                 reason: "FIFO entries not supported".into(),
             }),
 
-            _ => Err(ExtractionError::SecurityViolation {
+            _ => Err(ArchiveError::SecurityViolation {
                 reason: format!(
                     "unsupported entry type: {:?}",
                     tar_entry.header().entry_type()
@@ -616,7 +608,7 @@ impl TarEntryAdapter {
 ///     &ExtractionOptions::default(),
 ///     &mut exarch_core::NoopProgress,
 /// )?;
-/// # Ok::<(), exarch_core::ExtractionError>(())
+/// # Ok::<(), exarch_core::ArchiveError>(())
 /// ```
 pub fn open_tar_gz<P: AsRef<Path>>(
     path: P,
@@ -652,7 +644,7 @@ pub fn open_tar_gz<P: AsRef<Path>>(
 ///     &ExtractionOptions::default(),
 ///     &mut exarch_core::NoopProgress,
 /// )?;
-/// # Ok::<(), exarch_core::ExtractionError>(())
+/// # Ok::<(), exarch_core::ArchiveError>(())
 /// ```
 pub fn open_tar_bz2<P: AsRef<Path>>(
     path: P,
@@ -688,7 +680,7 @@ pub fn open_tar_bz2<P: AsRef<Path>>(
 ///     &ExtractionOptions::default(),
 ///     &mut exarch_core::NoopProgress,
 /// )?;
-/// # Ok::<(), exarch_core::ExtractionError>(())
+/// # Ok::<(), exarch_core::ArchiveError>(())
 /// ```
 pub fn open_tar_xz<P: AsRef<Path>>(
     path: P,
@@ -725,7 +717,7 @@ pub fn open_tar_xz<P: AsRef<Path>>(
 ///     &ExtractionOptions::default(),
 ///     &mut exarch_core::NoopProgress,
 /// )?;
-/// # Ok::<(), exarch_core::ExtractionError>(())
+/// # Ok::<(), exarch_core::ArchiveError>(())
 /// ```
 pub fn open_tar_zst<P: AsRef<Path>>(
     path: P,
@@ -1193,7 +1185,7 @@ mod tests {
                 assert_eq!(report.files_extracted, 1);
                 assert!(temp.path().join("sparse.txt").exists());
             }
-            Err(ExtractionError::InvalidArchive(_)) => {
+            Err(ArchiveError::InvalidArchive(_)) => {
                 // Acceptable: tar crate rejects malformed sparse header
             }
             Err(e) => panic!("unexpected error for GNUSparse entry: {e}"),
@@ -1226,7 +1218,7 @@ mod tests {
         );
 
         assert!(
-            matches!(result, Err(ExtractionError::SecurityViolation { .. })),
+            matches!(result, Err(ArchiveError::SecurityViolation { .. })),
             "expected SecurityViolation, got: {result:?}"
         );
     }
@@ -1749,7 +1741,7 @@ mod tests {
 
         assert!(result.is_err());
         match result {
-            Err(ExtractionError::PathTraversal { .. }) => {}
+            Err(ArchiveError::PathTraversal { .. }) => {}
             _ => panic!("Expected PathTraversal error"),
         }
     }
@@ -1785,7 +1777,7 @@ mod tests {
 
         assert!(result.is_err());
         match result {
-            Err(ExtractionError::PathTraversal { .. }) => {}
+            Err(ArchiveError::PathTraversal { .. }) => {}
             _ => panic!("Expected PathTraversal error for absolute path"),
         }
     }
@@ -1833,10 +1825,10 @@ mod tests {
         // A directory was created before the symlink escape, so the error is
         // wrapped in PartialExtraction. Unwrap one level to check the source.
         match result {
-            Err(ExtractionError::PartialExtraction { source, .. }) => {
-                assert!(matches!(*source, ExtractionError::SymlinkEscape { .. }));
+            Err(ArchiveError::PartialExtraction { source, .. }) => {
+                assert!(matches!(*source, ArchiveError::SymlinkEscape { .. }));
             }
-            Err(ExtractionError::SymlinkEscape { .. }) => {}
+            Err(ArchiveError::SymlinkEscape { .. }) => {}
             other => panic!("Expected SymlinkEscape error for symlink escape, got: {other:?}"),
         }
     }
@@ -1872,7 +1864,7 @@ mod tests {
 
         assert!(result.is_err());
         match result {
-            Err(ExtractionError::InvalidArchive(msg)) => {
+            Err(ArchiveError::InvalidArchive(msg)) => {
                 assert!(msg.contains("hardlink target does not exist"));
             }
             _ => panic!("Expected InvalidArchive error for missing hardlink target"),

--- a/crates/exarch-core/src/formats/zip.rs
+++ b/crates/exarch-core/src/formats/zip.rs
@@ -101,7 +101,7 @@
 //!     &mut exarch_core::NoopProgress,
 //! )?;
 //! println!("Extracted {} files", report.files_extracted);
-//! # Ok::<(), exarch_core::ExtractionError>(())
+//! # Ok::<(), exarch_core::ArchiveError>(())
 //! ```
 //!
 //! Custom security configuration:
@@ -125,7 +125,7 @@ use std::time::Instant;
 
 use zip::ZipArchive as ZipReader;
 
-use crate::ExtractionError;
+use crate::ArchiveError;
 use crate::ExtractionOptions;
 use crate::ExtractionReport;
 use crate::ProgressCallback;
@@ -179,7 +179,7 @@ use super::traits::ArchiveFormat;
 ///     &mut exarch_core::NoopProgress,
 /// )?;
 /// println!("Extracted {} files", report.files_extracted);
-/// # Ok::<(), exarch_core::ExtractionError>(())
+/// # Ok::<(), exarch_core::ArchiveError>(())
 /// ```
 pub struct ZipArchive<R: Read + Seek> {
     inner: ZipReader<R>,
@@ -206,16 +206,16 @@ impl<R: Read + Seek> ZipArchive<R> {
     ///
     /// let file = File::open("archive.zip")?;
     /// let archive = ZipArchive::new(file)?;
-    /// # Ok::<(), exarch_core::ExtractionError>(())
+    /// # Ok::<(), exarch_core::ArchiveError>(())
     /// ```
     pub fn new(reader: R) -> Result<Self> {
         let mut inner = ZipReader::new(reader).map_err(|e| {
-            ExtractionError::InvalidArchive(format!("failed to open ZIP archive: {e}"))
+            ArchiveError::InvalidArchive(format!("failed to open ZIP archive: {e}"))
         })?;
 
         // Detect password protection early (CRIT-003: robust check with entry limit)
         if Self::is_password_protected(&mut inner)? {
-            return Err(ExtractionError::SecurityViolation {
+            return Err(ArchiveError::SecurityViolation {
                 reason: "password-protected ZIP archives are not supported".into(),
             });
         }
@@ -241,7 +241,7 @@ impl<R: Read + Seek> ZipArchive<R> {
         match archive.by_index(index) {
             Ok(file) => Ok(file.encrypted()),
             Err(e) if e.to_string().contains("Password required to decrypt file") => Ok(true),
-            Err(e) => Err(ExtractionError::InvalidArchive(format!(
+            Err(e) => Err(ArchiveError::InvalidArchive(format!(
                 "failed to check entry {index} for encryption: {e}"
             ))),
         }
@@ -268,18 +268,18 @@ impl<R: Read + Seek> ZipArchive<R> {
     ) -> Result<()> {
         let mut zip_file = self.inner.by_index(index).map_err(|e| {
             if e.to_string().contains("Password required to decrypt file") {
-                return ExtractionError::SecurityViolation {
+                return ArchiveError::SecurityViolation {
                     reason: "archive is password-protected.\n  Password-protected ZIP archives are not supported. Decrypt the archive externally and try again.".into(),
                 };
             }
-            ExtractionError::InvalidArchive(format!("failed to read entry {index}: {e}"))
+            ArchiveError::InvalidArchive(format!("failed to read entry {index}: {e}"))
         })?;
 
         if zip_file.encrypted() {
             let name = zip_file
                 .name()
                 .map_or_else(|_| format!("<entry {index}>"), std::borrow::Cow::into_owned);
-            return Err(ExtractionError::SecurityViolation {
+            return Err(ArchiveError::SecurityViolation {
                 reason: format!("encrypted entry detected: {name}"),
             });
         }
@@ -288,7 +288,7 @@ impl<R: Read + Seek> ZipArchive<R> {
             zip_file
                 .name()
                 .map_err(|e| {
-                    ExtractionError::InvalidArchive(format!("invalid entry name at {index}: {e}"))
+                    ArchiveError::InvalidArchive(format!("invalid entry name at {index}: {e}"))
                 })?
                 .as_ref(),
         );
@@ -298,7 +298,7 @@ impl<R: Read + Seek> ZipArchive<R> {
 
         let compression = ZipEntryAdapter::get_compression_method(&zip_file);
         if matches!(compression, CompressionMethod::Unsupported) {
-            return Err(ExtractionError::SecurityViolation {
+            return Err(ArchiveError::SecurityViolation {
                 reason: format!(
                     "unsupported compression method: {:?}",
                     zip_file.compression()
@@ -421,14 +421,12 @@ impl<R: Read + Seek> ArchiveFormat for ZipArchive<R> {
             let entry_path = {
                 // Borrow ends before process_entry to satisfy the borrow checker.
                 let zf = self.inner.by_index(i).map_err(|e| {
-                    ExtractionError::InvalidArchive(format!("failed to open zip entry {i}: {e}"))
+                    ArchiveError::InvalidArchive(format!("failed to open zip entry {i}: {e}"))
                 })?;
                 std::path::PathBuf::from(
                     zf.name()
                         .map_err(|e| {
-                            ExtractionError::InvalidArchive(format!(
-                                "invalid entry name at {i}: {e}"
-                            ))
+                            ArchiveError::InvalidArchive(format!("invalid entry name at {i}: {e}"))
                         })?
                         .as_ref(),
                 )
@@ -446,7 +444,7 @@ impl<R: Read + Seek> ArchiveFormat for ZipArchive<R> {
                 config,
             ) {
                 return Err(if report.total_items() > 0 {
-                    ExtractionError::PartialExtraction {
+                    ArchiveError::PartialExtraction {
                         source: Box::new(e),
                         report: std::mem::take(&mut report),
                     }
@@ -498,7 +496,7 @@ impl ZipEntryAdapter {
 
         let size = zip_file.size();
         if size > MAX_SYMLINK_TARGET_SIZE {
-            return Err(ExtractionError::SecurityViolation {
+            return Err(ArchiveError::SecurityViolation {
                 reason: format!(
                     "symlink target too large: {size} bytes (max {MAX_SYMLINK_TARGET_SIZE})"
                 ),
@@ -513,11 +511,11 @@ impl ZipEntryAdapter {
             .take(MAX_SYMLINK_TARGET_SIZE)
             .read_to_end(&mut target_bytes)
             .map_err(|e| {
-                ExtractionError::InvalidArchive(format!("failed to read symlink target: {e}"))
+                ArchiveError::InvalidArchive(format!("failed to read symlink target: {e}"))
             })?;
 
         let target_str = std::str::from_utf8(&target_bytes).map_err(|_| {
-            ExtractionError::InvalidArchive("symlink target is not valid UTF-8".into())
+            ArchiveError::InvalidArchive("symlink target is not valid UTF-8".into())
         })?;
 
         Ok(PathBuf::from(target_str))
@@ -881,7 +879,7 @@ mod tests {
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
-            ExtractionError::PathTraversal { .. }
+            ArchiveError::PathTraversal { .. }
         ));
     }
 
@@ -1123,7 +1121,7 @@ mod tests {
         );
 
         match result {
-            Err(ExtractionError::SecurityViolation { reason }) => {
+            Err(ArchiveError::SecurityViolation { reason }) => {
                 assert!(
                     reason.contains("symlinks not allowed") || reason.contains("symlink"),
                     "error should mention symlinks: {reason}"
@@ -1549,7 +1547,7 @@ mod tests {
                 )
                 .unwrap_err();
             assert!(
-                matches!(err, ExtractionError::SecurityViolation { .. }),
+                matches!(err, ArchiveError::SecurityViolation { .. }),
                 "expected SecurityViolation for unsupported compression, got: {err:?}"
             );
         }
@@ -1581,7 +1579,7 @@ mod tests {
                 )
                 .unwrap_err();
             assert!(
-                matches!(err, ExtractionError::SecurityViolation { ref reason } if reason.contains("symlink target too large")),
+                matches!(err, ArchiveError::SecurityViolation { ref reason } if reason.contains("symlink target too large")),
                 "expected SecurityViolation(symlink target too large), got: {err:?}"
             );
         }
@@ -1607,7 +1605,7 @@ mod tests {
                 )
                 .unwrap_err();
             assert!(
-                matches!(err, ExtractionError::InvalidArchive(ref msg) if msg.contains("UTF-8")),
+                matches!(err, ArchiveError::InvalidArchive(ref msg) if msg.contains("UTF-8")),
                 "expected InvalidArchive(UTF-8), got: {err:?}"
             );
         }
@@ -1647,7 +1645,7 @@ mod tests {
         let cursor = Cursor::new(zip_data);
         let result = ZipArchive::new(cursor);
         assert!(
-            matches!(result, Err(ExtractionError::SecurityViolation { .. })),
+            matches!(result, Err(ArchiveError::SecurityViolation { .. })),
             "expected SecurityViolation for encrypted entry in first batch"
         );
     }
@@ -1659,7 +1657,7 @@ mod tests {
         let cursor = Cursor::new(zip_data);
         let result = ZipArchive::new(cursor);
         assert!(
-            matches!(result, Err(ExtractionError::SecurityViolation { .. })),
+            matches!(result, Err(ArchiveError::SecurityViolation { .. })),
             "expected SecurityViolation for encrypted entry in middle batch"
         );
     }
@@ -1671,7 +1669,7 @@ mod tests {
         let cursor = Cursor::new(zip_data);
         let result = ZipArchive::new(cursor);
         assert!(
-            matches!(result, Err(ExtractionError::SecurityViolation { .. })),
+            matches!(result, Err(ArchiveError::SecurityViolation { .. })),
             "expected SecurityViolation for encrypted entry in last batch"
         );
     }
@@ -1704,7 +1702,7 @@ mod tests {
         let cursor = Cursor::new(zip_data);
         let result = ZipArchive::new(cursor);
         assert!(
-            matches!(result, Err(ExtractionError::SecurityViolation { .. })),
+            matches!(result, Err(ArchiveError::SecurityViolation { .. })),
             "full scan must detect encrypted entry at index 125"
         );
     }
@@ -1823,7 +1821,7 @@ mod tests {
             panic!("expected error for encrypted ZIP, got Ok");
         };
         match err {
-            ExtractionError::SecurityViolation { reason } => {
+            ArchiveError::SecurityViolation { reason } => {
                 assert!(
                     reason.contains("password") || reason.contains("encrypted"),
                     "expected password/encryption mention in reason: {reason}"
@@ -1868,7 +1866,7 @@ mod tests {
             "archive with encrypted entry at index 3 must be rejected"
         );
         match result.err().unwrap() {
-            ExtractionError::SecurityViolation { reason } => {
+            ArchiveError::SecurityViolation { reason } => {
                 assert!(
                     reason.contains("password") || reason.contains("encrypted"),
                     "unexpected reason: {reason}"

--- a/crates/exarch-core/src/inspection/list.rs
+++ b/crates/exarch-core/src/inspection/list.rs
@@ -11,7 +11,7 @@ use std::time::SystemTime;
 
 use flate2::read::GzDecoder;
 
-use crate::ExtractionError;
+use crate::ArchiveError;
 use crate::Result;
 use crate::SecurityConfig;
 use crate::error::QuotaResource;
@@ -148,12 +148,11 @@ fn list_tar_entries<R: std::io::Read>(
 
     let entries = archive
         .entries()
-        .map_err(|e| ExtractionError::InvalidArchive(format!("failed to read TAR entries: {e}")))?;
+        .map_err(|e| ArchiveError::InvalidArchive(format!("failed to read TAR entries: {e}")))?;
 
     for entry_result in entries {
-        let entry = entry_result.map_err(|e| {
-            ExtractionError::InvalidArchive(format!("failed to read TAR entry: {e}"))
-        })?;
+        let entry = entry_result
+            .map_err(|e| ArchiveError::InvalidArchive(format!("failed to read TAR entry: {e}")))?;
 
         // Skip TAR metadata entries (PAX headers, GNU long names/links)
         if is_tar_metadata_entry(&entry) {
@@ -162,7 +161,7 @@ fn list_tar_entries<R: std::io::Read>(
 
         // Check file count quota
         if manifest.total_entries >= config.max_file_count {
-            return Err(ExtractionError::QuotaExceeded {
+            return Err(ArchiveError::QuotaExceeded {
                 resource: QuotaResource::FileCount {
                     current: manifest.total_entries + 1,
                     max: config.max_file_count,
@@ -172,11 +171,11 @@ fn list_tar_entries<R: std::io::Read>(
 
         let path = entry
             .path()
-            .map_err(|e| ExtractionError::InvalidArchive(format!("invalid path: {e}")))?
+            .map_err(|e| ArchiveError::InvalidArchive(format!("invalid path: {e}")))?
             .into_owned();
 
         if contains_traversal(&path) {
-            return Err(ExtractionError::PathTraversal { path });
+            return Err(ArchiveError::PathTraversal { path });
         }
 
         let entry_type = convert_tar_entry_type(&entry)?;
@@ -191,9 +190,7 @@ fn list_tar_entries<R: std::io::Read>(
             tar::EntryType::Symlink | tar::EntryType::Link => {
                 let target = entry
                     .link_name()
-                    .map_err(|e| {
-                        ExtractionError::InvalidArchive(format!("invalid link target: {e}"))
-                    })?
+                    .map_err(|e| ArchiveError::InvalidArchive(format!("invalid link target: {e}")))?
                     .map(std::borrow::Cow::into_owned);
 
                 if entry.header().entry_type() == tar::EntryType::Symlink {
@@ -218,7 +215,7 @@ fn list_tar_entries<R: std::io::Read>(
 
         // Check total size quota
         if manifest.total_size + archive_entry.size > config.max_total_size {
-            return Err(ExtractionError::QuotaExceeded {
+            return Err(ArchiveError::QuotaExceeded {
                 resource: QuotaResource::TotalSize {
                     current: manifest.total_size + archive_entry.size,
                     max: config.max_total_size,
@@ -239,7 +236,7 @@ fn list_zip(
 ) -> Result<ArchiveManifest> {
     let file = File::open(archive_path)?;
     let mut archive = zip::ZipArchive::new(file)
-        .map_err(|e| ExtractionError::InvalidArchive(format!("failed to open ZIP archive: {e}")))?;
+        .map_err(|e| ArchiveError::InvalidArchive(format!("failed to open ZIP archive: {e}")))?;
     list_zip_reader(&mut archive, config)
 }
 
@@ -267,7 +264,7 @@ pub(crate) fn list_zip_reader<R: Read + Seek>(
 
     for i in 0..archive.len() {
         if manifest.total_entries >= config.max_file_count {
-            return Err(ExtractionError::QuotaExceeded {
+            return Err(ArchiveError::QuotaExceeded {
                 resource: QuotaResource::FileCount {
                     current: manifest.total_entries + 1,
                     max: config.max_file_count,
@@ -277,26 +274,26 @@ pub(crate) fn list_zip_reader<R: Read + Seek>(
 
         let entry = archive.by_index(i).map_err(|e| {
             if e.to_string().contains("Password required to decrypt file") {
-                return ExtractionError::SecurityViolation {
+                return ArchiveError::SecurityViolation {
                     reason: "archive is password-protected".into(),
                 };
             }
-            ExtractionError::InvalidArchive(format!("failed to read ZIP entry: {e}"))
+            ArchiveError::InvalidArchive(format!("failed to read ZIP entry: {e}"))
         })?;
 
         if entry.encrypted() {
-            return Err(ExtractionError::SecurityViolation {
+            return Err(ArchiveError::SecurityViolation {
                 reason: "archive is password-protected".into(),
             });
         }
 
         let raw_name = entry
             .name()
-            .map_err(|e| ExtractionError::InvalidArchive(format!("invalid entry name: {e}")))?
+            .map_err(|e| ArchiveError::InvalidArchive(format!("invalid entry name: {e}")))?
             .into_owned();
         let path = entry
             .enclosed_name()
-            .ok_or_else(|| ExtractionError::PathTraversal {
+            .ok_or_else(|| ArchiveError::PathTraversal {
                 path: PathBuf::from(&raw_name),
             })?;
         let path = path.clone();
@@ -331,7 +328,7 @@ pub(crate) fn list_zip_reader<R: Read + Seek>(
         };
 
         if manifest.total_size + archive_entry.size > config.max_total_size {
-            return Err(ExtractionError::QuotaExceeded {
+            return Err(ArchiveError::QuotaExceeded {
                 resource: QuotaResource::TotalSize {
                     current: manifest.total_size + archive_entry.size,
                     max: config.max_total_size,
@@ -362,7 +359,7 @@ pub(crate) fn list_sevenz_reader<R: Read + Seek>(
         Err(e) => {
             let err_str = e.to_string().to_lowercase();
             if err_str.contains("encrypt") || err_str.contains("password") {
-                return Err(ExtractionError::SecurityViolation {
+                return Err(ArchiveError::SecurityViolation {
                     reason: "encrypted 7z archive detected. Password-protected archives are not \
                              supported. Decrypt the archive externally and try again."
                         .into(),
@@ -371,7 +368,7 @@ pub(crate) fn list_sevenz_reader<R: Read + Seek>(
             if is_empty_sevenz_archive_reader(&e, &mut source) {
                 return Ok(ArchiveManifest::new(ArchiveType::SevenZ));
             }
-            return Err(ExtractionError::InvalidArchive(format!(
+            return Err(ArchiveError::InvalidArchive(format!(
                 "failed to open 7z archive: {e}"
             )));
         }
@@ -421,7 +418,7 @@ fn list_sevenz_archive(
         }
 
         if manifest.total_entries >= config.max_file_count {
-            return Err(ExtractionError::QuotaExceeded {
+            return Err(ArchiveError::QuotaExceeded {
                 resource: QuotaResource::FileCount {
                     current: manifest.total_entries + 1,
                     max: config.max_file_count,
@@ -432,7 +429,7 @@ fn list_sevenz_archive(
         let path = PathBuf::from(&entry.name);
 
         if contains_traversal(&path) {
-            return Err(ExtractionError::PathTraversal { path });
+            return Err(ArchiveError::PathTraversal { path });
         }
 
         let entry_type = sevenz_manifest_entry_type(entry);
@@ -461,7 +458,7 @@ fn list_sevenz_archive(
         };
 
         if manifest.total_size + archive_entry.size > config.max_total_size {
-            return Err(ExtractionError::QuotaExceeded {
+            return Err(ArchiveError::QuotaExceeded {
                 resource: QuotaResource::TotalSize {
                     current: manifest.total_size + archive_entry.size,
                     max: config.max_total_size,
@@ -535,7 +532,7 @@ fn convert_tar_entry_type<R: std::io::Read>(
         tar::EntryType::Symlink => Ok(ManifestEntryType::Symlink),
         tar::EntryType::Link => Ok(ManifestEntryType::Hardlink),
         tar::EntryType::Char | tar::EntryType::Block | tar::EntryType::Fifo => {
-            Err(ExtractionError::InvalidArchive(
+            Err(ArchiveError::InvalidArchive(
                 "special files (char/block devices, FIFOs) are not supported".to_string(),
             ))
         }
@@ -883,7 +880,7 @@ mod tests {
 
         let result = list_archive(temp_file.path(), &config);
         match result {
-            Err(ExtractionError::QuotaExceeded {
+            Err(ArchiveError::QuotaExceeded {
                 resource: QuotaResource::FileCount { current, max },
             }) => {
                 assert_eq!(max, 1);
@@ -911,7 +908,7 @@ mod tests {
 
         let result = list_archive(temp_file.path(), &config);
         match result {
-            Err(ExtractionError::QuotaExceeded {
+            Err(ArchiveError::QuotaExceeded {
                 resource: QuotaResource::FileCount { current, max },
             }) => {
                 assert_eq!(max, 1);
@@ -989,7 +986,7 @@ mod tests {
         let config = SecurityConfig::default();
         let result = list_archive(temp_file.path(), &config);
         match result {
-            Err(ExtractionError::SecurityViolation { reason }) => {
+            Err(ArchiveError::SecurityViolation { reason }) => {
                 assert!(
                     reason.contains("password-protected"),
                     "expected 'password-protected' in reason: {reason}"
@@ -1101,7 +1098,7 @@ mod tests {
         let config = SecurityConfig::default();
         let result = list_archive(temp_file.path(), &config);
         assert!(
-            matches!(result, Err(ExtractionError::InvalidArchive(_))),
+            matches!(result, Err(ArchiveError::InvalidArchive(_))),
             "expected InvalidArchive for truncated 7z, got: {result:?}"
         );
     }
@@ -1125,7 +1122,7 @@ mod tests {
         let config = SecurityConfig::default();
         let result = list_archive(temp_file.path(), &config);
         assert!(
-            matches!(result, Err(ExtractionError::InvalidArchive(_))),
+            matches!(result, Err(ArchiveError::InvalidArchive(_))),
             "expected InvalidArchive for char device entry, got: {result:?}"
         );
     }
@@ -1149,7 +1146,7 @@ mod tests {
         assert!(
             matches!(
                 result,
-                Err(ExtractionError::QuotaExceeded {
+                Err(ArchiveError::QuotaExceeded {
                     resource: crate::error::QuotaResource::TotalSize { .. }
                 })
             ),
@@ -1181,7 +1178,7 @@ mod tests {
         assert!(
             matches!(
                 result,
-                Err(ExtractionError::QuotaExceeded {
+                Err(ArchiveError::QuotaExceeded {
                     resource: crate::error::QuotaResource::TotalSize { .. }
                 })
             ),
@@ -1205,7 +1202,7 @@ mod tests {
         let config = SecurityConfig::default();
         let result = list_archive(temp_file.path(), &config);
         assert!(
-            matches!(result, Err(ExtractionError::PathTraversal { .. })),
+            matches!(result, Err(ArchiveError::PathTraversal { .. })),
             "expected PathTraversal error, got: {result:?}"
         );
     }
@@ -1223,7 +1220,7 @@ mod tests {
         assert!(
             matches!(
                 &result,
-                Err(ExtractionError::PathTraversal { path }) if path == &PathBuf::from("../escape.txt")
+                Err(ArchiveError::PathTraversal { path }) if path == &PathBuf::from("../escape.txt")
             ),
             "expected PathTraversal {{ path: ../escape.txt }}, got: {result:?}"
         );
@@ -1240,7 +1237,7 @@ mod tests {
         let config = SecurityConfig::default();
         let result = list_archive(temp_file.path(), &config);
         assert!(
-            matches!(result, Err(ExtractionError::PathTraversal { .. })),
+            matches!(result, Err(ArchiveError::PathTraversal { .. })),
             "expected PathTraversal error for nested ../ in TAR, got: {result:?}"
         );
     }
@@ -1256,7 +1253,7 @@ mod tests {
         let config = SecurityConfig::default();
         let result = list_archive(temp_file.path(), &config);
         assert!(
-            matches!(result, Err(ExtractionError::PathTraversal { .. })),
+            matches!(result, Err(ArchiveError::PathTraversal { .. })),
             "expected PathTraversal error for absolute path in TAR, got: {result:?}"
         );
     }
@@ -1275,7 +1272,7 @@ mod tests {
         let config = SecurityConfig::default();
         let result = list_archive(temp_file.path(), &config);
         assert!(
-            matches!(result, Err(ExtractionError::PathTraversal { .. })),
+            matches!(result, Err(ArchiveError::PathTraversal { .. })),
             "expected PathTraversal error for tar.gz with ../ entry, got: {result:?}"
         );
     }
@@ -1314,7 +1311,7 @@ mod tests {
         let config = SecurityConfig::default();
         let result = list_archive(temp_file.path(), &config);
         assert!(
-            matches!(result, Err(ExtractionError::PathTraversal { .. })),
+            matches!(result, Err(ArchiveError::PathTraversal { .. })),
             "expected PathTraversal error for mixed-entry TAR, got: {result:?}"
         );
     }
@@ -1345,7 +1342,7 @@ mod tests {
         let config = SecurityConfig::default();
         let result = list_archive(temp_file.path(), &config);
         assert!(
-            matches!(result, Err(ExtractionError::SecurityViolation { .. })),
+            matches!(result, Err(ArchiveError::SecurityViolation { .. })),
             "expected SecurityViolation for encrypted ZIP in list, got: {result:?}"
         );
     }
@@ -1543,7 +1540,7 @@ mod tests {
         let config = SecurityConfig::default();
         let result = list_archive(temp_file.path(), &config);
         assert!(
-            matches!(result, Err(ExtractionError::PathTraversal { .. })),
+            matches!(result, Err(ArchiveError::PathTraversal { .. })),
             "expected PathTraversal error for ../ entry, got: {result:?}"
         );
     }
@@ -1565,7 +1562,7 @@ mod tests {
         assert!(
             matches!(
                 result,
-                Err(ExtractionError::QuotaExceeded {
+                Err(ArchiveError::QuotaExceeded {
                     resource: crate::error::QuotaResource::FileCount { .. }
                 })
             ),
@@ -1590,7 +1587,7 @@ mod tests {
         assert!(
             matches!(
                 result,
-                Err(ExtractionError::QuotaExceeded {
+                Err(ArchiveError::QuotaExceeded {
                     resource: crate::error::QuotaResource::TotalSize { .. }
                 })
             ),
@@ -1662,7 +1659,7 @@ mod tests {
         assert!(
             matches!(
                 list_archive(temp_file.path(), &small),
-                Err(ExtractionError::QuotaExceeded {
+                Err(ArchiveError::QuotaExceeded {
                     resource: QuotaResource::TotalSize { .. }
                 })
             ),
@@ -1700,7 +1697,7 @@ mod tests {
         assert!(
             matches!(
                 list_archive(temp_file.path(), &small),
-                Err(ExtractionError::QuotaExceeded {
+                Err(ArchiveError::QuotaExceeded {
                     resource: QuotaResource::TotalSize { .. }
                 })
             ),
@@ -1732,7 +1729,7 @@ mod tests {
         assert!(
             matches!(
                 list_archive(temp_file.path(), &small),
-                Err(ExtractionError::QuotaExceeded {
+                Err(ArchiveError::QuotaExceeded {
                     resource: QuotaResource::TotalSize { .. }
                 })
             ),
@@ -1806,7 +1803,7 @@ mod tests {
         assert!(
             matches!(
                 result,
-                Err(crate::ExtractionError::InvalidConfiguration { .. })
+                Err(crate::ArchiveError::InvalidConfiguration { .. })
             ),
             "list_archive must return InvalidConfiguration for zero max_file_size"
         );

--- a/crates/exarch-core/src/inspection/report.rs
+++ b/crates/exarch-core/src/inspection/report.rs
@@ -2,7 +2,7 @@
 
 use std::path::PathBuf;
 
-use crate::error::ExtractionError;
+use crate::error::ArchiveError;
 use crate::formats::detect::ArchiveType;
 
 /// Result of archive verification.
@@ -158,24 +158,24 @@ impl VerificationIssue {
     /// Creates a verification issue from an extraction error.
     #[must_use]
     #[allow(clippy::too_many_lines)]
-    pub fn from_error(error: &ExtractionError, entry_path: Option<PathBuf>) -> Self {
+    pub fn from_error(error: &ArchiveError, entry_path: Option<PathBuf>) -> Self {
         let (severity, category, message) = match error {
-            ExtractionError::PathTraversal { path } => (
+            ArchiveError::PathTraversal { path } => (
                 IssueSeverity::Critical,
                 IssueCategory::PathTraversal,
                 format!("Path traversal detected: {}", path.display()),
             ),
-            ExtractionError::SymlinkEscape { path } => (
+            ArchiveError::SymlinkEscape { path } => (
                 IssueSeverity::Critical,
                 IssueCategory::SymlinkEscape,
                 format!("Symlink escape: {}", path.display()),
             ),
-            ExtractionError::HardlinkEscape { path } => (
+            ArchiveError::HardlinkEscape { path } => (
                 IssueSeverity::Critical,
                 IssueCategory::HardlinkEscape,
                 format!("Hardlink escape: {}", path.display()),
             ),
-            ExtractionError::ZipBomb {
+            ArchiveError::ZipBomb {
                 compressed,
                 uncompressed,
                 ratio,
@@ -186,12 +186,12 @@ impl VerificationIssue {
                     "Potential zip bomb: {ratio:.1}x compression ratio (compressed={compressed}, uncompressed={uncompressed})"
                 ),
             ),
-            ExtractionError::QuotaExceeded { resource } => (
+            ArchiveError::QuotaExceeded { resource } => (
                 IssueSeverity::High,
                 IssueCategory::QuotaExceeded,
                 format!("{resource}"),
             ),
-            ExtractionError::InvalidPermissions { path, mode } => (
+            ArchiveError::InvalidPermissions { path, mode } => (
                 IssueSeverity::Medium,
                 IssueCategory::InvalidPermissions,
                 format!(
@@ -200,52 +200,52 @@ impl VerificationIssue {
                     mode
                 ),
             ),
-            ExtractionError::Io(io_err) => (
+            ArchiveError::Io(io_err) => (
                 IssueSeverity::High,
                 IssueCategory::InvalidArchive,
                 format!("I/O error: {io_err}"),
             ),
-            ExtractionError::InvalidArchive(msg) => (
+            ArchiveError::InvalidArchive(msg) => (
                 IssueSeverity::High,
                 IssueCategory::InvalidArchive,
                 format!("Invalid archive: {msg}"),
             ),
-            ExtractionError::SecurityViolation { reason } => (
+            ArchiveError::SecurityViolation { reason } => (
                 IssueSeverity::High,
                 IssueCategory::SuspiciousPath,
                 format!("Security violation: {reason}"),
             ),
-            ExtractionError::SourceNotFound { path } => (
+            ArchiveError::SourceNotFound { path } => (
                 IssueSeverity::High,
                 IssueCategory::InvalidArchive,
                 format!("Source not found: {}", path.display()),
             ),
-            ExtractionError::SourceNotAccessible { path } => (
+            ArchiveError::SourceNotAccessible { path } => (
                 IssueSeverity::High,
                 IssueCategory::InvalidArchive,
                 format!("Source not accessible: {}", path.display()),
             ),
-            ExtractionError::OutputExists { path } => (
+            ArchiveError::OutputExists { path } => (
                 IssueSeverity::Medium,
                 IssueCategory::InvalidArchive,
                 format!("Output already exists: {}", path.display()),
             ),
-            ExtractionError::InvalidCompressionLevel { level } => (
+            ArchiveError::InvalidCompressionLevel { level } => (
                 IssueSeverity::Medium,
                 IssueCategory::InvalidArchive,
                 format!("Invalid compression level: {level}"),
             ),
-            ExtractionError::UnknownFormat { path } => (
+            ArchiveError::UnknownFormat { path } => (
                 IssueSeverity::High,
                 IssueCategory::InvalidArchive,
                 format!("Unknown format: {}", path.display()),
             ),
-            ExtractionError::InvalidConfiguration { reason } => (
+            ArchiveError::InvalidConfiguration { reason } => (
                 IssueSeverity::High,
                 IssueCategory::InvalidArchive,
                 format!("Invalid configuration: {reason}"),
             ),
-            ExtractionError::PartialExtraction { source, .. } => {
+            ArchiveError::PartialExtraction { source, .. } => {
                 return Self::from_error(source, entry_path);
             }
         };
@@ -383,7 +383,7 @@ mod tests {
 
     #[test]
     fn test_verification_issue_from_path_traversal() {
-        let error = ExtractionError::PathTraversal {
+        let error = ArchiveError::PathTraversal {
             path: PathBuf::from("../../etc/passwd"),
         };
         let issue = VerificationIssue::from_error(&error, None);
@@ -395,7 +395,7 @@ mod tests {
 
     #[test]
     fn test_verification_issue_from_symlink_escape() {
-        let error = ExtractionError::SymlinkEscape {
+        let error = ArchiveError::SymlinkEscape {
             path: PathBuf::from("link"),
         };
         let issue = VerificationIssue::from_error(&error, Some(PathBuf::from("link")));
@@ -407,7 +407,7 @@ mod tests {
 
     #[test]
     fn test_verification_issue_from_zip_bomb() {
-        let error = ExtractionError::ZipBomb {
+        let error = ArchiveError::ZipBomb {
             compressed: 1000,
             uncompressed: 1_000_000,
             ratio: 1000.0,
@@ -421,7 +421,7 @@ mod tests {
 
     #[test]
     fn test_verification_issue_from_io_error() {
-        let error = ExtractionError::Io(io::Error::new(io::ErrorKind::NotFound, "not found"));
+        let error = ArchiveError::Io(io::Error::new(io::ErrorKind::NotFound, "not found"));
         let issue = VerificationIssue::from_error(&error, None);
 
         assert_eq!(issue.severity, IssueSeverity::High);
@@ -469,7 +469,7 @@ mod tests {
 
     #[test]
     fn test_verification_issue_from_hardlink_escape() {
-        let error = ExtractionError::HardlinkEscape {
+        let error = ArchiveError::HardlinkEscape {
             path: PathBuf::from("link"),
         };
         let issue = VerificationIssue::from_error(&error, None);
@@ -480,7 +480,7 @@ mod tests {
 
     #[test]
     fn test_verification_issue_from_quota_exceeded() {
-        let error = ExtractionError::QuotaExceeded {
+        let error = ArchiveError::QuotaExceeded {
             resource: crate::error::QuotaResource::FileCount {
                 current: 11,
                 max: 10,
@@ -493,7 +493,7 @@ mod tests {
 
     #[test]
     fn test_verification_issue_from_invalid_permissions() {
-        let error = ExtractionError::InvalidPermissions {
+        let error = ArchiveError::InvalidPermissions {
             path: PathBuf::from("file.txt"),
             mode: 0o777,
         };
@@ -505,7 +505,7 @@ mod tests {
 
     #[test]
     fn test_verification_issue_from_invalid_archive() {
-        let error = ExtractionError::InvalidArchive("bad header".into());
+        let error = ArchiveError::InvalidArchive("bad header".into());
         let issue = VerificationIssue::from_error(&error, None);
         assert_eq!(issue.severity, IssueSeverity::High);
         assert_eq!(issue.category, IssueCategory::InvalidArchive);
@@ -514,7 +514,7 @@ mod tests {
 
     #[test]
     fn test_verification_issue_from_security_violation() {
-        let error = ExtractionError::SecurityViolation {
+        let error = ArchiveError::SecurityViolation {
             reason: "encrypted".into(),
         };
         let issue = VerificationIssue::from_error(&error, None);
@@ -525,7 +525,7 @@ mod tests {
 
     #[test]
     fn test_verification_issue_from_source_not_found() {
-        let error = ExtractionError::SourceNotFound {
+        let error = ArchiveError::SourceNotFound {
             path: PathBuf::from("/missing"),
         };
         let issue = VerificationIssue::from_error(&error, None);
@@ -536,7 +536,7 @@ mod tests {
 
     #[test]
     fn test_verification_issue_from_source_not_accessible() {
-        let error = ExtractionError::SourceNotAccessible {
+        let error = ArchiveError::SourceNotAccessible {
             path: PathBuf::from("/restricted"),
         };
         let issue = VerificationIssue::from_error(&error, None);
@@ -547,7 +547,7 @@ mod tests {
 
     #[test]
     fn test_verification_issue_from_output_exists() {
-        let error = ExtractionError::OutputExists {
+        let error = ArchiveError::OutputExists {
             path: PathBuf::from("out/"),
         };
         let issue = VerificationIssue::from_error(&error, None);
@@ -558,7 +558,7 @@ mod tests {
 
     #[test]
     fn test_verification_issue_from_invalid_compression_level() {
-        let error = ExtractionError::InvalidCompressionLevel { level: 0 };
+        let error = ArchiveError::InvalidCompressionLevel { level: 0 };
         let issue = VerificationIssue::from_error(&error, None);
         assert_eq!(issue.severity, IssueSeverity::Medium);
         assert_eq!(issue.category, IssueCategory::InvalidArchive);
@@ -567,7 +567,7 @@ mod tests {
 
     #[test]
     fn test_verification_issue_from_unknown_format() {
-        let error = ExtractionError::UnknownFormat {
+        let error = ArchiveError::UnknownFormat {
             path: PathBuf::from("archive.rar"),
         };
         let issue = VerificationIssue::from_error(&error, None);
@@ -578,7 +578,7 @@ mod tests {
 
     #[test]
     fn test_verification_issue_from_invalid_configuration() {
-        let error = ExtractionError::InvalidConfiguration {
+        let error = ArchiveError::InvalidConfiguration {
             reason: "bad config".into(),
         };
         let issue = VerificationIssue::from_error(&error, None);

--- a/crates/exarch-core/src/inspection/verify.rs
+++ b/crates/exarch-core/src/inspection/verify.rs
@@ -3,7 +3,7 @@
 use std::path::Path;
 use std::path::PathBuf;
 
-use crate::ExtractionError;
+use crate::ArchiveError;
 use crate::Result;
 use crate::SecurityConfig;
 use crate::inspection::list::list_archive;
@@ -200,7 +200,7 @@ fn check_permissions(mode: u32, config: &SecurityConfig) -> Result<()> {
     if sanitized == mode {
         Ok(())
     } else {
-        Err(ExtractionError::InvalidPermissions {
+        Err(ArchiveError::InvalidPermissions {
             path: PathBuf::new(),
             mode,
         })
@@ -556,7 +556,7 @@ mod tests {
         assert!(
             matches!(
                 result,
-                Err(crate::ExtractionError::InvalidConfiguration { .. })
+                Err(crate::ArchiveError::InvalidConfiguration { .. })
             ),
             "verify_archive must return InvalidConfiguration for zero max_path_depth"
         );

--- a/crates/exarch-core/src/lib.rs
+++ b/crates/exarch-core/src/lib.rs
@@ -48,7 +48,7 @@ pub use archive::Archive;
 pub use archive::ArchiveBuilder;
 pub use config::ExtractionOptions;
 pub use config::SecurityConfig;
-pub use error::ExtractionError;
+pub use error::ArchiveError;
 pub use error::FfiErrorMessage;
 pub use error::QuotaResource;
 pub use error::Result;

--- a/crates/exarch-core/src/security/hardlink.rs
+++ b/crates/exarch-core/src/security/hardlink.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::path::PathBuf;
 
-use crate::ExtractionError;
+use crate::ArchiveError;
 use crate::Result;
 use crate::SecurityConfig;
 use crate::types::DestDir;
@@ -117,7 +117,7 @@ impl HardlinkTracker {
     ) -> Result<()> {
         // Check if hardlinks are allowed
         if !config.allowed.hardlinks {
-            return Err(ExtractionError::SecurityViolation {
+            return Err(ArchiveError::SecurityViolation {
                 reason: "hardlinks not allowed".into(),
             });
         }
@@ -129,7 +129,7 @@ impl HardlinkTracker {
         // \\server\share
         for component in target.components() {
             if matches!(component, Component::Prefix(_) | Component::RootDir) {
-                return Err(ExtractionError::HardlinkEscape {
+                return Err(ArchiveError::HardlinkEscape {
                     path: link_path.as_path().to_path_buf(),
                 });
             }
@@ -137,7 +137,7 @@ impl HardlinkTracker {
 
         // Also reject absolute targets (redundant with above, but keeps existing check)
         if target.is_absolute() {
-            return Err(ExtractionError::HardlinkEscape {
+            return Err(ArchiveError::HardlinkEscape {
                 path: link_path.as_path().to_path_buf(),
             });
         }
@@ -151,7 +151,7 @@ impl HardlinkTracker {
         // would pass (two-hop chain bypass, GHSA-83g3-92jg-28cx variant — #116).
         let resolved =
             resolve_through_symlinks(dest.as_path(), target, dest.as_path(), link_path.as_path())
-                .map_err(|_| ExtractionError::HardlinkEscape {
+                .map_err(|_| ArchiveError::HardlinkEscape {
                 path: link_path.as_path().to_path_buf(),
             })?;
 
@@ -244,10 +244,7 @@ mod tests {
         let target = PathBuf::from("/etc/passwd");
 
         let result = tracker.validate_hardlink(&link, &target, &dest, &config);
-        assert!(matches!(
-            result,
-            Err(ExtractionError::HardlinkEscape { .. })
-        ));
+        assert!(matches!(result, Err(ArchiveError::HardlinkEscape { .. })));
     }
 
     #[test]
@@ -261,10 +258,7 @@ mod tests {
         let target = PathBuf::from("../../etc/passwd");
 
         let result = tracker.validate_hardlink(&link, &target, &dest, &config);
-        assert!(matches!(
-            result,
-            Err(ExtractionError::HardlinkEscape { .. })
-        ));
+        assert!(matches!(result, Err(ArchiveError::HardlinkEscape { .. })));
     }
 
     #[test]
@@ -409,7 +403,7 @@ mod tests {
 
         let result = tracker.validate_hardlink(&link, &target, &dest, &config);
         assert!(
-            matches!(result, Err(ExtractionError::HardlinkEscape { .. })),
+            matches!(result, Err(ArchiveError::HardlinkEscape { .. })),
             "hardlink through two-hop symlink chain must be rejected"
         );
     }

--- a/crates/exarch-core/src/security/path.rs
+++ b/crates/exarch-core/src/security/path.rs
@@ -27,9 +27,8 @@ use crate::types::SafePath;
 /// # Errors
 ///
 /// Returns an error if the path contains:
-/// - `ExtractionError::PathTraversal` for `..` or absolute paths
-/// - `ExtractionError::SecurityViolation` for banned components or excessive
-///   depth
+/// - `ArchiveError::PathTraversal` for `..` or absolute paths
+/// - `ArchiveError::SecurityViolation` for banned components or excessive depth
 ///
 /// # Examples
 ///

--- a/crates/exarch-core/src/security/permissions.rs
+++ b/crates/exarch-core/src/security/permissions.rs
@@ -18,7 +18,7 @@ use crate::SecurityConfig;
 ///
 /// # Errors
 ///
-/// Returns `ExtractionError::InvalidPermissions` only for truly invalid modes.
+/// Returns `ArchiveError::InvalidPermissions` only for truly invalid modes.
 ///
 /// # Examples
 ///

--- a/crates/exarch-core/src/security/quota.rs
+++ b/crates/exarch-core/src/security/quota.rs
@@ -1,6 +1,6 @@
 //! Extraction quota tracking and validation.
 
-use crate::ExtractionError;
+use crate::ArchiveError;
 use crate::Result;
 use crate::SecurityConfig;
 
@@ -40,14 +40,14 @@ impl QuotaTracker {
             self.files_extracted =
                 self.files_extracted
                     .checked_add(1)
-                    .ok_or(ExtractionError::QuotaExceeded {
+                    .ok_or(ArchiveError::QuotaExceeded {
                         resource: crate::QuotaResource::IntegerOverflow,
                     })?;
 
             self.bytes_written =
                 self.bytes_written
                     .checked_add(size)
-                    .ok_or(ExtractionError::QuotaExceeded {
+                    .ok_or(ArchiveError::QuotaExceeded {
                         resource: crate::QuotaResource::IntegerOverflow,
                     })?;
 
@@ -64,7 +64,7 @@ impl QuotaTracker {
     #[inline(never)]
     fn record_file_checked(&mut self, size: u64, config: &SecurityConfig) -> Result<()> {
         if size > config.max_file_size {
-            return Err(ExtractionError::QuotaExceeded {
+            return Err(ArchiveError::QuotaExceeded {
                 resource: crate::QuotaResource::FileSize {
                     size,
                     max: config.max_file_size,
@@ -75,19 +75,19 @@ impl QuotaTracker {
         self.files_extracted =
             self.files_extracted
                 .checked_add(1)
-                .ok_or(ExtractionError::QuotaExceeded {
+                .ok_or(ArchiveError::QuotaExceeded {
                     resource: crate::QuotaResource::IntegerOverflow,
                 })?;
 
         self.bytes_written =
             self.bytes_written
                 .checked_add(size)
-                .ok_or(ExtractionError::QuotaExceeded {
+                .ok_or(ArchiveError::QuotaExceeded {
                     resource: crate::QuotaResource::IntegerOverflow,
                 })?;
 
         if self.files_extracted > config.max_file_count {
-            return Err(ExtractionError::QuotaExceeded {
+            return Err(ArchiveError::QuotaExceeded {
                 resource: crate::QuotaResource::FileCount {
                     current: self.files_extracted,
                     max: config.max_file_count,
@@ -96,7 +96,7 @@ impl QuotaTracker {
         }
 
         if self.bytes_written > config.max_total_size {
-            return Err(ExtractionError::QuotaExceeded {
+            return Err(ArchiveError::QuotaExceeded {
                 resource: crate::QuotaResource::TotalSize {
                     current: self.bytes_written,
                     max: config.max_total_size,
@@ -151,7 +151,7 @@ mod tests {
         assert!(tracker.record_file(100, &config).is_ok());
         assert!(tracker.record_file(100, &config).is_ok());
         let result = tracker.record_file(100, &config);
-        assert!(matches!(result, Err(ExtractionError::QuotaExceeded { .. })));
+        assert!(matches!(result, Err(ArchiveError::QuotaExceeded { .. })));
     }
 
     #[test]
@@ -162,7 +162,7 @@ mod tests {
 
         assert!(tracker.record_file(600, &config).is_ok());
         let result = tracker.record_file(500, &config);
-        assert!(matches!(result, Err(ExtractionError::QuotaExceeded { .. })));
+        assert!(matches!(result, Err(ArchiveError::QuotaExceeded { .. })));
     }
 
     #[test]
@@ -172,7 +172,7 @@ mod tests {
         config.max_file_size = 1000;
 
         let result = tracker.record_file(2000, &config);
-        assert!(matches!(result, Err(ExtractionError::QuotaExceeded { .. })));
+        assert!(matches!(result, Err(ArchiveError::QuotaExceeded { .. })));
     }
 
     // H-TEST-4: Quota boundary conditions test
@@ -204,7 +204,7 @@ mod tests {
         assert!(
             matches!(
                 result,
-                Err(ExtractionError::QuotaExceeded {
+                Err(ArchiveError::QuotaExceeded {
                     resource: crate::QuotaResource::FileCount { current: 4, max: 3 }
                 })
             ),
@@ -232,7 +232,7 @@ mod tests {
         assert!(
             matches!(
                 result,
-                Err(ExtractionError::QuotaExceeded {
+                Err(ArchiveError::QuotaExceeded {
                     resource: crate::QuotaResource::TotalSize {
                         current: 1001,
                         max: 1000
@@ -262,7 +262,7 @@ mod tests {
         assert!(
             matches!(
                 result,
-                Err(ExtractionError::QuotaExceeded {
+                Err(ArchiveError::QuotaExceeded {
                     resource: crate::QuotaResource::FileSize {
                         size: 5001,
                         max: 5000
@@ -286,7 +286,7 @@ mod tests {
 
         // Second file should fail (max is 1)
         let result = tracker.record_file(100, &config);
-        assert!(matches!(result, Err(ExtractionError::QuotaExceeded { .. })));
+        assert!(matches!(result, Err(ArchiveError::QuotaExceeded { .. })));
     }
 
     // OPT-C003: Test fast path for unlimited quotas
@@ -327,7 +327,7 @@ mod tests {
         assert!(
             matches!(
                 result,
-                Err(ExtractionError::QuotaExceeded {
+                Err(ArchiveError::QuotaExceeded {
                     resource: crate::QuotaResource::IntegerOverflow
                 })
             ),

--- a/crates/exarch-core/src/security/symlink.rs
+++ b/crates/exarch-core/src/security/symlink.rs
@@ -25,8 +25,8 @@ use crate::types::SafeSymlink;
 ///
 /// Returns an error if symlinks are not allowed or if the target
 /// escapes the extraction directory:
-/// - `ExtractionError::SecurityViolation` if symlinks disabled
-/// - `ExtractionError::SymlinkEscape` if target is outside destination
+/// - `ArchiveError::SecurityViolation` if symlinks disabled
+/// - `ArchiveError::SymlinkEscape` if target is outside destination
 ///
 /// # Examples
 ///

--- a/crates/exarch-core/src/security/validator.rs
+++ b/crates/exarch-core/src/security/validator.rs
@@ -135,12 +135,12 @@ impl<'a> EntryValidator<'a> {
     /// # Errors
     ///
     /// Returns an error if any validation fails. Common errors:
-    /// - `ExtractionError::PathTraversal` - Path escapes destination
-    /// - `ExtractionError::QuotaExceeded` - Size or count limits exceeded
-    /// - `ExtractionError::ZipBomb` - Compression ratio too high
-    /// - `ExtractionError::SymlinkEscape` - Symlink target escapes
-    /// - `ExtractionError::HardlinkEscape` - Hardlink target escapes
-    /// - `ExtractionError::InvalidPermissions` - Dangerous permissions
+    /// - `ArchiveError::PathTraversal` - Path escapes destination
+    /// - `ArchiveError::QuotaExceeded` - Size or count limits exceeded
+    /// - `ArchiveError::ZipBomb` - Compression ratio too high
+    /// - `ArchiveError::SymlinkEscape` - Symlink target escapes
+    /// - `ArchiveError::HardlinkEscape` - Hardlink target escapes
+    /// - `ArchiveError::InvalidPermissions` - Dangerous permissions
     pub fn validate_entry(
         &mut self,
         path: &Path,

--- a/crates/exarch-core/src/security/zipbomb.rs
+++ b/crates/exarch-core/src/security/zipbomb.rs
@@ -1,6 +1,6 @@
 //! Zip bomb detection.
 
-use crate::ExtractionError;
+use crate::ArchiveError;
 use crate::Result;
 use crate::SecurityConfig;
 
@@ -18,7 +18,7 @@ pub fn validate_compression_ratio(
     // Reject invalid entries where compressed_size is 0 but uncompressed_size > 0
     if compressed_size == 0 {
         if uncompressed_size > 0 {
-            return Err(ExtractionError::InvalidArchive(
+            return Err(ArchiveError::InvalidArchive(
                 "compressed_size is 0 but uncompressed_size > 0 (invalid archive metadata)".into(),
             ));
         }
@@ -30,7 +30,7 @@ pub fn validate_compression_ratio(
     let ratio = uncompressed_size as f64 / compressed_size as f64;
 
     if ratio > config.max_compression_ratio {
-        return Err(ExtractionError::ZipBomb {
+        return Err(ArchiveError::ZipBomb {
             compressed: compressed_size,
             uncompressed: uncompressed_size,
             ratio,
@@ -55,7 +55,7 @@ mod tests {
     fn test_validate_compression_ratio_bomb() {
         let config = SecurityConfig::default();
         let result = validate_compression_ratio(1000, 1_000_000, &config);
-        assert!(matches!(result, Err(ExtractionError::ZipBomb { .. })));
+        assert!(matches!(result, Err(ArchiveError::ZipBomb { .. })));
     }
 
     #[test]
@@ -65,7 +65,7 @@ mod tests {
         // HIGH-001: Zero compressed with non-zero uncompressed is invalid
         let result = validate_compression_ratio(0, 1000, &config);
         assert!(
-            matches!(result, Err(ExtractionError::InvalidArchive(_))),
+            matches!(result, Err(ArchiveError::InvalidArchive(_))),
             "zero compressed with non-zero uncompressed should be rejected"
         );
     }
@@ -88,7 +88,7 @@ mod tests {
         // This prevents zip bomb bypass for stored compression
         let result = validate_compression_ratio(0, 1_000_000, &config);
         assert!(
-            matches!(result, Err(ExtractionError::InvalidArchive(_))),
+            matches!(result, Err(ArchiveError::InvalidArchive(_))),
             "compressed_size == 0 but uncompressed_size > 0 should be rejected (HIGH-001 fix)"
         );
     }
@@ -101,7 +101,7 @@ mod tests {
         // This should trigger zip bomb detection
         let result = validate_compression_ratio(1, 1_000_000, &config);
         assert!(
-            matches!(result, Err(ExtractionError::ZipBomb { .. })),
+            matches!(result, Err(ArchiveError::ZipBomb { .. })),
             "extremely high compression ratio should be detected as zip bomb"
         );
     }

--- a/crates/exarch-core/src/types/dest_dir.rs
+++ b/crates/exarch-core/src/types/dest_dir.rs
@@ -1,6 +1,6 @@
 //! Validated destination directory type.
 
-use crate::ExtractionError;
+use crate::ArchiveError;
 use crate::Result;
 use std::path::Path;
 use std::path::PathBuf;
@@ -83,7 +83,7 @@ impl DestDir {
         let path = path.into();
         // Verify path exists
         if !path.exists() {
-            return Err(ExtractionError::Io(std::io::Error::new(
+            return Err(ArchiveError::Io(std::io::Error::new(
                 std::io::ErrorKind::NotFound,
                 format!("destination directory does not exist: {}", path.display()),
             )));
@@ -91,7 +91,7 @@ impl DestDir {
 
         // Verify it's a directory
         if !path.is_dir() {
-            return Err(ExtractionError::Io(std::io::Error::new(
+            return Err(ArchiveError::Io(std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
                 format!("path is not a directory: {}", path.display()),
             )));
@@ -99,7 +99,7 @@ impl DestDir {
 
         // Canonicalize to absolute path
         let canonical = path.canonicalize().map_err(|e| {
-            ExtractionError::Io(std::io::Error::new(
+            ArchiveError::Io(std::io::Error::new(
                 e.kind(),
                 format!("failed to canonicalize path {}: {}", path.display(), e),
             ))
@@ -113,7 +113,7 @@ impl DestDir {
 
             // Use access() syscall to check effective write permissions
             let path_cstring = CString::new(canonical.as_os_str().as_bytes()).map_err(|_| {
-                ExtractionError::Io(std::io::Error::new(
+                ArchiveError::Io(std::io::Error::new(
                     std::io::ErrorKind::InvalidInput,
                     "path contains null byte",
                 ))
@@ -126,7 +126,7 @@ impl DestDir {
             let result = unsafe { libc::access(path_cstring.as_ptr(), libc::W_OK) };
 
             if result != 0 {
-                return Err(ExtractionError::Io(std::io::Error::new(
+                return Err(ArchiveError::Io(std::io::Error::new(
                     std::io::ErrorKind::PermissionDenied,
                     format!("directory is not writable: {}", canonical.display()),
                 )));
@@ -148,7 +148,7 @@ impl DestDir {
     pub fn new_or_create(path: impl Into<PathBuf>) -> Result<Self> {
         let path = path.into();
         std::fs::create_dir_all(&path).map_err(|e| {
-            ExtractionError::Io(std::io::Error::new(
+            ArchiveError::Io(std::io::Error::new(
                 e.kind(),
                 format!(
                     "failed to create destination directory '{}': {}",
@@ -251,7 +251,7 @@ mod tests {
         let path = PathBuf::from("/nonexistent/directory/that/does/not/exist");
         let result = DestDir::new(path);
         assert!(result.is_err());
-        assert!(matches!(result, Err(ExtractionError::Io(_))));
+        assert!(matches!(result, Err(ArchiveError::Io(_))));
     }
 
     #[test]
@@ -262,7 +262,7 @@ mod tests {
 
         let result = DestDir::new(file_path);
         assert!(result.is_err());
-        assert!(matches!(result, Err(ExtractionError::Io(_))));
+        assert!(matches!(result, Err(ArchiveError::Io(_))));
     }
 
     #[test]

--- a/crates/exarch-core/src/types/safe_path.rs
+++ b/crates/exarch-core/src/types/safe_path.rs
@@ -1,6 +1,6 @@
 //! Validated safe path type for archive extraction.
 
-use crate::ExtractionError;
+use crate::ArchiveError;
 use crate::Result;
 use crate::SecurityConfig;
 use crate::security::context::ValidationContext;
@@ -78,9 +78,9 @@ impl SafePath {
     /// # Errors
     ///
     /// Returns an error if any validation step fails:
-    /// - `ExtractionError::PathTraversal` for `..` or absolute paths
-    /// - `ExtractionError::SecurityViolation` for banned components or
-    ///   excessive depth
+    /// - `ArchiveError::PathTraversal` for `..` or absolute paths
+    /// - `ArchiveError::SecurityViolation` for banned components or excessive
+    ///   depth
     ///
     /// # Examples
     ///
@@ -123,7 +123,7 @@ impl SafePath {
     ) -> Result<Self> {
         // Reject empty paths explicitly
         if path.as_os_str().is_empty() {
-            return Err(ExtractionError::SecurityViolation {
+            return Err(ArchiveError::SecurityViolation {
                 reason: "empty path not allowed".into(),
             });
         }
@@ -137,14 +137,14 @@ impl SafePath {
 
         // 1. Check for null bytes
         if has_null_bytes(path) {
-            return Err(ExtractionError::SecurityViolation {
+            return Err(ArchiveError::SecurityViolation {
                 reason: format!("path contains null bytes: {}", path.display()),
             });
         }
 
         // 2. Check for absolute paths
         if path.is_absolute() && !config.allowed.absolute_paths {
-            return Err(ExtractionError::PathTraversal {
+            return Err(ArchiveError::PathTraversal {
                 path: path.to_path_buf(),
             });
         }
@@ -158,7 +158,7 @@ impl SafePath {
         for component in path.components() {
             match component {
                 Component::ParentDir => {
-                    return Err(ExtractionError::PathTraversal {
+                    return Err(ArchiveError::PathTraversal {
                         path: path.to_path_buf(),
                     });
                 }
@@ -171,7 +171,7 @@ impl SafePath {
                             .map_or_else(|| comp.to_string_lossy(), Cow::Borrowed);
 
                         if !config.is_path_component_allowed(&comp_str) {
-                            return Err(ExtractionError::SecurityViolation {
+                            return Err(ArchiveError::SecurityViolation {
                                 reason: format!("banned path component: {comp_str}"),
                             });
                         }
@@ -184,7 +184,7 @@ impl SafePath {
                 }
                 Component::RootDir | Component::Prefix(_) => {
                     if !config.allowed.absolute_paths {
-                        return Err(ExtractionError::PathTraversal {
+                        return Err(ArchiveError::PathTraversal {
                             path: path.to_path_buf(),
                         });
                     }
@@ -195,7 +195,7 @@ impl SafePath {
 
         // Check path depth
         if depth > config.max_path_depth {
-            return Err(ExtractionError::SecurityViolation {
+            return Err(ArchiveError::SecurityViolation {
                 reason: format!(
                     "path depth {} exceeds maximum {}",
                     depth, config.max_path_depth
@@ -219,14 +219,14 @@ impl SafePath {
             match parent.canonicalize() {
                 Ok(canonical_parent) => {
                     if !paths_start_with(&canonical_parent, dest.as_path()) {
-                        return Err(ExtractionError::PathTraversal {
+                        return Err(ArchiveError::PathTraversal {
                             path: path.to_path_buf(),
                         });
                     }
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
                 Err(e) => {
-                    return Err(ExtractionError::Io(std::io::Error::new(
+                    return Err(ArchiveError::Io(std::io::Error::new(
                         e.kind(),
                         format!("failed to canonicalize parent: {e}"),
                     )));
@@ -239,20 +239,20 @@ impl SafePath {
             match resolved.canonicalize() {
                 Ok(canonical) => {
                     if !paths_start_with(&canonical, dest.as_path()) {
-                        return Err(ExtractionError::PathTraversal {
+                        return Err(ArchiveError::PathTraversal {
                             path: path.to_path_buf(),
                         });
                     }
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                     if !paths_start_with(&resolved, dest.as_path()) {
-                        return Err(ExtractionError::PathTraversal {
+                        return Err(ArchiveError::PathTraversal {
                             path: path.to_path_buf(),
                         });
                     }
                 }
                 Err(e) => {
-                    return Err(ExtractionError::Io(std::io::Error::new(
+                    return Err(ArchiveError::Io(std::io::Error::new(
                         e.kind(),
                         format!("failed to canonicalize path: {e}"),
                     )));
@@ -261,7 +261,7 @@ impl SafePath {
         } else {
             // Symlinks impossible -- prefix check is still mandatory
             if !paths_start_with(&resolved, dest.as_path()) {
-                return Err(ExtractionError::PathTraversal {
+                return Err(ArchiveError::PathTraversal {
                     path: path.to_path_buf(),
                 });
             }
@@ -361,7 +361,7 @@ mod tests {
 
         let result = SafePath::validate(&PathBuf::from(""), &dest, &config);
         assert!(
-            matches!(result, Err(ExtractionError::SecurityViolation { .. })),
+            matches!(result, Err(ArchiveError::SecurityViolation { .. })),
             "empty path should be explicitly rejected (MED-004)"
         );
     }
@@ -393,7 +393,7 @@ mod tests {
         for path in paths {
             let result = SafePath::validate(&path, &dest, &config);
             assert!(
-                matches!(result, Err(ExtractionError::PathTraversal { .. })),
+                matches!(result, Err(ArchiveError::PathTraversal { .. })),
                 "path should be rejected: {}",
                 path.display()
             );
@@ -408,7 +408,7 @@ mod tests {
 
         let path = PathBuf::from("/etc/passwd");
         let result = SafePath::validate(&path, &dest, &config);
-        assert!(matches!(result, Err(ExtractionError::PathTraversal { .. })));
+        assert!(matches!(result, Err(ArchiveError::PathTraversal { .. })));
     }
 
     #[test]
@@ -424,7 +424,7 @@ mod tests {
 
         for path in paths {
             let result = SafePath::validate(&path, &dest, &config);
-            assert!(matches!(result, Err(ExtractionError::PathTraversal { .. })));
+            assert!(matches!(result, Err(ArchiveError::PathTraversal { .. })));
         }
     }
 
@@ -453,7 +453,7 @@ mod tests {
         let result = SafePath::validate(&path, &dest, &config);
         assert!(matches!(
             result,
-            Err(ExtractionError::SecurityViolation { .. })
+            Err(ArchiveError::SecurityViolation { .. })
         ));
 
         // 3 components - should be allowed
@@ -476,7 +476,7 @@ mod tests {
         for path in paths {
             let result = SafePath::validate(&path, &dest, &config);
             assert!(
-                matches!(result, Err(ExtractionError::SecurityViolation { .. })),
+                matches!(result, Err(ArchiveError::SecurityViolation { .. })),
                 "path should be rejected: {}",
                 path.display()
             );
@@ -513,7 +513,7 @@ mod tests {
             let result = SafePath::validate(&path, &dest, &config);
             assert!(matches!(
                 result,
-                Err(ExtractionError::SecurityViolation { .. })
+                Err(ArchiveError::SecurityViolation { .. })
             ));
         }
 
@@ -530,7 +530,7 @@ mod tests {
             let result = SafePath::validate(&path, &dest, &config);
             assert!(matches!(
                 result,
-                Err(ExtractionError::SecurityViolation { .. })
+                Err(ArchiveError::SecurityViolation { .. })
             ));
         }
     }
@@ -609,7 +609,7 @@ mod tests {
 
         // Empty paths are now explicitly rejected
         assert!(
-            matches!(result, Err(ExtractionError::SecurityViolation { .. })),
+            matches!(result, Err(ArchiveError::SecurityViolation { .. })),
             "empty path should be explicitly rejected"
         );
     }
@@ -631,7 +631,7 @@ mod tests {
         let result = SafePath::validate(&path, &dest, &config);
         assert!(matches!(
             result,
-            Err(ExtractionError::SecurityViolation { .. })
+            Err(ArchiveError::SecurityViolation { .. })
         ));
     }
 
@@ -702,7 +702,7 @@ mod tests {
 
         let result = SafePath::validate(&malicious_path, &dest, &config);
         assert!(
-            matches!(result, Err(ExtractionError::PathTraversal { .. })),
+            matches!(result, Err(ArchiveError::PathTraversal { .. })),
             "symlink in parent chain should be detected and rejected"
         );
     }
@@ -729,7 +729,7 @@ mod tests {
 
         let result = SafePath::validate(&malicious_path, &dest, &config);
         assert!(
-            matches!(result, Err(ExtractionError::PathTraversal { .. })),
+            matches!(result, Err(ArchiveError::PathTraversal { .. })),
             "symlink in middle of path should be detected"
         );
     }
@@ -841,7 +841,7 @@ mod tests {
         let path = PathBuf::from("evil_dir/payload.txt");
         let result = SafePath::validate_with_context(&path, &dest, &config, &ctx);
         assert!(
-            matches!(result, Err(ExtractionError::PathTraversal { .. })),
+            matches!(result, Err(ArchiveError::PathTraversal { .. })),
             "symlink attack must be caught even with context: {result:?}"
         );
     }
@@ -874,7 +874,7 @@ mod tests {
         let path = PathBuf::from("subdir/escape/payload.txt");
         let result = SafePath::validate_with_context(&path, &dest, &config, &ctx);
         assert!(
-            matches!(result, Err(ExtractionError::PathTraversal { .. })),
+            matches!(result, Err(ArchiveError::PathTraversal { .. })),
             "parent canonicalization must catch symlink even in fast path: {result:?}"
         );
 
@@ -884,10 +884,7 @@ mod tests {
         let result_with_symlink =
             SafePath::validate_with_context(&path, &dest, &config, &ctx_with_symlink);
         assert!(
-            matches!(
-                result_with_symlink,
-                Err(ExtractionError::PathTraversal { .. })
-            ),
+            matches!(result_with_symlink, Err(ArchiveError::PathTraversal { .. })),
             "symlink attack must also be caught with symlink_seen=true: {result_with_symlink:?}"
         );
     }
@@ -1018,7 +1015,7 @@ mod tests {
         let evil_path = PathBuf::from("evil/payload.txt");
         let result = SafePath::validate_with_context(&evil_path, &dest, &config, &ctx);
         assert!(
-            matches!(result, Err(ExtractionError::PathTraversal { .. })),
+            matches!(result, Err(ArchiveError::PathTraversal { .. })),
             "symlink escape must be caught with symlinks_allowed + dir_cache: {result:?}"
         );
     }
@@ -1036,7 +1033,7 @@ mod tests {
         let path = PathBuf::from("../escape.txt");
         let result = SafePath::validate_with_context(&path, &dest, &config, &ctx);
         assert!(
-            matches!(result, Err(ExtractionError::PathTraversal { .. })),
+            matches!(result, Err(ArchiveError::PathTraversal { .. })),
             "parent traversal must be caught in fast path"
         );
     }
@@ -1124,7 +1121,7 @@ mod tests {
         // ".." must still be rejected — it is a traversal attempt, not an archive root
         let result = SafePath::validate(Path::new(".."), &dest, &config);
         assert!(
-            matches!(result, Err(ExtractionError::PathTraversal { .. })),
+            matches!(result, Err(ArchiveError::PathTraversal { .. })),
             "'..' must be rejected as path traversal"
         );
     }
@@ -1138,7 +1135,7 @@ mod tests {
         for p in paths {
             let result = SafePath::validate(Path::new(p), &dest, &config);
             assert!(
-                matches!(result, Err(ExtractionError::PathTraversal { .. })),
+                matches!(result, Err(ArchiveError::PathTraversal { .. })),
                 "path '{p}' must be rejected as path traversal"
             );
         }

--- a/crates/exarch-core/src/types/safe_symlink.rs
+++ b/crates/exarch-core/src/types/safe_symlink.rs
@@ -1,6 +1,6 @@
 //! Validated safe symlink type.
 
-use crate::ExtractionError;
+use crate::ArchiveError;
 use crate::Result;
 use crate::SecurityConfig;
 use std::path::Path;
@@ -100,14 +100,14 @@ impl SafeSymlink {
     ) -> Result<Self> {
         // 1. Verify symlinks are allowed
         if !config.allowed.symlinks {
-            return Err(ExtractionError::SecurityViolation {
+            return Err(ArchiveError::SecurityViolation {
                 reason: "symlinks not allowed".into(),
             });
         }
 
         // 2. Validate target is relative
         if target.is_absolute() {
-            return Err(ExtractionError::SymlinkEscape {
+            return Err(ArchiveError::SymlinkEscape {
                 path: link.as_path().to_path_buf(),
             });
         }
@@ -119,7 +119,7 @@ impl SafeSymlink {
                 target_depth += 1;
                 let comp_str = comp.to_string_lossy();
                 if !config.is_path_component_allowed(&comp_str) {
-                    return Err(ExtractionError::SecurityViolation {
+                    return Err(ArchiveError::SecurityViolation {
                         reason: format!("symlink target contains banned component: {comp_str}"),
                     });
                 }
@@ -128,7 +128,7 @@ impl SafeSymlink {
 
         // Validate target depth against max_path_depth
         if target_depth > config.max_path_depth {
-            return Err(ExtractionError::SecurityViolation {
+            return Err(ArchiveError::SecurityViolation {
                 reason: format!(
                     "symlink target depth {target_depth} exceeds maximum {}",
                     config.max_path_depth
@@ -201,14 +201,13 @@ fn verify_parent_not_symlink(path: &Path, dest: &DestDir) -> Result<()> {
 
         // Check if current path exists and is a symlink
         if current.exists() {
-            let metadata = std::fs::symlink_metadata(&current).map_err(|_| {
-                ExtractionError::SymlinkEscape {
+            let metadata =
+                std::fs::symlink_metadata(&current).map_err(|_| ArchiveError::SymlinkEscape {
                     path: path.to_path_buf(),
-                }
-            })?;
+                })?;
 
             if metadata.is_symlink() {
-                return Err(ExtractionError::SymlinkEscape {
+                return Err(ArchiveError::SymlinkEscape {
                     path: path.to_path_buf(),
                 });
             }
@@ -255,13 +254,13 @@ pub(crate) fn resolve_through_symlinks(
                 // filesystem topology rather than the string representation.
                 if std::fs::symlink_metadata(&current).is_ok_and(|m| m.file_type().is_symlink()) {
                     current = std::fs::canonicalize(&current).map_err(|_| {
-                        ExtractionError::SymlinkEscape {
+                        ArchiveError::SymlinkEscape {
                             path: link_path.to_path_buf(),
                         }
                     })?;
                 }
                 if !current.pop() {
-                    return Err(ExtractionError::SymlinkEscape {
+                    return Err(ArchiveError::SymlinkEscape {
                         path: link_path.to_path_buf(),
                     });
                 }
@@ -273,7 +272,7 @@ pub(crate) fn resolve_through_symlinks(
                 // any subsequent `..` steps use the real resolved path.
                 if std::fs::symlink_metadata(&current).is_ok_and(|m| m.file_type().is_symlink()) {
                     current = std::fs::canonicalize(&current).map_err(|_| {
-                        ExtractionError::SymlinkEscape {
+                        ArchiveError::SymlinkEscape {
                             path: link_path.to_path_buf(),
                         }
                     })?;
@@ -285,7 +284,7 @@ pub(crate) fn resolve_through_symlinks(
         }
 
         if !current.starts_with(dest) {
-            return Err(ExtractionError::SymlinkEscape {
+            return Err(ArchiveError::SymlinkEscape {
                 path: link_path.to_path_buf(),
             });
         }
@@ -347,7 +346,7 @@ mod tests {
         let result = SafeSymlink::validate(&link, &target, &dest, &config);
         assert!(matches!(
             result,
-            Err(ExtractionError::SecurityViolation { .. })
+            Err(ArchiveError::SecurityViolation { .. })
         ));
     }
 
@@ -362,7 +361,7 @@ mod tests {
         let target = PathBuf::from("/etc/passwd");
 
         let result = SafeSymlink::validate(&link, &target, &dest, &config);
-        assert!(matches!(result, Err(ExtractionError::SymlinkEscape { .. })));
+        assert!(matches!(result, Err(ArchiveError::SymlinkEscape { .. })));
     }
 
     #[test]
@@ -376,7 +375,7 @@ mod tests {
         let target = PathBuf::from("C:\\Windows\\System32");
 
         let result = SafeSymlink::validate(&link, &target, &dest, &config);
-        assert!(matches!(result, Err(ExtractionError::SymlinkEscape { .. })));
+        assert!(matches!(result, Err(ArchiveError::SymlinkEscape { .. })));
     }
 
     #[test]
@@ -391,7 +390,7 @@ mod tests {
         let target = PathBuf::from("../../../../etc/passwd");
 
         let result = SafeSymlink::validate(&link, &target, &dest, &config);
-        assert!(matches!(result, Err(ExtractionError::SymlinkEscape { .. })));
+        assert!(matches!(result, Err(ArchiveError::SymlinkEscape { .. })));
     }
 
     #[test]
@@ -537,7 +536,7 @@ mod tests {
         let target = PathBuf::from("../".repeat(50) + "file.txt");
 
         let result = SafeSymlink::validate(&link, &target, &dest, &config);
-        assert!(matches!(result, Err(ExtractionError::SymlinkEscape { .. })));
+        assert!(matches!(result, Err(ArchiveError::SymlinkEscape { .. })));
     }
 
     // Test for symlink with banned target component
@@ -554,7 +553,7 @@ mod tests {
 
         let result = SafeSymlink::validate(&link, &target, &dest, &config);
         assert!(
-            matches!(result, Err(ExtractionError::SecurityViolation { .. })),
+            matches!(result, Err(ArchiveError::SecurityViolation { .. })),
             "symlink to banned component should be rejected"
         );
     }
@@ -676,7 +675,7 @@ mod tests {
 
         let result = SafeSymlink::validate(&link, &target, &dest, &config);
         assert!(
-            matches!(result, Err(ExtractionError::SymlinkEscape { .. })),
+            matches!(result, Err(ArchiveError::SymlinkEscape { .. })),
             "two-hop symlink chain must be rejected"
         );
     }

--- a/crates/exarch-core/tests/integration_tests.rs
+++ b/crates/exarch-core/tests/integration_tests.rs
@@ -10,7 +10,7 @@
 
 mod security;
 
-use exarch_core::ExtractionError;
+use exarch_core::ArchiveError;
 use exarch_core::SecurityConfig;
 use exarch_core::types::DestDir;
 use exarch_core::types::SafePath;
@@ -116,7 +116,7 @@ fn test_path_traversal_blocked() {
     for path in paths {
         let result = SafePath::validate(&PathBuf::from(path), &dest, &config);
         assert!(
-            matches!(result, Err(ExtractionError::PathTraversal { .. })),
+            matches!(result, Err(ArchiveError::PathTraversal { .. })),
             "Path {path} should be rejected"
         );
     }
@@ -133,7 +133,7 @@ fn test_banned_components_blocked() {
     for path in paths {
         let result = SafePath::validate(&PathBuf::from(path), &dest, &config);
         assert!(
-            matches!(result, Err(ExtractionError::SecurityViolation { .. })),
+            matches!(result, Err(ArchiveError::SecurityViolation { .. })),
             "Path {path} should be rejected"
         );
     }
@@ -204,7 +204,7 @@ fn test_depth_limit_enforced() {
     let result = SafePath::validate(&PathBuf::from(bad_path), &dest, &config);
     assert!(matches!(
         result,
-        Err(ExtractionError::SecurityViolation { .. })
+        Err(ArchiveError::SecurityViolation { .. })
     ));
 }
 

--- a/crates/exarch-core/tests/property_tests.rs
+++ b/crates/exarch-core/tests/property_tests.rs
@@ -11,7 +11,7 @@
 
 use std::path::PathBuf;
 
-use exarch_core::ExtractionError;
+use exarch_core::ArchiveError;
 use exarch_core::QuotaResource;
 use exarch_core::SecurityConfig;
 use exarch_core::security::HardlinkTracker;
@@ -184,7 +184,7 @@ proptest! {
         if num_files > max_files {
             let result = tracker.record_file(100, &config);
             prop_assert!(
-                matches!(result, Err(ExtractionError::QuotaExceeded { .. })),
+                matches!(result, Err(ArchiveError::QuotaExceeded { .. })),
                 "exceeding file count should fail"
             );
         }
@@ -214,7 +214,7 @@ proptest! {
                 // Quota was exceeded - this is the security boundary
                 // Verify it's a quota error
                 prop_assert!(
-                    matches!(result, Err(ExtractionError::QuotaExceeded { .. })),
+                    matches!(result, Err(ArchiveError::QuotaExceeded { .. })),
                     "error should be QuotaExceeded"
                 );
                 break;
@@ -246,7 +246,7 @@ proptest! {
             prop_assert_eq!(tracker.bytes_written(), file_size);
         } else {
             prop_assert!(
-                matches!(result, Err(ExtractionError::QuotaExceeded {
+                matches!(result, Err(ArchiveError::QuotaExceeded {
                     resource: QuotaResource::FileSize { .. }
                 })),
                 "file exceeding size limit should fail"
@@ -323,7 +323,7 @@ proptest! {
         let result = validate_compression_ratio(0, uncompressed, &config);
 
         prop_assert!(
-            matches!(result, Err(ExtractionError::InvalidArchive(_))),
+            matches!(result, Err(ArchiveError::InvalidArchive(_))),
             "zero compressed with non-zero uncompressed must be rejected"
         );
     }
@@ -353,7 +353,7 @@ proptest! {
         let result = validate_compression_ratio(compressed, uncompressed, &config);
 
         prop_assert!(
-            matches!(result, Err(ExtractionError::ZipBomb { .. })),
+            matches!(result, Err(ArchiveError::ZipBomb { .. })),
             "extreme compression ratio should be detected"
         );
     }
@@ -398,7 +398,7 @@ proptest! {
         let result = tracker.validate_hardlink(&link, &target, &dest, &config);
 
         prop_assert!(
-            matches!(result, Err(ExtractionError::HardlinkEscape { .. })),
+            matches!(result, Err(ArchiveError::HardlinkEscape { .. })),
             "excessive parent traversal should be rejected"
         );
     }
@@ -517,7 +517,7 @@ proptest! {
         let result = SafeSymlink::validate(&link, &target_path, &dest, &config);
 
         prop_assert!(
-            matches!(result, Err(ExtractionError::SecurityViolation { .. })),
+            matches!(result, Err(ArchiveError::SecurityViolation { .. })),
             "symlinks should be rejected when disabled"
         );
     }

--- a/crates/exarch-core/tests/security/cve_regression.rs
+++ b/crates/exarch-core/tests/security/cve_regression.rs
@@ -6,7 +6,7 @@
 
 #![allow(clippy::unwrap_used, clippy::cast_possible_truncation)]
 
-use exarch_core::ExtractionError;
+use exarch_core::ArchiveError;
 use exarch_core::ExtractionOptions;
 use exarch_core::SecurityConfig;
 use exarch_core::formats::ArchiveFormat;
@@ -159,7 +159,7 @@ fn test_cve_2024_12718_dotslash_prefix_traversal() {
     );
 
     assert!(
-        matches!(result, Err(ExtractionError::PathTraversal { .. })),
+        matches!(result, Err(ArchiveError::PathTraversal { .. })),
         "dotslash-prefixed traversal must be rejected, got: {result:?}"
     );
 }
@@ -179,7 +179,7 @@ fn test_cve_2024_12718_dotslash_complex_traversal() {
     );
 
     assert!(
-        matches!(result, Err(ExtractionError::PathTraversal { .. })),
+        matches!(result, Err(ArchiveError::PathTraversal { .. })),
         "complex dotslash traversal must be rejected, got: {result:?}"
     );
 }
@@ -241,7 +241,7 @@ fn test_cve_2024_12905_symlink_outside_dest_rejected_by_default() {
     assert!(
         matches!(
             result,
-            Err(ExtractionError::SecurityViolation { .. } | ExtractionError::SymlinkEscape { .. })
+            Err(ArchiveError::SecurityViolation { .. } | ArchiveError::SymlinkEscape { .. })
         ),
         "symlink to outside dest must be rejected with default config, got: {result:?}"
     );
@@ -269,7 +269,7 @@ fn test_cve_2024_12905_symlink_outside_dest_rejected_when_allowed() {
     );
 
     assert!(
-        matches!(result, Err(ExtractionError::SymlinkEscape { .. })),
+        matches!(result, Err(ArchiveError::SymlinkEscape { .. })),
         "symlink to outside destination must be rejected, got: {result:?}"
     );
 }
@@ -295,7 +295,7 @@ fn test_cve_2024_12905_deep_symlink_chain() {
     );
 
     assert!(
-        matches!(result, Err(ExtractionError::SymlinkEscape { .. })),
+        matches!(result, Err(ArchiveError::SymlinkEscape { .. })),
         "deep symlink chain escape must be rejected, got: {result:?}"
     );
 }
@@ -325,7 +325,7 @@ fn test_cve_2025_48387_hardlink_outside_dest_rejected_by_default() {
     assert!(
         matches!(
             result,
-            Err(ExtractionError::SecurityViolation { .. } | ExtractionError::HardlinkEscape { .. })
+            Err(ArchiveError::SecurityViolation { .. } | ArchiveError::HardlinkEscape { .. })
         ),
         "hardlink outside dest must be rejected with default config, got: {result:?}"
     );
@@ -352,7 +352,7 @@ fn test_cve_2025_48387_hardlink_outside_dest_rejected_when_allowed() {
     );
 
     assert!(
-        matches!(result, Err(ExtractionError::HardlinkEscape { .. })),
+        matches!(result, Err(ArchiveError::HardlinkEscape { .. })),
         "hardlink traversal outside dest must be rejected, got: {result:?}"
     );
 }
@@ -377,7 +377,7 @@ fn test_cve_2025_48387_absolute_hardlink_rejected() {
     );
 
     assert!(
-        matches!(result, Err(ExtractionError::HardlinkEscape { .. })),
+        matches!(result, Err(ArchiveError::HardlinkEscape { .. })),
         "absolute hardlink target must be rejected, got: {result:?}"
     );
 }
@@ -414,9 +414,9 @@ fn test_rustsec_2026_0067_symlink_dir_chmod_default_config() {
     assert!(
         matches!(
             result,
-            Err(ExtractionError::SecurityViolation { .. }
-                | ExtractionError::SymlinkEscape { .. }
-                | ExtractionError::PathTraversal { .. })
+            Err(ArchiveError::SecurityViolation { .. }
+                | ArchiveError::SymlinkEscape { .. }
+                | ArchiveError::PathTraversal { .. })
         ),
         "symlink+dir chmod attack must be rejected with default config, got: {result:?}"
     );
@@ -451,7 +451,7 @@ fn test_rustsec_2026_0067_symlink_dir_chmod_symlinks_allowed() {
     );
 
     assert!(
-        matches!(result, Err(ExtractionError::SymlinkEscape { .. })),
+        matches!(result, Err(ArchiveError::SymlinkEscape { .. })),
         "symlink escaping root must be rejected even when symlinks are allowed, got: {result:?}"
     );
 
@@ -575,7 +575,7 @@ fn test_cve_2026_24842_deep_nested_hardlink_escape_rejected_by_default() {
     assert!(
         matches!(
             result,
-            Err(ExtractionError::SecurityViolation { .. } | ExtractionError::HardlinkEscape { .. })
+            Err(ArchiveError::SecurityViolation { .. } | ArchiveError::HardlinkEscape { .. })
         ),
         "deep nested hardlink escape must be rejected with default config, got: {result:?}"
     );
@@ -603,7 +603,7 @@ fn test_cve_2026_24842_deep_nested_hardlink_escape_rejected_when_allowed() {
     );
 
     assert!(
-        matches!(result, Err(ExtractionError::HardlinkEscape { .. })),
+        matches!(result, Err(ArchiveError::HardlinkEscape { .. })),
         "deep nested hardlink escape must be rejected even with hardlinks allowed, got: {result:?}"
     );
 
@@ -810,7 +810,7 @@ fn test_cve_2025_29787_zip_slip_blocked_with_symlinks_enabled() {
         "extraction must fail: escaping symlink must be rejected"
     );
     assert!(
-        matches!(result.unwrap_err(), ExtractionError::SymlinkEscape { .. }),
+        matches!(result.unwrap_err(), ArchiveError::SymlinkEscape { .. }),
         "expected SymlinkEscape"
     );
 

--- a/crates/exarch-core/tests/sevenz_integration.rs
+++ b/crates/exarch-core/tests/sevenz_integration.rs
@@ -2,7 +2,7 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-use exarch_core::ExtractionError;
+use exarch_core::ArchiveError;
 use exarch_core::ExtractionOptions;
 use exarch_core::ProgressCallback;
 use exarch_core::SecurityConfig;
@@ -67,7 +67,7 @@ fn test_7z_security_config_integration() {
         &ExtractionOptions::default(),
         &mut exarch_core::NoopProgress,
     );
-    assert!(matches!(result, Err(ExtractionError::QuotaExceeded { .. })));
+    assert!(matches!(result, Err(ArchiveError::QuotaExceeded { .. })));
 }
 
 #[test]
@@ -120,7 +120,7 @@ fn test_7z_solid_archive_rejected_at_new() {
     assert!(result.is_err());
     assert!(matches!(
         result.unwrap_err(),
-        ExtractionError::SecurityViolation { .. }
+        ArchiveError::SecurityViolation { .. }
     ));
 }
 
@@ -132,7 +132,7 @@ fn test_7z_encrypted_archive_rejected_at_new() {
     let result = SevenZArchive::new(cursor);
     assert!(result.is_err());
     let err = result.unwrap_err();
-    assert!(matches!(err, ExtractionError::SecurityViolation { .. }));
+    assert!(matches!(err, ArchiveError::SecurityViolation { .. }));
 
     // Verify error message is helpful
     let msg = err.to_string();
@@ -162,7 +162,7 @@ fn test_7z_quota_file_count() {
         &ExtractionOptions::default(),
         &mut exarch_core::NoopProgress,
     );
-    assert!(matches!(result, Err(ExtractionError::QuotaExceeded { .. })));
+    assert!(matches!(result, Err(ArchiveError::QuotaExceeded { .. })));
 }
 
 #[test]
@@ -180,7 +180,7 @@ fn test_7z_quota_total_size() {
         &ExtractionOptions::default(),
         &mut exarch_core::NoopProgress,
     );
-    assert!(matches!(result, Err(ExtractionError::QuotaExceeded { .. })));
+    assert!(matches!(result, Err(ArchiveError::QuotaExceeded { .. })));
 }
 
 // ============================================================================
@@ -234,7 +234,7 @@ fn test_7z_solid_archive_with_file_count_quota() {
         &ExtractionOptions::default(),
         &mut exarch_core::NoopProgress,
     );
-    assert!(matches!(result, Err(ExtractionError::QuotaExceeded { .. })));
+    assert!(matches!(result, Err(ArchiveError::QuotaExceeded { .. })));
 }
 
 // ============================================================================
@@ -506,7 +506,7 @@ fn test_7z_partial_extraction_accurate_report() {
         &mut exarch_core::NoopProgress,
     );
 
-    let Err(ExtractionError::PartialExtraction { report, .. }) = result else {
+    let Err(ArchiveError::PartialExtraction { report, .. }) = result else {
         panic!("expected PartialExtraction, got: {result:?}");
     };
     assert!(
@@ -555,7 +555,7 @@ fn test_7z_no_partial_extraction_when_zero_items() {
 
     assert!(result.is_err(), "expected an error, got Ok");
     assert!(
-        !matches!(result, Err(ExtractionError::PartialExtraction { .. })),
+        !matches!(result, Err(ArchiveError::PartialExtraction { .. })),
         "must NOT be PartialExtraction when zero items were written; got: {result:?}"
     );
 }

--- a/crates/exarch-core/tests/zip_family_integration.rs
+++ b/crates/exarch-core/tests/zip_family_integration.rs
@@ -11,7 +11,7 @@
     clippy::cast_possible_truncation
 )]
 
-use exarch_core::ExtractionError;
+use exarch_core::ArchiveError;
 use exarch_core::SecurityConfig;
 use exarch_core::create_archive;
 use exarch_core::creation::CreationConfig;
@@ -150,7 +150,7 @@ fn inferred_creation_is_rejected_for_zip_family() {
         let output = dest.path().join(format!("out.{ext}"));
         let result = create_archive(&output, &[] as &[&str], &config);
         match result {
-            Err(ExtractionError::InvalidArchive(msg)) => {
+            Err(ArchiveError::InvalidArchive(msg)) => {
                 assert!(
                     msg.contains(ext),
                     ".{ext} error should mention the extension (got: {msg})",
@@ -312,9 +312,9 @@ fn zip_partial_extraction_stops_on_path_traversal() {
     let result = extract_archive(&archive_path, dest.path(), &config);
 
     match result {
-        Err(ExtractionError::PartialExtraction { source, report }) => {
+        Err(ArchiveError::PartialExtraction { source, report }) => {
             assert!(
-                matches!(*source, ExtractionError::PathTraversal { .. }),
+                matches!(*source, ArchiveError::PathTraversal { .. }),
                 "source error must be PathTraversal, got: {source:?}"
             );
             assert!(

--- a/crates/exarch-node/src/error.rs
+++ b/crates/exarch-node/src/error.rs
@@ -1,6 +1,6 @@
 //! Error conversion for Node.js bindings.
 
-use exarch_core::ExtractionError as CoreError;
+use exarch_core::ArchiveError as CoreError;
 use exarch_core::QuotaResource as CoreQuotaResource;
 use napi::bindgen_prelude::*;
 use std::path::Path;

--- a/crates/exarch-python/README.md
+++ b/crates/exarch-python/README.md
@@ -104,7 +104,7 @@ except exarch.ZipBombError as e:
     print(f"Zip bomb detected: {e}")
 except exarch.SecurityViolationError as e:
     print(f"Security violation: {e}")
-except exarch.ExtractionError as e:
+except exarch.ArchiveError as e:
     print(f"Extraction failed: {e}")
 ```
 

--- a/crates/exarch-python/exarch.pyi
+++ b/crates/exarch-python/exarch.pyi
@@ -615,12 +615,12 @@ def verify_archive(
     """
     ...
 
-class ExtractionError(Exception):
+class ArchiveError(Exception):
     """Base exception for all extraction errors."""
 
     ...
 
-class PathTraversalError(ExtractionError):
+class PathTraversalError(ArchiveError):
     """
     Path traversal attempt detected.
 
@@ -635,7 +635,7 @@ class PathTraversalError(ExtractionError):
     files_extracted: int
     bytes_written: int
 
-class SymlinkEscapeError(ExtractionError):
+class SymlinkEscapeError(ArchiveError):
     """
     Symlink points outside extraction directory.
 
@@ -650,7 +650,7 @@ class SymlinkEscapeError(ExtractionError):
     files_extracted: int
     bytes_written: int
 
-class HardlinkEscapeError(ExtractionError):
+class HardlinkEscapeError(ArchiveError):
     """
     Hardlink target outside extraction directory.
 
@@ -665,7 +665,7 @@ class HardlinkEscapeError(ExtractionError):
     files_extracted: int
     bytes_written: int
 
-class ZipBombError(ExtractionError):
+class ZipBombError(ArchiveError):
     """
     Potential zip bomb detected.
 
@@ -680,7 +680,7 @@ class ZipBombError(ExtractionError):
     files_extracted: int
     bytes_written: int
 
-class InvalidPermissionsError(ExtractionError):
+class InvalidPermissionsError(ArchiveError):
     """
     File permissions are invalid or unsafe.
 
@@ -695,7 +695,7 @@ class InvalidPermissionsError(ExtractionError):
     files_extracted: int
     bytes_written: int
 
-class QuotaExceededError(ExtractionError):
+class QuotaExceededError(ArchiveError):
     """
     Resource quota exceeded.
 
@@ -710,7 +710,7 @@ class QuotaExceededError(ExtractionError):
     files_extracted: int
     bytes_written: int
 
-class SecurityViolationError(ExtractionError):
+class SecurityViolationError(ArchiveError):
     """
     Security policy violation.
 
@@ -725,7 +725,7 @@ class SecurityViolationError(ExtractionError):
     files_extracted: int
     bytes_written: int
 
-class UnsupportedFormatError(ExtractionError):
+class UnsupportedFormatError(ArchiveError):
     """Archive format not supported."""
 
     ...
@@ -742,7 +742,7 @@ class UnknownFormatError(UnsupportedFormatError):
 
     ...
 
-class InvalidArchiveError(ExtractionError):
+class InvalidArchiveError(ArchiveError):
     """Archive is corrupted."""
 
     ...

--- a/crates/exarch-python/src/error.rs
+++ b/crates/exarch-python/src/error.rs
@@ -1,6 +1,6 @@
 //! Python exception types for archive extraction errors.
 
-use exarch_core::ExtractionError as CoreError;
+use exarch_core::ArchiveError as CoreError;
 use exarch_core::QuotaResource as CoreQuotaResource;
 use pyo3::create_exception;
 use pyo3::exceptions::PyException;
@@ -9,22 +9,22 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
 // Base exception for all extraction errors
-create_exception!(exarch, ExtractionError, PyException);
+create_exception!(exarch, ArchiveError, PyException);
 
 // Specific exception types
-create_exception!(exarch, PathTraversalError, ExtractionError);
-create_exception!(exarch, SymlinkEscapeError, ExtractionError);
-create_exception!(exarch, HardlinkEscapeError, ExtractionError);
-create_exception!(exarch, ZipBombError, ExtractionError);
-create_exception!(exarch, InvalidPermissionsError, ExtractionError);
-create_exception!(exarch, QuotaExceededError, ExtractionError);
-create_exception!(exarch, SecurityViolationError, ExtractionError);
-create_exception!(exarch, UnsupportedFormatError, ExtractionError);
+create_exception!(exarch, PathTraversalError, ArchiveError);
+create_exception!(exarch, SymlinkEscapeError, ArchiveError);
+create_exception!(exarch, HardlinkEscapeError, ArchiveError);
+create_exception!(exarch, ZipBombError, ArchiveError);
+create_exception!(exarch, InvalidPermissionsError, ArchiveError);
+create_exception!(exarch, QuotaExceededError, ArchiveError);
+create_exception!(exarch, SecurityViolationError, ArchiveError);
+create_exception!(exarch, UnsupportedFormatError, ArchiveError);
 // Subclass of UnsupportedFormatError: raised when the format cannot be
 // identified at all (as opposed to being known but unsupported). Callers
 // catching the parent still work.
 create_exception!(exarch, UnknownFormatError, UnsupportedFormatError);
-create_exception!(exarch, InvalidArchiveError, ExtractionError);
+create_exception!(exarch, InvalidArchiveError, ArchiveError);
 
 /// Converts Rust extraction errors to Python exceptions.
 ///
@@ -120,7 +120,7 @@ pub fn convert_error(err: CoreError) -> PyErr {
 
 /// Registers all exception types with the Python module.
 pub fn register_exceptions(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add("ExtractionError", m.py().get_type::<ExtractionError>())?;
+    m.add("ArchiveError", m.py().get_type::<ArchiveError>())?;
     m.add(
         "PathTraversalError",
         m.py().get_type::<PathTraversalError>(),
@@ -450,8 +450,8 @@ mod tests {
 
             // Verify all exception types are registered
             assert!(
-                module.getattr("ExtractionError").is_ok(),
-                "ExtractionError not registered"
+                module.getattr("ArchiveError").is_ok(),
+                "ArchiveError not registered"
             );
             assert!(
                 module.getattr("PathTraversalError").is_ok(),

--- a/specs/001-exarch-system/plan.md
+++ b/specs/001-exarch-system/plan.md
@@ -107,7 +107,7 @@ exarch/
     │   │   ├── report.rs               # ExtractionReport, ProgressCallback, NoopProgress
     │   │   ├── error/
     │   │   │   ├── mod.rs
-    │   │   │   ├── types.rs            # ExtractionError enum
+    │   │   │   ├── types.rs            # ArchiveError enum
     │   │   │   └── messages.rs         # FfiErrorMessage for FFI-safe error passing
     │   │   ├── formats/
     │   │   │   ├── mod.rs              # re-exports TarArchive, ZipArchive, SevenZArchive

--- a/specs/001-exarch-system/spec.md
+++ b/specs/001-exarch-system/spec.md
@@ -71,7 +71,7 @@ THEN all entries are written to output_dir, no entry escapes output_dir,
 ```
 GIVEN an archive containing a path traversal entry (e.g. "../etc/passwd")
 WHEN I call extract_archive()
-THEN extraction fails with ExtractionError::PathTraversal before any file is written
+THEN extraction fails with ArchiveError::PathTraversal before any file is written
 ```
 
 ### US-002: Archive Creation (Rust API)
@@ -90,7 +90,7 @@ THEN an archive is produced containing all source files, and CreationReport.file
 ```
 GIVEN a 7z output path
 WHEN I call create_archive()
-THEN the call fails with ExtractionError::InvalidConfiguration
+THEN the call fails with ArchiveError::InvalidConfiguration
 ```
 
 ### US-003: Archive Inspection
@@ -190,7 +190,7 @@ THEN extraction runs on the libuv thread pool, files are extracted, and an Extra
 | FR-020 | WHEN an archive path has extension `.tar`, `.tgz`, `.tar.gz`, `.tar.bz2`, `.tbz`, `.tbz2`, `.tar.xz`, `.txz`, `.tar.zst`, `.tzst`, THE SYSTEM SHALL extract it as a TAR archive with the appropriate decompressor | must |
 | FR-021 | WHEN an archive path has extension `.zip` or any ZIP-family alias (`.jar`, `.war`, `.apk`, `.whl`, etc.), THE SYSTEM SHALL extract it as a ZIP archive | must |
 | FR-022 | WHEN an archive path has extension `.7z`, THE SYSTEM SHALL extract it using the 7z handler (extraction only) | must |
-| FR-023 | WHEN format detection is ambiguous or the extension is unrecognized, THE SYSTEM SHALL return `ExtractionError::UnknownFormat { path }` | must |
+| FR-023 | WHEN format detection is ambiguous or the extension is unrecognized, THE SYSTEM SHALL return `ArchiveError::UnknownFormat { path }` | must |
 | FR-024 | WHEN creating archives, THE SYSTEM SHALL support TAR (all compression variants) and ZIP; 7z creation SHALL return `InvalidConfiguration` | must |
 | FR-025 | WHEN creating archives for ZIP-family aliases without an explicit `CreationConfig::format` override, THE SYSTEM SHALL return an error explaining that the format requires extra structure | should |
 
@@ -245,7 +245,7 @@ THEN extraction runs on the libuv thread pool, files are extracted, and an Extra
 | FR-072 | WHEN paths contain null bytes or exceed 4096 bytes, THE SYSTEM SHALL raise `ValueError` at the Python boundary before calling into Rust | must |
 | FR-073 | WHEN no Python progress callback is provided, THE SYSTEM SHALL release the GIL during extraction/creation | must |
 | FR-074 | WHEN a Python progress callback is provided, THE SYSTEM SHALL NOT release the GIL (callback requires GIL to call Python) | must |
-| FR-075 | Rust `ExtractionError` variants SHALL map to specific Python exception types registered on the module | must |
+| FR-075 | Rust `ArchiveError` variants SHALL map to specific Python exception types registered on the module | must |
 
 ### 3.8 Node.js Bindings
 
@@ -254,7 +254,7 @@ THEN extraction runs on the libuv thread pool, files are extracted, and an Extra
 | FR-080 | THE SYSTEM SHALL expose async Node.js functions that return Promises: `extractArchive`, `createArchive`, `listArchive`, `verifyArchive` | must |
 | FR-081 | ALL async operations SHALL run on the libuv thread pool (not the main event loop thread) | must |
 | FR-082 | WHEN paths contain null bytes or exceed 4096 bytes, THE SYSTEM SHALL reject with a JavaScript Error before spawning a thread | must |
-| FR-083 | Rust `ExtractionError` variants SHALL map to named JavaScript Error types | must |
+| FR-083 | Rust `ArchiveError` variants SHALL map to named JavaScript Error types | must |
 
 ## 4. Non-Functional Requirements
 
@@ -300,26 +300,26 @@ THEN extraction runs on the libuv thread pool, files are extracted, and an Extra
 
 | Scenario | Expected Behavior |
 |----------|-------------------|
-| Archive path does not exist | `ExtractionError::Io` returned immediately |
-| Extension unrecognized or bare `.gz` without `.tar` stem | `ExtractionError::UnknownFormat { path }` |
+| Archive path does not exist | `ArchiveError::Io` returned immediately |
+| Extension unrecognized or bare `.gz` without `.tar` stem | `ArchiveError::UnknownFormat { path }` |
 | ZIP-family alias (`.apk`, `.whl`) extraction | Proceeds as ZIP |
-| ZIP-family alias creation without format override | `ExtractionError::InvalidArchive` with explanation naming the alias and referencing `CreationConfig::format` override |
-| 7z creation | `ExtractionError::InvalidConfiguration` |
+| ZIP-family alias creation without format override | `ArchiveError::InvalidArchive` with explanation naming the alias and referencing `CreationConfig::format` override |
+| 7z creation | `ArchiveError::InvalidConfiguration` |
 | Duplicate entry paths in archive | Logged as warning in `ExtractionReport.warnings` when `skip_duplicates` is true; error when false |
-| Atomic extraction to existing non-empty directory | `ExtractionError::OutputExists` on rename failure; temp dir cleaned up |
-| Path traversal `../` or absolute path | `ExtractionError::PathTraversal` |
-| File exceeds `max_file_size` | `ExtractionError::QuotaExceeded { resource: FileSizeBytes }` |
-| Total size exceeds `max_total_size` | `ExtractionError::QuotaExceeded { resource: TotalSizeBytes }` |
-| File count exceeds `max_file_count` | `ExtractionError::QuotaExceeded { resource: FileCount }` |
-| Compression ratio > `max_compression_ratio` | `ExtractionError::ZipBomb` |
+| Atomic extraction to existing non-empty directory | `ArchiveError::OutputExists` on rename failure; temp dir cleaned up |
+| Path traversal `../` or absolute path | `ArchiveError::PathTraversal` |
+| File exceeds `max_file_size` | `ArchiveError::QuotaExceeded { resource: FileSizeBytes }` |
+| Total size exceeds `max_total_size` | `ArchiveError::QuotaExceeded { resource: TotalSizeBytes }` |
+| File count exceeds `max_file_count` | `ArchiveError::QuotaExceeded { resource: FileCount }` |
+| Compression ratio > `max_compression_ratio` | `ArchiveError::ZipBomb` |
 | Symlink with `allowed.symlinks = false` | Entry skipped (not an error) |
-| Symlink pointing outside output_dir | `ExtractionError::SymlinkEscape` |
+| Symlink pointing outside output_dir | `ArchiveError::SymlinkEscape` |
 | Hardlink with `allowed.hardlinks = false` | Entry skipped |
-| Hardlink to a path not previously seen in this archive | `ExtractionError::HardlinkEscape` |
+| Hardlink to a path not previously seen in this archive | `ArchiveError::HardlinkEscape` |
 | setuid/setgid bits on Unix | Stripped silently; `mode` in `ValidatedEntry` reflects sanitized value |
-| Solid 7z archive with `allow_solid_archives = false` | `ExtractionError::InvalidArchive` or format-specific rejection |
-| Path depth > `max_path_depth` | `ExtractionError::PathTraversal` (depth exceeded) |
-| Banned component (`.git`) in path | `ExtractionError::PathTraversal` (banned component) |
+| Solid 7z archive with `allow_solid_archives = false` | `ArchiveError::InvalidArchive` or format-specific rejection |
+| Path depth > `max_path_depth` | `ArchiveError::PathTraversal` (depth exceeded) |
+| Banned component (`.git`) in path | `ArchiveError::PathTraversal` (banned component) |
 | `SecurityConfig` with zero limit | `SecurityConfig::validate()` returns `InvalidConfiguration` before extraction begins |
 | Python: null byte in path | `ValueError` raised at Python boundary |
 | Python: path exceeds 4096 bytes | `ValueError` raised at Python boundary |

--- a/specs/001-security-pipeline/spec.md
+++ b/specs/001-security-pipeline/spec.md
@@ -59,13 +59,13 @@ components are rejected before I/O begins
 ```
 GIVEN an archive containing a path traversal entry (e.g. "../etc/passwd")
 WHEN extract_archive() is called
-THEN extraction fails with ExtractionError::PathTraversal before any file is written
+THEN extraction fails with ArchiveError::PathTraversal before any file is written
 ```
 
 ```
 GIVEN an archive entry path containing a banned component (e.g. ".git/config")
 WHEN extract_archive() is called
-THEN extraction fails with ExtractionError::PathTraversal (banned component)
+THEN extraction fails with ArchiveError::PathTraversal (banned component)
 ```
 
 ### US-002: Zip Bomb Detection
@@ -78,7 +78,7 @@ SO THAT a malicious archive cannot exhaust disk space or memory
 ```
 GIVEN an archive entry where uncompressed_size / compressed_size > max_compression_ratio
 WHEN the entry is validated
-THEN the entry is rejected with ExtractionError::ZipBomb before any bytes are written
+THEN the entry is rejected with ArchiveError::ZipBomb before any bytes are written
 ```
 
 ### US-003: Symlink and Hardlink Control
@@ -97,7 +97,7 @@ THEN the entry is skipped (not an error)
 ```
 GIVEN a symlink entry and SecurityConfig with allowed.symlinks = true
 WHEN the resolved target escapes output_dir
-THEN extraction fails with ExtractionError::SymlinkEscape
+THEN extraction fails with ArchiveError::SymlinkEscape
 ```
 
 ### US-004: Quota Enforcement
@@ -110,13 +110,13 @@ SO THAT a single archive cannot exhaust disk space
 ```
 GIVEN a file entry whose uncompressed size exceeds max_file_size
 WHEN the entry is validated
-THEN extraction fails with ExtractionError::QuotaExceeded { resource: FileSizeBytes }
+THEN extraction fails with ArchiveError::QuotaExceeded { resource: FileSizeBytes }
 ```
 
 ```
 GIVEN cumulative uncompressed size across entries exceeds max_total_size
 WHEN the next entry is validated
-THEN extraction fails with ExtractionError::QuotaExceeded { resource: TotalSizeBytes }
+THEN extraction fails with ArchiveError::QuotaExceeded { resource: TotalSizeBytes }
 ```
 
 ### US-005: Permission Sanitization
@@ -145,7 +145,7 @@ THEN the written file has those bits cleared; ValidatedEntry.mode reflects the s
 | FR-007 | WHEN a hardlink entry is encountered and `allowed.hardlinks` is false, THE SYSTEM SHALL skip the entry | must |
 | FR-008 | WHEN a hardlink entry is encountered and `allowed.hardlinks` is true, THE SYSTEM SHALL validate that the hardlink target path is within `output_dir` and references a path previously seen in this archive | must |
 | FR-009 | WHEN extracting files on Unix, THE SYSTEM SHALL strip setuid (0o4000) and setgid (0o2000) bits from all file permissions | must |
-| FR-010 | WHEN the path depth of an entry exceeds `max_path_depth`, THE SYSTEM SHALL reject the entry with `ExtractionError::PathTraversal` | must |
+| FR-010 | WHEN the path depth of an entry exceeds `max_path_depth`, THE SYSTEM SHALL reject the entry with `ArchiveError::PathTraversal` | must |
 | FR-011 | WHEN `allowed_extensions` is non-empty and an entry's extension is not in the list, THE SYSTEM SHALL skip the entry and record it in `ExtractionReport::files_skipped` with a warning | must |
 | FR-012 | WHEN the file count across all entries exceeds `max_file_count`, THE SYSTEM SHALL reject further entries with `QuotaExceeded { resource: FileCount }` | must |
 | FR-013 | WHEN `allowed.world_writable` is false and a file entry has world-writable permissions (`mode & 0o002 != 0`), THE SYSTEM SHALL strip that bit or reject the entry | must |
@@ -180,19 +180,19 @@ THEN the written file has those bits cleared; ValidatedEntry.mode reflects the s
 
 | Scenario | Expected Behavior |
 |----------|-------------------|
-| Path traversal `../` or absolute path | `ExtractionError::PathTraversal` |
-| Null byte in path | `ExtractionError::PathTraversal` |
-| Banned component (e.g. `.git`) in path | `ExtractionError::PathTraversal` (banned component) |
-| Path depth > `max_path_depth` | `ExtractionError::PathTraversal` (depth exceeded) |
-| File exceeds `max_file_size` | `ExtractionError::QuotaExceeded { resource: FileSizeBytes }` |
-| Total size exceeds `max_total_size` | `ExtractionError::QuotaExceeded { resource: TotalSizeBytes }` |
-| File count exceeds `max_file_count` | `ExtractionError::QuotaExceeded { resource: FileCount }` |
-| Compression ratio > `max_compression_ratio` | `ExtractionError::ZipBomb` (before any bytes written) |
+| Path traversal `../` or absolute path | `ArchiveError::PathTraversal` |
+| Null byte in path | `ArchiveError::PathTraversal` |
+| Banned component (e.g. `.git`) in path | `ArchiveError::PathTraversal` (banned component) |
+| Path depth > `max_path_depth` | `ArchiveError::PathTraversal` (depth exceeded) |
+| File exceeds `max_file_size` | `ArchiveError::QuotaExceeded { resource: FileSizeBytes }` |
+| Total size exceeds `max_total_size` | `ArchiveError::QuotaExceeded { resource: TotalSizeBytes }` |
+| File count exceeds `max_file_count` | `ArchiveError::QuotaExceeded { resource: FileCount }` |
+| Compression ratio > `max_compression_ratio` | `ArchiveError::ZipBomb` (before any bytes written) |
 | Compression ratio not available (TAR streams) | Zip bomb check skipped for that entry; quota still enforced |
 | Symlink with `allowed.symlinks = false` | Entry skipped (not an error) |
-| Symlink pointing outside `output_dir` | `ExtractionError::SymlinkEscape` |
+| Symlink pointing outside `output_dir` | `ArchiveError::SymlinkEscape` |
 | Hardlink with `allowed.hardlinks = false` | Entry skipped |
-| Hardlink to a path not previously seen | `ExtractionError::HardlinkEscape` |
+| Hardlink to a path not previously seen | `ArchiveError::HardlinkEscape` |
 | setuid/setgid bits on Unix | Stripped silently; `ValidatedEntry.mode` reflects sanitized value |
 | `SecurityConfig` with zero `max_file_size`, `max_total_size`, `max_path_depth`, `max_file_count`, or `max_solid_block_memory` | `SecurityConfig::validate()` returns `InvalidConfiguration` before extraction begins |
 | `SecurityConfig` with `max_compression_ratio` of 0.0, negative, or NaN | `SecurityConfig::validate()` returns `InvalidConfiguration` before extraction begins |
@@ -225,7 +225,7 @@ THEN the written file has those bits cleared; ValidatedEntry.mode reflects the s
 - Remove existing security checks or lower default quota limits without a security review
 - Add `#[allow(unsafe_code)]` in any security module
 - Call `canonicalize()` inside the hot per-entry validation path
-- Allow `ExtractionError` variants to be constructed outside `exarch-core`
+- Allow `ArchiveError` variants to be constructed outside `exarch-core`
 
 ## 9. Open Questions
 

--- a/specs/002-format-handlers/spec.md
+++ b/specs/002-format-handlers/spec.md
@@ -90,7 +90,7 @@ SO THAT I am not silently given a bare ZIP file named .apk
 ```
 GIVEN an output path with a ZIP-family alias extension and no CreationConfig::format override
 WHEN create_archive() is called
-THEN the call fails with ExtractionError::InvalidArchive with an explanatory message
+THEN the call fails with ArchiveError::InvalidArchive with an explanatory message
 ```
 
 ### US-004: 7z Extraction Only
@@ -109,7 +109,7 @@ THEN extraction proceeds through the security pipeline and files are written to 
 ```
 GIVEN a .7z output path
 WHEN create_archive() is called
-THEN the call fails with ExtractionError::InvalidConfiguration
+THEN the call fails with ArchiveError::InvalidConfiguration
 ```
 
 ### US-005: Solid 7z Rejection by Default
@@ -135,7 +135,7 @@ SO THAT I do not need to specify the format explicitly
 ```
 GIVEN an archive path with an unrecognized extension
 WHEN any archive operation is called
-THEN ExtractionError::UnknownFormat { path } is returned immediately
+THEN ArchiveError::UnknownFormat { path } is returned immediately
 ```
 
 ## 3. Functional Requirements
@@ -145,15 +145,15 @@ THEN ExtractionError::UnknownFormat { path } is returned immediately
 | FR-020 | WHEN an archive path has extension `.tar`, `.tgz`, `.tar.gz`, `.tar.bz2`, `.tbz`, `.tbz2`, `.tar.xz`, `.txz`, `.tar.zst`, `.tzst`, THE SYSTEM SHALL extract it as a TAR archive with the appropriate decompressor | must |
 | FR-021 | WHEN an archive path has extension `.zip` or any ZIP-family alias, THE SYSTEM SHALL extract it as a ZIP archive | must |
 | FR-022 | WHEN an archive path has extension `.7z`, THE SYSTEM SHALL extract it using the 7z handler | must |
-| FR-023 | WHEN format detection finds an unrecognized or ambiguous extension (e.g. bare `.gz` without `.tar` stem), THE SYSTEM SHALL return `ExtractionError::UnknownFormat { path }` | must |
+| FR-023 | WHEN format detection finds an unrecognized or ambiguous extension (e.g. bare `.gz` without `.tar` stem), THE SYSTEM SHALL return `ArchiveError::UnknownFormat { path }` | must |
 | FR-024 | WHEN creating archives, THE SYSTEM SHALL support TAR (all compression variants) and ZIP; 7z creation SHALL return `InvalidConfiguration` | must |
-| FR-025 | WHEN creating archives for ZIP-family aliases without an explicit `CreationConfig::format` override, THE SYSTEM SHALL return `ExtractionError::InvalidArchive` with an explanation | should |
+| FR-025 | WHEN creating archives for ZIP-family aliases without an explicit `CreationConfig::format` override, THE SYSTEM SHALL return `ArchiveError::InvalidArchive` with an explanation | should |
 | FR-026 | WHEN a 7z archive is solid and `allow_solid_archives` is false, THE SYSTEM SHALL reject extraction before decompressing the solid block | must |
 | FR-027 | WHEN a 7z solid archive extraction is permitted, THE SYSTEM SHALL reject it if total uncompressed size exceeds `max_solid_block_memory` | must |
 | FR-028 | Every format handler SHALL route all entries through `EntryValidator` before writing to disk | must |
 | FR-029 | WHEN listing or verifying an archive, THE SYSTEM SHALL NOT write any files to disk | must |
 | FR-030 | WHEN `allowed_extensions` in `SecurityConfig` is non-empty, ALL three format handlers (TAR, ZIP, 7z) SHALL skip entries whose extension is not in the allowlist and record them in `ExtractionReport::files_skipped` | must |
-| FR-031 | `ArchiveFormat::extract` SHALL accept and invoke a `ProgressCallback` for every entry; ZIP-family alias creation without an explicit `CreationConfig::format` override SHALL be rejected with `ExtractionError::InvalidArchive` naming the alias | must |
+| FR-031 | `ArchiveFormat::extract` SHALL accept and invoke a `ProgressCallback` for every entry; ZIP-family alias creation without an explicit `CreationConfig::format` override SHALL be rejected with `ArchiveError::InvalidArchive` naming the alias | must |
 
 ## 4. Non-Functional Requirements
 
@@ -226,14 +226,14 @@ FormatCreator:
 
 | Scenario | Expected Behavior |
 |----------|-------------------|
-| Archive path does not exist | `ExtractionError::Io` returned immediately |
-| Extension unrecognized or bare `.gz` without `.tar` stem | `ExtractionError::UnknownFormat { path }` |
+| Archive path does not exist | `ArchiveError::Io` returned immediately |
+| Extension unrecognized or bare `.gz` without `.tar` stem | `ArchiveError::UnknownFormat { path }` |
 | ZIP-family alias extraction | Proceeds as ZIP |
-| ZIP-family alias creation without format override | `ExtractionError::InvalidArchive` with explanation |
-| 7z creation | `ExtractionError::InvalidConfiguration` |
+| ZIP-family alias creation without format override | `ArchiveError::InvalidArchive` with explanation |
+| 7z creation | `ArchiveError::InvalidConfiguration` |
 | Solid 7z with `allow_solid_archives = false` | Extraction rejected before decompressing |
-| Solid 7z with total uncompressed size > `max_solid_block_memory` | `ExtractionError::QuotaExceeded` or format-specific rejection |
-| Corrupt archive (unreadable headers) | `ExtractionError::InvalidArchive`; `verify_archive` returns `VerificationReport` with issues |
+| Solid 7z with total uncompressed size > `max_solid_block_memory` | `ArchiveError::QuotaExceeded` or format-specific rejection |
+| Corrupt archive (unreadable headers) | `ArchiveError::InvalidArchive`; `verify_archive` returns `VerificationReport` with issues |
 | Compression ratio unavailable per-entry (TAR streams) | Zip bomb check skipped for that entry; total quota still enforced |
 
 ## 7. Success Criteria

--- a/specs/002-format-handlers/tasks.md
+++ b/specs/002-format-handlers/tasks.md
@@ -45,7 +45,7 @@ graph TD
 ### T001: Improve ZIP-family alias creation error message
 
 **Context**: `reject_zip_family_creation()` in `api.rs` already returns
-`ExtractionError::InvalidArchive` when a caller tries to create an archive with
+`ArchiveError::InvalidArchive` when a caller tries to create an archive with
 a ZIP-family alias extension (e.g. `.apk`, `.whl`) without an explicit
 `CreationConfig::format` override. However the current error string does not
 tell the user which extension was detected or how to bypass the guard. FR-025
@@ -75,14 +75,14 @@ Single task; can be merged independently.
 
 ### Common patterns
 
-- The existing error is constructed with `ExtractionError::InvalidArchive`.
+- The existing error is constructed with `ArchiveError::InvalidArchive`.
   Extend the message string inline — no new error variant needed.
 - Retrieve the extension from the `output` path argument already available in
   `reject_zip_family_creation()`.
 
 ### Gotchas
 
-- `ExtractionError::InvalidArchive` carries a `String` message field; confirm
+- `ArchiveError::InvalidArchive` carries a `String` message field; confirm
   the exact field name before editing.
 - Keep the message concise — it will appear in CLI stderr output and in Python
   / Node.js `ExarchError` messages.

--- a/specs/003-config-api/spec.md
+++ b/specs/003-config-api/spec.md
@@ -83,7 +83,7 @@ SO THAT extraction does not start with a zero or non-finite limit
 ```
 GIVEN SecurityConfig::default().with_max_file_size(0)
 WHEN validate() is called
-THEN it returns ExtractionError::InvalidConfiguration before extraction begins
+THEN it returns ArchiveError::InvalidConfiguration before extraction begins
 ```
 
 ### US-004: Archive Creation Configuration
@@ -171,9 +171,9 @@ THEN no files are present in the output directory; the temp dir is cleaned up
 | `SecurityConfig` with zero `max_file_size`, `max_total_size`, `max_path_depth`, `max_file_count`, or `max_solid_block_memory` | `validate()` returns `InvalidConfiguration` |
 | `SecurityConfig` with `max_compression_ratio` of 0.0, negative, or NaN | `validate()` returns `InvalidConfiguration` |
 | `compression_level` outside 1–9 | `CreationConfig` builder panics or returns error at construction |
-| `atomic = true` and output on a different filesystem than temp dir | `fs::rename` may fail; caller receives `ExtractionError::Io` |
-| `skip_duplicates = false` and duplicate entry | `ExtractionError::InvalidArchive` (duplicate entry) |
-| Atomic extraction fails mid-archive | Temp dir deleted; `ExtractionError` returned; no files in output dir |
+| `atomic = true` and output on a different filesystem than temp dir | `fs::rename` may fail; caller receives `ArchiveError::Io` |
+| `skip_duplicates = false` and duplicate entry | `ArchiveError::InvalidArchive` (duplicate entry) |
+| Atomic extraction fails mid-archive | Temp dir deleted; `ArchiveError` returned; no files in output dir |
 
 ## 7. Success Criteria
 

--- a/specs/005-cli/spec.md
+++ b/specs/005-cli/spec.md
@@ -218,7 +218,7 @@ exarch completion <SHELL>    # bash | zsh | fish | powershell | elvish  (output 
 | SC-001 | All subcommands produce correct output in human mode | Manual and integration tests |
 | SC-002 | `--json` output is valid JSON parseable by `jq` | Integration test with JSON schema validation |
 | SC-003 | Progress bar suppressed with `--json` and `--quiet` | Integration test checking stderr |
-| SC-004 | Exit code non-zero on all error paths | Test matrix covering each `ExtractionError` variant |
+| SC-004 | Exit code non-zero on all error paths | Test matrix covering each `ArchiveError` variant |
 
 ## 8. Agent Boundaries
 

--- a/specs/006-python-bindings/spec.md
+++ b/specs/006-python-bindings/spec.md
@@ -103,7 +103,7 @@ THEN the GIL is held (callback requires GIL to call Python)
 ### US-004: Pythonic Error Types
 
 AS A Python developer
-I WANT Rust ExtractionError variants to map to specific Python exception classes
+I WANT Rust ArchiveError variants to map to specific Python exception classes
 SO THAT I can catch specific error types in a try/except block
 
 **Acceptance criteria:**
@@ -135,7 +135,7 @@ THEN extraction respects those settings
 | FR-072 | WHEN paths contain null bytes or exceed 4096 bytes, THE SYSTEM SHALL raise `ValueError` at the Python boundary before calling into Rust | must |
 | FR-073 | WHEN no Python progress callback is provided, THE SYSTEM SHALL release the GIL during extraction/creation | must |
 | FR-074 | WHEN a Python progress callback is provided, THE SYSTEM SHALL NOT release the GIL (callback requires GIL to invoke Python) | must |
-| FR-075 | Rust `ExtractionError` variants SHALL map to specific Python exception types; `SourceNotFound`/`OutputExists` → `PyIOError`; `InvalidCompressionLevel`/`InvalidConfiguration` → `PyValueError`; `PartialExtraction` → the specific inner exception type (e.g. `SymlinkEscapeError`, `QuotaExceededError`) with `files_extracted` and `bytes_written` attributes attached to that exception | must |
+| FR-075 | Rust `ArchiveError` variants SHALL map to specific Python exception types; `SourceNotFound`/`OutputExists` → `PyIOError`; `InvalidCompressionLevel`/`InvalidConfiguration` → `PyValueError`; `PartialExtraction` → the specific inner exception type (e.g. `SymlinkEscapeError`, `QuotaExceededError`) with `files_extracted` and `bytes_written` attributes attached to that exception | must |
 | FR-076 | ALL Python exception types SHALL be subclasses of `ExarchError(Exception)` | must |
 | FR-077 | `PySecurityConfig` and `PyCreationConfig` SHALL expose the same fluent builder API as the Rust counterparts | must |
 | FR-078 | `PyExtractionReport`, `PyCreationReport`, `PyArchiveManifest`, and `PyVerificationReport` SHALL expose all fields as Python attributes | must |
@@ -190,10 +190,10 @@ Use `hasattr(e, "files_extracted")` to detect whether a partial extraction occur
 > - `InvalidCompressionLevel` and `InvalidConfiguration` now raise
 >   `PyValueError` (was `InvalidArchiveError`).
 > - In v0.4.0, `PartialExtraction` incorrectly collapsed all partial-extraction
->   failures into a generic `PartialExtractionError` (#216). Fixed in v0.4.1
+>   failures into a generic `PartialArchiveError` (#216). Fixed in v0.4.1
 >   (#251): the specific inner exception type is raised (e.g. `SymlinkEscapeError`)
 >   with `files_extracted` and `bytes_written` attached directly to it (#210).
->   `PartialExtractionError` has been removed from the public API.
+>   `PartialArchiveError` has been removed from the public API.
 > These corrections allow Python callers to distinguish I/O failures, validation
 > errors, and archive corruption with specific `except` clauses.
 
@@ -217,10 +217,10 @@ def verify_archive(archive_path, config=None) -> VerificationReport
 | Path contains null byte | `ValueError` at Python boundary |
 | Path exceeds 4096 bytes | `ValueError` at Python boundary |
 | Path is `pathlib.Path` | Converted to `str` via `.as_os_str()` before Rust call |
-| Rust returns `ExtractionError::PathTraversal` | `PathTraversalError` raised in Python |
-| Rust returns `ExtractionError::SourceNotFound` or `OutputExists` | `PyIOError` raised (not `InvalidArchiveError`) |
-| Rust returns `ExtractionError::InvalidCompressionLevel` or `InvalidConfiguration` | `PyValueError` raised (not `InvalidArchiveError`) |
-| Rust returns `ExtractionError::PartialExtraction` | The specific inner exception (e.g. `SymlinkEscapeError`) is raised; `files_extracted` and `bytes_written` attributes are attached; detect partiality via `hasattr(e, "files_extracted")` |
+| Rust returns `ArchiveError::PathTraversal` | `PathTraversalError` raised in Python |
+| Rust returns `ArchiveError::SourceNotFound` or `OutputExists` | `PyIOError` raised (not `InvalidArchiveError`) |
+| Rust returns `ArchiveError::InvalidCompressionLevel` or `InvalidConfiguration` | `PyValueError` raised (not `InvalidArchiveError`) |
+| Rust returns `ArchiveError::PartialExtraction` | The specific inner exception (e.g. `SymlinkEscapeError`) is raised; `files_extracted` and `bytes_written` attributes are attached; detect partiality via `hasattr(e, "files_extracted")` |
 | Progress callback raises Python exception | Exception propagates through `PyProgressAdapter`; extraction aborted |
 | GIL state with progress callback | GIL held throughout; no concurrent Python threads during extraction |
 
@@ -230,7 +230,7 @@ def verify_archive(archive_path, config=None) -> VerificationReport
 |----|--------|--------|
 | SC-001 | All Python functions return correct report objects | `pytest` test coverage for each function |
 | SC-002 | GIL released when no callback provided | Verified by thread concurrency test |
-| SC-003 | All `ExtractionError` variants map to Python exceptions | Test for each variant |
+| SC-003 | All `ArchiveError` variants map to Python exceptions | Test for each variant |
 | SC-004 | Path boundary validation catches null bytes and long paths | Unit tests at Python boundary |
 | SC-005 | `maturin develop` + `pytest` passes on CI | CI job for Python crate |
 
@@ -239,7 +239,7 @@ def verify_archive(archive_path, config=None) -> VerificationReport
 ### Always (without asking)
 - Validate paths at the Python boundary before calling into Rust
 - Release GIL during Rust calls when no Python progress callback is present
-- Map every `ExtractionError` variant to a Python exception subclass of `ExarchError`
+- Map every `ArchiveError` variant to a Python exception subclass of `ExarchError`
 - Keep all security logic in `exarch-core`; Python crate contains only type mapping
 
 ### Ask First
@@ -250,7 +250,7 @@ def verify_archive(archive_path, config=None) -> VerificationReport
 ### Never
 - Implement security validation in the Python crate
 - Hold the GIL during long I/O operations without a progress callback
-- Expose `ExtractionError` as a raw Rust type to Python callers
+- Expose `ArchiveError` as a raw Rust type to Python callers
 
 ## 9. Open Questions
 

--- a/specs/006-python-bindings/tasks.md
+++ b/specs/006-python-bindings/tasks.md
@@ -25,7 +25,7 @@ related:
 > The Python bindings subsystem is fully implemented. PyO3 wrappers for all
 > core operations (`extract`, `create`, `list`, `verify`) are in place. The
 > GIL is released during I/O, `SecurityConfig` and `CreationConfig` are
-> exposed as Python classes, `ExarchError` maps all `ExtractionError` variants,
+> exposed as Python classes, `ExarchError` maps all `ArchiveError` variants,
 > and `exarch.pyi` provides complete type stubs. All functional requirements
 > from the spec are satisfied.
 

--- a/specs/007-node-bindings/spec.md
+++ b/specs/007-node-bindings/spec.md
@@ -86,7 +86,7 @@ THEN a JavaScript Error is thrown synchronously
 ### US-003: Named JavaScript Error Types
 
 AS A Node.js developer
-I WANT Rust ExtractionError variants to produce named JS Error objects
+I WANT Rust ArchiveError variants to produce named JS Error objects
 SO THAT I can differentiate errors in a catch block by type name
 
 **Acceptance criteria:**
@@ -129,7 +129,7 @@ THEN extraction respects those settings
 | FR-080 | THE SYSTEM SHALL expose async Node.js functions returning Promises: `extractArchive`, `createArchive`, `listArchive`, `verifyArchive` | must |
 | FR-081 | ALL async operations SHALL run on the libuv thread pool, not the main event loop thread | must |
 | FR-082 | WHEN paths contain null bytes or exceed 4096 bytes, THE SYSTEM SHALL throw a synchronous JavaScript Error before spawning a thread | must |
-| FR-083 | Rust `ExtractionError` variants SHALL map to named JavaScript Error types; when `PartialExtraction` wraps an inner error, the error message SHALL begin with the specific inner error code (e.g. `SYMLINK_ESCAPE`, `QUOTA_EXCEEDED`) and SHALL append `filesExtracted` and `bytesWritten` fields for caller inspection | must |
+| FR-083 | Rust `ArchiveError` variants SHALL map to named JavaScript Error types; when `PartialExtraction` wraps an inner error, the error message SHALL begin with the specific inner error code (e.g. `SYMLINK_ESCAPE`, `QUOTA_EXCEEDED`) and SHALL append `filesExtracted` and `bytesWritten` fields for caller inspection | must |
 | FR-084 | `SecurityConfig` and `CreationConfig` SHALL be exposed as JavaScript classes with fluent builder methods | must |
 | FR-085 | `ExtractionReport`, `CreationReport`, `ArchiveManifest`, and `VerificationReport` SHALL be exposed as JavaScript objects with typed fields | must |
 | FR-086 | napi-rs SHALL generate TypeScript `.d.ts` files for all exported functions and classes | must |
@@ -204,7 +204,7 @@ class CreationConfig {
 
 ### JavaScript Error Mapping
 
-| Rust `ExtractionError` variant | JavaScript Error name |
+| Rust `ArchiveError` variant | JavaScript Error name |
 |---|---|
 | `PathTraversal` | `PathTraversalError` |
 | `SymlinkEscape` | `SymlinkEscapeError` |
@@ -234,8 +234,8 @@ class CreationConfig {
 | Path is `null` or `undefined` | TypeError thrown by napi-rs before boundary check |
 | Path contains null byte | Synchronous `Error` thrown before Promise creation |
 | Path exceeds 4096 bytes | Synchronous `Error` thrown before Promise creation |
-| Rust returns `ExtractionError::PathTraversal` | Promise rejects with `PathTraversalError` |
-| Rust returns `ExtractionError::PartialExtraction` | Promise rejects with the specific inner error code as prefix (e.g. `SYMLINK_ESCAPE: ...`); message appends `filesExtracted` and `bytesWritten` |
+| Rust returns `ArchiveError::PathTraversal` | Promise rejects with `PathTraversalError` |
+| Rust returns `ArchiveError::PartialExtraction` | Promise rejects with the specific inner error code as prefix (e.g. `SYMLINK_ESCAPE: ...`); message appends `filesExtracted` and `bytesWritten` |
 | Thread pool exhausted | Promise eventually resolves when thread becomes available; no timeout |
 | `sources` array is empty for `createArchive` | [NEEDS CLARIFICATION: reject immediately or produce empty archive?] |
 
@@ -245,7 +245,7 @@ class CreationConfig {
 |----|--------|--------|
 | SC-001 | All async functions resolve with correct report objects | `npm test` passes |
 | SC-002 | Event loop not blocked during extraction | Test with concurrent timer; timer fires during extraction |
-| SC-003 | All `ExtractionError` variants produce named JS Errors | Test for each variant |
+| SC-003 | All `ArchiveError` variants produce named JS Errors | Test for each variant |
 | SC-004 | Path boundary validation throws synchronously | Unit test: no Promise.reject, synchronous throw |
 | SC-005 | TypeScript definitions are valid and complete | `tsc --noEmit` passes on test file |
 
@@ -254,7 +254,7 @@ class CreationConfig {
 ### Always (without asking)
 - Validate paths synchronously at the JS boundary before creating a Promise
 - Run all I/O on the libuv thread pool via napi-rs async pattern
-- Map every `ExtractionError` variant to a named JS Error
+- Map every `ArchiveError` variant to a named JS Error
 - Keep all security logic in `exarch-core`; Node.js crate contains only type mapping
 
 ### Ask First

--- a/specs/007-node-bindings/tasks.md
+++ b/specs/007-node-bindings/tasks.md
@@ -24,7 +24,7 @@ related:
 > [!note] No open work
 > The Node.js bindings subsystem is fully implemented. napi-rs wrappers expose
 > all core operations as async Promises backed by a tokio runtime. `SecurityConfig`
-> and `CreationConfig` are mapped to JavaScript objects. All `ExtractionError`
+> and `CreationConfig` are mapped to JavaScript objects. All `ArchiveError`
 > variants are translated to `ExarchError`. Report types (`ExtractionReport`,
 > `CreationReport`, `ArchiveManifest`, `VerificationReport`) are serialized to
 > plain JavaScript objects. No functional requirements from the spec remain

--- a/tests/cve/cve_2025_29787.rs
+++ b/tests/cve/cve_2025_29787.rs
@@ -19,7 +19,7 @@
 //! With symlinks disabled (default) the archive is rejected at entry 1 with
 //! `SecurityViolation` — that branch is also covered.
 
-use exarch_core::ExtractionError;
+use exarch_core::ArchiveError;
 use exarch_core::SecurityConfig;
 use exarch_core::formats::ZipArchive;
 use exarch_core::formats::traits::ArchiveFormat;
@@ -173,7 +173,7 @@ fn zip_symlink_zip_slip_blocked_with_symlinks_enabled() {
 
     let err = result.unwrap_err();
     assert!(
-        matches!(err, ExtractionError::SymlinkEscape { .. }),
+        matches!(err, ArchiveError::SymlinkEscape { .. }),
         "expected SymlinkEscape, got: {err:?}"
     );
 

--- a/tests/cve/ghsa_83g3_92jg_28cx.rs
+++ b/tests/cve/ghsa_83g3_92jg_28cx.rs
@@ -18,7 +18,7 @@
 //!
 //! Requires: `--allow-symlinks` AND `--allow-hardlinks` (both non-default).
 
-use exarch_core::ExtractionError;
+use exarch_core::ArchiveError;
 use exarch_core::SecurityConfig;
 use exarch_core::formats::TarArchive;
 use exarch_core::formats::traits::ArchiveFormat;
@@ -101,7 +101,7 @@ fn two_hop_symlink_chain_is_rejected() {
     assert!(
         matches!(
             err,
-            ExtractionError::SymlinkEscape { .. } | ExtractionError::HardlinkEscape { .. }
+            ArchiveError::SymlinkEscape { .. } | ArchiveError::HardlinkEscape { .. }
         ),
         "expected SymlinkEscape or HardlinkEscape, got: {err:?}"
     );

--- a/tests/cve/rustsec_2026_0067.rs
+++ b/tests/cve/rustsec_2026_0067.rs
@@ -17,7 +17,7 @@
 //! 3. The specific symlink+directory chmod attack pattern is blocked even when
 //!    the symlink uses a relative (`../`) escape.
 
-use exarch_core::ExtractionError;
+use exarch_core::ArchiveError;
 use exarch_core::formats::TarArchive;
 use exarch_core::formats::traits::ArchiveFormat;
 use exarch_core::SecurityConfig;
@@ -131,7 +131,7 @@ fn test_rustsec_2026_0067_symlink_dir_chmod_blocked() {
     let result = ArchiveFormat::extract(&mut archive, temp.path(), &config);
 
     match result {
-        Err(ExtractionError::SymlinkEscape { .. } | ExtractionError::PathTraversal { .. }) => {
+        Err(ArchiveError::SymlinkEscape { .. } | ArchiveError::PathTraversal { .. }) => {
             // Ideal: exarch's security layer rejected the escape attempt.
         }
         Err(other) => {

--- a/tests/security/hardlink_attack.rs
+++ b/tests/security/hardlink_attack.rs
@@ -2,7 +2,7 @@
 
 use exarch_core::security::EntryValidator;
 use exarch_core::types::{DestDir, EntryType};
-use exarch_core::{ExtractionError, SecurityConfig};
+use exarch_core::{ArchiveError, SecurityConfig};
 use std::path::{Path, PathBuf};
 use tempfile::TempDir;
 
@@ -27,7 +27,7 @@ fn test_hardlink_absolute_target() {
 
     assert!(matches!(
         result,
-        Err(ExtractionError::HardlinkEscape { .. })
+        Err(ArchiveError::HardlinkEscape { .. })
     ));
 }
 
@@ -52,7 +52,7 @@ fn test_hardlink_parent_traversal() {
 
     assert!(matches!(
         result,
-        Err(ExtractionError::HardlinkEscape { .. })
+        Err(ArchiveError::HardlinkEscape { .. })
     ));
 }
 
@@ -76,7 +76,7 @@ fn test_hardlink_disabled_by_default() {
 
     assert!(matches!(
         result,
-        Err(ExtractionError::SecurityViolation { .. })
+        Err(ArchiveError::SecurityViolation { .. })
     ));
 }
 
@@ -183,6 +183,6 @@ fn test_hardlink_chain_escape() {
 
     assert!(matches!(
         result,
-        Err(ExtractionError::HardlinkEscape { .. })
+        Err(ArchiveError::HardlinkEscape { .. })
     ));
 }

--- a/tests/security/path_traversal.rs
+++ b/tests/security/path_traversal.rs
@@ -4,7 +4,7 @@
 
 use exarch_core::security::EntryValidator;
 use exarch_core::types::{DestDir, EntryType};
-use exarch_core::{ExtractionError, SecurityConfig};
+use exarch_core::{ArchiveError, SecurityConfig};
 use std::path::{Path, PathBuf};
 use tempfile::TempDir;
 
@@ -33,7 +33,7 @@ fn test_cve_2025_4517_python_tarfile_traversal() {
         );
 
         assert!(
-            matches!(result, Err(ExtractionError::PathTraversal { .. })),
+            matches!(result, Err(ArchiveError::PathTraversal { .. })),
             "Path should be rejected: {}",
             path
         );
@@ -86,7 +86,7 @@ fn test_null_byte_injection() {
 
         assert!(matches!(
             result,
-            Err(ExtractionError::SecurityViolation { .. })
+            Err(ArchiveError::SecurityViolation { .. })
         ));
     }
 }

--- a/tests/security/symlink_escape.rs
+++ b/tests/security/symlink_escape.rs
@@ -2,7 +2,7 @@
 
 use exarch_core::security::EntryValidator;
 use exarch_core::types::{DestDir, EntryType};
-use exarch_core::{ExtractionError, SecurityConfig};
+use exarch_core::{ArchiveError, SecurityConfig};
 use std::path::{Path, PathBuf};
 use tempfile::TempDir;
 
@@ -27,7 +27,7 @@ fn test_symlink_absolute_target() {
 
     assert!(matches!(
         result,
-        Err(ExtractionError::SymlinkEscape { .. })
+        Err(ArchiveError::SymlinkEscape { .. })
     ));
 }
 
@@ -52,7 +52,7 @@ fn test_symlink_parent_traversal() {
 
     assert!(matches!(
         result,
-        Err(ExtractionError::SymlinkEscape { .. })
+        Err(ArchiveError::SymlinkEscape { .. })
     ));
 }
 
@@ -76,7 +76,7 @@ fn test_symlink_disabled_by_default() {
 
     assert!(matches!(
         result,
-        Err(ExtractionError::SecurityViolation { .. })
+        Err(ArchiveError::SecurityViolation { .. })
     ));
 }
 
@@ -146,6 +146,6 @@ fn test_symlink_chain_escape() {
 
     assert!(matches!(
         result,
-        Err(ExtractionError::SymlinkEscape { .. })
+        Err(ArchiveError::SymlinkEscape { .. })
     ));
 }

--- a/tests/security/zip_bomb.rs
+++ b/tests/security/zip_bomb.rs
@@ -2,7 +2,7 @@
 
 use exarch_core::security::EntryValidator;
 use exarch_core::types::{DestDir, EntryType};
-use exarch_core::{ExtractionError, SecurityConfig};
+use exarch_core::{ArchiveError, SecurityConfig};
 use std::path::Path;
 use tempfile::TempDir;
 
@@ -23,7 +23,7 @@ fn test_42_zip_bomb_simulation() {
         Some(0o644),
     );
 
-    assert!(matches!(result, Err(ExtractionError::ZipBomb { .. })));
+    assert!(matches!(result, Err(ArchiveError::ZipBomb { .. })));
 }
 
 #[test]
@@ -43,7 +43,7 @@ fn test_high_compression_ratio_individual() {
         Some(0o644),
     );
 
-    assert!(matches!(result, Err(ExtractionError::ZipBomb { .. })));
+    assert!(matches!(result, Err(ArchiveError::ZipBomb { .. })));
 }
 
 #[test]
@@ -103,7 +103,7 @@ fn test_just_over_compression_ratio() {
         Some(0o644),
     );
 
-    assert!(matches!(result, Err(ExtractionError::ZipBomb { .. })));
+    assert!(matches!(result, Err(ArchiveError::ZipBomb { .. })));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Rename `ExtractionError` → `ArchiveError` across the entire codebase (exarch-core, exarch-cli, exarch-python, exarch-node, test files, `exarch.pyi`, READMEs, specs). The old name was misleading because the type was used for creation, inspection, and verification — not just extraction (#253).
- Consolidate the four `extract_archive*` public functions into a clean delegation chain: `extract_archive` → `extract_archive_with_progress` → `extract_archive_with_options_and_progress` → `extract_atomic`/`extract_impl`. No logic duplication; `extract_archive_with_options_and_progress` is the canonical implementation (#259).

## Breaking Changes

- `ExtractionError` is removed; replace with `ArchiveError` in all match arms, `use` imports, and type aliases: `use exarch_core::ArchiveError`.
- Python base exception is now `exarch.ArchiveError` (was `exarch.ExtractionError`).

## Test plan

- [x] 688 unit/integration tests pass (`cargo nextest run --workspace --all-features --lib --bins`)
- [x] 103 doc-tests pass (`cargo test --doc --workspace --all-features`)
- [x] Docs build clean (`RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace`)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo +nightly fmt --all -- --check` clean
- [x] Zero residual `ExtractionError` references in any `.rs`, `.py`, `.pyi`, or `.md` file

Closes #253, #259