### PR TITLE
refactor(creation): DRY cleanup in tar.rs and zip.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `check_permissions` in `inspection/verify.rs` now passes the actual entry path to
   `InvalidPermissions` instead of an empty `PathBuf`, so error messages include the
   offending archive entry (#286).
+- ZIP archives created via the non-progress `create_zip` path no longer include a spurious `"/"` root directory entry. The entry was an artefact of formatting an empty archive path as `"{}/"`; it has been absent from the `create_zip_with_progress` path since #289 (#290).
 
 ### Breaking Changes
 
@@ -48,6 +49,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `creation/tar`: replace manual entry counter with `ProgressTracker`; add `ProgressTracker::callback()` accessor to enable byte-level progress in nested helpers without lifetime conflicts (#284).
 - `creation/zip`: same `ProgressTracker` wiring as tar, removing manual `idx + 1` counter (#284).
+- `creation/zip`: `create_zip_internal` now delegates to `create_zip_internal_with_progress` via `NoopProgress`, eliminating ~167 lines of duplicate traversal, compression-option, and file-add logic (#290).
+- `creation/tar`: dead `_buffer: &mut [u8]` parameter removed from `add_file_to_tar_with_progress_impl`; the two 64 KB heap allocations at the former call sites are eliminated (#291).
 - `api`: collapse five identical `extract_tar*` private functions into a single generic `extract_tar_with_decoder` helper parametrised by a decoder closure; eliminates ~80 lines of structural duplication (#254).
 - `sevenz`: eliminate `Rc`/`RefCell` interior mutability in `extract_with_callback`; state is now owned by a local context struct, matching the `tar.rs` and `zip.rs` patterns (#273, #258).
 - `sevenz`: narrow `std::process` import to `std::process::id` to prevent accidental use of `process::exit` in library code (#270).

--- a/crates/exarch-core/src/creation/tar.rs
+++ b/crates/exarch-core/src/creation/tar.rs
@@ -223,9 +223,6 @@ fn create_tar_internal_with_progress<W: Write, P: AsRef<Path>>(
 
     let mut tracker = ProgressTracker::new(progress, total_entries);
 
-    // Reusable buffer for file copying (fixes HIGH #2)
-    let mut buffer = vec![0u8; 64 * 1024]; // 64 KB
-
     for entry in &entries {
         match &entry.entry_type {
             EntryType::File => {
@@ -237,7 +234,6 @@ fn create_tar_internal_with_progress<W: Write, P: AsRef<Path>>(
                     config,
                     &mut report,
                     tracker.callback(),
-                    &mut buffer,
                 )?;
                 tracker.on_entry_complete(&entry.archive_path);
             }
@@ -256,7 +252,6 @@ fn create_tar_internal_with_progress<W: Write, P: AsRef<Path>>(
                         config,
                         &mut report,
                         tracker.callback(),
-                        &mut buffer,
                     )?;
                 } else {
                     add_symlink_to_tar(&mut builder, &entry.archive_path, target, &mut report)?;
@@ -280,8 +275,7 @@ fn create_tar_internal_with_progress<W: Write, P: AsRef<Path>>(
     Ok((report, counting_writer.into_inner()))
 }
 
-/// Adds a single file to the TAR archive with progress reporting and reusable
-/// buffer.
+/// Adds a single file to the TAR archive with progress reporting.
 fn add_file_to_tar_with_progress_impl<W: Write>(
     builder: &mut Builder<W>,
     file_path: &Path,
@@ -289,7 +283,6 @@ fn add_file_to_tar_with_progress_impl<W: Write>(
     config: &CreationConfig,
     report: &mut CreationReport,
     progress: &mut dyn ProgressCallback,
-    _buffer: &mut [u8],
 ) -> Result<()> {
     let file = File::open(file_path)?;
     let metadata = file.metadata()?;
@@ -303,9 +296,6 @@ fn add_file_to_tar_with_progress_impl<W: Write>(
         set_permissions(&mut header, &metadata);
     }
 
-    // Use progress-tracking reader with batched updates (1 MB batches)
-    // Note: tar crate's append_data does its own buffering internally,
-    // so we use ProgressReader wrapper instead of manual buffer
     let mut tracked_file = ProgressReader::new(file, progress);
     builder.append_data(&mut header, archive_path, &mut tracked_file)?;
 

--- a/crates/exarch-core/src/creation/zip.rs
+++ b/crates/exarch-core/src/creation/zip.rs
@@ -4,14 +4,13 @@
 //! compression levels and security options.
 
 use crate::ArchiveError;
+use crate::NoopProgress;
 use crate::ProgressCallback;
 use crate::Result;
 use crate::creation::config::CreationConfig;
-use crate::creation::filters;
 use crate::creation::progress::ProgressTracker;
 use crate::creation::report::CreationReport;
 use crate::creation::walker::EntryType;
-use crate::creation::walker::FilteredWalker;
 use crate::creation::walker::collect_entries;
 use std::fs::File;
 use std::io::Read;
@@ -162,8 +161,7 @@ fn create_zip_internal_with_progress<W: Write + Seek, P: AsRef<Path>>(
 
     let mut tracker = ProgressTracker::new(progress, total_entries);
 
-    // Reusable buffer for file copying (fixes HIGH #2)
-    let mut buffer = vec![0u8; 64 * 1024]; // 64 KB
+    let mut buffer = vec![0u8; 64 * 1024];
 
     for entry in &entries {
         match &entry.entry_type {
@@ -215,167 +213,12 @@ fn create_zip_internal_with_progress<W: Write + Seek, P: AsRef<Path>>(
     Ok(report)
 }
 
-/// Internal function that creates ZIP with any writer.
-///
-/// Handles the core logic of walking sources and adding entries to the archive.
 fn create_zip_internal<W: Write + Seek, P: AsRef<Path>>(
     writer: W,
     sources: &[P],
     config: &CreationConfig,
 ) -> Result<CreationReport> {
-    let mut zip = ZipWriter::new(writer);
-    let mut report = CreationReport::default();
-    let start = std::time::Instant::now();
-
-    // Configure ZIP file options with compression level
-    let options = if config.compression_level == Some(0) {
-        SimpleFileOptions::default().compression_method(CompressionMethod::Stored)
-    } else {
-        // Convert compression level (1-9) to zip crate level
-        let level = config.compression_level.unwrap_or(6);
-        SimpleFileOptions::default()
-            .compression_method(CompressionMethod::Deflated)
-            .compression_level(Some(i64::from(level)))
-    };
-
-    for source in sources {
-        let path = source.as_ref();
-
-        // Validate source exists
-        if !path.exists() {
-            return Err(ArchiveError::SourceNotFound {
-                path: path.to_path_buf(),
-            });
-        }
-
-        // Walk directory or add single file
-        if path.is_dir() {
-            add_directory_to_zip(&mut zip, path, config, &mut report, &options)?;
-        } else {
-            // For single files, use filename as archive path
-            let archive_path =
-                filters::compute_archive_path(path, path.parent().unwrap_or(path), config)?;
-            add_file_to_zip(&mut zip, path, &archive_path, config, &mut report, &options)?;
-        }
-    }
-
-    // Finish writing ZIP
-    zip.finish()
-        .map_err(|e| std::io::Error::other(format!("failed to finish ZIP archive: {e}")))?;
-
-    report.duration = start.elapsed();
-
-    Ok(report)
-}
-
-/// Adds a directory tree to the ZIP archive using the walker.
-fn add_directory_to_zip<W: Write + Seek>(
-    zip: &mut ZipWriter<W>,
-    dir: &Path,
-    config: &CreationConfig,
-    report: &mut CreationReport,
-    options: &SimpleFileOptions,
-) -> Result<()> {
-    let walker = FilteredWalker::new(dir, config);
-
-    for entry in walker.walk() {
-        let entry = entry?;
-
-        match entry.entry_type {
-            EntryType::File => {
-                add_file_to_zip(
-                    zip,
-                    &entry.path,
-                    &entry.archive_path,
-                    config,
-                    report,
-                    options,
-                )?;
-            }
-            EntryType::Directory => {
-                // ZIP requires explicit directory entries with trailing /
-                let dir_path = format!("{}/", normalize_zip_path(&entry.archive_path)?);
-                zip.add_directory(&dir_path, *options)
-                    .map_err(|e| std::io::Error::other(format!("failed to add directory: {e}")))?;
-                report.directories_added += 1;
-            }
-            EntryType::Symlink { .. } => {
-                if !config.follow_symlinks {
-                    // ZIP doesn't have native symlink support like TAR
-                    // Skip symlinks when not following them
-                    report.files_skipped += 1;
-                    report.add_warning(format!("Skipped symlink: {}", entry.path.display()));
-                }
-            }
-        }
-    }
-
-    Ok(())
-}
-
-/// Adds a single file to the ZIP archive.
-fn add_file_to_zip<W: Write + Seek>(
-    zip: &mut ZipWriter<W>,
-    file_path: &Path,
-    archive_path: &Path,
-    config: &CreationConfig,
-    report: &mut CreationReport,
-    options: &SimpleFileOptions,
-) -> Result<()> {
-    let mut file = File::open(file_path)?;
-    let metadata = file.metadata()?;
-    let size = metadata.len();
-
-    // Check file size limit
-    if let Some(max_size) = config.max_file_size
-        && size > max_size
-    {
-        report.files_skipped += 1;
-        report.add_warning(format!(
-            "Skipped file (too large): {} ({} bytes)",
-            file_path.display(),
-            size
-        ));
-        return Ok(());
-    }
-
-    // Configure options with permissions if needed
-    let file_options = if config.preserve_permissions {
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            options.unix_permissions(metadata.permissions().mode())
-        }
-        #[cfg(not(unix))]
-        {
-            *options
-        }
-    } else {
-        *options
-    };
-
-    // Convert archive_path to ZIP format (forward slashes)
-    let archive_name = normalize_zip_path(archive_path)?;
-
-    zip.start_file(&archive_name, file_options)
-        .map_err(|e| std::io::Error::other(format!("failed to start file in ZIP: {e}")))?;
-
-    // Copy file contents with 64KB buffer for better throughput
-    let mut buffer = vec![0u8; 64 * 1024]; // 64 KB
-    let mut bytes_written = 0u64;
-    loop {
-        let bytes_read = file.read(&mut buffer)?;
-        if bytes_read == 0 {
-            break;
-        }
-        zip.write_all(&buffer[..bytes_read])?;
-        bytes_written += bytes_read as u64;
-    }
-
-    report.files_added += 1;
-    report.bytes_written += bytes_written;
-
-    Ok(())
+    create_zip_internal_with_progress(writer, sources, config, &mut NoopProgress)
 }
 
 /// Adds a single file to the ZIP archive with progress reporting and reusable
@@ -535,8 +378,9 @@ mod tests {
 
         // Should have exactly 3 files: file1.txt, file2.txt, subdir/file3.txt
         assert_eq!(report.files_added, 3);
-        // Should have exactly 2 directories: root and subdir
-        assert_eq!(report.directories_added, 2);
+        // Should have exactly 1 directory: subdir (root is omitted — empty archive path
+        // is invalid in ZIP)
+        assert_eq!(report.directories_added, 1);
         assert!(output.exists());
     }
 


### PR DESCRIPTION
## Summary

- Remove dead `_buffer: &mut [u8]` parameter and two 64 KB heap allocations from `create_tar_internal_with_progress` in `tar.rs` — the `tar` crate buffers internally via `append_data`, so the buffer was never read (#291)
- Unify `create_zip_internal` to delegate to `create_zip_internal_with_progress` via `NoopProgress`, eliminating ~167 lines of duplicated ZIP option-building and file-add logic (#290)
- Fix latent bug: old non-progress path emitted a spurious `"/"` root directory entry in every ZIP archive; unified path matches the correct behavior already used by the progress path

## Changes

- `crates/exarch-core/src/creation/tar.rs` — remove `_buffer` param and call-site allocations
- `crates/exarch-core/src/creation/zip.rs` — unify internals, remove `add_file_to_zip`, `add_directory_to_zip`, `FilteredWalker` import (~167 lines deleted)
- `CHANGELOG.md` — Fixed + Changed entries under `[Unreleased]`

## Test plan

- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` — 844/844 passed
- [x] `cargo test --doc --workspace --all-features` — 101/101 passed
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — 0 warnings
- [x] `cargo +nightly fmt --all -- --check` — clean
- [x] `cargo deny check --all-features` — clean
- [x] Security audit: `FilteredWalker` removal verified safe — `collect_entries` calls the identical walker internally; no security filtering dropped

Closes #290, #291