### PR TITLE
feat(cli): add --strict flag to verify command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `verify` CLI command now accepts a `--strict` flag. When set, a verification report with
+  `Warning` status causes the process to exit with code 2 instead of 0. Without the flag,
+  the previous behaviour (exit 0 on warnings) is unchanged (#269).
+- `ValidationReport` is now re-exported at the crate root as `exarch_core::ValidationReport`
+  (was only accessible as `exarch_core::security::ValidationReport`) (#256).
+
 ### Fixed
 
 - `PyProgressAdapter` and `NodeProgressAdapter` now reset `bytes_written` to 0 at the start of each entry, eliminating stale values from previous entries (#285).
@@ -39,11 +47,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `UnknownFormat { path }` (format-detection failures) and `InvalidConfiguration` (7z creation),
   matching the post-#255 Rust API. Python exception hierarchy updated to include
   `UnknownFormatError(UnsupportedFormatError)` (#265, #264).
-
-### Added
-
-- `ValidationReport` is now re-exported at the crate root as `exarch_core::ValidationReport`
-  (was only accessible as `exarch_core::security::ValidationReport`) (#256).
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,10 +553,12 @@ dependencies = [
  "clap_complete",
  "console",
  "exarch-core",
+ "flate2",
  "indicatif",
  "predicates",
  "serde",
  "serde_json",
+ "tar",
  "tempfile",
 ]
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,18 @@ exarch provides defense-in-depth protection against common archive vulnerabiliti
 > [!CAUTION]
 > Enabling symlinks or hardlinks should only be done when you fully trust the archive source.
 
+### CLI: Strict Verification
+
+The `verify` command accepts `--strict` to treat warnings as errors:
+
+```bash
+# Exit 0 — only hard failures are errors
+exarch verify archive.tar.gz
+
+# Exit 2 if any warnings are found (e.g. setuid bits), exit 1 on failure
+exarch verify --strict archive.tar.gz
+```
+
 ### Security Configuration
 
 ```rust

--- a/crates/exarch-cli/Cargo.toml
+++ b/crates/exarch-cli/Cargo.toml
@@ -27,7 +27,9 @@ serde_json.workspace = true
 
 [dev-dependencies]
 assert_cmd.workspace = true
+flate2.workspace = true
 predicates.workspace = true
+tar.workspace = true
 tempfile.workspace = true
 
 [lints]

--- a/crates/exarch-cli/src/cli.rs
+++ b/crates/exarch-cli/src/cli.rs
@@ -202,6 +202,10 @@ pub struct VerifyArgs {
     /// Allow solid 7z archives (higher memory usage during verification)
     #[arg(long)]
     pub allow_solid_archives: bool,
+
+    /// Treat warnings as errors and exit with status code 2
+    #[arg(long)]
+    pub strict: bool,
 }
 
 /// Parse byte size with optional suffix (K, M, G, T)

--- a/crates/exarch-cli/src/commands/verify.rs
+++ b/crates/exarch-cli/src/commands/verify.rs
@@ -1,6 +1,7 @@
 //! Verify command implementation
 
 use crate::cli::VerifyArgs;
+use crate::error::StrictWarning;
 use crate::output::OutputFormatter;
 use anyhow::Result;
 use anyhow::bail;
@@ -14,17 +15,17 @@ pub fn execute(args: &VerifyArgs, formatter: &dyn OutputFormatter) -> Result<()>
         .with_max_total_size(args.max_total_size.unwrap_or(500 * 1024 * 1024))
         .with_allow_solid_archives(args.allow_solid_archives);
 
-    // Verify archive
     let report = verify_archive(&args.archive, &config)?;
 
-    // Format output
     formatter.format_verification_report(&report)?;
 
-    // Exit with appropriate code
     match report.status {
         VerificationStatus::Pass => Ok(()),
         VerificationStatus::Warning => {
-            // Exit 0 for warnings unless strict mode
+            if args.strict {
+                eprintln!("Archive has warnings; exiting with code 2 (--strict)");
+                return Err(anyhow::Error::new(StrictWarning));
+            }
             Ok(())
         }
         VerificationStatus::Fail => {

--- a/crates/exarch-cli/src/error.rs
+++ b/crates/exarch-cli/src/error.rs
@@ -9,6 +9,21 @@ use exarch_core::ExtractionReport;
 use std::fmt;
 use std::path::Path;
 
+/// Sentinel error returned by `verify::execute` when `--strict` is active and
+/// the archive has a `Warning`-status verification report. `main` maps this to
+/// exit code 2 without printing an error message (the formatter already
+/// reported the warning details to stdout/stderr before this is returned).
+#[derive(Debug)]
+pub struct StrictWarning;
+
+impl fmt::Display for StrictWarning {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("Archive has warnings (--strict mode)")
+    }
+}
+
+impl std::error::Error for StrictWarning {}
+
 /// Carrier for partial-extraction progress embedded in the anyhow error chain.
 ///
 /// `ArchiveError::PartialExtraction` uses `#[error("{source}")]` with

--- a/crates/exarch-cli/src/main.rs
+++ b/crates/exarch-cli/src/main.rs
@@ -8,6 +8,7 @@ mod output;
 mod progress;
 
 use clap::Parser;
+use error::StrictWarning;
 use output::OutputFormatter;
 use std::process;
 
@@ -36,6 +37,9 @@ fn main() {
 
     let (result, operation) = run(&cli, &*formatter);
     if let Err(err) = result {
+        if err.is::<StrictWarning>() {
+            process::exit(2);
+        }
         formatter.format_error(operation, &err);
         process::exit(1);
     }

--- a/crates/exarch-cli/tests/cli_tests.rs
+++ b/crates/exarch-cli/tests/cli_tests.rs
@@ -917,6 +917,72 @@ fn test_verify_archive_safe() {
 }
 
 #[test]
+fn test_verify_strict_passes_on_clean_archive() {
+    exarch_cmd()
+        .arg("verify")
+        .arg("--strict")
+        .arg(fixture_path("sample.tar.gz"))
+        .assert()
+        .success();
+}
+
+/// Builds a tar.gz archive at `path` containing one file with a setuid bit set.
+/// The setuid bit triggers an `InvalidPermissions` issue (Medium severity),
+/// which causes the verification report to have `VerificationStatus::Warning`.
+#[cfg(unix)]
+fn create_setuid_tar_gz(path: &std::path::Path) {
+    use flate2::Compression;
+    use flate2::write::GzEncoder;
+
+    let file = std::fs::File::create(path).expect("create archive");
+    let gz = GzEncoder::new(file, Compression::default());
+    let mut builder = tar::Builder::new(gz);
+    let mut header = tar::Header::new_gnu();
+    header.set_size(4);
+    header.set_mode(0o4755); // setuid bit — triggers InvalidPermissions Medium issue
+    header.set_path("binary").expect("set path");
+    header.set_cksum();
+    builder
+        .append_data(&mut header, "binary", &b"data"[..])
+        .expect("append entry");
+    let gz = builder.into_inner().expect("get gz encoder");
+    gz.finish().expect("finish gzip stream");
+}
+
+/// On Unix, an archive containing a setuid file produces a Warning-severity
+/// verification report. With --strict, the CLI must exit with code 2.
+#[test]
+#[cfg(unix)]
+fn test_verify_strict_exits_2_on_warning() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let archive_path = temp.path().join("setuid.tar.gz");
+    create_setuid_tar_gz(&archive_path);
+
+    exarch_cmd()
+        .arg("verify")
+        .arg("--strict")
+        .arg(&archive_path)
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("warnings"));
+}
+
+/// Without --strict, the same setuid archive must still exit 0.
+#[test]
+#[cfg(unix)]
+fn test_verify_without_strict_exits_0_on_warning() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let archive_path = temp.path().join("setuid_lenient.tar.gz");
+    create_setuid_tar_gz(&archive_path);
+
+    exarch_cmd()
+        .arg("verify")
+        .arg(&archive_path)
+        .assert()
+        .success();
+}
+
+#[test]
 fn test_verify_archive_json_output() {
     let output = exarch_cmd()
         .arg("verify")


### PR DESCRIPTION
## Summary

- Adds `--strict` flag to `exarch verify`; exit code 2 when warnings are present (exit 0 without flag, unchanged)
- Introduces `StrictWarning` sentinel error in `error.rs`; `main.rs` maps it to `exit(2)` — no `process::exit` in command code, RAII runs cleanly
- Always emits a stderr message before exit 2, even under `--quiet`
- 3 new integration tests covering exit-code semantics (clean, warning+strict, warning without strict)
- README and CHANGELOG updated

## Exit code contract

| Status | `--strict` | Exit code |
|---|---|---|
| Pass | any | 0 |
| Warning | absent | 0 |
| Warning | present | 2 |
| Fail | any | 1 |

## Test plan

- [x] `cargo nextest run` — 847/847 pass
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo +nightly fmt --all -- --check` — clean
- [x] Integration tests: `test_verify_strict_exits_2_on_warning`, `test_verify_without_strict_exits_0_on_warning`, `test_verify_strict_passes_on_clean_archive`

Closes #269