### PR TITLE
fix(cli): remove eprintln! from verify --strict path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `verify --strict` no longer writes an unstructured message to stderr that bypassed `--quiet` suppression and `--json` mode. Exit code 2 already conveys the strict-warning condition (#298).
+
 ## [0.4.1] - 2026-06-05
 
 ### Added

--- a/crates/exarch-cli/src/commands/verify.rs
+++ b/crates/exarch-cli/src/commands/verify.rs
@@ -23,7 +23,6 @@ pub fn execute(args: &VerifyArgs, formatter: &dyn OutputFormatter) -> Result<()>
         VerificationStatus::Pass => Ok(()),
         VerificationStatus::Warning => {
             if args.strict {
-                eprintln!("Archive has warnings; exiting with code 2 (--strict)");
                 return Err(anyhow::Error::new(StrictWarning));
             }
             Ok(())

--- a/crates/exarch-cli/tests/cli_tests.rs
+++ b/crates/exarch-cli/tests/cli_tests.rs
@@ -950,7 +950,8 @@ fn create_setuid_tar_gz(path: &std::path::Path) {
 }
 
 /// On Unix, an archive containing a setuid file produces a Warning-severity
-/// verification report. With --strict, the CLI must exit with code 2.
+/// verification report. With --strict, the CLI must exit with code 2 and
+/// must not write any unstructured text to stderr.
 #[test]
 #[cfg(unix)]
 fn test_verify_strict_exits_2_on_warning() {
@@ -964,7 +965,7 @@ fn test_verify_strict_exits_2_on_warning() {
         .arg(&archive_path)
         .assert()
         .code(2)
-        .stderr(predicate::str::contains("warnings"));
+        .stderr(predicate::str::is_empty());
 }
 
 /// Without --strict, the same setuid archive must still exit 0.
@@ -980,6 +981,44 @@ fn test_verify_without_strict_exits_0_on_warning() {
         .arg(&archive_path)
         .assert()
         .success();
+}
+
+/// --quiet suppresses all non-error output; --strict must not bypass this
+/// by writing directly to stderr.
+#[test]
+#[cfg(unix)]
+fn test_verify_strict_quiet_produces_no_stderr() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let archive_path = temp.path().join("setuid_quiet.tar.gz");
+    create_setuid_tar_gz(&archive_path);
+
+    exarch_cmd()
+        .arg("--quiet")
+        .arg("verify")
+        .arg("--strict")
+        .arg(&archive_path)
+        .assert()
+        .code(2)
+        .stderr(predicate::str::is_empty());
+}
+
+/// --json mode must not mix unstructured text into stderr alongside
+/// structured JSON on stdout.
+#[test]
+#[cfg(unix)]
+fn test_verify_strict_json_produces_no_stderr() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let archive_path = temp.path().join("setuid_json.tar.gz");
+    create_setuid_tar_gz(&archive_path);
+
+    exarch_cmd()
+        .arg("--json")
+        .arg("verify")
+        .arg("--strict")
+        .arg(&archive_path)
+        .assert()
+        .code(2)
+        .stderr(predicate::str::is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Removes the bare `eprintln!` from `verify.rs:26` that bypassed `OutputFormatter`, writing to stderr unconditionally regardless of `--quiet` or `--json` flags.
- Exit code 2 already signals the strict-warning condition, making the print redundant.
- Updates the existing `test_verify_strict_exits_2_on_warning` assertion from `stderr(contains("warnings"))` to `stderr(is_empty())`.
- Adds two new regression tests: `test_verify_strict_quiet_produces_no_stderr` and `test_verify_strict_json_produces_no_stderr`.

## Test plan

- [x] `cargo nextest run -p exarch-cli` — 139 tests pass
- [x] `cargo +nightly fmt --all -- --check` — no issues
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — no warnings

Closes #298