### PR TITLE
fix(bindings): expose max_solid_block_memory in Python and Node.js bindings

### DIFF
--- a/crates/exarch-node/src/config.rs
+++ b/crates/exarch-node/src/config.rs
@@ -171,6 +171,29 @@ impl SecurityConfig {
         self
     }
 
+    /// Sets the maximum memory that may be used to decompress a solid 7z block.
+    ///
+    /// Solid archives decompress entire blocks into memory before individual
+    /// entries can be read. This limit caps that allocation to prevent
+    /// memory exhaustion from crafted archives. Default: 512 MB.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if size is negative or zero.
+    #[napi(js_name = "setMaxSolidBlockMemory")]
+    pub fn set_max_solid_block_memory(&mut self, size: i64) -> Result<&Self> {
+        if size <= 0 {
+            return Err(Error::from_reason(
+                "max solid block memory must be a positive number",
+            ));
+        }
+        #[allow(clippy::cast_sign_loss)]
+        {
+            self.inner.max_solid_block_memory = size as u64;
+        }
+        Ok(self)
+    }
+
     /// Sets whether to preserve permissions from archive.
     #[napi(js_name = "setPreservePermissions")]
     pub fn set_preserve_permissions(&mut self, preserve: Option<bool>) -> &Self {
@@ -317,6 +340,13 @@ impl SecurityConfig {
     #[napi(getter)]
     pub fn get_allow_solid_archives(&self) -> bool {
         self.inner.allow_solid_archives
+    }
+
+    /// Maximum memory in bytes for decompressing a solid 7z block.
+    #[napi(getter)]
+    #[allow(clippy::cast_possible_wrap)]
+    pub fn get_max_solid_block_memory(&self) -> i64 {
+        self.inner.max_solid_block_memory as i64
     }
 
     /// List of allowed file extensions.
@@ -849,6 +879,54 @@ mod tests {
             config.get_allow_solid_archives(),
             "allow_solid_archives getter should reflect setter value"
         );
+    }
+
+    #[test]
+    fn test_max_solid_block_memory_default() {
+        let config = SecurityConfig::new();
+        assert_eq!(
+            config.get_max_solid_block_memory(),
+            512 * 1024 * 1024,
+            "max_solid_block_memory should default to 512 MB"
+        );
+    }
+
+    #[test]
+    fn test_max_solid_block_memory_round_trip() {
+        let mut config = SecurityConfig::new();
+        let result = config.set_max_solid_block_memory(256 * 1024 * 1024);
+        assert!(result.is_ok());
+        assert_eq!(
+            config.get_max_solid_block_memory(),
+            256 * 1024 * 1024,
+            "getter should reflect set value"
+        );
+    }
+
+    #[test]
+    fn test_max_solid_block_memory_rejects_negative() {
+        let mut config = SecurityConfig::new();
+        let result = config.set_max_solid_block_memory(-1);
+        assert!(result.is_err(), "negative value should be rejected");
+        assert!(
+            result.unwrap_err().to_string().contains("positive"),
+            "error should mention positive requirement"
+        );
+    }
+
+    #[test]
+    fn test_max_solid_block_memory_rejects_zero() {
+        let mut config = SecurityConfig::new();
+        let result = config.set_max_solid_block_memory(0);
+        assert!(result.is_err(), "zero should be rejected");
+    }
+
+    #[test]
+    fn test_max_solid_block_memory_accepts_one_byte() {
+        let mut config = SecurityConfig::new();
+        let result = config.set_max_solid_block_memory(1);
+        assert!(result.is_ok(), "1 byte should be accepted");
+        assert_eq!(config.get_max_solid_block_memory(), 1);
     }
 
     #[test]

--- a/crates/exarch-python/exarch.pyi
+++ b/crates/exarch-python/exarch.pyi
@@ -77,6 +77,15 @@ class SecurityConfig:
         """Allows or denies solid 7z archives."""
         ...
 
+    def max_solid_block_memory(self, size: int) -> SecurityConfig:
+        """
+        Sets the maximum memory budget in bytes for decompressing a solid 7z block.
+
+        Only enforced when ``allow_solid_archives`` is ``True``. Raises
+        ``ValueError`` if *size* is zero.
+        """
+        ...
+
     def preserve_permissions(self, preserve: bool = True) -> SecurityConfig:
         """Sets whether to preserve permissions from archive."""
         ...

--- a/crates/exarch-python/src/config.rs
+++ b/crates/exarch-python/src/config.rs
@@ -161,6 +161,29 @@ impl PySecurityConfig {
         slf
     }
 
+    /// Sets the maximum memory budget in bytes for decompressing a solid 7z
+    /// block.
+    ///
+    /// Only enforced when `allow_solid_archives` is `True`. A crafted solid
+    /// archive can force the decompressor to buffer many preceding entries in
+    /// memory before reaching the target entry; this limit caps that buffer.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ValueError` if `size` is zero.
+    fn max_solid_block_memory(
+        mut slf: PyRefMut<'_, Self>,
+        size: u64,
+    ) -> PyResult<PyRefMut<'_, Self>> {
+        if size == 0 {
+            return Err(PyValueError::new_err(
+                "max_solid_block_memory must not be zero",
+            ));
+        }
+        slf.inner.max_solid_block_memory = size;
+        Ok(slf)
+    }
+
     /// Sets whether to preserve permissions from archive.
     #[pyo3(signature = (preserve=true))]
     fn preserve_permissions(mut slf: PyRefMut<'_, Self>, preserve: bool) -> PyRefMut<'_, Self> {
@@ -302,6 +325,22 @@ impl PySecurityConfig {
     #[setter]
     fn set_preserve_permissions(&mut self, value: bool) {
         self.inner.preserve_permissions = value;
+    }
+
+    #[getter]
+    fn get_max_solid_block_memory(&self) -> u64 {
+        self.inner.max_solid_block_memory
+    }
+
+    #[setter]
+    fn set_max_solid_block_memory(&mut self, value: u64) -> PyResult<()> {
+        if value == 0 {
+            return Err(PyValueError::new_err(
+                "max_solid_block_memory must not be zero",
+            ));
+        }
+        self.inner.max_solid_block_memory = value;
+        Ok(())
     }
 
     /// Returns a copy of the allowed extensions list.
@@ -942,6 +981,68 @@ mod tests {
             core_config.max_file_size,
             50 * 1024 * 1024,
             "as_core() should return reference to inner config"
+        );
+    }
+
+    #[test]
+    fn test_default_max_solid_block_memory() {
+        let config = PySecurityConfig::new();
+        assert_eq!(
+            config.get_max_solid_block_memory(),
+            512 * 1024 * 1024,
+            "Default max_solid_block_memory should be 512 MB"
+        );
+    }
+
+    #[test]
+    fn test_builder_max_solid_block_memory_valid() {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
+            let config = PySecurityConfig::new();
+            let py_config = Py::new(py, config).expect("Failed to create Py object");
+            let obj = py_config.bind(py);
+
+            let result = obj.call_method1("max_solid_block_memory", (256 * 1024 * 1024_u64,));
+            assert!(result.is_ok(), "Should accept valid memory size");
+            assert_eq!(
+                py_config.borrow(py).get_max_solid_block_memory(),
+                256 * 1024 * 1024,
+                "max_solid_block_memory should be updated"
+            );
+        });
+    }
+
+    #[test]
+    fn test_builder_max_solid_block_memory_rejects_zero() {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
+            let config = PySecurityConfig::new();
+            let py_config = Py::new(py, config).expect("Failed to create Py object");
+            let obj = py_config.bind(py);
+
+            let result = obj.call_method1("max_solid_block_memory", (0_u64,));
+            assert!(result.is_err(), "Should reject zero memory size");
+        });
+    }
+
+    #[test]
+    fn test_property_setter_max_solid_block_memory_valid() {
+        let mut config = PySecurityConfig::new();
+        let result = config.set_max_solid_block_memory(128 * 1024 * 1024);
+        assert!(result.is_ok(), "Should accept valid memory size");
+        assert_eq!(
+            config.get_max_solid_block_memory(),
+            128 * 1024 * 1024,
+            "Property setter should update max_solid_block_memory"
+        );
+    }
+
+    #[test]
+    fn test_property_setter_max_solid_block_memory_rejects_zero() {
+        let mut config = PySecurityConfig::new();
+        assert!(
+            config.set_max_solid_block_memory(0).is_err(),
+            "Should reject zero"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Adds `max_solid_block_memory(size: int)` builder method and `get/set_max_solid_block_memory` property to `PySecurityConfig` in `exarch-python`
- Adds `setMaxSolidBlockMemory(size: number)` setter and `maxSolidBlockMemory` getter to `SecurityConfig` in `exarch-node`
- Updates `exarch.pyi` stub with the new builder method signature
- Both bindings reject zero (and Node.js also rejects negative values) with an appropriate error

The field was silently capped at the 512 MB default for all callers of `allow_solid_archives`, making it impossible for power users to adjust the memory budget for large trusted solid archives.

## Test plan

- [x] `cargo nextest run -p exarch-node --all-features` — 136/136 pass (5 new tests for default, round-trip, reject zero, reject negative, accept 1 byte)
- [x] Python unit tests in source cover default, builder valid, builder rejects zero, setter valid, setter rejects zero
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo +nightly fmt --all -- --check` — clean
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` — 853/853 pass
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace` — clean

Closes #301