### PR TITLE
test(exarch-core): add integration tests for skip_duplicates option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Tests
+
+- Added integration tests for `ExtractionOptions::skip_duplicates`: covers `skip_duplicates=true` (first entry kept, duplicate skipped with warning) and `skip_duplicates=false` (second entry overwrites first) for TAR archives. Documents that the `zip` crate 8.x deduplicates entries at parse time, making the flag a no-op for ZIP (#302).
+
 ### Fixed
 
 - `verify --strict` no longer writes an unstructured message to stderr that bypassed `--quiet` suppression and `--json` mode. Exit code 2 already conveys the strict-warning condition (#298).

--- a/crates/exarch-core/tests/skip_duplicates_integration.rs
+++ b/crates/exarch-core/tests/skip_duplicates_integration.rs
@@ -1,0 +1,131 @@
+//! Integration tests for `ExtractionOptions::skip_duplicates`.
+//!
+//! Covers both the default behavior (skip=true, first entry wins) and the
+//! opt-in overwrite behavior (skip=false, last entry wins) using TAR archives
+//! built in-memory with two entries sharing the same path.
+//!
+//! ZIP duplicate behavior is documented in a separate note below: the `zip`
+//! crate (8.x) deduplicates entries at `ZipArchive::new()` time, so the raw
+//! archive with two identical filenames appears as a single entry regardless of
+//! `skip_duplicates`.  The ZIP-specific unit tests in `src/formats/zip.rs`
+//! cover this boundary.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use exarch_core::ExtractionOptions;
+use exarch_core::SecurityConfig;
+use exarch_core::extract_archive_with_options;
+use std::io::Write as _;
+use tempfile::NamedTempFile;
+use tempfile::TempDir;
+
+/// Build a TAR archive in memory containing two entries with the same path.
+fn make_tar_with_duplicate(path: &str, first: &[u8], second: &[u8]) -> Vec<u8> {
+    let mut builder = tar::Builder::new(Vec::new());
+
+    let mut hdr = tar::Header::new_gnu();
+    hdr.set_size(first.len() as u64);
+    hdr.set_mode(0o644);
+    hdr.set_cksum();
+    builder.append_data(&mut hdr, path, first).unwrap();
+
+    let mut hdr = tar::Header::new_gnu();
+    hdr.set_size(second.len() as u64);
+    hdr.set_mode(0o644);
+    hdr.set_cksum();
+    builder.append_data(&mut hdr, path, second).unwrap();
+
+    builder.into_inner().unwrap()
+}
+
+/// Write bytes to a named temp file with a `.tar` suffix and return the file
+/// (kept alive so the path remains valid for the duration of the test).
+fn write_tar(data: &[u8]) -> NamedTempFile {
+    let mut f = NamedTempFile::with_suffix(".tar").unwrap();
+    f.write_all(data).unwrap();
+    f.flush().unwrap();
+    f
+}
+
+/// `skip_duplicates=true` (the default): the second entry is skipped and the
+/// file on disk retains the content of the first entry.
+#[test]
+fn tar_skip_duplicates_true_keeps_first_entry() {
+    let data = make_tar_with_duplicate("file.txt", b"first", b"second");
+    let archive = write_tar(&data);
+    let dest = TempDir::new().unwrap();
+    let config = SecurityConfig::default();
+    let options = ExtractionOptions::default(); // skip_duplicates = true
+
+    let report = extract_archive_with_options(archive.path(), dest.path(), &config, &options)
+        .expect("extraction with skip_duplicates=true must succeed");
+
+    assert_eq!(
+        report.files_extracted, 1,
+        "only the first entry is extracted"
+    );
+    assert_eq!(
+        report.files_skipped, 1,
+        "second entry must be counted as skipped"
+    );
+    assert_eq!(
+        report.warnings.len(),
+        1,
+        "exactly one duplicate warning expected"
+    );
+    assert!(
+        report.warnings[0].contains("file.txt"),
+        "warning must identify the duplicate path"
+    );
+
+    let content = std::fs::read(dest.path().join("file.txt")).unwrap();
+    assert_eq!(content, b"first", "first entry content must be preserved");
+}
+
+/// `skip_duplicates=false`: both entries are processed; the second entry
+/// overwrites the first, so the file on disk contains the content of the
+/// second entry.
+#[test]
+fn tar_skip_duplicates_false_overwrites_with_last_entry() {
+    let data = make_tar_with_duplicate("file.txt", b"first", b"second");
+    let archive = write_tar(&data);
+    let dest = TempDir::new().unwrap();
+    let config = SecurityConfig::default();
+    let options = ExtractionOptions::default().with_skip_duplicates(false);
+
+    let report = extract_archive_with_options(archive.path(), dest.path(), &config, &options)
+        .expect("extraction with skip_duplicates=false must succeed");
+
+    assert_eq!(
+        report.files_extracted, 2,
+        "both entries must be counted as extracted (second overwrites first)"
+    );
+    assert_eq!(report.files_skipped, 0, "no entries must be skipped");
+
+    let content = std::fs::read(dest.path().join("file.txt")).unwrap();
+    assert_eq!(
+        content, b"second",
+        "second entry must have overwritten the first"
+    );
+}
+
+/// `skip_duplicates=false` with a nested path: verifies parent directories are
+/// created correctly and the overwrite path works for entries under
+/// subdirectories.
+#[test]
+fn tar_skip_duplicates_false_overwrites_nested_path() {
+    let data = make_tar_with_duplicate("subdir/nested.txt", b"original", b"overwritten");
+    let archive = write_tar(&data);
+    let dest = TempDir::new().unwrap();
+    let config = SecurityConfig::default();
+    let options = ExtractionOptions::default().with_skip_duplicates(false);
+
+    let report = extract_archive_with_options(archive.path(), dest.path(), &config, &options)
+        .expect("extraction with skip_duplicates=false must succeed for nested paths");
+
+    assert_eq!(report.files_extracted, 2);
+    assert_eq!(report.files_skipped, 0);
+
+    let content = std::fs::read(dest.path().join("subdir/nested.txt")).unwrap();
+    assert_eq!(content, b"overwritten");
+}


### PR DESCRIPTION
## Summary

- Adds `crates/exarch-core/tests/skip_duplicates_integration.rs` with 3 integration tests exercising `ExtractionOptions::skip_duplicates` via the public `extract_archive_with_options()` API
- Covers `skip_duplicates=true` (default: first entry kept, duplicate skipped, exactly one warning naming the path) and `skip_duplicates=false` (overwrite: second entry wins, `files_extracted=2`) for TAR archives
- Documents that `zip` crate 8.x deduplicates entries at `ZipArchive::new()` time, making the flag a no-op for ZIP at the public API level

**Note on behavior:** `skip_duplicates=false` for regular files means overwrite (not abort). This is consistent for TAR/ZIP; 7z already errors on duplicates regardless of the flag. The asymmetry is an existing design characteristic documented in the test file header.

## Test plan

- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` — 856/856 pass
- [x] `cargo +nightly fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test --doc -p exarch-core -p exarch-cli --all-features` — 98/98 pass

Closes #302