### PR TITLE
feat(cli): expose --max-path-depth, --banned-component, --allow-absolute-paths on extract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `extract` command now exposes three previously hidden `SecurityConfig` fields as CLI flags:
+  `--max-path-depth <N>` (default 32), `--banned-component <COMPONENT>` (repeatable; replaces
+  the default ban list when provided), and `--allow-absolute-paths` (flag). Operators can now
+  tune path depth and component ban lists without recompiling (#303).
+
 ### Tests
 
 - Added integration tests for `ExtractionOptions::skip_duplicates`: covers `skip_duplicates=true` (first entry kept, duplicate skipped with warning) and `skip_duplicates=false` (second entry overwrites first) for TAR archives. Documents that the `zip` crate 8.x deduplicates entries at parse time, making the flag a no-op for ZIP (#302).

--- a/crates/exarch-cli/src/cli.rs
+++ b/crates/exarch-cli/src/cli.rs
@@ -81,6 +81,22 @@ pub struct ExtractArgs {
     #[arg(long)]
     pub allow_hardlinks: bool,
 
+    /// Maximum path depth allowed (default: 32, minimum: 1)
+    #[arg(long, default_value = "32")]
+    pub max_path_depth: usize,
+
+    /// Banned path component; can be repeated.
+    ///
+    /// When specified, replaces the default ban list (.git, .ssh, .gnupg,
+    /// .aws, .kube, .docker, .env). Use an empty value to allow all
+    /// components.
+    #[arg(long = "banned-component", value_name = "COMPONENT")]
+    pub banned_components: Vec<String>,
+
+    /// Allow absolute paths in archive entries
+    #[arg(long)]
+    pub allow_absolute_paths: bool,
+
     /// Allow solid 7z archives (multiple files compressed as one block)
     #[arg(long)]
     pub allow_solid_archives: bool,
@@ -261,6 +277,79 @@ mod tests {
             panic!("expected Extract command");
         };
         assert!(args.allow_solid_archives);
+    }
+
+    #[test]
+    fn test_max_path_depth_default() {
+        let cli = Cli::parse_from(["exarch", "extract", "archive.tar.gz"]);
+        let Commands::Extract(args) = cli.command else {
+            panic!("expected Extract command");
+        };
+        assert_eq!(args.max_path_depth, 32);
+    }
+
+    #[test]
+    fn test_max_path_depth_override() {
+        let cli = Cli::parse_from([
+            "exarch",
+            "extract",
+            "--max-path-depth",
+            "8",
+            "archive.tar.gz",
+        ]);
+        let Commands::Extract(args) = cli.command else {
+            panic!("expected Extract command");
+        };
+        assert_eq!(args.max_path_depth, 8);
+    }
+
+    #[test]
+    fn test_banned_component_repeatable() {
+        let cli = Cli::parse_from([
+            "exarch",
+            "extract",
+            "--banned-component",
+            ".secrets",
+            "--banned-component",
+            ".private",
+            "archive.tar.gz",
+        ]);
+        let Commands::Extract(args) = cli.command else {
+            panic!("expected Extract command");
+        };
+        assert_eq!(args.banned_components, vec![".secrets", ".private"]);
+    }
+
+    #[test]
+    fn test_banned_component_empty_by_default() {
+        let cli = Cli::parse_from(["exarch", "extract", "archive.tar.gz"]);
+        let Commands::Extract(args) = cli.command else {
+            panic!("expected Extract command");
+        };
+        assert!(args.banned_components.is_empty());
+    }
+
+    #[test]
+    fn test_allow_absolute_paths_flag() {
+        let cli = Cli::parse_from([
+            "exarch",
+            "extract",
+            "--allow-absolute-paths",
+            "archive.tar.gz",
+        ]);
+        let Commands::Extract(args) = cli.command else {
+            panic!("expected Extract command");
+        };
+        assert!(args.allow_absolute_paths);
+    }
+
+    #[test]
+    fn test_allow_absolute_paths_default_false() {
+        let cli = Cli::parse_from(["exarch", "extract", "archive.tar.gz"]);
+        let Commands::Extract(args) = cli.command else {
+            panic!("expected Extract command");
+        };
+        assert!(!args.allow_absolute_paths);
     }
 
     #[test]

--- a/crates/exarch-cli/src/commands/extract.rs
+++ b/crates/exarch-cli/src/commands/extract.rs
@@ -61,12 +61,20 @@ pub fn execute(
         .with_max_total_size(args.max_total_size.unwrap_or(500 * 1024 * 1024))
         .with_max_file_size(args.max_file_size.unwrap_or(50 * 1024 * 1024))
         .with_max_compression_ratio(f64::from(args.max_compression_ratio))
+        .with_max_path_depth(args.max_path_depth)
         .with_allow_symlinks(args.allow_symlinks)
         .with_allow_hardlinks(args.allow_hardlinks)
+        .with_allow_absolute_paths(args.allow_absolute_paths)
         .with_allow_world_writable(args.allow_world_writable)
         .with_preserve_permissions(args.preserve_permissions)
         .with_allow_solid_archives(args.allow_solid_archives)
         .with_allowed_extensions(allowed_extensions);
+
+    let config = if args.banned_components.is_empty() {
+        config
+    } else {
+        config.with_banned_path_components(args.banned_components.clone())
+    };
 
     // list_config shares quota params with config but uses safe defaults for
     // security flags — listing must not be blocked by allow_symlinks etc.


### PR DESCRIPTION
## Summary

- Adds `--max-path-depth <N>` (default 32) to let operators cap path nesting depth; validated by `SecurityConfig::validate()` (rejects 0)
- Adds `--banned-component <COMPONENT>` (repeatable) to replace the default component ban list (`.git`, `.ssh`, `.gnupg`, `.aws`, `.kube`, `.docker`, `.env`) with a custom one when provided; omitting the flag preserves the secure defaults
- Adds `--allow-absolute-paths` flag to opt into absolute path entries (denied by default)

All three flags wire directly into the existing `SecurityConfig` builder methods; no core logic changed.

Closes #303

## Test plan

- [ ] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` — all 862 tests pass
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [ ] `cargo +nightly fmt --all -- --check` — clean
- [ ] `cargo test --doc -p exarch-core -p exarch-cli --all-features` — 98 doc-tests pass
- [ ] `exarch extract --help` shows the three new flags
- [ ] `exarch extract --max-path-depth 8 archive.tar.gz` correctly limits depth
- [ ] `exarch extract --banned-component .secrets archive.tar.gz` replaces default ban list
- [ ] `exarch extract --allow-absolute-paths archive.tar.gz` enables absolute paths