### PR TITLE
fix(creation): validate compression_level and add missing CLI create flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- **`ArchiveCreator::compression_level`** now returns `Result<Self, ArchiveError>` instead of
+  `Self`. Call sites must propagate the error with `?` or handle it explicitly; passing an
+  out-of-range level (0 or >9) now returns `ArchiveError::InvalidCompressionLevel` instead of
+  silently clamping or panicking (#308).
+
 ### Added
 
 - `extract` command now exposes three previously hidden `SecurityConfig` fields as CLI flags:
   `--max-path-depth <N>` (default 32), `--banned-component <COMPONENT>` (repeatable; replaces
   the default ban list when provided), and `--allow-absolute-paths` (flag). Operators can now
   tune path depth and component ban lists without recompiling (#303).
+- `create` CLI subcommand: `--max-file-size <BYTES>` flag (supports K/M/G/T suffixes) skips
+  source files larger than the given threshold during archive creation (#306).
+- `create` CLI subcommand: `--preserve-permissions` flag (default: true) controls whether
+  Unix file permissions are stored in the archive; pass `--preserve-permissions=false` to
+  create a portable archive without platform-specific permission bits (#306).
 
 ### Tests
 

--- a/crates/exarch-cli/src/cli.rs
+++ b/crates/exarch-cli/src/cli.rs
@@ -161,6 +161,17 @@ pub struct CreateArgs {
     #[arg(long, value_name = "PREFIX")]
     pub strip_prefix: Option<PathBuf>,
 
+    /// Maximum size for a single file in bytes (supports K, M, G, T suffixes)
+    #[arg(long, value_name = "BYTES", value_parser = parse_byte_size)]
+    pub max_file_size: Option<u64>,
+
+    /// Preserve file permissions when creating the archive.
+    ///
+    /// Pass `--preserve-permissions=false` to create a portable archive
+    /// without platform-specific permission bits.
+    #[arg(long, action = clap::ArgAction::Set, default_value_t = true)]
+    pub preserve_permissions: bool,
+
     /// Overwrite output file if exists
     #[arg(short = 'f', long)]
     pub force: bool,
@@ -438,5 +449,60 @@ mod tests {
         };
         assert_eq!(args.max_files, 1_000_000);
         assert_eq!(args.max_total_size, Some(10 * 1024 * 1024 * 1024));
+    }
+
+    #[test]
+    fn test_create_args_max_file_size_parsed() {
+        let cli = Cli::parse_from([
+            "exarch",
+            "create",
+            "--max-file-size",
+            "50M",
+            "out.tar.gz",
+            "src/",
+        ]);
+        let Commands::Create(args) = cli.command else {
+            panic!("expected Create command");
+        };
+        assert_eq!(args.max_file_size, Some(50 * 1024 * 1024));
+    }
+
+    #[test]
+    fn test_create_args_preserve_permissions_default() {
+        let cli = Cli::parse_from(["exarch", "create", "out.tar.gz", "src/"]);
+        let Commands::Create(args) = cli.command else {
+            panic!("expected Create command");
+        };
+        assert!(args.preserve_permissions);
+    }
+
+    #[test]
+    fn test_create_args_preserve_permissions_explicit() {
+        let cli = Cli::parse_from([
+            "exarch",
+            "create",
+            "--preserve-permissions=true",
+            "out.tar.gz",
+            "src/",
+        ]);
+        let Commands::Create(args) = cli.command else {
+            panic!("expected Create command");
+        };
+        assert!(args.preserve_permissions);
+    }
+
+    #[test]
+    fn test_create_args_preserve_permissions_false() {
+        let cli = Cli::parse_from([
+            "exarch",
+            "create",
+            "--preserve-permissions=false",
+            "out.tar.gz",
+            "src/",
+        ]);
+        let Commands::Create(args) = cli.command else {
+            panic!("expected Create command");
+        };
+        assert!(!args.preserve_permissions);
     }
 }

--- a/crates/exarch-cli/src/commands/create.rs
+++ b/crates/exarch-cli/src/commands/create.rs
@@ -31,6 +31,8 @@ pub fn execute(args: &CreateArgs, formatter: &dyn OutputFormatter, quiet: bool) 
         include_hidden: args.include_hidden,
         compression_level: args.compression_level,
         strip_prefix: args.strip_prefix.clone(),
+        max_file_size: args.max_file_size,
+        preserve_permissions: args.preserve_permissions,
         ..Default::default()
     };
 

--- a/crates/exarch-cli/tests/cli_tests.rs
+++ b/crates/exarch-cli/tests/cli_tests.rs
@@ -635,6 +635,61 @@ fn test_create_compression_level_max() {
 }
 
 // ============================================================================
+// #306 — CLI create flags: --max-file-size, --preserve-permissions
+// ============================================================================
+
+#[test]
+fn test_create_max_file_size_flag_accepted() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let archive = temp.path().join("test.tar.gz");
+
+    exarch_cmd()
+        .arg("create")
+        .arg("--max-file-size")
+        .arg("10M")
+        .arg(&archive)
+        .arg(fixture_path("sample.txt"))
+        .assert()
+        .success();
+
+    assert!(archive.exists());
+}
+
+#[test]
+fn test_create_preserve_permissions_default_true() {
+    // --preserve-permissions=true explicitly mirrors the default behaviour
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let archive = temp.path().join("perms.tar.gz");
+
+    exarch_cmd()
+        .arg("create")
+        .arg("--preserve-permissions=true")
+        .arg(&archive)
+        .arg(fixture_path("sample.txt"))
+        .assert()
+        .success();
+
+    assert!(archive.exists());
+}
+
+#[test]
+fn test_create_preserve_permissions_false() {
+    // --preserve-permissions=false must be accepted without error
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let archive = temp.path().join("noperms.tar.gz");
+
+    exarch_cmd()
+        .arg("create")
+        .arg("--preserve-permissions=false")
+        .arg(&archive)
+        .arg(fixture_path("sample.txt"))
+        .assert()
+        .success();
+
+    assert!(archive.exists());
+}
+
+// ============================================================================
 // Error Handling Tests
 // ============================================================================
 

--- a/crates/exarch-core/examples/create_archive.rs
+++ b/crates/exarch-core/examples/create_archive.rs
@@ -29,7 +29,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let report = ArchiveCreator::new()
         .output("example.zip")
         .add_source("example_file.txt")
-        .compression_level(9)
+        .compression_level(9)?
         .create()?;
     println!("  Created ZIP with {} files", report.files_added);
 

--- a/crates/exarch-core/src/creation/creator.rs
+++ b/crates/exarch-core/src/creation/creator.rs
@@ -23,7 +23,7 @@ use crate::formats::detect::ArchiveType;
 ///     .output("backup.tar.gz")
 ///     .add_source("src/")
 ///     .add_source("Cargo.toml")
-///     .compression_level(9)
+///     .compression_level(9)?
 ///     .create()?;
 ///
 /// println!("Created archive with {} files", report.files_added);
@@ -124,17 +124,26 @@ impl ArchiveCreator {
     ///
     /// Higher values provide better compression but slower speed.
     ///
+    /// # Errors
+    ///
+    /// Returns [`ArchiveError::InvalidCompressionLevel`] if `level` is not in
+    /// the range 1–9.
+    ///
     /// # Examples
     ///
     /// ```
     /// use exarch_core::creation::ArchiveCreator;
     ///
-    /// let creator = ArchiveCreator::new().compression_level(9); // Maximum compression
+    /// let creator = ArchiveCreator::new().compression_level(9)?; // Maximum compression
+    ///
+    /// # Ok::<(), exarch_core::ArchiveError>(())
     /// ```
-    #[must_use]
-    pub fn compression_level(mut self, level: u8) -> Self {
+    pub fn compression_level(mut self, level: u8) -> Result<Self> {
+        if !(1..=9).contains(&level) {
+            return Err(ArchiveError::InvalidCompressionLevel { level });
+        }
         self.config.compression_level = Some(level);
-        self
+        Ok(self)
     }
 
     /// Sets whether to follow symlinks.
@@ -306,6 +315,7 @@ mod tests {
     fn test_builder_config_methods() {
         let creator = ArchiveCreator::new()
             .compression_level(9)
+            .unwrap()
             .follow_symlinks(true)
             .include_hidden(true)
             .exclude("*.log")
@@ -358,9 +368,26 @@ mod tests {
 
     #[test]
     fn test_builder_compression_level() {
-        let creator = ArchiveCreator::new().compression_level(9);
-
+        let creator = ArchiveCreator::new().compression_level(9).unwrap();
         assert_eq!(creator.config.compression_level, Some(9));
+    }
+
+    #[test]
+    fn test_builder_compression_level_mid() {
+        let creator = ArchiveCreator::new().compression_level(5).unwrap();
+        assert_eq!(creator.config.compression_level, Some(5));
+    }
+
+    #[test]
+    fn test_builder_compression_level_invalid() {
+        assert!(matches!(
+            ArchiveCreator::new().compression_level(0),
+            Err(ArchiveError::InvalidCompressionLevel { level: 0 })
+        ));
+        assert!(matches!(
+            ArchiveCreator::new().compression_level(10),
+            Err(ArchiveError::InvalidCompressionLevel { level: 10 })
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fixes `ArchiveCreator::compression_level` to validate range 1–9 at the call site, returning `Err(InvalidCompressionLevel)` immediately instead of deferring the error to `create()`. This is a **breaking API change** — call sites must now propagate with `?`. (#308)
- Adds two previously inaccessible `CreationConfig` fields as CLI flags on the `create` subcommand: `--max-file-size <BYTES>` (K/M/G/T suffixes supported) and `--preserve-permissions=<bool>` (default `true`). (#306)

## Breaking change

`ArchiveCreator::compression_level` now returns `Result<Self>` instead of `Self`. Update call sites:

```rust
// before
let creator = ArchiveCreator::new(path).compression_level(5);

// after
let creator = ArchiveCreator::new(path).compression_level(5)?;
```

## Test plan

- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` — 865 passed, 0 failed
- [x] `cargo test --doc -p exarch-core -p exarch-cli --all-features` — 98 passed
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo +nightly fmt --all -- --check` — clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace` — clean
- [x] New unit + integration tests for `compression_level(0/5/10)`, `--max-file-size`, `--preserve-permissions=false`

Closes #308
Closes #306