### PR TITLE
fix(progress): call on_bytes_written during extraction and on_entry_complete on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `verify --strict` no longer writes an unstructured message to stderr that bypassed `--quiet` suppression and `--json` mode. Exit code 2 already conveys the strict-warning condition (#298).
+- `ProgressCallback::on_bytes_written` is now called during extraction for TAR, ZIP, and 7z formats; previously the method was documented but never invoked (#304).
+- `ProgressCallback::on_entry_complete` is now guaranteed to be called for every entry for which `on_entry_start` was called, including entries that fail mid-extraction; previously a failure left the callback pair unbalanced (#305).
 
 ## [0.4.1] - 2026-06-05
 

--- a/crates/exarch-core/src/api.rs
+++ b/crates/exarch-core/src/api.rs
@@ -1096,4 +1096,451 @@ mod tests {
         );
         assert!(progress.finished, "on_complete not called for 7z");
     }
+
+    // Regression test for issue #304: on_bytes_written must be called with > 0
+    // bytes when extracting non-empty files from TAR archives.
+    #[test]
+    fn test_on_bytes_written_called_for_tar() {
+        use crate::ProgressCallback;
+        use std::path::Path;
+
+        struct ByteTracker {
+            total: u64,
+        }
+
+        impl ProgressCallback for ByteTracker {
+            fn on_entry_start(&mut self, _path: &Path, _total: usize, _current: usize) {}
+
+            fn on_bytes_written(&mut self, bytes: u64) {
+                self.total += bytes;
+            }
+
+            fn on_entry_complete(&mut self, _path: &Path) {}
+
+            fn on_complete(&mut self) {}
+        }
+
+        let archive_dir = tempfile::TempDir::new().unwrap();
+        let archive_path = archive_dir.path().join("test.tar.gz");
+        let src_dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(src_dir.path().join("hello.txt"), b"hello world").unwrap();
+        create_archive(&archive_path, &[src_dir.path()], &CreationConfig::default()).unwrap();
+
+        let dest = tempfile::TempDir::new().unwrap();
+        let mut progress = ByteTracker { total: 0 };
+        let report = extract_archive_with_progress(
+            &archive_path,
+            dest.path(),
+            &SecurityConfig::default(),
+            &mut progress,
+        )
+        .unwrap();
+
+        assert!(
+            report.bytes_written > 0,
+            "report.bytes_written must be > 0, got {}",
+            report.bytes_written
+        );
+        assert!(
+            progress.total > 0,
+            "on_bytes_written must be called with > 0 bytes for TAR, got {}",
+            progress.total
+        );
+    }
+
+    // Regression test for issue #304: on_bytes_written must be called with > 0
+    // bytes when extracting non-empty files from ZIP archives.
+    #[test]
+    fn test_on_bytes_written_called_for_zip() {
+        use crate::ProgressCallback;
+        use std::path::Path;
+
+        struct ByteTracker {
+            total: u64,
+        }
+
+        impl ProgressCallback for ByteTracker {
+            fn on_entry_start(&mut self, _path: &Path, _total: usize, _current: usize) {}
+
+            fn on_bytes_written(&mut self, bytes: u64) {
+                self.total += bytes;
+            }
+
+            fn on_entry_complete(&mut self, _path: &Path) {}
+
+            fn on_complete(&mut self) {}
+        }
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let archive_path = tmp.path().join("test.zip");
+        let src_dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(src_dir.path().join("data.txt"), b"hello world").unwrap();
+        let config = CreationConfig::default().with_format(Some(ArchiveType::Zip));
+        create_archive(&archive_path, &[src_dir.path()], &config).unwrap();
+
+        let dest = tempfile::TempDir::new().unwrap();
+        let mut progress = ByteTracker { total: 0 };
+        let report = extract_archive_with_progress(
+            &archive_path,
+            dest.path(),
+            &SecurityConfig::default(),
+            &mut progress,
+        )
+        .unwrap();
+
+        assert!(
+            report.bytes_written > 0,
+            "report.bytes_written must be > 0, got {}",
+            report.bytes_written
+        );
+        assert!(
+            progress.total > 0,
+            "on_bytes_written must be called with > 0 bytes for ZIP, got {}",
+            progress.total
+        );
+    }
+
+    // Regression test for issue #304: on_bytes_written must be called with > 0
+    // bytes when extracting non-empty files from 7z archives.
+    #[test]
+    fn test_on_bytes_written_called_for_sevenz() {
+        use crate::ProgressCallback;
+        use std::path::Path;
+
+        struct ByteTracker {
+            total: u64,
+        }
+
+        impl ProgressCallback for ByteTracker {
+            fn on_entry_start(&mut self, _path: &Path, _total: usize, _current: usize) {}
+
+            fn on_bytes_written(&mut self, bytes: u64) {
+                self.total += bytes;
+            }
+
+            fn on_entry_complete(&mut self, _path: &Path) {}
+
+            fn on_complete(&mut self) {}
+        }
+
+        let fixture =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tests/fixtures/simple.7z");
+
+        let dest = tempfile::TempDir::new().unwrap();
+        let mut progress = ByteTracker { total: 0 };
+        let report = extract_archive_with_progress(
+            &fixture,
+            dest.path(),
+            &SecurityConfig::default(),
+            &mut progress,
+        )
+        .unwrap();
+
+        assert!(
+            report.bytes_written > 0,
+            "report.bytes_written must be > 0, got {}",
+            report.bytes_written
+        );
+        assert!(
+            progress.total > 0,
+            "on_bytes_written must be called with > 0 bytes for 7z, got {}",
+            progress.total
+        );
+    }
+
+    // Regression test for BYTES-1: on_bytes_written must be called when TAR
+    // hardlinks are extracted (copy path in create_hardlink).
+    #[test]
+    fn test_tar_hardlink_calls_on_bytes_written() {
+        use crate::ProgressCallback;
+        use crate::formats::TarArchive;
+        use crate::formats::traits::ArchiveFormat;
+        use std::io::Cursor;
+        use std::path::Path;
+
+        struct ByteTracker {
+            total: u64,
+        }
+
+        impl ProgressCallback for ByteTracker {
+            fn on_entry_start(&mut self, _path: &Path, _total: usize, _current: usize) {}
+
+            fn on_bytes_written(&mut self, bytes: u64) {
+                self.total += bytes;
+            }
+
+            fn on_entry_complete(&mut self, _path: &Path) {}
+
+            fn on_complete(&mut self) {}
+        }
+
+        // Build a TAR with one regular file and one hardlink pointing to it.
+        let content = b"hello hardlink";
+        let tar_data = {
+            let mut builder = tar::Builder::new(Vec::new());
+
+            let mut header = tar::Header::new_gnu();
+            header.set_size(content.len() as u64);
+            header.set_mode(0o644);
+            header.set_entry_type(tar::EntryType::Regular);
+            header.set_cksum();
+            builder
+                .append_data(&mut header, "original.txt", content.as_ref())
+                .unwrap();
+
+            let mut hdr = tar::Header::new_gnu();
+            hdr.set_size(0);
+            hdr.set_mode(0o644);
+            hdr.set_entry_type(tar::EntryType::Link);
+            hdr.set_link_name("original.txt").unwrap();
+            hdr.set_cksum();
+            builder
+                .append_data(&mut hdr, "link.txt", std::io::empty())
+                .unwrap();
+
+            builder.into_inner().unwrap()
+        };
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let mut config = SecurityConfig::default();
+        config.allowed.hardlinks = true;
+
+        let mut archive = TarArchive::new(Cursor::new(tar_data));
+        let mut progress = ByteTracker { total: 0 };
+        let report = archive
+            .extract(
+                temp.path(),
+                &config,
+                &ExtractionOptions::default(),
+                &mut progress,
+            )
+            .unwrap();
+
+        // The hardlink copies the file content — bytes should be reported twice.
+        let expected = (content.len() as u64) * 2;
+        assert_eq!(
+            progress.total, expected,
+            "on_bytes_written must report bytes for both original and hardlink copy, \
+             got {} (report.bytes_written={})",
+            progress.total, report.bytes_written
+        );
+    }
+
+    // Regression test for issue #305: on_entry_complete must be called even
+    // when TAR extraction fails mid-entry due to a path traversal violation.
+    #[test]
+    fn test_tar_on_entry_complete_called_on_path_traversal_error() {
+        use crate::ProgressCallback;
+        use crate::formats::TarArchive;
+        use crate::formats::traits::ArchiveFormat;
+        use std::io::Cursor;
+        use std::path::Path;
+
+        struct SymmetryTracker {
+            started: usize,
+            completed: usize,
+        }
+
+        impl ProgressCallback for SymmetryTracker {
+            fn on_entry_start(&mut self, _path: &Path, _total: usize, _current: usize) {
+                self.started += 1;
+            }
+
+            fn on_bytes_written(&mut self, _bytes: u64) {}
+
+            fn on_entry_complete(&mut self, _path: &Path) {
+                self.completed += 1;
+            }
+
+            fn on_complete(&mut self) {}
+        }
+
+        // Build a minimal TAR with a path-traversal entry at raw bytes level
+        // (bypassing the `tar` crate's sanitization).
+        let tar_data = make_raw_tar_single(b"../../etc/passwd", b"evil");
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let mut archive = TarArchive::new(Cursor::new(tar_data));
+        let mut progress = SymmetryTracker {
+            started: 0,
+            completed: 0,
+        };
+        let result = archive.extract(
+            temp.path(),
+            &SecurityConfig::default(),
+            &ExtractionOptions::default(),
+            &mut progress,
+        );
+
+        assert!(result.is_err(), "traversal entry must be rejected");
+        assert_eq!(
+            progress.started, progress.completed,
+            "on_entry_complete must be called for every on_entry_start, \
+             even when extraction fails: started={}, completed={}",
+            progress.started, progress.completed
+        );
+    }
+
+    // Regression test for issue #305: on_entry_complete must be called even
+    // when ZIP extraction fails mid-entry due to a path traversal violation.
+    #[test]
+    fn test_zip_on_entry_complete_called_on_path_traversal_error() {
+        use crate::ProgressCallback;
+        use crate::formats::ZipArchive;
+        use crate::formats::traits::ArchiveFormat;
+        use std::io::Cursor;
+        use std::path::Path;
+
+        struct SymmetryTracker {
+            started: usize,
+            completed: usize,
+        }
+
+        impl ProgressCallback for SymmetryTracker {
+            fn on_entry_start(&mut self, _path: &Path, _total: usize, _current: usize) {
+                self.started += 1;
+            }
+
+            fn on_bytes_written(&mut self, _bytes: u64) {}
+
+            fn on_entry_complete(&mut self, _path: &Path) {
+                self.completed += 1;
+            }
+
+            fn on_complete(&mut self) {}
+        }
+
+        // Build a ZIP with a traversal path using zip::ZipWriter.
+        let zip_data = make_zip_with_traversal(b"../../etc/passwd", b"evil");
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let mut archive = ZipArchive::new(Cursor::new(zip_data)).unwrap();
+        let mut progress = SymmetryTracker {
+            started: 0,
+            completed: 0,
+        };
+        let result = archive.extract(
+            temp.path(),
+            &SecurityConfig::default(),
+            &ExtractionOptions::default(),
+            &mut progress,
+        );
+
+        assert!(result.is_err(), "traversal entry must be rejected");
+        assert_eq!(
+            progress.started, progress.completed,
+            "on_entry_complete must be called for every on_entry_start in ZIP, \
+             even when extraction fails: started={}, completed={}",
+            progress.started, progress.completed
+        );
+    }
+
+    // Builds a single-entry POSIX ustar TAR with an arbitrary raw path,
+    // bypassing the `tar` crate's path sanitization.
+    fn make_raw_tar_single(path: &[u8], data: &[u8]) -> Vec<u8> {
+        let mut out = Vec::new();
+        let mut header = [0u8; 512];
+
+        let path_len = path.len().min(100);
+        header[..path_len].copy_from_slice(&path[..path_len]);
+        header[100..108].copy_from_slice(b"0000644\0");
+        header[108..116].copy_from_slice(b"0000000\0");
+        header[116..124].copy_from_slice(b"0000000\0");
+        let size_str = format!("{:011o}\0", data.len());
+        header[124..136].copy_from_slice(size_str.as_bytes());
+        header[136..148].copy_from_slice(b"00000000000\0");
+        header[156] = b'0';
+        header[257..263].copy_from_slice(b"ustar ");
+        header[263..265].copy_from_slice(b" \0");
+        header[148..156].copy_from_slice(b"        ");
+        let checksum: u32 = header.iter().map(|&b| u32::from(b)).sum();
+        let ck_str = format!("{checksum:06o}\0 ");
+        header[148..156].copy_from_slice(ck_str.as_bytes());
+
+        out.extend_from_slice(&header);
+        out.extend_from_slice(data);
+        let rem = data.len() % 512;
+        if rem != 0 {
+            out.extend(std::iter::repeat_n(0u8, 512 - rem));
+        }
+        out.extend(std::iter::repeat_n(0u8, 1024));
+        out
+    }
+
+    // Builds a single-entry ZIP with a raw traversal path by writing the
+    // local file header and central directory manually.
+    #[allow(clippy::cast_possible_truncation)]
+    fn make_zip_with_traversal(path: &[u8], data: &[u8]) -> Vec<u8> {
+        let mut buf: Vec<u8> = Vec::new();
+
+        let crc = crc32_ieee(data);
+        let name_len = path.len() as u16;
+        let content_len = data.len() as u32;
+
+        let local_offset: u32 = 0;
+
+        // Local file header
+        buf.extend_from_slice(b"PK\x03\x04");
+        buf.extend_from_slice(&20u16.to_le_bytes()); // version needed
+        buf.extend_from_slice(&0u16.to_le_bytes()); // flags
+        buf.extend_from_slice(&0u16.to_le_bytes()); // compression: Stored
+        buf.extend_from_slice(&0u16.to_le_bytes()); // mod time
+        buf.extend_from_slice(&0u16.to_le_bytes()); // mod date
+        buf.extend_from_slice(&crc.to_le_bytes());
+        buf.extend_from_slice(&content_len.to_le_bytes());
+        buf.extend_from_slice(&content_len.to_le_bytes());
+        buf.extend_from_slice(&name_len.to_le_bytes());
+        buf.extend_from_slice(&0u16.to_le_bytes()); // extra field length
+        buf.extend_from_slice(path);
+        buf.extend_from_slice(data);
+
+        let central_dir_offset = buf.len() as u32;
+
+        // Central directory file header
+        buf.extend_from_slice(b"PK\x01\x02");
+        buf.extend_from_slice(&0x031eu16.to_le_bytes()); // version made by: Unix
+        buf.extend_from_slice(&20u16.to_le_bytes()); // version needed
+        buf.extend_from_slice(&0u16.to_le_bytes()); // flags
+        buf.extend_from_slice(&0u16.to_le_bytes()); // compression
+        buf.extend_from_slice(&0u16.to_le_bytes()); // mod time
+        buf.extend_from_slice(&0u16.to_le_bytes()); // mod date
+        buf.extend_from_slice(&crc.to_le_bytes());
+        buf.extend_from_slice(&content_len.to_le_bytes());
+        buf.extend_from_slice(&content_len.to_le_bytes());
+        buf.extend_from_slice(&name_len.to_le_bytes());
+        buf.extend_from_slice(&0u16.to_le_bytes()); // extra field len
+        buf.extend_from_slice(&0u16.to_le_bytes()); // file comment len
+        buf.extend_from_slice(&0u16.to_le_bytes()); // disk number start
+        buf.extend_from_slice(&0u16.to_le_bytes()); // internal attrs
+        buf.extend_from_slice(&(0o100_644u32 << 16).to_le_bytes()); // external attrs
+        buf.extend_from_slice(&local_offset.to_le_bytes());
+        buf.extend_from_slice(path);
+
+        let central_dir_size = (buf.len() as u32) - central_dir_offset;
+
+        // End of central directory
+        buf.extend_from_slice(b"PK\x05\x06");
+        buf.extend_from_slice(&0u16.to_le_bytes()); // disk number
+        buf.extend_from_slice(&0u16.to_le_bytes()); // disk with central dir
+        buf.extend_from_slice(&1u16.to_le_bytes()); // entries on this disk
+        buf.extend_from_slice(&1u16.to_le_bytes()); // total entries
+        buf.extend_from_slice(&central_dir_size.to_le_bytes());
+        buf.extend_from_slice(&central_dir_offset.to_le_bytes());
+        buf.extend_from_slice(&0u16.to_le_bytes()); // comment length
+        buf
+    }
+
+    // CRC-32 (IEEE 802.3) used to produce valid ZIP checksums in helpers above.
+    fn crc32_ieee(data: &[u8]) -> u32 {
+        let mut crc: u32 = 0xFFFF_FFFF;
+        for &byte in data {
+            let mut val = crc ^ u32::from(byte);
+            for _ in 0..8 {
+                let mask = (val & 1).wrapping_neg();
+                val = (val >> 1) ^ (0xEDB8_8320 & mask);
+            }
+            crc = val;
+        }
+        !crc
+    }
 }

--- a/crates/exarch-core/src/formats/common.rs
+++ b/crates/exarch-core/src/formats/common.rs
@@ -21,6 +21,7 @@ use std::path::PathBuf;
 
 use crate::ArchiveError;
 use crate::ExtractionReport;
+use crate::ProgressCallback;
 use crate::Result;
 use crate::copy::CopyBuffer;
 use crate::copy::copy_with_buffer;
@@ -28,6 +29,51 @@ use crate::error::QuotaResource;
 use crate::security::validator::ValidatedEntry;
 use crate::types::DestDir;
 use crate::types::SafeSymlink;
+
+/// RAII guard that calls `on_entry_complete` when dropped.
+///
+/// Ensures `on_entry_complete` is always paired with `on_entry_start`, even
+/// when extraction fails mid-entry and the caller returns early via `?`.
+pub struct EntryCompleteGuard<'a> {
+    progress: &'a mut dyn ProgressCallback,
+    path: &'a std::path::Path,
+    fired: bool,
+}
+
+impl<'a> EntryCompleteGuard<'a> {
+    /// Creates a new guard. `on_entry_complete` will fire on drop unless
+    /// `disarm` is called first.
+    pub fn new(progress: &'a mut dyn ProgressCallback, path: &'a std::path::Path) -> Self {
+        Self {
+            progress,
+            path,
+            fired: false,
+        }
+    }
+
+    /// Returns a mutable reference to the underlying progress callback.
+    ///
+    /// Use this to pass the callback to nested helpers while keeping the guard
+    /// in scope for RAII completion.
+    pub fn progress_mut(&mut self) -> &mut dyn ProgressCallback {
+        self.progress
+    }
+
+    /// Fire `on_entry_complete` immediately and prevent the drop from firing
+    /// again.
+    pub fn complete(mut self) {
+        self.progress.on_entry_complete(self.path);
+        self.fired = true;
+    }
+}
+
+impl Drop for EntryCompleteGuard<'_> {
+    fn drop(&mut self) {
+        if !self.fired {
+            self.progress.on_entry_complete(self.path);
+        }
+    }
+}
 
 /// Cache for tracking created directories during extraction.
 ///
@@ -387,6 +433,7 @@ pub fn extract_file_generic<R: Read>(
     copy_buffer: &mut CopyBuffer,
     dir_cache: &mut DirCache,
     skip_duplicates: bool,
+    progress: &mut dyn ProgressCallback,
 ) -> Result<()> {
     let output_path = dest.join(&validated.safe_path);
 
@@ -418,6 +465,10 @@ pub fn extract_file_generic<R: Read>(
     let mut buffered_writer = BufWriter::with_capacity(64 * 1024, output_file);
     let bytes_written = copy_with_buffer(reader, &mut buffered_writer, copy_buffer)?;
     buffered_writer.flush()?;
+
+    if bytes_written > 0 {
+        progress.on_bytes_written(bytes_written);
+    }
 
     report.files_extracted += 1;
     report.bytes_written =
@@ -555,6 +606,7 @@ mod tests {
     use super::*;
     use crate::ArchiveError;
     use crate::ExtractionReport;
+    use crate::NoopProgress;
     use crate::SecurityConfig;
     use crate::copy::CopyBuffer;
     use crate::security::validator::ValidatedEntry;
@@ -597,6 +649,7 @@ mod tests {
             &mut copy_buffer,
             &mut dir_cache,
             true,
+            &mut NoopProgress,
         );
 
         // Should return QuotaExceeded with IntegerOverflow
@@ -982,6 +1035,7 @@ mod tests {
             &mut copy_buffer,
             &mut dir_cache,
             true,
+            &mut NoopProgress,
         )
         .expect("extraction should succeed");
 

--- a/crates/exarch-core/src/formats/sevenz.rs
+++ b/crates/exarch-core/src/formats/sevenz.rs
@@ -288,6 +288,109 @@ impl<R: Read + Seek> SevenZArchive<R> {
 }
 
 impl<R: Read + Seek> SevenZArchive<R> {
+    /// Processes a single 7z entry: validates, extracts file or creates
+    /// directory.
+    ///
+    /// Returns `(continue, bytes_written)` on success so the caller can
+    /// invoke `on_bytes_written` and `on_entry_complete` after this returns,
+    /// guaranteeing both callbacks are always paired with `on_entry_start`.
+    #[allow(clippy::too_many_arguments)]
+    fn process_entry_inner(
+        entry: &sevenz_rust2::ArchiveEntry,
+        reader: &mut dyn Read,
+        entry_path: &std::path::Path,
+        validator: &mut EntryValidator,
+        dest: &DestDir,
+        report: &mut ExtractionReport,
+        dir_cache: &mut common::DirCache,
+        skip_duplicates: bool,
+        config: &SecurityConfig,
+    ) -> std::result::Result<u64, sevenz_rust2::Error> {
+        let entry_type = SevenZEntryAdapter::to_entry_type(entry).map_err(|e| {
+            sevenz_rust2::Error::Other(format!("entry type detection failed: {e}").into())
+        })?;
+
+        // Extension filter runs before validate_entry to avoid quota
+        // double-counting for skipped files.
+        if matches!(entry_type, EntryType::File) {
+            let ext = entry_path.extension().and_then(|e| e.to_str());
+            if !config.is_path_extension_allowed(ext) {
+                report.files_skipped += 1;
+                report.warnings.push(format!(
+                    "skipped entry with disallowed extension: {}",
+                    entry_path.display()
+                ));
+                return Ok(0);
+            }
+        }
+
+        // Re-validate (defense in depth)
+        let validated = validator
+            .validate_entry(entry_path, &entry_type, entry.size, None, None, None)
+            .map_err(|e| sevenz_rust2::Error::Other(format!("validation failed: {e}").into()))?;
+
+        // Extract based on type
+        match validated.entry_type {
+            ValidatedEntryType::Directory => {
+                let dest_path = dest.join_path(validated.safe_path.as_path());
+                dir_cache.ensure_dir(&dest_path)?;
+                report.directories_created += 1;
+                Ok(0)
+            }
+            ValidatedEntryType::File => {
+                let dest_path = dest.join_path(validated.safe_path.as_path());
+
+                dir_cache.ensure_parent_dir(&dest_path)?;
+
+                if dest_path.exists() {
+                    if skip_duplicates {
+                        report.files_skipped += 1;
+                        report.warnings.push(format!(
+                            "skipped duplicate entry: {}",
+                            validated.safe_path.as_path().display()
+                        ));
+                        return Ok(0);
+                    }
+                    return Err(sevenz_rust2::Error::Other(
+                        format!(
+                            "duplicate entry: {}",
+                            validated.safe_path.as_path().display()
+                        )
+                        .into(),
+                    ));
+                }
+
+                // Atomic write (temp + rename) with unique temp file name
+                let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+                let pid = id();
+                let original_name = dest_path
+                    .file_name()
+                    .map_or_else(|| "file".to_string(), |n| n.to_string_lossy().to_string());
+                let temp_name = format!(".{original_name}.exarch-tmp-{pid}-{counter}");
+                let temp_path = dest_path.with_file_name(&temp_name);
+
+                let temp_guard = TempFileGuard::new(temp_path.clone());
+                let bytes_written = {
+                    let mut temp_file = std::fs::File::create(&temp_path)?;
+                    let n = std::io::copy(reader, &mut temp_file)?;
+                    report.bytes_written =
+                        report.bytes_written.checked_add(n).ok_or_else(|| {
+                            sevenz_rust2::Error::Other("bytes_written overflow".into())
+                        })?;
+                    n
+                };
+                std::fs::rename(&temp_path, &dest_path)?;
+                temp_guard.persist();
+
+                report.files_extracted += 1;
+                Ok(bytes_written)
+            }
+            _ => Err(sevenz_rust2::Error::Other(
+                "symlinks/hardlinks not supported".into(),
+            )),
+        }
+    }
+
     /// Extract archive using sevenz-rust2 callback API with security
     /// validation.
     ///
@@ -341,102 +444,33 @@ impl<R: Read + Seek> SevenZArchive<R> {
             ctx.progress
                 .on_entry_start(entry_path.as_path(), total, idx);
 
-            // Convert entry metadata
-            let entry_type = SevenZEntryAdapter::to_entry_type(entry).map_err(|e| {
-                sevenz_rust2::Error::Other(format!("entry type detection failed: {e}").into())
-            })?;
+            let result = Self::process_entry_inner(
+                entry,
+                reader,
+                &entry_path,
+                validator,
+                dest,
+                &mut ctx.report,
+                ctx.dir_cache,
+                skip_duplicates,
+                config,
+            );
 
-            // Extension filter runs before validate_entry to avoid quota
-            // double-counting for skipped files.
-            if matches!(entry_type, EntryType::File) {
-                let ext = entry_path.extension().and_then(|e| e.to_str());
-                if !config.is_path_extension_allowed(ext) {
-                    ctx.report.files_skipped += 1;
-                    ctx.report.warnings.push(format!(
-                        "skipped entry with disallowed extension: {}",
-                        entry_path.display()
-                    ));
+            // INVARIANT: every branch below must call on_entry_complete exactly once.
+            // Fire on_bytes_written before on_entry_complete on success.
+            match result {
+                Ok(bytes_written) => {
+                    if bytes_written > 0 {
+                        ctx.progress.on_bytes_written(bytes_written);
+                    }
                     ctx.progress.on_entry_complete(entry_path.as_path());
-                    return Ok(true);
+                    Ok(true)
+                }
+                Err(e) => {
+                    ctx.progress.on_entry_complete(entry_path.as_path());
+                    Err(e)
                 }
             }
-
-            // Re-validate (defense in depth)
-            let validated = validator
-                .validate_entry(&entry_path, &entry_type, entry.size, None, None, None)
-                .map_err(|e| {
-                    sevenz_rust2::Error::Other(format!("validation failed: {e}").into())
-                })?;
-
-            // Extract based on type
-            match validated.entry_type {
-                ValidatedEntryType::Directory => {
-                    let dest_path = dest.join_path(validated.safe_path.as_path());
-                    // Use cache to avoid redundant mkdir syscalls
-                    ctx.dir_cache.ensure_dir(&dest_path)?;
-                    ctx.report.directories_created += 1;
-                }
-                ValidatedEntryType::File => {
-                    let dest_path = dest.join_path(validated.safe_path.as_path());
-
-                    // Create parent directories using cache
-                    ctx.dir_cache.ensure_parent_dir(&dest_path)?;
-
-                    if dest_path.exists() {
-                        if skip_duplicates {
-                            ctx.report.files_skipped += 1;
-                            ctx.report.warnings.push(format!(
-                                "skipped duplicate entry: {}",
-                                validated.safe_path.as_path().display()
-                            ));
-                            ctx.progress.on_entry_complete(entry_path.as_path());
-                            return Ok(true);
-                        }
-                        return Err(sevenz_rust2::Error::Other(
-                            format!(
-                                "duplicate entry: {}",
-                                validated.safe_path.as_path().display()
-                            )
-                            .into(),
-                        ));
-                    }
-
-                    // Atomic write (temp + rename) with unique temp file name
-                    let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
-                    let pid = id();
-                    let original_name = dest_path
-                        .file_name()
-                        .map_or_else(|| "file".to_string(), |n| n.to_string_lossy().to_string());
-                    let temp_name = format!(".{original_name}.exarch-tmp-{pid}-{counter}");
-                    let temp_path = dest_path.with_file_name(&temp_name);
-
-                    // Guard ensures temp file cleanup on error
-                    let guard = TempFileGuard::new(temp_path.clone());
-                    {
-                        let mut temp_file = std::fs::File::create(&temp_path)?;
-                        let bytes_written = std::io::copy(reader, &mut temp_file)?;
-                        ctx.report.bytes_written = ctx
-                            .report
-                            .bytes_written
-                            .checked_add(bytes_written)
-                            .ok_or_else(|| {
-                                sevenz_rust2::Error::Other("bytes_written overflow".into())
-                            })?;
-                    }
-                    std::fs::rename(&temp_path, &dest_path)?;
-                    guard.persist(); // Success - don't cleanup
-
-                    ctx.report.files_extracted += 1;
-                }
-                _ => {
-                    return Err(sevenz_rust2::Error::Other(
-                        "symlinks/hardlinks not supported".into(),
-                    ));
-                }
-            }
-
-            ctx.progress.on_entry_complete(entry_path.as_path());
-            Ok(true) // Continue extraction
         };
 
         let result = sevenz_rust2::decompress_with_extract_fn(source, dest.as_path(), extract_fn);

--- a/crates/exarch-core/src/formats/tar.rs
+++ b/crates/exarch-core/src/formats/tar.rs
@@ -285,6 +285,7 @@ impl<R: Read> TarArchive<R> {
             ctx.copy_buffer,
             ctx.dir_cache,
             ctx.skip_duplicates,
+            ctx.progress,
         )
     }
 
@@ -329,6 +330,7 @@ impl<R: Read> TarArchive<R> {
 
         ctx.report.files_extracted += 1;
         ctx.report.bytes_written += bytes_copied;
+        ctx.progress.on_bytes_written(bytes_copied);
 
         Ok(())
     }
@@ -382,6 +384,7 @@ impl<R: Read> ArchiveFormat for TarArchive<R> {
             dir_cache: &mut dir_cache,
             skip_duplicates,
             config,
+            progress,
         };
 
         for entry_result in entries {
@@ -404,17 +407,19 @@ impl<R: Read> ArchiveFormat for TarArchive<R> {
                 .map(std::borrow::Cow::into_owned)
                 .unwrap_or_default();
             current_entry = current_entry.saturating_add(1);
-            progress.on_entry_start(&entry_path, 0, current_entry);
+            ctx.progress.on_entry_start(&entry_path, 0, current_entry);
 
+            // INVARIANT: every branch below must call on_entry_complete exactly once.
             match Self::process_entry(entry, &mut ctx) {
                 Ok(Some(hardlink_info)) => {
-                    progress.on_entry_complete(&entry_path);
+                    ctx.progress.on_entry_complete(&entry_path);
                     hardlinks.push(hardlink_info);
                 }
                 Ok(None) => {
-                    progress.on_entry_complete(&entry_path);
+                    ctx.progress.on_entry_complete(&entry_path);
                 }
                 Err(e) => {
+                    ctx.progress.on_entry_complete(&entry_path);
                     return Err(if ctx.report.total_items() > 0 {
                         ArchiveError::PartialExtraction {
                             source: Box::new(e),
@@ -441,7 +446,7 @@ impl<R: Read> ArchiveFormat for TarArchive<R> {
             }
         }
 
-        progress.on_complete();
+        ctx.progress.on_complete();
         report.duration = start.elapsed();
 
         Ok(report)
@@ -497,6 +502,7 @@ struct ExtractionContext<'a, 'v> {
     dir_cache: &'a mut common::DirCache,
     skip_duplicates: bool,
     config: &'v SecurityConfig,
+    progress: &'a mut dyn ProgressCallback,
 }
 
 #[allow(dead_code)] // Fields used only on Unix

--- a/crates/exarch-core/src/formats/zip.rs
+++ b/crates/exarch-core/src/formats/zip.rs
@@ -138,6 +138,7 @@ use crate::types::DestDir;
 use crate::types::EntryType;
 
 use super::common;
+use super::common::EntryCompleteGuard;
 use super::traits::ArchiveFormat;
 
 /// ZIP archive handler with random-access extraction.
@@ -265,6 +266,7 @@ impl<R: Read + Seek> ZipArchive<R> {
         dir_cache: &mut common::DirCache,
         skip_duplicates: bool,
         config: &SecurityConfig,
+        progress: &mut dyn ProgressCallback,
     ) -> Result<()> {
         let mut zip_file = self.inner.by_index(index).map_err(|e| {
             if e.to_string().contains("Password required to decrypt file") {
@@ -361,6 +363,7 @@ impl<R: Read + Seek> ZipArchive<R> {
                 copy_buffer,
                 dir_cache,
                 skip_duplicates,
+                progress,
             )?;
         }
 
@@ -378,6 +381,7 @@ impl<R: Read + Seek> ZipArchive<R> {
         copy_buffer: &mut CopyBuffer,
         dir_cache: &mut common::DirCache,
         skip_duplicates: bool,
+        progress: &mut dyn ProgressCallback,
     ) -> Result<()> {
         common::extract_file_generic(
             zip_file,
@@ -388,6 +392,7 @@ impl<R: Read + Seek> ZipArchive<R> {
             copy_buffer,
             dir_cache,
             skip_duplicates,
+            progress,
         )
     }
 }
@@ -432,8 +437,9 @@ impl<R: Read + Seek> ArchiveFormat for ZipArchive<R> {
                 )
             };
             progress.on_entry_start(&entry_path, entry_count, i.saturating_add(1));
+            let mut guard = EntryCompleteGuard::new(progress, &entry_path);
 
-            if let Err(e) = self.process_entry(
+            let result = self.process_entry(
                 i,
                 &mut validator,
                 &dest,
@@ -442,7 +448,11 @@ impl<R: Read + Seek> ArchiveFormat for ZipArchive<R> {
                 &mut dir_cache,
                 skip_duplicates,
                 config,
-            ) {
+                guard.progress_mut(),
+            );
+
+            if let Err(e) = result {
+                drop(guard);
                 return Err(if report.total_items() > 0 {
                     ArchiveError::PartialExtraction {
                         source: Box::new(e),
@@ -452,7 +462,7 @@ impl<R: Read + Seek> ArchiveFormat for ZipArchive<R> {
                     e
                 });
             }
-            progress.on_entry_complete(&entry_path);
+            guard.complete();
         }
 
         progress.on_complete();

--- a/crates/exarch-core/src/report.rs
+++ b/crates/exarch-core/src/report.rs
@@ -98,12 +98,20 @@ pub trait ProgressCallback: Send {
 
     /// Called when bytes are written during extraction or read during creation.
     ///
+    /// Granularity is per-entry: called once after the full entry is written.
+    /// Partial writes on failure are not reported. Not called for entries that
+    /// produce no output (directories, skipped entries).
+    ///
     /// # Arguments
     ///
     /// * `bytes` - Number of bytes written/read in this update
     fn on_bytes_written(&mut self, bytes: u64);
 
     /// Called when an entry has been completely processed.
+    ///
+    /// Always called after [`on_entry_start`](Self::on_entry_start) for the
+    /// same entry, including when extraction of that entry fails. Callers can
+    /// rely on this pairing for cleanup or progress accounting.
     ///
     /// # Arguments
     ///


### PR DESCRIPTION
## Summary

- **#304**: `ProgressCallback::on_bytes_written` was documented but never called during extraction. Added calls in all three format handlers (TAR, ZIP, 7z), including the TAR hardlink path via `create_hardlink()`.
- **#305**: `on_entry_complete` could be skipped when extraction failed mid-entry, leaving `on_entry_start`/`on_entry_complete` unbalanced. ZIP now uses an `EntryCompleteGuard` RAII struct; TAR and 7z use explicit calls on every branch with an INVARIANT comment.

Updated `on_entry_complete` doc to document the always-fire guarantee. Updated `on_bytes_written` doc to note per-entry granularity (called once after the full write, not per chunk).

## Test plan

- [x] `test_on_bytes_written_called_for_tar` — verifies bytes reported > 0 during TAR extraction
- [x] `test_on_bytes_written_called_for_zip` — same for ZIP
- [x] `test_on_bytes_written_called_for_sevenz` — same for 7z
- [x] `test_tar_on_entry_complete_called_on_path_traversal_error` — verifies start == complete after TAR traversal error
- [x] `test_zip_on_entry_complete_called_on_path_traversal_error` — same for ZIP
- [x] `test_tar_hardlink_calls_on_bytes_written` — verifies hardlink bytes reported via `create_hardlink()`
- [x] `cargo nextest run --workspace --all-features`: 877/877 passed
- [x] `cargo test --doc --workspace --all-features`: 98/98 passed
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean
- [x] `cargo +nightly fmt --all -- --check`: clean

Closes #304, #305