### PR TITLE
fix(cli): make --allow-absolute-paths effective in list_archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Python: `SecurityConfig` and `CreationConfig` scalar getters (`max_file_size`, `max_total_size`, `max_compression_ratio`, `max_file_count`, `max_path_depth`, `max_solid_block_memory`, `preserve_permissions`, `compression_level`, `follow_symlinks`, `include_hidden`, `exclude_patterns`) now return their values correctly instead of a bound method. Builder methods were renamed to `with_<field>` (e.g. `with_max_file_size(...)`) to eliminate the PyO3 name collision (#315).
 - Node.js: `index.d.ts` now declares `setMaxSolidBlockMemory(size: number): this` and `get maxSolidBlockMemory(): number` for `SecurityConfig`; the file is committed to the repository so TypeScript consumers have correct types without building from source (#311).
 - Python: `exarch.pyi` now declares `allowed_extensions` and `banned_path_components` as `@property` with setters, replacing bare class-level annotations that did not express read/write semantics (#312).
+- `list_archive` now respects `SecurityConfig::allowed.absolute_paths`; absolute paths in TAR
+  and 7z archives are accepted during listing when the flag is set (previously silently rejected
+  regardless of config) (#318). The `--allow-absolute-paths` CLI flag now consistently applies
+  to both the listing and extraction phases.
 - `verify --strict` no longer writes an unstructured message to stderr that bypassed `--quiet` suppression and `--json` mode. Exit code 2 already conveys the strict-warning condition (#298).
 - `ProgressCallback::on_bytes_written` is now called during extraction for TAR, ZIP, and 7z formats; previously the method was documented but never invoked (#304).
 - `ProgressCallback::on_entry_complete` is now guaranteed to be called for every entry for which `on_entry_start` was called, including entries that fail mid-extraction; previously a failure left the callback pair unbalanced (#305).

--- a/crates/exarch-cli/src/commands/extract.rs
+++ b/crates/exarch-cli/src/commands/extract.rs
@@ -76,14 +76,22 @@ pub fn execute(
         config.with_banned_path_components(args.banned_components.clone())
     };
 
-    // list_config shares quota params with config but uses safe defaults for
-    // security flags — listing must not be blocked by allow_symlinks etc.
+    // list_config shares quota and path-filtering params with config but uses
+    // safe defaults for flags that only apply during extraction (symlinks,
+    // hardlinks, world-writable, permissions). allow_absolute_paths,
+    // max_path_depth, and banned_path_components are propagated so listing
+    // rejects paths that extraction would also reject on traversal grounds.
+    // Note: depth and component checks are enforced later by SafePath::validate,
+    // not by the listing phase.
     let list_config = SecurityConfig::default()
         .with_max_file_count(config.max_file_count)
         .with_max_total_size(config.max_total_size)
         .with_max_file_size(config.max_file_size)
         .with_max_compression_ratio(config.max_compression_ratio)
-        .with_allow_solid_archives(config.allow_solid_archives);
+        .with_allow_solid_archives(config.allow_solid_archives)
+        .with_allow_absolute_paths(config.allowed.absolute_paths)
+        .with_max_path_depth(config.max_path_depth)
+        .with_banned_path_components(config.banned_path_components.clone());
 
     // Always list the archive: needed for conflict detection and for obtaining
     // the real entry count that drives the progress bar.

--- a/crates/exarch-core/src/inspection/list.rs
+++ b/crates/exarch-core/src/inspection/list.rs
@@ -174,7 +174,7 @@ fn list_tar_entries<R: std::io::Read>(
             .map_err(|e| ArchiveError::InvalidArchive(format!("invalid path: {e}")))?
             .into_owned();
 
-        if contains_traversal(&path) {
+        if contains_traversal(&path, config) {
             return Err(ArchiveError::PathTraversal { path });
         }
 
@@ -428,7 +428,7 @@ fn list_sevenz_archive(
 
         let path = PathBuf::from(&entry.name);
 
-        if contains_traversal(&path) {
+        if contains_traversal(&path, config) {
             return Err(ArchiveError::PathTraversal { path });
         }
 
@@ -501,15 +501,15 @@ fn sevenz_manifest_entry_type(entry: &sevenz_rust2::ArchiveEntry) -> ManifestEnt
 /// Checks whether a sevenz-rust2 parse failure is due to a valid empty 7z
 /// Returns `true` if the path contains traversal attempts.
 ///
-/// Mirrors zip crate `enclosed_name()` semantics: rejects paths with `..`
-/// components, Unix root (`/`), or Windows drive prefixes (`C:\`).
-fn contains_traversal(path: &Path) -> bool {
+/// `ParentDir` (`..`) is always rejected. `RootDir` and `Prefix` (Windows drive
+/// paths such as `C:\`) are rejected only when `config.allowed.absolute_paths`
+/// is false, matching the behaviour of `SafePath::validate`.
+fn contains_traversal(path: &Path, config: &SecurityConfig) -> bool {
     use std::path::Component;
-    path.components().any(|c| {
-        matches!(
-            c,
-            Component::ParentDir | Component::RootDir | Component::Prefix(_)
-        )
+    path.components().any(|c| match c {
+        Component::ParentDir => true,
+        Component::Prefix(_) | Component::RootDir => !config.allowed.absolute_paths,
+        _ => false,
     })
 }
 
@@ -1255,6 +1255,77 @@ mod tests {
         assert!(
             matches!(result, Err(ArchiveError::PathTraversal { .. })),
             "expected PathTraversal error for absolute path in TAR, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_list_tar_absolute_path_allowed_when_flag_set() {
+        // Regression for #318: allow_absolute_paths must also take effect during
+        // the listing phase, not only during extraction.
+        let mut temp_file = NamedTempFile::with_suffix(".tar").unwrap();
+        temp_file
+            .write_all(&tar_with_raw_path("/etc/passwd"))
+            .unwrap();
+        temp_file.flush().unwrap();
+
+        let config = SecurityConfig::default().with_allow_absolute_paths(true);
+        let result = list_archive(temp_file.path(), &config);
+        assert!(
+            result.is_ok(),
+            "list_archive must accept absolute paths when allow_absolute_paths=true, got: {result:?}"
+        );
+        let manifest = result.unwrap();
+        assert_eq!(manifest.total_entries, 1);
+    }
+
+    #[test]
+    fn test_list_sevenz_absolute_path_allowed_when_flag_set() {
+        // Regression for #318: allow_absolute_paths must propagate to 7z listing.
+        let archive_bytes = make_sevenz_archive(&[("/absolute/path.txt", b"data")]);
+        let mut temp_file = NamedTempFile::with_suffix(".7z").unwrap();
+        temp_file.write_all(&archive_bytes).unwrap();
+        temp_file.flush().unwrap();
+
+        let config = SecurityConfig::default().with_allow_absolute_paths(true);
+        let result = list_archive(temp_file.path(), &config);
+        assert!(
+            result.is_ok(),
+            "list_archive must accept absolute paths in 7z when allow_absolute_paths=true, got: {result:?}"
+        );
+    }
+
+    /// Unit test for `contains_traversal` — verifies that `Prefix` (Windows
+    /// drive paths) is gated by `allow_absolute_paths`, matching
+    /// `SafePath::validate`. On Unix there is no native way to produce a
+    /// `Prefix` component via the filesystem, so we test the function logic
+    /// directly with a crafted `PathBuf`.
+    #[test]
+    fn test_contains_traversal_prefix_gated_by_flag() {
+        // A path whose string representation starts with a Windows-style drive
+        // prefix. On Windows this produces Component::Prefix; on Unix the entire
+        // string is treated as a relative path component (no Prefix produced), so
+        // this test exercises the flag-gating logic via the RootDir path instead.
+        // The critical invariant — Prefix and RootDir share the same gate — is
+        // verified by the match arm `Component::Prefix(_) | Component::RootDir`.
+        let absolute = PathBuf::from("/absolute/path.txt");
+
+        let config_deny = SecurityConfig::default(); // absolute_paths = false
+        assert!(
+            contains_traversal(&absolute, &config_deny),
+            "absolute path must be rejected when allow_absolute_paths=false"
+        );
+
+        let config_allow = SecurityConfig::default().with_allow_absolute_paths(true);
+        assert!(
+            !contains_traversal(&absolute, &config_allow),
+            "absolute path must be accepted when allow_absolute_paths=true"
+        );
+
+        // ParentDir must always be rejected regardless of the flag.
+        let dotdot = PathBuf::from("../escape.txt");
+        assert!(
+            contains_traversal(&dotdot, &config_allow),
+            "ParentDir must be rejected even when allow_absolute_paths=true"
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes #318. The `--allow-absolute-paths` CLI flag was silently non-functional due to two separate bugs:

- **`list.rs`**: `contains_traversal` unconditionally blocked `Component::RootDir` (and `Component::Prefix`) regardless of `SecurityConfig::allowed.absolute_paths`. Now both `RootDir` and `Prefix(_)` are gated together on `!config.allowed.absolute_paths`, matching the existing policy in `SafePath::validate`. `Component::ParentDir` remains unconditionally blocked.
- **`extract.rs`**: `list_config` was built without forwarding `allow_absolute_paths`, `max_path_depth`, or `banned_path_components` from the user-supplied config. All three fields are now propagated so the listing pre-scan and extraction phase use a consistent policy.

Also corrects a misleading comment in `extract.rs` that implied listing enforces the same depth/component checks as extraction (those run later in `SafePath::validate`).

## Tests

Three new regression tests:
- `test_list_tar_absolute_path_allowed_when_flag_set`
- `test_list_sevenz_absolute_path_allowed_when_flag_set`
- `test_contains_traversal_prefix_gated_by_flag`

880 tests pass.

## Out of scope (follow-up issues)

- #325 — `--allow-absolute-paths` has no effect for ZIP archives (`enclosed_name()` upstream limitation in the `zip` crate)
- #327 — conflict scan probes real absolute paths when `allow_absolute_paths` is set (`output_dir.join` discards prefix for absolute paths)