### PR TITLE
fix(formats): 7z force-overwrite removes existing file before re-extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Python: `SecurityConfig` and `CreationConfig` scalar getters (`max_file_size`, `max_total_size`, `max_compression_ratio`, `max_file_count`, `max_path_depth`, `max_solid_block_memory`, `preserve_permissions`, `compression_level`, `follow_symlinks`, `include_hidden`, `exclude_patterns`) now return their values correctly instead of a bound method. Builder methods were renamed to `with_<field>` (e.g. `with_max_file_size(...)`) to eliminate the PyO3 name collision (#315).
+- 7z force-overwrite now removes existing file before re-extraction when `skip_duplicates=false`; previously it returned a `PartialExtraction` error instead of overwriting (#323).
 - Node.js: `index.d.ts` now declares `setMaxSolidBlockMemory(size: number): this` and `get maxSolidBlockMemory(): number` for `SecurityConfig`; the file is committed to the repository so TypeScript consumers have correct types without building from source (#311).
 - Python: `exarch.pyi` now declares `allowed_extensions` and `banned_path_components` as `@property` with setters, replacing bare class-level annotations that did not express read/write semantics (#312).
 - `list_archive` now respects `SecurityConfig::allowed.absolute_paths`; absolute paths in TAR

--- a/crates/exarch-core/src/formats/sevenz.rs
+++ b/crates/exarch-core/src/formats/sevenz.rs
@@ -342,13 +342,23 @@ impl<R: Read + Seek> SevenZArchive<R> {
 
                 dir_cache.ensure_parent_dir(&dest_path)?;
 
-                if dest_path.exists() && skip_duplicates {
-                    report.files_skipped += 1;
-                    report.warnings.push(format!(
-                        "skipped duplicate entry: {}",
-                        validated.safe_path.as_path().display()
-                    ));
-                    return Ok(0);
+                if dest_path.exists() {
+                    if skip_duplicates {
+                        report.files_skipped += 1;
+                        report.warnings.push(format!(
+                            "skipped duplicate entry: {}",
+                            validated.safe_path.as_path().display()
+                        ));
+                        return Ok(0);
+                    }
+                    // 7z uses temp+rename (unlike TAR/ZIP which truncate in-place via
+                    // File::create). Remove the existing path first so `rename`
+                    // can succeed.
+                    if dest_path.is_dir() {
+                        std::fs::remove_dir_all(&dest_path)?;
+                    } else {
+                        std::fs::remove_file(&dest_path)?;
+                    }
                 }
 
                 // Atomic write (temp + rename) with unique temp file name

--- a/crates/exarch-core/tests/sevenz_integration.rs
+++ b/crates/exarch-core/tests/sevenz_integration.rs
@@ -459,24 +459,58 @@ fn test_7z_bytes_written_accumulates_correctly() {
 // Regression tests for issues #207 and #210: PartialExtraction report
 // ============================================================================
 
-/// Regression test for #207: the `ExtractionReport` accumulated before a quota
-/// error must survive and be returned inside `PartialExtraction`.
-///
-/// Uses a quota violation (not a duplicate entry) to trigger
-/// `PartialExtraction` after at least one file has been successfully extracted.
+/// Regression test for #207: quota errors caught in the pre-validation pass
+/// return `QuotaExceeded` directly (no partial state on disk), not wrapped in
+/// `PartialExtraction`. This verifies the fix for the accumulated-report bug
+/// is moot for 7z because pre-validation prevents any extraction from starting.
 #[test]
 fn test_7z_partial_extraction_accurate_report() {
-    // Build an in-memory 7z archive with two entries: a small file and a large one.
-    // The quota is set to allow the first but reject the second.
+    // simple.7z contains 2 files totalling 25 bytes.  A quota smaller than
+    // the total triggers QuotaExceeded during pre-validation, before any file
+    // is written.  The result is a direct error, not PartialExtraction.
+    let data = load_fixture("simple.7z");
+    let cursor = Cursor::new(data);
+    let mut archive = SevenZArchive::new(cursor).unwrap();
+    let out_temp = TempDir::new().unwrap();
+
+    let config = SecurityConfig::default().with_max_total_size(20);
+    let result = archive.extract(
+        out_temp.path(),
+        &config,
+        &ExtractionOptions::default(),
+        &mut exarch_core::NoopProgress,
+    );
+
+    assert!(
+        matches!(result, Err(ArchiveError::QuotaExceeded { .. })),
+        "pre-validation quota check must return QuotaExceeded directly, got: {result:?}"
+    );
+    // No files should have been written — the output directory is empty.
+    let entries: Vec<_> = std::fs::read_dir(out_temp.path()).unwrap().collect();
+    assert!(
+        entries.is_empty(),
+        "no files should be on disk after a pre-validation quota failure"
+    );
+}
+
+/// Regression test for #323: `skip_duplicates=false` must overwrite an existing
+/// file rather than returning an error, matching TAR/ZIP handler behaviour.
+#[test]
+fn test_7z_force_overwrite_duplicate_entry() {
     let mut buf = std::io::Cursor::new(Vec::<u8>::new());
     {
         let mut writer = ArchiveWriter::new(&mut buf).unwrap();
         writer
-            .push_archive_entry(ArchiveEntry::new_file("small.txt"), Some(&b"small"[..]))
+            .push_archive_entry(
+                ArchiveEntry::new_file("file.txt"),
+                Some(b"first content".as_ref()),
+            )
             .unwrap();
-        let large_data = vec![0u8; 2048];
         writer
-            .push_archive_entry(ArchiveEntry::new_file("large.txt"), Some(&large_data[..]))
+            .push_archive_entry(
+                ArchiveEntry::new_file("file.txt"),
+                Some(b"second content".as_ref()),
+            )
             .unwrap();
         writer.finish().unwrap();
     }
@@ -487,34 +521,25 @@ fn test_7z_partial_extraction_accurate_report() {
     let mut archive = SevenZArchive::new(cursor).unwrap();
     let out_temp = TempDir::new().unwrap();
 
-    // small.txt (5 bytes) passes; large.txt (2048 bytes) exceeds the 1024-byte
-    // limit.
-    let config = SecurityConfig::default().with_max_file_size(1024);
-    let result = archive.extract(
-        out_temp.path(),
-        &SecurityConfig::default().with_max_file_count(1),
-        &ExtractionOptions::default(),
-        &mut exarch_core::NoopProgress,
+    let options = ExtractionOptions::default().with_skip_duplicates(false);
+    let report = archive
+        .extract(
+            out_temp.path(),
+            &SecurityConfig::default(),
+            &options,
+            &mut exarch_core::NoopProgress,
+        )
+        .expect("force-overwrite must succeed, not return an error");
+
+    assert_eq!(
+        report.files_extracted, 2,
+        "both entries must be counted as extracted"
     );
-
-    // Either PartialExtraction or QuotaExceeded is acceptable; the key invariant
-    // is that a real error is returned and the extracted bytes are not zero when
-    // PartialExtraction is the variant.
-    match result {
-        Err(ArchiveError::PartialExtraction { report, .. }) => {
-            assert!(
-                report.files_extracted > 0,
-                "report must record at least one extracted file, got files_extracted={}",
-                report.files_extracted
-            );
-        }
-        Err(ArchiveError::QuotaExceeded { .. }) => {
-            // Acceptable: quota rejected before any file was written
-        }
-        other => panic!("expected extraction error, got: {other:?}"),
-    }
-
-    let _ = config; // suppress unused warning
+    let content = std::fs::read_to_string(out_temp.path().join("file.txt")).unwrap();
+    assert_eq!(
+        content, "second content",
+        "second entry must overwrite the first"
+    );
 }
 
 /// Regression test for #207: when the very first entry triggers a security


### PR DESCRIPTION
## Summary

- `formats/sevenz.rs`: when `skip_duplicates=false` and the destination path already exists, `process_entry_inner` now removes the existing file (or directory) before the temp-write + rename flow, instead of returning a `duplicate entry` error that propagated as `PartialExtraction`
- `tests/sevenz_integration.rs`: added `test_7z_force_overwrite_duplicate_entry` regression test; updated `test_7z_partial_extraction_accurate_report` to document current correct behavior
- `CHANGELOG.md`: added fix entry under `[Unreleased]`

## Test plan

- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` — 878 tests pass
- [x] `cargo test --doc --workspace --all-features --exclude exarch-python --exclude exarch-node` — 98 doc-tests pass
- [x] `cargo +nightly fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] New regression test `test_7z_force_overwrite_duplicate_entry` exercises the fixed code path

Fixes #323