### PR TITLE
feat(bindings): expose ExtractionOptions.atomic in Node.js and Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ExtractionOptions` class with `with_skip_duplicates(skip=True)` builder. Node.js:
   `ExtractionOptions` class with `withSkipDuplicates(skip?)` builder. Both `extract_archive`
   and `extract_archive_with_progress` accept an optional `options` parameter (#313).
+- Python and Node.js bindings expose `ExtractionOptions.atomic`. Python: `with_atomic(bool)`
+  builder and `atomic` getter/setter. Node.js: `withAtomic(bool?)` builder and `atomic` getter.
+  Atomic mode extracts to a staging directory first, then renames it to the destination — the
+  output directory must not pre-exist (#322).
 
 ### Tests
 
@@ -41,6 +45,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Python: `SecurityConfig` and `CreationConfig` scalar getters (`max_file_size`, `max_total_size`, `max_compression_ratio`, `max_file_count`, `max_path_depth`, `max_solid_block_memory`, `preserve_permissions`, `compression_level`, `follow_symlinks`, `include_hidden`, `exclude_patterns`) now return their values correctly instead of a bound method. Builder methods were renamed to `with_<field>` (e.g. `with_max_file_size(...)`) to eliminate the PyO3 name collision (#315).
 - 7z force-overwrite now removes existing file before re-extraction when `skip_duplicates=false`; previously it returned a `PartialExtraction` error instead of overwriting (#323).
 - Node.js: `index.d.ts` now declares `setMaxSolidBlockMemory(size: number): this` and `get maxSolidBlockMemory(): number` for `SecurityConfig`; the file is committed to the repository so TypeScript consumers have correct types without building from source (#311).
+- Node.js: `index.d.ts` regenerated to include `ExtractionOptions` class and the fourth
+  `options` parameter on all `extract*` signatures; the file was stale after PR #324 (#330).
+- Node.js: `extractArchiveWithProgress` JSDoc corrected — numeric callback arguments
+  (`total`, `current`, `bytesWritten`) were documented as `bigint` but NAPI-RS maps `i64` to
+  `number` (#326).
 - Python: `exarch.pyi` now declares `allowed_extensions` and `banned_path_components` as `@property` with setters, replacing bare class-level annotations that did not express read/write semantics (#312).
 - `list_archive` now respects `SecurityConfig::allowed.absolute_paths`; absolute paths in TAR
   and 7z archives are accepted during listing when the flag is set (previously silently rejected

--- a/crates/exarch-node/index.d.ts
+++ b/crates/exarch-node/index.d.ts
@@ -95,6 +95,57 @@ export declare class CreationConfig {
 }
 
 /**
+ * Options controlling extraction behavior (non-security).
+ *
+ * Separate from `SecurityConfig` to keep security settings focused.
+ * These options control operational behavior such as duplicate handling.
+ *
+ * # Defaults
+ *
+ * | Setting | Default Value |
+ * |---------|--------------|
+ * | `skipDuplicates` | `true` |
+ * | `atomic` | `false` |
+ */
+export declare class ExtractionOptions {
+  /** Creates a new `ExtractionOptions` with defaults. */
+  constructor()
+  /**
+   * Creates an `ExtractionOptions` with defaults.
+   *
+   * This is equivalent to calling `new ExtractionOptions()`.
+   */
+  static default(): ExtractionOptions
+  /**
+   * Sets whether duplicate archive entries are skipped silently.
+   *
+   * When `true` (default), duplicate entries produce a warning in the
+   * report. When `false`, a duplicate entry causes an error.
+   */
+  withSkipDuplicates(skip?: boolean | undefined | null): this
+  /**
+   * Sets whether extraction uses a temporary directory for atomic commits.
+   *
+   * When `true`, files are extracted to a temp dir in the same parent as
+   * the output directory, then atomically renamed on completion. On failure
+   * the temp dir is removed, leaving the output directory untouched.
+   * Default: `false`.
+   *
+   * **Important:** atomic mode requires that the output directory does not
+   * already exist. If it does, extraction fails with an
+   * output-already-exists error. Non-atomic mode extracts into an
+   * existing directory without error.
+   */
+  withAtomic(atomic?: boolean | undefined | null): this
+  /** Finalizes the configuration (for API consistency). */
+  build(): this
+  /** Whether duplicate entries are skipped silently. */
+  get skipDuplicates(): boolean
+  /** Whether atomic extraction is enabled. */
+  get atomic(): boolean
+}
+
+/**
  * Security configuration for archive extraction.
  *
  * All security features default to deny (secure-by-default policy).
@@ -456,11 +507,15 @@ export interface CreationReport {
  * console.log(`Extracted ${report.filesExtracted} files`);
  *
  * // Customize security settings
- * const config = new SecurityConfig().maxFileSize(100 * 1024 * 1024);
+ * const config = new SecurityConfig().setMaxFileSize(100 * 1024 * 1024);
  * const report = await extractArchive('archive.tar.gz', '/tmp/output', config);
+ *
+ * // Customize extraction options
+ * const opts = new ExtractionOptions().withSkipDuplicates(false);
+ * const report = await extractArchive('archive.tar.gz', '/tmp/output', null, opts);
  * ```
  */
-export declare function extractArchive(archivePath: string, outputDir: string, config?: SecurityConfig | undefined | null): Promise<ExtractionReport>
+export declare function extractArchive(archivePath: string, outputDir: string, config?: SecurityConfig | undefined | null, options?: ExtractionOptions | undefined | null): Promise<ExtractionReport>
 
 /**
  * Extract an archive to the specified directory (sync).
@@ -491,11 +546,11 @@ export declare function extractArchive(archivePath: string, outputDir: string, c
  * console.log(`Extracted ${report.filesExtracted} files`);
  *
  * // Customize security settings
- * const config = new SecurityConfig().maxFileSize(100 * 1024 * 1024);
+ * const config = new SecurityConfig().setMaxFileSize(100 * 1024 * 1024);
  * const report = extractArchiveSync('archive.tar.gz', '/tmp/output', config);
  * ```
  */
-export declare function extractArchiveSync(archivePath: string, outputDir: string, config?: SecurityConfig | undefined | null): ExtractionReport
+export declare function extractArchiveSync(archivePath: string, outputDir: string, config?: SecurityConfig | undefined | null, options?: ExtractionOptions | undefined | null): ExtractionReport
 
 /**
  * Extract an archive to the specified directory with a progress callback
@@ -504,10 +559,10 @@ export declare function extractArchiveSync(archivePath: string, outputDir: strin
  * The `progress` callback is called once per entry with
  * `(path, total, current, bytesWritten)` where:
  * - `path` — entry path inside the archive
- * - `total` — total number of entries as `bigint` (0 for TAR-family formats
+ * - `total` — total number of entries as `number` (0 for TAR-family formats
  *   because the entry count is unknown until the stream is fully read)
- * - `current` — 1-based index of the current entry as `bigint`
- * - `bytesWritten` — cumulative bytes written to disk so far as `bigint`
+ * - `current` — 1-based index of the current entry as `number`
+ * - `bytesWritten` — cumulative bytes written to disk so far as `number`
  *   (always 0 during extraction because the core library does not emit
  *   byte-level progress events for extraction; only entry-level events fire)
  *
@@ -519,8 +574,9 @@ export declare function extractArchiveSync(archivePath: string, outputDir: strin
  * * `archive_path` - Path to the archive file
  * * `output_dir` - Directory where files will be extracted
  * * `config` - Optional `SecurityConfig` (uses secure defaults if omitted)
- * * `progress` - Optional progress callback `(path: string, total: bigint,
- *   current: bigint, bytesWritten: bigint) => void`
+ * * `options` - Optional `ExtractionOptions` (uses defaults if omitted)
+ * * `progress` - Optional progress callback `(path: string, total: number,
+ *   current: number, bytesWritten: number) => void`
  *
  * # Returns
  *
@@ -539,6 +595,7 @@ export declare function extractArchiveSync(archivePath: string, outputDir: strin
  *   'archive.tar.gz',
  *   '/tmp/output',
  *   null,
+ *   null,
  *   (path, total, current, bytesWritten) => {
  *     console.log(`${current}/${total}: ${path}`);
  *   },
@@ -546,7 +603,7 @@ export declare function extractArchiveSync(archivePath: string, outputDir: strin
  * console.log(`Extracted ${report.filesExtracted} files`);
  * ```
  */
-export declare function extractArchiveWithProgress(archivePath: string, outputDir: string, config?: SecurityConfig | undefined | null, progress?: (((err: Error | null, arg: [string, number, number, number]) => any)) | undefined | null): Promise<ExtractionReport>
+export declare function extractArchiveWithProgress(archivePath: string, outputDir: string, config?: SecurityConfig | undefined | null, options?: ExtractionOptions | undefined | null, progress?: (((err: Error | null, arg: [string, number, number, number]) => any)) | undefined | null): Promise<ExtractionReport>
 
 /**
  * Report of an archive extraction operation.

--- a/crates/exarch-node/src/config.rs
+++ b/crates/exarch-node/src/config.rs
@@ -597,6 +597,7 @@ impl CreationConfig {
 /// | Setting | Default Value |
 /// |---------|--------------|
 /// | `skipDuplicates` | `true` |
+/// | `atomic` | `false` |
 #[napi]
 #[derive(Debug, Clone)]
 pub struct ExtractionOptions {
@@ -631,6 +632,23 @@ impl ExtractionOptions {
         self
     }
 
+    /// Sets whether extraction uses a temporary directory for atomic commits.
+    ///
+    /// When `true`, files are extracted to a temp dir in the same parent as
+    /// the output directory, then atomically renamed on completion. On failure
+    /// the temp dir is removed, leaving the output directory untouched.
+    /// Default: `false`.
+    ///
+    /// **Important:** atomic mode requires that the output directory does not
+    /// already exist. If it does, extraction fails with an
+    /// output-already-exists error. Non-atomic mode extracts into an
+    /// existing directory without error.
+    #[napi(js_name = "withAtomic")]
+    pub fn with_atomic(&mut self, atomic: Option<bool>) -> &Self {
+        self.inner.atomic = atomic.unwrap_or(true);
+        self
+    }
+
     /// Finalizes the configuration (for API consistency).
     #[napi]
     pub fn build(&self) -> &Self {
@@ -641,6 +659,12 @@ impl ExtractionOptions {
     #[napi(getter)]
     pub fn get_skip_duplicates(&self) -> bool {
         self.inner.skip_duplicates
+    }
+
+    /// Whether atomic extraction is enabled.
+    #[napi(getter)]
+    pub fn get_atomic(&self) -> bool {
+        self.inner.atomic
     }
 }
 

--- a/crates/exarch-node/src/lib.rs
+++ b/crates/exarch-node/src/lib.rs
@@ -564,10 +564,10 @@ pub fn verify_archive_sync(
 /// The `progress` callback is called once per entry with
 /// `(path, total, current, bytesWritten)` where:
 /// - `path` — entry path inside the archive
-/// - `total` — total number of entries as `bigint` (0 for TAR-family formats
+/// - `total` — total number of entries as `number` (0 for TAR-family formats
 ///   because the entry count is unknown until the stream is fully read)
-/// - `current` — 1-based index of the current entry as `bigint`
-/// - `bytesWritten` — cumulative bytes written to disk so far as `bigint`
+/// - `current` — 1-based index of the current entry as `number`
+/// - `bytesWritten` — cumulative bytes written to disk so far as `number`
 ///   (always 0 during extraction because the core library does not emit
 ///   byte-level progress events for extraction; only entry-level events fire)
 ///
@@ -580,8 +580,8 @@ pub fn verify_archive_sync(
 /// * `output_dir` - Directory where files will be extracted
 /// * `config` - Optional `SecurityConfig` (uses secure defaults if omitted)
 /// * `options` - Optional `ExtractionOptions` (uses defaults if omitted)
-/// * `progress` - Optional progress callback `(path: string, total: bigint,
-///   current: bigint, bytesWritten: bigint) => void`
+/// * `progress` - Optional progress callback `(path: string, total: number,
+///   current: number, bytesWritten: number) => void`
 ///
 /// # Returns
 ///

--- a/crates/exarch-python/exarch.pyi
+++ b/crates/exarch-python/exarch.pyi
@@ -151,12 +151,39 @@ class ExtractionOptions:
         """
         ...
 
+    def with_atomic(self, atomic: bool = True) -> ExtractionOptions:
+        """
+        Sets whether extraction uses a temporary directory for atomic commits.
+
+        When ``True``, files are extracted to a temp dir in the same parent as
+        the output directory, then atomically renamed on completion. On failure
+        the temp dir is removed, leaving the output directory untouched.
+        Default: ``False``.
+
+        **Important:** atomic mode requires that the output directory does not
+        already exist. If it does, extraction raises ``OutputExistsError``.
+        Non-atomic mode extracts into an existing directory without error.
+        """
+        ...
+
     def build(self) -> ExtractionOptions:
         """Finalizes the configuration."""
         ...
 
-    skip_duplicates: bool
-    """Whether to skip duplicate entries silently (default: True)."""
+    @property
+    def skip_duplicates(self) -> bool:
+        """Whether to skip duplicate entries silently (default: True)."""
+        ...
+
+    @skip_duplicates.setter
+    def skip_duplicates(self, value: bool) -> None: ...
+    @property
+    def atomic(self) -> bool:
+        """Whether atomic extraction is enabled (default: False)."""
+        ...
+
+    @atomic.setter
+    def atomic(self, value: bool) -> None: ...
 
 class CreationConfig:
     """

--- a/crates/exarch-python/src/config.rs
+++ b/crates/exarch-python/src/config.rs
@@ -614,6 +614,8 @@ impl PyCreationConfig {
 ///
 /// * `skip_duplicates` - Skip duplicate entries silently instead of aborting
 ///   (default: `True`)
+/// * `atomic` - Extract to a temp dir then rename atomically on success
+///   (default: `False`)
 ///
 /// # Examples
 ///
@@ -623,6 +625,9 @@ impl PyCreationConfig {
 ///
 /// # Disable duplicate skipping
 /// opts = ExtractionOptions().with_skip_duplicates(False)
+///
+/// # Enable atomic extraction
+/// opts = ExtractionOptions().with_atomic(True)
 /// ```
 #[pyclass(name = "ExtractionOptions", skip_from_py_object)]
 #[derive(Clone)]
@@ -658,6 +663,23 @@ impl PyExtractionOptions {
         slf
     }
 
+    /// Sets whether extraction uses a temporary directory for atomic commits.
+    ///
+    /// When `True`, files are extracted to a temp dir in the same parent as
+    /// the output directory, then atomically renamed on completion. On failure
+    /// the temp dir is removed, leaving the output directory untouched.
+    /// Default: `False`.
+    ///
+    /// **Important:** atomic mode requires that the output directory does not
+    /// already exist. If it does, extraction raises ``OutputExistsError``.
+    /// Non-atomic mode extracts into an existing directory without error.
+    #[pyo3(name = "with_atomic")]
+    #[pyo3(signature = (atomic=true))]
+    fn with_atomic(mut slf: PyRefMut<'_, Self>, atomic: bool) -> PyRefMut<'_, Self> {
+        slf.inner.atomic = atomic;
+        slf
+    }
+
     /// Finalizes the configuration (for API consistency).
     fn build(slf: PyRefMut<'_, Self>) -> PyRefMut<'_, Self> {
         slf
@@ -673,11 +695,21 @@ impl PyExtractionOptions {
         self.inner.skip_duplicates = value;
     }
 
+    #[getter]
+    fn get_atomic(&self) -> bool {
+        self.inner.atomic
+    }
+
+    #[setter]
+    fn set_atomic(&mut self, value: bool) {
+        self.inner.atomic = value;
+    }
+
     /// Returns a debug string representation.
     fn __repr__(&self) -> String {
         format!(
-            "ExtractionOptions(skip_duplicates={})",
-            self.inner.skip_duplicates
+            "ExtractionOptions(skip_duplicates={}, atomic={})",
+            self.inner.skip_duplicates, self.inner.atomic
         )
     }
 }


### PR DESCRIPTION
## Summary

- Adds `withAtomic(bool?)` builder and `atomic` getter to Node.js `ExtractionOptions` (`crates/exarch-node/src/config.rs`), following the `skip_duplicates` pattern from #324
- Adds `with_atomic(bool)` builder and `atomic` getter/setter to Python `ExtractionOptions` (`crates/exarch-python/src/config.rs`), following the same pattern
- Updates `crates/exarch-python/exarch.pyi` with `@property`/`@setter` descriptors for `atomic` and `skip_duplicates`
- Fixes `extractArchiveWithProgress` JSDoc: callback args documented as `bigint` but NAPI-RS maps `i64` to `number` (#326)
- Regenerates `crates/exarch-node/index.d.ts` which was stale after #324: now includes `ExtractionOptions` class and the fourth `options` parameter on all `extract*` signatures (#330)

Doc note: `withAtomic`/`with_atomic` doc comments explicitly state that atomic mode fails if the output directory already exists (`OutputExists` error), unlike non-atomic mode which extracts into an existing directory.

## Test plan

- [ ] `cargo +nightly fmt --all -- --check` — clean
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — 0 warnings
- [ ] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` — 882/882
- [ ] `cargo test --doc --workspace --all-features --exclude exarch-python` — 98/98
- [ ] `cargo deny check --all-features` — clean
- [ ] Verify `index.d.ts` includes `ExtractionOptions` class with `withAtomic`/`atomic` and all three `extract*` signatures have the fourth `options` parameter
- [ ] Verify `exarch.pyi` uses `@property`/`@setter` for `atomic` and `skip_duplicates`

Closes #322, #330, #326
Related follow-up: #332 (add round-trip tests for `atomic` and `skip_duplicates` in binding test suites)