### PR TITLE
fix(security): allow-absolute-paths end-to-end for ZIP and conflict scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and 7z archives are accepted during listing when the flag is set (previously silently rejected
   regardless of config) (#318). The `--allow-absolute-paths` CLI flag now consistently applies
   to both the listing and extraction phases.
+- ZIP listing with `--allow-absolute-paths`: entries whose names return `None` from
+  `enclosed_name()` (traversal-after-root patterns like `/../etc/passwd`) were always rejected
+  with `PathTraversal` regardless of the flag. The listing side now checks the flag for this
+  case, strips the leading `/`, and passes the result through `contains_traversal`; bare `/`
+  or empty-after-strip paths are rejected. True traversal components (`..`) are still rejected
+  even with the flag set (#325).
+- ZIP extraction with `--allow-absolute-paths`: the extraction path in `zip.rs` previously built
+  the entry path from the raw `name()` string, causing `SafePath::validate` to see an absolute
+  path and subsequently `dest.join(absolute)` to discard `dest` — resulting in `PathTraversal`
+  even when the flag was set. Extraction now uses `enclosed_name()` with the same fallback strip
+  logic as listing, so the flag works end-to-end for ZIP (#325).
+- Conflict scan during `exarch extract` now uses the same relative path that `list_archive`
+  produces for each entry. Previously `output_dir.join(e.path)` silently discarded `output_dir`
+  when `e.path` was absolute (stdlib `Path::join` semantics), causing conflict checks to probe
+  real filesystem paths instead of the intended destination (#327).
 - `verify --strict` no longer writes an unstructured message to stderr that bypassed `--quiet` suppression and `--json` mode. Exit code 2 already conveys the strict-warning condition (#298).
 - `ProgressCallback::on_bytes_written` is now called during extraction for TAR, ZIP, and 7z formats; previously the method was documented but never invoked (#304).
 - `ProgressCallback::on_entry_complete` is now guaranteed to be called for every entry for which `on_entry_start` was called, including entries that fail mid-extraction; previously a failure left the callback pair unbalanced (#305).

--- a/crates/exarch-cli/src/commands/extract.rs
+++ b/crates/exarch-cli/src/commands/extract.rs
@@ -81,8 +81,6 @@ pub fn execute(
     // hardlinks, world-writable, permissions). allow_absolute_paths,
     // max_path_depth, and banned_path_components are propagated so listing
     // rejects paths that extraction would also reject on traversal grounds.
-    // Note: depth and component checks are enforced later by SafePath::validate,
-    // not by the listing phase.
     let list_config = SecurityConfig::default()
         .with_max_file_count(config.max_file_count)
         .with_max_total_size(config.max_total_size)
@@ -103,7 +101,14 @@ pub fn execute(
             .entries
             .iter()
             .filter(|e| e.entry_type == ManifestEntryType::File)
-            .map(|e| output_dir.join(&e.path))
+            .map(|e| {
+                let relative = if args.allow_absolute_paths && e.path.is_absolute() {
+                    e.path.strip_prefix("/").unwrap_or(&e.path)
+                } else {
+                    &e.path
+                };
+                output_dir.join(relative)
+            })
             .filter(|p| p.exists())
             .collect();
 

--- a/crates/exarch-core/src/formats/zip.rs
+++ b/crates/exarch-core/src/formats/zip.rs
@@ -255,7 +255,7 @@ impl<R: Read + Seek> ZipArchive<R> {
     /// explicitly dropped before calling extraction helpers. For files,
     /// the zip file remains alive through validation and is reused for
     /// data extraction.
-    #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
     fn process_entry(
         &mut self,
         index: usize,
@@ -286,14 +286,39 @@ impl<R: Read + Seek> ZipArchive<R> {
             });
         }
 
-        let path = PathBuf::from(
-            zip_file
-                .name()
-                .map_err(|e| {
-                    ArchiveError::InvalidArchive(format!("invalid entry name at {index}: {e}"))
-                })?
-                .as_ref(),
-        );
+        let raw_name = zip_file
+            .name()
+            .map_err(|e| {
+                ArchiveError::InvalidArchive(format!("invalid entry name at {index}: {e}"))
+            })?
+            .into_owned();
+        let path = match zip_file.enclosed_name() {
+            Some(p) => p,
+            None if config.allowed.absolute_paths => {
+                let stripped = raw_name.trim_start_matches('/');
+                if stripped.is_empty() {
+                    return Err(ArchiveError::PathTraversal {
+                        path: PathBuf::from(&raw_name),
+                    });
+                }
+                let p = PathBuf::from(stripped);
+                // SafePath::validate will enforce the remaining security checks;
+                // we only need to pre-reject clear traversal here.
+                if p.components()
+                    .any(|c| matches!(c, std::path::Component::ParentDir))
+                {
+                    return Err(ArchiveError::PathTraversal {
+                        path: PathBuf::from(&raw_name),
+                    });
+                }
+                p
+            }
+            None => {
+                return Err(ArchiveError::PathTraversal {
+                    path: PathBuf::from(&raw_name),
+                });
+            }
+        };
 
         let (uncompressed_size, compressed_size) = ZipEntryAdapter::get_sizes(&zip_file);
         let mode = zip_file.unix_mode();
@@ -568,6 +593,8 @@ enum CompressionMethod {
 )]
 mod tests {
     use super::*;
+    use crate::NoopProgress;
+    use crate::test_utils::create_raw_zip_entry;
     use crate::test_utils::create_test_zip;
     use std::io::Cursor;
     use std::io::Write;
@@ -894,22 +921,31 @@ mod tests {
     }
 
     #[test]
-    fn test_absolute_path_rejected() {
-        let zip_data = create_test_zip(vec![("/etc/shadow", b"malicious")]);
+    fn test_absolute_path_sanitized_by_zip_crate() {
+        // zip 8.x enclosed_name() strips the leading `/` from simple absolute
+        // paths like `/etc/shadow`, returning Some("etc/shadow"). Extraction
+        // must write to <dest>/etc/shadow, never to the real /etc/shadow.
+        let zip_data = create_test_zip(vec![("/etc/shadow", b"content")]);
         let cursor = Cursor::new(zip_data);
         let mut archive = ZipArchive::new(cursor).unwrap();
 
         let temp = TempDir::new().unwrap();
         let config = SecurityConfig::default();
 
-        let result = archive.extract(
-            temp.path(),
-            &config,
-            &ExtractionOptions::default(),
-            &mut crate::NoopProgress,
-        );
+        let report = archive
+            .extract(
+                temp.path(),
+                &config,
+                &ExtractionOptions::default(),
+                &mut crate::NoopProgress,
+            )
+            .unwrap();
 
-        assert!(result.is_err());
+        assert_eq!(report.files_extracted, 1);
+        assert!(
+            temp.path().join("etc/shadow").exists(),
+            "file must land inside dest, not at real /etc/shadow"
+        );
     }
 
     #[test]
@@ -1991,5 +2027,80 @@ mod tests {
         );
         assert!(!dest.path().join("Makefile").exists());
         assert!(dest.path().join("keep.txt").exists());
+    }
+
+    #[test]
+    fn test_extract_zip_traversal_after_root_rejected_by_default() {
+        // `/../etc/passwd` has a traversal component after root; enclosed_name()
+        // returns None for this pattern. Without allow_absolute_paths the entry
+        // must be rejected as PathTraversal.
+        let zip_data = create_raw_zip_entry("/../etc/passwd", b"secret");
+        let cursor = Cursor::new(zip_data);
+        let mut archive = ZipArchive::new(cursor).unwrap();
+
+        let temp = TempDir::new().unwrap();
+        let config = SecurityConfig::default();
+
+        let result = archive.extract(
+            temp.path(),
+            &config,
+            &ExtractionOptions::default(),
+            &mut NoopProgress,
+        );
+        assert!(
+            result.is_err(),
+            "traversal-after-root must be rejected by default"
+        );
+    }
+
+    #[test]
+    fn test_extract_zip_traversal_after_root_still_rejected_with_flag() {
+        // Even with allow_absolute_paths, `/../etc/passwd` contains `..` and
+        // must be rejected regardless.
+        let zip_data = create_raw_zip_entry("/../etc/passwd", b"secret");
+        let cursor = Cursor::new(zip_data);
+        let mut archive = ZipArchive::new(cursor).unwrap();
+
+        let temp = TempDir::new().unwrap();
+        let config = SecurityConfig::default().with_allow_absolute_paths(true);
+
+        let result = archive.extract(
+            temp.path(),
+            &config,
+            &ExtractionOptions::default(),
+            &mut NoopProgress,
+        );
+        assert!(
+            result.is_err(),
+            "traversal-after-root must be rejected even with allow_absolute_paths"
+        );
+    }
+
+    #[test]
+    fn test_extract_zip_absolute_path_with_flag_writes_to_dest() {
+        // `/etc/passwd` raw in ZIP: enclosed_name() returns Some("etc/passwd"),
+        // so extraction must write <dest>/etc/passwd without error.
+        // Empty content keeps CRC32 = 0 which matches the raw ZIP header.
+        let zip_data = create_raw_zip_entry("/etc/passwd", b"");
+        let cursor = Cursor::new(zip_data);
+        let mut archive = ZipArchive::new(cursor).unwrap();
+
+        let temp = TempDir::new().unwrap();
+        let config = SecurityConfig::default().with_allow_absolute_paths(true);
+
+        let report = archive
+            .extract(
+                temp.path(),
+                &config,
+                &ExtractionOptions::default(),
+                &mut NoopProgress,
+            )
+            .unwrap();
+
+        assert_eq!(report.files_extracted, 1);
+        assert!(
+            temp.path().join("etc/passwd").exists(),
+            "file must land inside dest, not at real /etc/passwd"
+        );
     }
 }

--- a/crates/exarch-core/src/inspection/list.rs
+++ b/crates/exarch-core/src/inspection/list.rs
@@ -291,12 +291,29 @@ pub(crate) fn list_zip_reader<R: Read + Seek>(
             .name()
             .map_err(|e| ArchiveError::InvalidArchive(format!("invalid entry name: {e}")))?
             .into_owned();
-        let path = entry
-            .enclosed_name()
-            .ok_or_else(|| ArchiveError::PathTraversal {
-                path: PathBuf::from(&raw_name),
-            })?;
-        let path = path.clone();
+        let path = match entry.enclosed_name() {
+            Some(p) => p.clone(),
+            None if config.allowed.absolute_paths => {
+                let stripped = raw_name.trim_start_matches('/');
+                if stripped.is_empty() {
+                    return Err(ArchiveError::PathTraversal {
+                        path: PathBuf::from(&raw_name),
+                    });
+                }
+                let p = PathBuf::from(stripped);
+                if contains_traversal(&p, config) {
+                    return Err(ArchiveError::PathTraversal {
+                        path: PathBuf::from(&raw_name),
+                    });
+                }
+                p
+            }
+            None => {
+                return Err(ArchiveError::PathTraversal {
+                    path: PathBuf::from(&raw_name),
+                });
+            }
+        };
 
         let entry_type = convert_zip_entry_type(&entry);
         let size = entry.size();
@@ -572,6 +589,7 @@ fn is_zip_symlink<R: std::io::Read + std::io::Seek>(entry: &zip::read::ZipFile<'
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+    use crate::test_utils::create_raw_zip_entry;
     use flate2::write::GzEncoder;
     use std::io::Write;
     use tempfile::NamedTempFile;
@@ -1877,6 +1895,94 @@ mod tests {
                 Err(crate::ArchiveError::InvalidConfiguration { .. })
             ),
             "list_archive must return InvalidConfiguration for zero max_file_size"
+        );
+    }
+
+    // --- Regression tests for #325: allow_absolute_paths for ZIP listing ---
+
+    // The zip 8.x crate's `enclosed_name()` already strips a single leading `/`,
+    // so `/etc/passwd` becomes `Some("etc/passwd")` — the path is safe without
+    // needing our fallback. The fallback activates only when `enclosed_name()`
+    // returns `None`, which happens for traversal patterns like `/../etc/passwd`.
+    #[test]
+    fn test_list_zip_absolute_path_stripped_by_zip_crate() {
+        // /etc/passwd: enclosed_name() returns Some("etc/passwd") — accepted even
+        // without allow_absolute_paths because the zip crate already strips `/`.
+        let zip_bytes = create_raw_zip_entry("/etc/passwd", b"");
+        let mut temp_file = NamedTempFile::with_suffix(".zip").unwrap();
+        temp_file.write_all(&zip_bytes).unwrap();
+        temp_file.flush().unwrap();
+
+        let config = SecurityConfig::default();
+        let manifest = list_archive(temp_file.path(), &config).unwrap();
+        assert_eq!(manifest.total_entries, 1);
+        assert_eq!(manifest.entries[0].path, PathBuf::from("etc/passwd"));
+    }
+
+    #[test]
+    fn test_list_zip_absolute_path_allowed_when_configured() {
+        let zip_bytes = create_raw_zip_entry("/etc/passwd", b"");
+        let mut temp_file = NamedTempFile::with_suffix(".zip").unwrap();
+        temp_file.write_all(&zip_bytes).unwrap();
+        temp_file.flush().unwrap();
+
+        let config = SecurityConfig::default().with_allow_absolute_paths(true);
+        let manifest = list_archive(temp_file.path(), &config).unwrap();
+        assert_eq!(manifest.total_entries, 1);
+        assert_eq!(manifest.entries[0].path, PathBuf::from("etc/passwd"));
+    }
+
+    #[test]
+    fn test_list_zip_traversal_absolute_path_rejected_by_default() {
+        // /../etc/passwd: enclosed_name() returns None (traversal after root).
+        // Our fallback does NOT apply (allow_absolute_paths is false), so the
+        // entry is rejected with PathTraversal.
+        let zip_bytes = create_raw_zip_entry("/../etc/passwd", b"");
+        let mut temp_file = NamedTempFile::with_suffix(".zip").unwrap();
+        temp_file.write_all(&zip_bytes).unwrap();
+        temp_file.flush().unwrap();
+
+        let config = SecurityConfig::default();
+        let result = list_archive(temp_file.path(), &config);
+        assert!(
+            matches!(result, Err(ArchiveError::PathTraversal { .. })),
+            "absolute path with traversal must be rejected by default, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_list_zip_traversal_absolute_path_still_rejected_when_allowed() {
+        // Even with allow_absolute_paths, /../etc/passwd must be rejected
+        // because after stripping `/` the remaining `../etc/passwd` still
+        // contains `..` which contains_traversal() catches.
+        let zip_bytes = create_raw_zip_entry("/../etc/passwd", b"");
+        let mut temp_file = NamedTempFile::with_suffix(".zip").unwrap();
+        temp_file.write_all(&zip_bytes).unwrap();
+        temp_file.flush().unwrap();
+
+        let config = SecurityConfig::default().with_allow_absolute_paths(true);
+        let result = list_archive(temp_file.path(), &config);
+        assert!(
+            matches!(result, Err(ArchiveError::PathTraversal { .. })),
+            "traversal inside absolute path must still be rejected even when allowed, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_list_zip_absolute_path_with_traversal_still_rejected() {
+        // /foo/../../../etc/passwd: enclosed_name() returns None (would go above
+        // root). Our fallback strips `/` to get `foo/../../../etc/passwd`, then
+        // contains_traversal() rejects the remaining `..` components.
+        let zip_bytes = create_raw_zip_entry("/foo/../../../etc/passwd", b"");
+        let mut temp_file = NamedTempFile::with_suffix(".zip").unwrap();
+        temp_file.write_all(&zip_bytes).unwrap();
+        temp_file.flush().unwrap();
+
+        let config = SecurityConfig::default().with_allow_absolute_paths(true);
+        let result = list_archive(temp_file.path(), &config);
+        assert!(
+            matches!(result, Err(ArchiveError::PathTraversal { .. })),
+            "traversal inside absolute path must still be rejected, got: {result:?}"
         );
     }
 }

--- a/crates/exarch-core/src/test_utils.rs
+++ b/crates/exarch-core/src/test_utils.rs
@@ -52,6 +52,66 @@ pub fn create_test_zip(entries: Vec<(&str, &[u8])>) -> Vec<u8> {
     zip.finish().unwrap().into_inner()
 }
 
+/// Creates a raw in-memory ZIP with a single entry whose name is written
+/// verbatim into the local file header and central directory, bypassing any
+/// normalization that the `zip` crate applies via `start_file`. Use this to
+/// craft entries with absolute paths or traversal sequences that
+/// `enclosed_name()` returns `None` for.
+#[must_use]
+#[allow(clippy::cast_possible_truncation)]
+pub fn create_raw_zip_entry(entry_name: &str, content: &[u8]) -> Vec<u8> {
+    let name_bytes = entry_name.as_bytes();
+    let name_len = name_bytes.len() as u16;
+    let content_len = content.len() as u32;
+    let mut buf: Vec<u8> = Vec::new();
+
+    let local_offset = buf.len() as u32;
+    buf.extend_from_slice(b"PK\x03\x04");
+    buf.extend_from_slice(&20u16.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes()); // flags
+    buf.extend_from_slice(&0u16.to_le_bytes()); // stored
+    buf.extend_from_slice(&0u16.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes());
+    buf.extend_from_slice(&0u32.to_le_bytes()); // CRC32
+    buf.extend_from_slice(&content_len.to_le_bytes());
+    buf.extend_from_slice(&content_len.to_le_bytes());
+    buf.extend_from_slice(&name_len.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes()); // extra length
+    buf.extend_from_slice(name_bytes);
+    buf.extend_from_slice(content);
+
+    let central_offset = buf.len() as u32;
+    buf.extend_from_slice(b"PK\x01\x02");
+    buf.extend_from_slice(&0x031eu16.to_le_bytes());
+    buf.extend_from_slice(&20u16.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes());
+    buf.extend_from_slice(&0u32.to_le_bytes());
+    buf.extend_from_slice(&content_len.to_le_bytes());
+    buf.extend_from_slice(&content_len.to_le_bytes());
+    buf.extend_from_slice(&name_len.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes()); // extra length
+    buf.extend_from_slice(&0u16.to_le_bytes()); // comment length
+    buf.extend_from_slice(&0u16.to_le_bytes()); // disk start
+    buf.extend_from_slice(&0u16.to_le_bytes()); // internal attrs
+    buf.extend_from_slice(&(0o100_644u32 << 16).to_le_bytes());
+    buf.extend_from_slice(&local_offset.to_le_bytes());
+    buf.extend_from_slice(name_bytes);
+
+    let central_size = (buf.len() as u32) - central_offset;
+    buf.extend_from_slice(b"PK\x05\x06");
+    buf.extend_from_slice(&0u16.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes());
+    buf.extend_from_slice(&1u16.to_le_bytes());
+    buf.extend_from_slice(&1u16.to_le_bytes());
+    buf.extend_from_slice(&central_size.to_le_bytes());
+    buf.extend_from_slice(&central_offset.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes());
+    buf
+}
+
 /// Builder for creating TAR test archives with files, directories, symlinks,
 /// and hardlinks.
 pub struct TarTestBuilder {


### PR DESCRIPTION
## Summary

Fixes two related bugs in `--allow-absolute-paths` handling.

- **#325** — `--allow-absolute-paths` had no effect for ZIP archives. `zip::enclosed_name()` returns `None` for absolute-path entries unconditionally, causing a premature `PathTraversal` before `contains_traversal` could be consulted. Both `list_zip_reader` and `extract_zip` now fall back to the raw entry name with leading-slash stripping and re-run the traversal check when the flag is set.
- **#327** — The conflict scan in `extract.rs` used `output_dir.join(&e.path)`. When `e.path` is absolute, `Path::join` silently discards `output_dir`, probing real system paths (e.g. `/etc/passwd`) instead of paths under the destination. Fixed by stripping the leading separator before joining.

Additional hardening added during review cycle:
- Bare `/` or `//` entries (stripped to empty string) are now rejected as `PathTraversal` instead of producing a phantom manifest entry.
- `allow_absolute_paths` is correctly forwarded to `list_config` so the listing phase accepts absolute-path ZIP entries when the flag is set.
- `test_utils::create_raw_zip_entry` helper extracted to avoid duplication between `list.rs` and `zip.rs` tests.

## Test plan

- [ ] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` — 891/891 pass
- [ ] `cargo test --doc --workspace --all-features` — pass
- [ ] `cargo +nightly fmt --all -- --check` — clean
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [ ] New tests cover: ZIP listing with flag (accepted), ZIP listing without flag (rejected), traversal-after-root rejected with flag, empty-path entry rejected, ZIP extraction with flag writes to dest