### PR TITLE
test(core): verify extracted file contents in roundtrip tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Roundtrip integration tests now verify extracted file contents against the source data for
+  all supported formats (tar.gz, tar.bz2, tar.xz, tar.zst, zip). Previously, tests only
+  asserted that extraction succeeded and files existed, which would have allowed silent data
+  corruption to go undetected (#335).
+- CLI roundtrip tests (`test_roundtrip_tar_gz_single_file`, `test_roundtrip_zip_directory`)
+  now assert extracted file contents match the original source bytes (#335).
+
 ### Breaking Changes
 
 - **`ArchiveCreator::compression_level`** now returns `Result<Self, ArchiveError>` instead of

--- a/crates/exarch-cli/tests/cli_tests.rs
+++ b/crates/exarch-cli/tests/cli_tests.rs
@@ -742,12 +742,11 @@ fn test_create_no_sources() {
 fn test_roundtrip_tar_gz_single_file() {
     let temp = TempDir::new().expect("failed to create temp dir");
     let src_file = temp.path().join("original.txt");
-    let content = "Hello, World!";
+    let content = b"Hello, World!";
     std::fs::write(&src_file, content).expect("failed to write source file");
 
     let archive = temp.path().join("roundtrip.tar.gz");
 
-    // Create archive
     exarch_cmd()
         .arg("create")
         .arg(&archive)
@@ -755,7 +754,6 @@ fn test_roundtrip_tar_gz_single_file() {
         .assert()
         .success();
 
-    // Extract archive
     let extract_dir = temp.path().join("extracted");
     std::fs::create_dir(&extract_dir).expect("failed to create extract dir");
 
@@ -765,6 +763,14 @@ fn test_roundtrip_tar_gz_single_file() {
         .arg(&extract_dir)
         .assert()
         .success();
+
+    let extracted =
+        std::fs::read(extract_dir.join("original.txt")).expect("extracted file must exist");
+    assert_eq!(
+        extracted.as_slice(),
+        content,
+        "extracted content must match source"
+    );
 }
 
 #[test]
@@ -772,12 +778,11 @@ fn test_roundtrip_zip_directory() {
     let temp = TempDir::new().expect("failed to create temp dir");
     let src_dir = temp.path().join("source");
     std::fs::create_dir(&src_dir).expect("failed to create source dir");
-    std::fs::write(src_dir.join("file1.txt"), "content1").expect("failed to write file1");
-    std::fs::write(src_dir.join("file2.txt"), "content2").expect("failed to write file2");
+    std::fs::write(src_dir.join("file1.txt"), b"content1").expect("failed to write file1");
+    std::fs::write(src_dir.join("file2.txt"), b"content2").expect("failed to write file2");
 
     let archive = temp.path().join("roundtrip.zip");
 
-    // Create archive
     exarch_cmd()
         .arg("create")
         .arg(&archive)
@@ -785,7 +790,6 @@ fn test_roundtrip_zip_directory() {
         .assert()
         .success();
 
-    // Extract archive
     let extract_dir = temp.path().join("extracted");
     std::fs::create_dir(&extract_dir).expect("failed to create extract dir");
 
@@ -796,8 +800,21 @@ fn test_roundtrip_zip_directory() {
         .assert()
         .success();
 
-    // Verify roundtrip completed
-    assert!(archive.exists());
+    let actual1 =
+        std::fs::read(extract_dir.join("file1.txt")).expect("file1.txt must be extracted");
+    assert_eq!(
+        actual1.as_slice(),
+        b"content1",
+        "file1.txt content must match"
+    );
+
+    let actual2 =
+        std::fs::read(extract_dir.join("file2.txt")).expect("file2.txt must be extracted");
+    assert_eq!(
+        actual2.as_slice(),
+        b"content2",
+        "file2.txt content must match"
+    );
 }
 
 // ============================================================================

--- a/crates/exarch-core/tests/integration_tests.rs
+++ b/crates/exarch-core/tests/integration_tests.rs
@@ -12,6 +12,10 @@ mod security;
 
 use exarch_core::ArchiveError;
 use exarch_core::SecurityConfig;
+use exarch_core::create_archive;
+use exarch_core::creation::CreationConfig;
+use exarch_core::extract_archive;
+use exarch_core::formats::detect::ArchiveType;
 use exarch_core::types::DestDir;
 use exarch_core::types::SafePath;
 use exarch_core::types::SafeSymlink;
@@ -249,3 +253,72 @@ fn verify_archive_concurrent_calls_do_not_collide() {
         );
     }
 }
+
+// ============================================================================
+// Roundtrip tests: create → extract → verify content
+// ============================================================================
+
+/// Source layout written by all roundtrip tests.
+///
+/// Returns `(src_dir, files)` where `files` is a list of `(relative_path,
+/// content)` pairs that can be used to assert the extracted output.
+fn make_roundtrip_source() -> (TempDir, Vec<(&'static str, &'static [u8])>) {
+    let src = TempDir::new().unwrap();
+    let files: Vec<(&str, &[u8])> = vec![
+        ("hello.txt", b"hello world"),
+        ("data.bin", b"\x00\x01\x02\x03\xfe\xff"),
+        ("nested/deep.txt", b"deep content"),
+        ("nested/sub/leaf.txt", b"leaf content"),
+    ];
+    for (rel, content) in &files {
+        let dest = src.path().join(rel);
+        if let Some(parent) = dest.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&dest, content).unwrap();
+    }
+    (src, files)
+}
+
+fn assert_roundtrip_content(extract_dir: &TempDir, files: &[(&str, &[u8])]) {
+    for (rel, expected) in files {
+        let path = extract_dir.path().join(rel);
+        let actual =
+            fs::read(&path).unwrap_or_else(|e| panic!("cannot read extracted file {rel}: {e}"));
+        assert_eq!(
+            actual.as_slice(),
+            *expected,
+            "content mismatch for {rel}: got {} bytes, expected {} bytes",
+            actual.len(),
+            expected.len()
+        );
+    }
+}
+
+macro_rules! roundtrip_test {
+    ($name:ident, $ext:literal, $format:expr) => {
+        #[test]
+        fn $name() {
+            let (src, files) = make_roundtrip_source();
+            let archive_dir = TempDir::new().unwrap();
+            let archive = archive_dir.path().join(concat!("out.", $ext));
+
+            let config = CreationConfig::default()
+                .with_include_hidden(true)
+                .with_format(Some($format));
+            create_archive(&archive, &[src.path()], &config).unwrap();
+            assert!(archive.exists(), "archive file must exist after creation");
+
+            let extract_dir = TempDir::new().unwrap();
+            extract_archive(&archive, extract_dir.path(), &SecurityConfig::default()).unwrap();
+
+            assert_roundtrip_content(&extract_dir, &files);
+        }
+    };
+}
+
+roundtrip_test!(roundtrip_tar_gz, "tar.gz", ArchiveType::TarGz);
+roundtrip_test!(roundtrip_tar_bz2, "tar.bz2", ArchiveType::TarBz2);
+roundtrip_test!(roundtrip_tar_xz, "tar.xz", ArchiveType::TarXz);
+roundtrip_test!(roundtrip_tar_zst, "tar.zst", ArchiveType::TarZst);
+roundtrip_test!(roundtrip_zip, "zip", ArchiveType::Zip);


### PR DESCRIPTION
## Summary

- Add 5 new integration tests to `exarch-core` that verify extracted file contents byte-for-byte for all supported formats (tar.gz, tar.bz2, tar.xz, tar.zst, zip)
- Fix CLI roundtrip tests to read back extracted files and assert content matches the source instead of only checking exit code or archive existence
- Tests include binary content (`\x00\x01\x02\x03\xfe\xff`) to catch encoding and truncation bugs

Closes #335

## Test plan

- [ ] `cargo nextest run -p exarch-core --test integration_tests roundtrip` — all 5 new tests pass
- [ ] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` — 888 tests pass, 0 failed
- [ ] `cargo +nightly fmt --all -- --check` — clean
- [ ] `cargo clippy --workspace --all-targets --all-features --exclude exarch-python --exclude exarch-node -- -D warnings` — clean