### PR TITLE
fix(inspection): correct ZIP symlink_target in list_archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 7z extraction with `skip_duplicates=false` now overwrites the existing file instead of
   returning an error. Previously a duplicate entry with `skip_duplicates=false` would fail;
   now it falls through to the atomic temp+rename overwrite path (#314).
+- `list_archive` now reports the correct `symlink_target` for ZIP symlink entries. Previously
+  `ArchiveManifest` entries were set to the entry's own path instead of reading the actual
+  target from the entry data (where the ZIP spec stores it). The symlink detection mask in the
+  listing path has also been corrected to use `S_IFMT & S_IFLNK`, matching the extraction path (#336).
 
 ## [0.4.1] - 2026-06-05
 

--- a/crates/exarch-core/src/formats/zip.rs
+++ b/crates/exarch-core/src/formats/zip.rs
@@ -573,6 +573,26 @@ impl ZipEntryAdapter {
     }
 }
 
+/// Reads the symlink target stored as file data in a ZIP entry.
+///
+/// The ZIP spec stores symlink targets as the uncompressed file content of the
+/// entry, not in any metadata field. This function enforces a hard cap of 4096
+/// bytes (`PATH_MAX`) to prevent unbounded allocation.
+pub(crate) fn read_zip_symlink_target<R: Read>(
+    zip_file: &mut zip::read::ZipFile<'_, R>,
+) -> Result<PathBuf> {
+    ZipEntryAdapter::read_symlink_target(zip_file)
+}
+
+/// Returns `true` if `mode` has the `S_IFLNK` file-type bits set.
+///
+/// Uses the correct POSIX mask (`S_IFMT`) to isolate the file-type field before
+/// comparing — without the mask, mode bits from the permission bits can
+/// spuriously match `S_IFLNK`.
+pub(crate) fn zip_mode_is_symlink(mode: Option<u32>) -> bool {
+    ZipEntryAdapter::is_symlink_from_mode(mode)
+}
+
 /// Compression methods supported by ZIP.
 #[derive(Debug, Clone, Copy)]
 enum CompressionMethod {

--- a/crates/exarch-core/src/inspection/list.rs
+++ b/crates/exarch-core/src/inspection/list.rs
@@ -17,6 +17,8 @@ use crate::SecurityConfig;
 use crate::error::QuotaResource;
 use crate::formats::detect::ArchiveType;
 use crate::formats::detect::detect_format;
+use crate::formats::zip::read_zip_symlink_target;
+use crate::formats::zip::zip_mode_is_symlink;
 use crate::inspection::manifest::ArchiveEntry;
 use crate::inspection::manifest::ArchiveManifest;
 use crate::inspection::manifest::ManifestEntryType;
@@ -327,8 +329,15 @@ pub(crate) fn list_zip_reader<R: Read + Seek>(
             })
         });
 
+        // Drop `entry` before conditionally re-opening the archive for symlink
+        // target data: the borrow checker requires the mutable borrow to end.
+        drop(entry);
+
         let symlink_target = if entry_type == ManifestEntryType::Symlink {
-            Some(path.clone())
+            let mut sym_entry = archive.by_index(i).map_err(|e| {
+                ArchiveError::InvalidArchive(format!("failed to re-read ZIP entry {i}: {e}"))
+            })?;
+            Some(read_zip_symlink_target(&mut sym_entry)?)
         } else {
             None
         };
@@ -571,18 +580,7 @@ fn convert_zip_entry_type<R: std::io::Read + std::io::Seek>(
 }
 
 fn is_zip_symlink<R: std::io::Read + std::io::Seek>(entry: &zip::read::ZipFile<'_, R>) -> bool {
-    #[cfg(unix)]
-    {
-        if let Some(mode) = entry.unix_mode() {
-            const S_IFLNK: u32 = 0o120_000;
-            return (mode & S_IFLNK) == S_IFLNK;
-        }
-    }
-
-    #[cfg(not(unix))]
-    let _ = entry;
-
-    false
+    zip_mode_is_symlink(entry.unix_mode())
 }
 
 #[cfg(test)]
@@ -836,6 +834,26 @@ mod tests {
         assert_eq!(
             manifest.entries[0].symlink_target,
             Some(PathBuf::from("target.txt"))
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_list_zip_symlink_target_is_actual_target() {
+        use crate::test_utils::create_zip_with_symlink;
+        use std::io::Cursor;
+
+        let zip_bytes = create_zip_with_symlink("link", "target.txt");
+        let mut archive = zip::ZipArchive::new(Cursor::new(zip_bytes)).unwrap();
+        let config = SecurityConfig::default();
+        let manifest = list_zip_reader(&mut archive, &config).unwrap();
+
+        assert_eq!(manifest.total_entries, 1);
+        assert_eq!(manifest.entries[0].entry_type, ManifestEntryType::Symlink);
+        assert_eq!(
+            manifest.entries[0].symlink_target,
+            Some(PathBuf::from("target.txt")),
+            "symlink_target must be the actual link target, not the entry path"
         );
     }
 

--- a/crates/exarch-core/src/test_utils.rs
+++ b/crates/exarch-core/src/test_utils.rs
@@ -206,6 +206,85 @@ impl Default for TarTestBuilder {
     }
 }
 
+/// Creates a raw ZIP archive containing a single symlink entry.
+///
+/// The ZIP spec encodes symlink targets as uncompressed file data, with
+/// `S_IFLNK` mode bits stored in the high 16 bits of the central directory's
+/// external attributes field. This bypasses the zip crate writer's
+/// `unix_permissions()` path, which does not set external attributes reliably.
+#[must_use]
+pub fn create_zip_with_symlink(link_path: &str, target: &str) -> Vec<u8> {
+    let content = target.as_bytes();
+    let crc = {
+        let mut c: u32 = 0xFFFF_FFFF;
+        for &b in content {
+            c ^= u32::from(b);
+            for _ in 0..8 {
+                if c & 1 != 0 {
+                    c = (c >> 1) ^ 0xEDB8_8320;
+                } else {
+                    c >>= 1;
+                }
+            }
+        }
+        c ^ 0xFFFF_FFFF
+    };
+    // S_IFLNK | rwxrwxrwx — encodes mode in high word of external attributes
+    let external_attributes: u32 = 0o120_777 << 16;
+    let name_bytes = link_path.as_bytes();
+    let name_len = u16::try_from(name_bytes.len()).unwrap();
+    let content_len = u32::try_from(content.len()).unwrap();
+
+    let mut buf: Vec<u8> = Vec::new();
+
+    let local_offset = u32::try_from(buf.len()).unwrap();
+    buf.extend_from_slice(b"PK\x03\x04");
+    buf.extend_from_slice(&20u16.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes()); // flags
+    buf.extend_from_slice(&0u16.to_le_bytes()); // compression: Stored
+    buf.extend_from_slice(&0u16.to_le_bytes()); // mod time
+    buf.extend_from_slice(&0u16.to_le_bytes()); // mod date
+    buf.extend_from_slice(&crc.to_le_bytes());
+    buf.extend_from_slice(&content_len.to_le_bytes());
+    buf.extend_from_slice(&content_len.to_le_bytes());
+    buf.extend_from_slice(&name_len.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes()); // extra field length
+    buf.extend_from_slice(name_bytes);
+    buf.extend_from_slice(content);
+
+    let central_offset = u32::try_from(buf.len()).unwrap();
+    buf.extend_from_slice(b"PK\x01\x02");
+    buf.extend_from_slice(&0x031eu16.to_le_bytes()); // version made by: Unix
+    buf.extend_from_slice(&20u16.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes()); // flags
+    buf.extend_from_slice(&0u16.to_le_bytes()); // compression
+    buf.extend_from_slice(&0u16.to_le_bytes()); // mod time
+    buf.extend_from_slice(&0u16.to_le_bytes()); // mod date
+    buf.extend_from_slice(&crc.to_le_bytes());
+    buf.extend_from_slice(&content_len.to_le_bytes());
+    buf.extend_from_slice(&content_len.to_le_bytes());
+    buf.extend_from_slice(&name_len.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes()); // extra length
+    buf.extend_from_slice(&0u16.to_le_bytes()); // comment length
+    buf.extend_from_slice(&0u16.to_le_bytes()); // disk number start
+    buf.extend_from_slice(&0u16.to_le_bytes()); // internal attributes
+    buf.extend_from_slice(&external_attributes.to_le_bytes());
+    buf.extend_from_slice(&local_offset.to_le_bytes());
+    buf.extend_from_slice(name_bytes);
+
+    let central_size = u32::try_from(buf.len()).unwrap() - central_offset;
+    buf.extend_from_slice(b"PK\x05\x06");
+    buf.extend_from_slice(&0u16.to_le_bytes()); // disk number
+    buf.extend_from_slice(&0u16.to_le_bytes()); // disk with central dir
+    buf.extend_from_slice(&1u16.to_le_bytes()); // entries on this disk
+    buf.extend_from_slice(&1u16.to_le_bytes()); // total entries
+    buf.extend_from_slice(&central_size.to_le_bytes());
+    buf.extend_from_slice(&central_offset.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes()); // comment length
+
+    buf
+}
+
 /// Builder for creating ZIP test archives with files, directories, and
 /// symlinks.
 pub struct ZipTestBuilder {


### PR DESCRIPTION
## Summary

- `list_zip_reader` was setting `symlink_target` to `Some(path.clone())` — the entry's own path — instead of reading the actual target from the entry data bytes (where the ZIP spec stores it), causing `ArchiveManifest` entries for ZIP symlinks to report incorrect targets during listing
- Fix reopens each symlink entry by index and delegates to a new `read_zip_symlink_target` pub(crate) helper (a wrapper around the existing `ZipEntryAdapter::read_symlink_target` used during extraction), so listing and extraction now use identical logic
- Also corrects the symlink detection mask in `is_zip_symlink` from `(mode & S_IFLNK) == S_IFLNK` to the proper `S_IFMT`-masked test via a new `zip_mode_is_symlink` helper, eliminating latent divergence from the extraction path

## Test plan

- [ ] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` — 884/884 tests pass including new `test_list_zip_symlink_target_is_actual_target` regression test
- [ ] `cargo test --doc --workspace --all-features --exclude exarch-python --exclude exarch-node` — 98 doc tests pass
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [ ] `cargo +nightly fmt --all -- --check` — clean
- [ ] Manually verify: create a ZIP with a symlink entry, call `list_archive()`, confirm `symlink_target` equals the actual link destination (not the entry path)

Fixes #336