### PR TITLE
test(python): activate ExtractionOptions round-trip tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Python `ExtractionOptions` tests no longer unconditionally skip: replaced the
+  `pytest.skip(...)` guard with `pytest.importorskip("exarch")` at module level so all 14
+  round-trip assertions execute when the extension is built (#342).
 - Roundtrip integration tests now verify extracted file contents against the source data for
   all supported formats (tar.gz, tar.bz2, tar.xz, tar.zst, zip). Previously, tests only
   asserted that extraction succeeded and files existed, which would have allowed silent data

--- a/crates/exarch-python/tests/test_extraction_options.py
+++ b/crates/exarch-python/tests/test_extraction_options.py
@@ -2,8 +2,8 @@
 
 import pytest
 
-# TODO: Import exarch module once the extension is built
-# from exarch import ExtractionOptions, extract_archive
+pytest.importorskip("exarch")
+from exarch import ExtractionOptions, extract_archive  # noqa: E402
 
 
 class TestExtractionOptions:
@@ -11,101 +11,87 @@ class TestExtractionOptions:
 
     def test_default_skip_duplicates_is_true(self):
         """Test that skip_duplicates defaults to True."""
-        pytest.skip("Requires compiled Python extension module")
-        # opts = ExtractionOptions()
-        # assert opts.skip_duplicates is True
+        opts = ExtractionOptions()
+        assert opts.skip_duplicates is True
 
     def test_default_static_method(self):
         """Test that ExtractionOptions.default() equals ExtractionOptions()."""
-        pytest.skip("Requires compiled Python extension module")
-        # opts = ExtractionOptions.default()
-        # assert opts.skip_duplicates is True
+        opts = ExtractionOptions.default()
+        assert opts.skip_duplicates is True
 
     def test_with_skip_duplicates_false(self):
         """Test with_skip_duplicates(False) sets the flag and returns self."""
-        pytest.skip("Requires compiled Python extension module")
-        # opts = ExtractionOptions()
-        # result = opts.with_skip_duplicates(False)
-        # assert opts.skip_duplicates is False
-        # assert result is opts
+        opts = ExtractionOptions()
+        result = opts.with_skip_duplicates(False)
+        assert opts.skip_duplicates is False
+        assert result is opts
 
     def test_with_skip_duplicates_true(self):
         """Test with_skip_duplicates(True) sets the flag."""
-        pytest.skip("Requires compiled Python extension module")
-        # opts = ExtractionOptions()
-        # opts.with_skip_duplicates(False)
-        # opts.with_skip_duplicates(True)
-        # assert opts.skip_duplicates is True
+        opts = ExtractionOptions()
+        opts.with_skip_duplicates(False)
+        opts.with_skip_duplicates(True)
+        assert opts.skip_duplicates is True
 
     def test_skip_duplicates_property_setter(self):
         """Test skip_duplicates property setter."""
-        pytest.skip("Requires compiled Python extension module")
-        # opts = ExtractionOptions()
-        # opts.skip_duplicates = False
-        # assert opts.skip_duplicates is False
+        opts = ExtractionOptions()
+        opts.skip_duplicates = False
+        assert opts.skip_duplicates is False
 
     def test_build_returns_self(self):
         """Test build() returns self for builder consistency."""
-        pytest.skip("Requires compiled Python extension module")
-        # opts = ExtractionOptions()
-        # result = opts.build()
-        # assert result is opts
+        opts = ExtractionOptions()
+        result = opts.build()
+        assert result is opts
 
     def test_repr(self):
         """Test string representation."""
-        pytest.skip("Requires compiled Python extension module")
-        # opts = ExtractionOptions()
-        # repr_str = repr(opts)
-        # assert "ExtractionOptions" in repr_str
-        # assert "skip_duplicates" in repr_str
+        opts = ExtractionOptions()
+        repr_str = repr(opts)
+        assert "ExtractionOptions" in repr_str
+        assert "skip_duplicates" in repr_str
 
     def test_extract_archive_with_default_options(self, sample_tar_gz, temp_dir):
         """Test extract_archive with ExtractionOptions() succeeds."""
-        pytest.skip("Requires compiled Python extension module")
-        # output = temp_dir / "output"
-        # output.mkdir()
-        # opts = ExtractionOptions()
-        # report = extract_archive(sample_tar_gz, output, options=opts)
-        # assert report.files_extracted >= 1
+        output = temp_dir / "output"
+        output.mkdir()
+        opts = ExtractionOptions()
+        report = extract_archive(sample_tar_gz, output, options=opts)
+        assert report.files_extracted >= 1
 
     def test_extract_archive_with_skip_duplicates_false(self, sample_tar_gz, temp_dir):
         """Test extract_archive with skip_duplicates=False on a non-duplicate archive succeeds."""
-        pytest.skip("Requires compiled Python extension module")
-        # output = temp_dir / "output"
-        # output.mkdir()
-        # opts = ExtractionOptions().with_skip_duplicates(False)
-        # report = extract_archive(sample_tar_gz, output, options=opts)
-        # assert report.files_extracted >= 1
+        output = temp_dir / "output"
+        output.mkdir()
+        opts = ExtractionOptions().with_skip_duplicates(False)
+        report = extract_archive(sample_tar_gz, output, options=opts)
+        assert report.files_extracted >= 1
 
     def test_extract_archive_options_keyword_arg(self, sample_tar_gz, temp_dir):
         """Test extract_archive accepts options as keyword argument."""
-        pytest.skip("Requires compiled Python extension module")
-        # output = temp_dir / "output"
-        # output.mkdir()
-        # opts = ExtractionOptions()
-        # report = extract_archive(sample_tar_gz, output, options=opts)
-        # assert report.files_extracted >= 1
+        output = temp_dir / "output"
+        output.mkdir()
+        opts = ExtractionOptions()
+        report = extract_archive(sample_tar_gz, output, options=opts)
+        assert report.files_extracted >= 1
 
     def test_atomic_default(self):
         """Test that atomic defaults to False."""
-        pytest.skip("Requires compiled Python extension module")
-        # opts = ExtractionOptions()
-        # assert opts.atomic is False
+        opts = ExtractionOptions()
+        assert opts.atomic is False
 
     def test_atomic_round_trip(self):
         """Test with_atomic(True) sets the flag and returns self."""
-        pytest.skip("Requires compiled Python extension module")
-        # opts = ExtractionOptions().with_atomic(True)
-        # assert opts.atomic is True
+        opts = ExtractionOptions().with_atomic(True)
+        assert opts.atomic is True
 
     def test_skip_duplicates_default(self):
         """Test that skip_duplicates defaults to True."""
-        pytest.skip("Requires compiled Python extension module")
-        # opts = ExtractionOptions()
-        # assert opts.skip_duplicates is True
+        opts = ExtractionOptions()
+        assert opts.skip_duplicates is True
 
     def test_skip_duplicates_round_trip(self):
         """Test with_skip_duplicates(True) sets the flag after toggling."""
-        pytest.skip("Requires compiled Python extension module")
-        # opts = ExtractionOptions().with_skip_duplicates(True)
-        # assert opts.skip_duplicates is True
+        opts = ExtractionOptions().with_skip_duplicates(True)
+        assert opts.skip_duplicates is True


### PR DESCRIPTION
## Summary

- Replaces 14 unconditional `pytest.skip()` calls with a `pytest.importorskip("exarch")` module-level guard in `test_extraction_options.py`
- Uncomments the assertion bodies for all round-trip tests covering `skip_duplicates` and `atomic` getters, setters, and builder methods
- All 14 tests now pass after `maturin develop` instead of producing 14 skip markers

## Test plan

- [ ] `cd crates/exarch-python && maturin develop --features abi3`
- [ ] `pytest tests/test_extraction_options.py -v` — 14 passed, 0 skipped
- [ ] `pytest tests/ -v` — no regressions in other test files

Fixes #342.