### PR TITLE
perf(core): eliminate duplicate by_index() call in ZipArchive::extract()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Performance
+
+- `ZipArchive::extract()` now calls `by_index()` exactly once per entry instead of twice.
+  The local file header seek+read was previously performed once for the progress callback and
+  again inside `process_entry`; the two calls are now merged, halving header I/O on archives
+  with many small entries (#341).
+
 ### Fixed
 
 - Python `ExtractionOptions` tests no longer unconditionally skip: replaced the

--- a/crates/exarch-core/src/formats/zip.rs
+++ b/crates/exarch-core/src/formats/zip.rs
@@ -248,16 +248,17 @@ impl<R: Read + Seek> ZipArchive<R> {
         }
     }
 
-    /// Processes a single ZIP entry with a single `by_index()` call.
+    /// Processes a single ZIP entry using an already-opened `ZipFile`.
     ///
-    /// Branches on entry type (directory/symlink/file) within the same
-    /// borrow scope. For directories and symlinks, the zip file is
-    /// explicitly dropped before calling extraction helpers. For files,
-    /// the zip file remains alive through validation and is reused for
-    /// data extraction.
+    /// The caller is responsible for opening the entry via `by_index` exactly
+    /// once and passing it here, so the local header is read only once per
+    /// entry. Branches on entry type (directory/symlink/file) within the same
+    /// borrow scope. For directories and symlinks, the zip file is explicitly
+    /// dropped before calling extraction helpers. For files, the zip file
+    /// remains alive through validation and is reused for data extraction.
     #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
     fn process_entry(
-        &mut self,
+        mut zip_file: zip::read::ZipFile<'_, R>,
         index: usize,
         validator: &mut EntryValidator,
         dest: &DestDir,
@@ -268,15 +269,6 @@ impl<R: Read + Seek> ZipArchive<R> {
         config: &SecurityConfig,
         progress: &mut dyn ProgressCallback,
     ) -> Result<()> {
-        let mut zip_file = self.inner.by_index(index).map_err(|e| {
-            if e.to_string().contains("Password required to decrypt file") {
-                return ArchiveError::SecurityViolation {
-                    reason: "archive is password-protected.\n  Password-protected ZIP archives are not supported. Decrypt the archive externally and try again.".into(),
-                };
-            }
-            ArchiveError::InvalidArchive(format!("failed to read entry {index}: {e}"))
-        })?;
-
         if zip_file.encrypted() {
             let name = zip_file
                 .name()
@@ -448,23 +440,27 @@ impl<R: Read + Seek> ArchiveFormat for ZipArchive<R> {
         let entry_count = self.inner.len();
 
         for i in 0..entry_count {
-            let entry_path = {
-                // Borrow ends before process_entry to satisfy the borrow checker.
-                let zf = self.inner.by_index(i).map_err(|e| {
-                    ArchiveError::InvalidArchive(format!("failed to open zip entry {i}: {e}"))
-                })?;
-                std::path::PathBuf::from(
-                    zf.name()
-                        .map_err(|e| {
-                            ArchiveError::InvalidArchive(format!("invalid entry name at {i}: {e}"))
-                        })?
-                        .as_ref(),
-                )
-            };
+            let zip_file = self.inner.by_index(i).map_err(|e| {
+                if e.to_string().contains("Password required to decrypt file") {
+                    return ArchiveError::SecurityViolation {
+                        reason: "archive is password-protected.\n  Password-protected ZIP archives are not supported. Decrypt the archive externally and try again.".into(),
+                    };
+                }
+                ArchiveError::InvalidArchive(format!("failed to open zip entry {i}: {e}"))
+            })?;
+            let entry_path = PathBuf::from(
+                zip_file
+                    .name()
+                    .map_err(|e| {
+                        ArchiveError::InvalidArchive(format!("invalid entry name at {i}: {e}"))
+                    })?
+                    .as_ref(),
+            );
             progress.on_entry_start(&entry_path, entry_count, i.saturating_add(1));
             let mut guard = EntryCompleteGuard::new(progress, &entry_path);
 
-            let result = self.process_entry(
+            let result = Self::process_entry(
+                zip_file,
                 i,
                 &mut validator,
                 &dest,


### PR DESCRIPTION
Closes #341

## Summary

- `process_entry` is now an associated function accepting an already-opened `zip::read::ZipFile` instead of an instance method that calls `by_index` internally
- The `extract()` loop opens each entry with a single `by_index(i)` call; the resulting `ZipFile` is used both to extract the path for the progress callback and as input to `process_entry`
- The password-protection error mapping previously located inside `process_entry` is moved to the outer `by_index` call site

## Impact

Each entry's local file header is now read exactly once. On archives with 10 000 small entries this halves the number of seek + read operations during extraction.

## Test plan

- [x] `cargo nextest run -p exarch-core --all-features` — 740 tests passed
- [x] `cargo +nightly fmt --all -- --check` — no formatting issues
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — no warnings
- [x] `cargo test --doc --workspace --all-features --exclude exarch-python --exclude exarch-node` — 98 doc-tests passed