### PR TITLE
fix(core): strip absolute entry paths in TAR and 7z when allow_absolute_paths=true

### DIFF
--- a/crates/exarch-core/src/formats/sevenz.rs
+++ b/crates/exarch-core/src/formats/sevenz.rs
@@ -439,7 +439,11 @@ impl<R: Read + Seek> SevenZArchive<R> {
                           reader: &mut dyn Read,
                           _dest_dir: &PathBuf|
          -> std::result::Result<bool, sevenz_rust2::Error> {
-            let entry_path = PathBuf::from(&entry.name);
+            let entry_path = strip_absolute_entry_name(&entry.name, config)
+                .map_err(|e| {
+                    sevenz_rust2::Error::Other(format!("path validation failed: {e}").into())
+                })?
+                .into_owned();
             ctx.current_idx = ctx.current_idx.saturating_add(1);
             let idx = ctx.current_idx;
             ctx.progress
@@ -548,8 +552,7 @@ impl<R: Read + Seek> ArchiveFormat for SevenZArchive<R> {
         // - symlink detection: Not exposed, non-directory entries treated as files
         let mut prevalidator = EntryValidator::new(config, &dest);
         for entry in &self.entries {
-            // OPT-H002: Use Path::new instead of PathBuf::from to avoid allocation
-            let path = Path::new(&entry.name);
+            let path = strip_absolute_entry_name(&entry.name, config)?;
             let entry_type = if entry.is_directory {
                 EntryType::Directory
             } else {
@@ -560,7 +563,7 @@ impl<R: Read + Seek> ArchiveFormat for SevenZArchive<R> {
             // skipped. Defense relies on max_total_size and max_file_size
             // quotas.
             let validated =
-                prevalidator.validate_entry(path, &entry_type, entry.size, None, None, None)?;
+                prevalidator.validate_entry(&path, &entry_type, entry.size, None, None, None)?;
 
             match validated.entry_type {
                 ValidatedEntryType::File | ValidatedEntryType::Directory => {
@@ -748,6 +751,39 @@ fn is_empty_sevenz_archive<R: Read + Seek>(err: &sevenz_rust2::Error, source: &m
     };
     let mut magic = [0u8; 6];
     source.read_exact(&mut magic).is_ok() && magic == SEVENZ_MAGIC
+}
+
+/// Strips the leading `/` from absolute entry names when `allow_absolute_paths`
+/// is enabled, preventing `PathBuf::join` from discarding the destination
+/// prefix.
+///
+/// Returns a `Cow<Path>`: borrowed when the name is already relative, owned
+/// when the leading slash is stripped. Returns `PathTraversal` if the stripped
+/// name is empty or still contains a `..` component.
+fn strip_absolute_entry_name<'a>(
+    name: &'a str,
+    config: &SecurityConfig,
+) -> Result<std::borrow::Cow<'a, Path>> {
+    let raw = Path::new(name);
+    if raw.is_absolute() && config.allowed.absolute_paths {
+        let stripped = name.trim_start_matches('/');
+        if stripped.is_empty() {
+            return Err(ArchiveError::PathTraversal {
+                path: raw.to_path_buf(),
+            });
+        }
+        let p = PathBuf::from(stripped);
+        if p.components()
+            .any(|c| matches!(c, std::path::Component::ParentDir))
+        {
+            return Err(ArchiveError::PathTraversal {
+                path: raw.to_path_buf(),
+            });
+        }
+        Ok(std::borrow::Cow::Owned(p))
+    } else {
+        Ok(std::borrow::Cow::Borrowed(raw))
+    }
 }
 
 /// Converts sevenz-rust2 errors to our `ArchiveError` type.
@@ -1482,6 +1518,133 @@ mod tests {
                 .join("no-ext-fixture")
                 .join("document.txt")
                 .exists()
+        );
+    }
+
+    fn make_sevenz_archive(entries: &[(&str, &[u8])]) -> Vec<u8> {
+        use sevenz_rust2::ArchiveEntry;
+        use sevenz_rust2::ArchiveWriter;
+        use sevenz_rust2::EncoderConfiguration;
+        use sevenz_rust2::EncoderMethod;
+
+        let buf = Cursor::new(Vec::new());
+        let mut writer = ArchiveWriter::new(buf).unwrap();
+        writer.set_content_methods(vec![EncoderConfiguration::new(EncoderMethod::COPY)]);
+        for (name, data) in entries {
+            let mut entry = ArchiveEntry::new_file(name);
+            entry.has_stream = true;
+            entry.size = data.len() as u64;
+            writer
+                .push_archive_entry(entry, Some(Cursor::new(*data)))
+                .unwrap();
+        }
+        writer.finish().unwrap().into_inner()
+    }
+
+    #[test]
+    fn test_strip_absolute_entry_name_relative_passthrough() {
+        let config = SecurityConfig::default();
+        let result = strip_absolute_entry_name("relative/path.txt", &config).unwrap();
+        assert_eq!(result.as_ref(), std::path::Path::new("relative/path.txt"));
+    }
+
+    #[test]
+    fn test_strip_absolute_entry_name_absolute_with_flag() {
+        let config = SecurityConfig::default().with_allow_absolute_paths(true);
+        let result = strip_absolute_entry_name("/etc/shadow", &config).unwrap();
+        assert_eq!(result.as_ref(), std::path::Path::new("etc/shadow"));
+    }
+
+    #[test]
+    fn test_strip_absolute_entry_name_absolute_without_flag() {
+        // Without the flag, absolute paths are passed through unchanged so that
+        // SafePath::validate can apply its own rejection logic.
+        let config = SecurityConfig::default();
+        let result = strip_absolute_entry_name("/etc/shadow", &config).unwrap();
+        assert_eq!(result.as_ref(), std::path::Path::new("/etc/shadow"));
+    }
+
+    #[test]
+    fn test_strip_absolute_entry_name_bare_slash_rejected() {
+        let config = SecurityConfig::default().with_allow_absolute_paths(true);
+        let result = strip_absolute_entry_name("/", &config);
+        assert!(
+            matches!(result, Err(ArchiveError::PathTraversal { .. })),
+            "bare slash must be rejected"
+        );
+    }
+
+    #[test]
+    fn test_strip_absolute_entry_name_traversal_after_root_rejected() {
+        let config = SecurityConfig::default().with_allow_absolute_paths(true);
+        let result = strip_absolute_entry_name("/../etc/passwd", &config);
+        assert!(
+            matches!(result, Err(ArchiveError::PathTraversal { .. })),
+            "traversal after root must be rejected"
+        );
+    }
+
+    #[test]
+    fn test_7z_absolute_path_rejected_by_default() {
+        let data = make_sevenz_archive(&[("/etc/shadow", b"secret")]);
+        let mut archive = SevenZArchive::new(Cursor::new(data)).unwrap();
+
+        let temp = TempDir::new().unwrap();
+        let config = SecurityConfig::default();
+
+        let result = archive.extract(
+            temp.path(),
+            &config,
+            &ExtractionOptions::default(),
+            &mut crate::NoopProgress,
+        );
+        assert!(
+            result.is_err(),
+            "absolute path must be rejected by default, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_7z_absolute_path_with_flag_writes_to_dest() {
+        let data = make_sevenz_archive(&[("/etc/shadow", b"content")]);
+        let mut archive = SevenZArchive::new(Cursor::new(data)).unwrap();
+
+        let temp = TempDir::new().unwrap();
+        let config = SecurityConfig::default().with_allow_absolute_paths(true);
+
+        let report = archive
+            .extract(
+                temp.path(),
+                &config,
+                &ExtractionOptions::default(),
+                &mut crate::NoopProgress,
+            )
+            .unwrap();
+
+        assert_eq!(report.files_extracted, 1);
+        assert!(
+            temp.path().join("etc/shadow").exists(),
+            "file must land inside dest, not at real /etc/shadow"
+        );
+    }
+
+    #[test]
+    fn test_7z_absolute_path_traversal_still_rejected_with_flag() {
+        let data = make_sevenz_archive(&[("/../etc/passwd", b"secret")]);
+        let mut archive = SevenZArchive::new(Cursor::new(data)).unwrap();
+
+        let temp = TempDir::new().unwrap();
+        let config = SecurityConfig::default().with_allow_absolute_paths(true);
+
+        let result = archive.extract(
+            temp.path(),
+            &config,
+            &ExtractionOptions::default(),
+            &mut crate::NoopProgress,
+        );
+        assert!(
+            result.is_err(),
+            "traversal-after-root must be rejected even with allow_absolute_paths"
         );
     }
 }

--- a/crates/exarch-core/src/formats/sevenz.rs
+++ b/crates/exarch-core/src/formats/sevenz.rs
@@ -765,7 +765,7 @@ fn strip_absolute_entry_name<'a>(
     config: &SecurityConfig,
 ) -> Result<std::borrow::Cow<'a, Path>> {
     let raw = Path::new(name);
-    if raw.is_absolute() && config.allowed.absolute_paths {
+    if name.starts_with('/') && config.allowed.absolute_paths {
         let stripped = name.trim_start_matches('/');
         if stripped.is_empty() {
             return Err(ArchiveError::PathTraversal {

--- a/crates/exarch-core/src/formats/tar.rs
+++ b/crates/exarch-core/src/formats/tar.rs
@@ -207,10 +207,29 @@ impl<R: Read> TarArchive<R> {
             return Ok(None);
         }
 
-        let path = entry
+        let raw_path = entry
             .path()
             .map_err(|e| ArchiveError::InvalidArchive(format!("invalid path: {e}")))?
             .into_owned();
+
+        let path = if raw_path.is_absolute() && ctx.config.allowed.absolute_paths {
+            let stripped = raw_path
+                .to_str()
+                .map(|s| s.trim_start_matches('/'))
+                .unwrap_or_default();
+            if stripped.is_empty() {
+                return Err(ArchiveError::PathTraversal { path: raw_path });
+            }
+            let p = std::path::PathBuf::from(stripped);
+            if p.components()
+                .any(|c| matches!(c, std::path::Component::ParentDir))
+            {
+                return Err(ArchiveError::PathTraversal { path: raw_path });
+            }
+            p
+        } else {
+            raw_path
+        };
 
         let entry_type = TarEntryAdapter::to_entry_type(&entry)?;
         let size = TarEntryAdapter::get_uncompressed_size(&entry);
@@ -2244,6 +2263,87 @@ mod tests {
 
         assert!(report.is_safe());
         assert_eq!(report.total_entries, 1);
+    }
+
+    fn create_tar_with_absolute_path(path_bytes: &[u8], content: &[u8]) -> Vec<u8> {
+        let mut builder = tar::Builder::new(Vec::new());
+        let mut header = tar::Header::new_gnu();
+        header.set_size(content.len() as u64);
+        header.set_mode(0o644);
+        let mut name_field = [0u8; 100];
+        let len = path_bytes.len().min(100);
+        name_field[..len].copy_from_slice(&path_bytes[..len]);
+        header.as_gnu_mut().unwrap().name = name_field;
+        header.set_cksum();
+        builder.append(&header, content).unwrap();
+        builder.into_inner().unwrap()
+    }
+
+    #[test]
+    fn test_tar_absolute_path_rejected_by_default() {
+        let tar_data = create_tar_with_absolute_path(b"/etc/shadow", b"secret");
+        let mut archive = TarArchive::new(Cursor::new(tar_data));
+
+        let temp = TempDir::new().unwrap();
+        let config = SecurityConfig::default();
+
+        let result = archive.extract(
+            temp.path(),
+            &config,
+            &ExtractionOptions::default(),
+            &mut NoopProgress,
+        );
+        assert!(result.is_err(), "absolute path must be rejected by default");
+        assert!(
+            matches!(result.unwrap_err(), ArchiveError::PathTraversal { .. }),
+            "expected PathTraversal"
+        );
+    }
+
+    #[test]
+    fn test_tar_absolute_path_with_flag_writes_to_dest() {
+        let tar_data = create_tar_with_absolute_path(b"/etc/shadow", b"content");
+        let mut archive = TarArchive::new(Cursor::new(tar_data));
+
+        let temp = TempDir::new().unwrap();
+        let config = SecurityConfig::default().with_allow_absolute_paths(true);
+
+        let report = archive
+            .extract(
+                temp.path(),
+                &config,
+                &ExtractionOptions::default(),
+                &mut NoopProgress,
+            )
+            .unwrap();
+
+        assert_eq!(report.files_extracted, 1);
+        assert!(
+            temp.path().join("etc/shadow").exists(),
+            "file must land inside dest, not at real /etc/shadow"
+        );
+    }
+
+    #[test]
+    fn test_tar_absolute_path_traversal_still_rejected_with_flag() {
+        // Even with allow_absolute_paths, `/../etc/passwd` contains `..` and
+        // must be rejected regardless.
+        let tar_data = create_tar_with_absolute_path(b"/../etc/passwd", b"secret");
+        let mut archive = TarArchive::new(Cursor::new(tar_data));
+
+        let temp = TempDir::new().unwrap();
+        let config = SecurityConfig::default().with_allow_absolute_paths(true);
+
+        let result = archive.extract(
+            temp.path(),
+            &config,
+            &ExtractionOptions::default(),
+            &mut NoopProgress,
+        );
+        assert!(
+            result.is_err(),
+            "traversal-after-root must be rejected even with allow_absolute_paths"
+        );
     }
 
     #[test]

--- a/crates/exarch-core/src/formats/tar.rs
+++ b/crates/exarch-core/src/formats/tar.rs
@@ -212,7 +212,9 @@ impl<R: Read> TarArchive<R> {
             .map_err(|e| ArchiveError::InvalidArchive(format!("invalid path: {e}")))?
             .into_owned();
 
-        let path = if raw_path.is_absolute() && ctx.config.allowed.absolute_paths {
+        let path = if raw_path.to_str().is_some_and(|s| s.starts_with('/'))
+            && ctx.config.allowed.absolute_paths
+        {
             let stripped = raw_path
                 .to_str()
                 .map(|s| s.trim_start_matches('/'))


### PR DESCRIPTION
## Summary

Fixes #340. After the ZIP fix in commit 20e0285, `--allow-absolute-paths` still failed for TAR and 7z archives.

Root cause: `PathBuf::join` on Unix discards the destination prefix when the right-hand side is absolute, so entries like `/abs/path/file.txt` would pass the `allow_absolute_paths` guard but hit `SafePath::validate` with the raw absolute path and be rejected as traversal.

Fix: strip the leading `/` before calling `validate_entry` — matching the ZIP approach — so the entry is joined to dest as a relative path.

## Changes

- `crates/exarch-core/src/formats/tar.rs`: inline strip in `process_entry()` when `allow_absolute_paths=true`; adds 3 regression tests
- `crates/exarch-core/src/formats/sevenz.rs`: `strip_absolute_entry_name()` helper applied at both extraction sites (pre-validate loop and extract callback); adds 5 unit tests for the helper and 3 integration tests symmetric to the TAR ones

## Test plan

- [ ] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` — 907/907 pass
- [ ] `cargo test --doc --workspace --all-features` — 98/98 pass
- [ ] `cargo +nightly fmt --all -- --check` — clean
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [ ] New tests verify: flag=false rejects, flag=true extracts to dest/abs/path, traversal still rejected with flag (all three formats)

## Follow-up

- #347 — `allow_absolute_paths` does not handle Windows drive/UNC prefixes
- #348 — centralize slash-stripping in `SafePath::validate` instead of per-format workarounds