### PR TITLE
fix(cli): include symlink_target in JSON list output (#346)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `exarch list --json -l` now includes `symlink_target` and `hardlink_target` in
+  the JSON output for symlink and hardlink entries. Previously the fields were
+  populated in `exarch-core` but silently dropped by the CLI JSON formatter (#346).
 - Python `ExtractionOptions` tests no longer unconditionally skip: replaced the
   `pytest.skip(...)` guard with `pytest.importorskip("exarch")` at module level so all 14
   round-trip assertions execute when the extension is built (#342).

--- a/crates/exarch-cli/src/output/json.rs
+++ b/crates/exarch-cli/src/output/json.rs
@@ -175,6 +175,10 @@ impl OutputFormatter for JsonFormatter {
             compressed_size: Option<u64>,
             mode: Option<u32>,
             modified: Option<u64>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            symlink_target: Option<String>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            hardlink_target: Option<String>,
         }
 
         #[derive(Serialize)]
@@ -199,6 +203,8 @@ impl OutputFormatter for JsonFormatter {
                         .ok()
                         .map(|d| d.as_secs())
                 }),
+                symlink_target: e.symlink_target.as_ref().map(|p| p.display().to_string()),
+                hardlink_target: e.hardlink_target.as_ref().map(|p| p.display().to_string()),
             })
             .collect();
 

--- a/crates/exarch-cli/src/output/json.rs
+++ b/crates/exarch-cli/src/output/json.rs
@@ -172,8 +172,11 @@ impl OutputFormatter for JsonFormatter {
             path: String,
             entry_type: String,
             size: u64,
+            #[serde(skip_serializing_if = "Option::is_none")]
             compressed_size: Option<u64>,
+            #[serde(skip_serializing_if = "Option::is_none")]
             mode: Option<u32>,
+            #[serde(skip_serializing_if = "Option::is_none")]
             modified: Option<u64>,
             #[serde(skip_serializing_if = "Option::is_none")]
             symlink_target: Option<String>,

--- a/crates/exarch-cli/tests/cli_tests.rs
+++ b/crates/exarch-cli/tests/cli_tests.rs
@@ -1763,3 +1763,47 @@ fn test_list_json_long_symlink_target() {
         "symlink_target must equal the link target stored in the archive"
     );
 }
+
+/// Regular file entries must NOT contain `symlink_target` or `hardlink_target`
+/// keys in JSON output, pinning the `skip_serializing_if` contract (#346).
+#[test]
+fn test_list_json_long_regular_file_omits_link_fields() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let archive = temp.path().join("regular.tar.gz");
+
+    exarch_cmd()
+        .arg("create")
+        .arg(&archive)
+        .arg(fixture_path("sample.txt"))
+        .assert()
+        .success();
+
+    let output = exarch_cmd()
+        .arg("list")
+        .arg("--json")
+        .arg("-l")
+        .arg(&archive)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json: serde_json::Value = serde_json::from_slice(&output).expect("invalid JSON output");
+    let entries = json["data"]["entries"]
+        .as_array()
+        .expect("entries must be array");
+    let file_entry = entries
+        .iter()
+        .find(|e| e["entry_type"] == "File")
+        .expect("expected a File entry in the listing");
+
+    assert!(
+        file_entry.get("symlink_target").is_none(),
+        "regular file entry must not contain symlink_target key"
+    );
+    assert!(
+        file_entry.get("hardlink_target").is_none(),
+        "regular file entry must not contain hardlink_target key"
+    );
+}

--- a/crates/exarch-cli/tests/cli_tests.rs
+++ b/crates/exarch-cli/tests/cli_tests.rs
@@ -1649,3 +1649,117 @@ fn test_extract_with_force_overwrites_conflicts() {
         .success()
         .stdout(predicate::str::contains("Extraction complete"));
 }
+
+// ============================================================================
+// symlink_target in JSON list output (#346)
+// ============================================================================
+
+/// Builds a minimal ZIP archive containing a single symlink entry using raw
+/// bytes. The symlink target is stored as the file content with `S_IFLNK` mode
+/// bits set in the central-directory `external_attributes` field.
+fn make_zip_with_symlink(link_name: &str, target: &str) -> Vec<u8> {
+    let content = target.as_bytes();
+    let crc = {
+        let mut c: u32 = 0xFFFF_FFFF;
+        for &b in content {
+            c ^= u32::from(b);
+            for _ in 0..8 {
+                if c & 1 != 0 {
+                    c = (c >> 1) ^ 0xEDB8_8320;
+                } else {
+                    c >>= 1;
+                }
+            }
+        }
+        c ^ 0xFFFF_FFFF
+    };
+    let external_attributes: u32 = 0o120_777 << 16;
+    let name_bytes = link_name.as_bytes();
+    let name_len = u16::try_from(name_bytes.len()).unwrap();
+    let content_len = u32::try_from(content.len()).unwrap();
+
+    let mut buf: Vec<u8> = Vec::new();
+
+    let local_offset = u32::try_from(buf.len()).unwrap();
+    buf.extend_from_slice(b"PK\x03\x04");
+    buf.extend_from_slice(&20u16.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes());
+    buf.extend_from_slice(&crc.to_le_bytes());
+    buf.extend_from_slice(&content_len.to_le_bytes());
+    buf.extend_from_slice(&content_len.to_le_bytes());
+    buf.extend_from_slice(&name_len.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes());
+    buf.extend_from_slice(name_bytes);
+    buf.extend_from_slice(content);
+
+    let central_offset = u32::try_from(buf.len()).unwrap();
+    buf.extend_from_slice(b"PK\x01\x02");
+    buf.extend_from_slice(&0x031eu16.to_le_bytes());
+    buf.extend_from_slice(&20u16.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes());
+    buf.extend_from_slice(&crc.to_le_bytes());
+    buf.extend_from_slice(&content_len.to_le_bytes());
+    buf.extend_from_slice(&content_len.to_le_bytes());
+    buf.extend_from_slice(&name_len.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes());
+    buf.extend_from_slice(&external_attributes.to_le_bytes());
+    buf.extend_from_slice(&local_offset.to_le_bytes());
+    buf.extend_from_slice(name_bytes);
+
+    let central_size = u32::try_from(buf.len()).unwrap() - central_offset;
+    buf.extend_from_slice(b"PK\x05\x06");
+    buf.extend_from_slice(&0u16.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes());
+    buf.extend_from_slice(&1u16.to_le_bytes());
+    buf.extend_from_slice(&1u16.to_le_bytes());
+    buf.extend_from_slice(&central_size.to_le_bytes());
+    buf.extend_from_slice(&central_offset.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes());
+
+    buf
+}
+
+/// `exarch list --json -l` must include `symlink_target` for symlink entries
+/// (regression test for issue #346).
+#[test]
+fn test_list_json_long_symlink_target() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let archive = temp.path().join("symlink.zip");
+    let zip_bytes = make_zip_with_symlink("link.txt", "target.txt");
+    std::fs::write(&archive, &zip_bytes).expect("failed to write zip fixture");
+
+    let output = exarch_cmd()
+        .arg("list")
+        .arg("--json")
+        .arg("-l")
+        .arg(&archive)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json: serde_json::Value = serde_json::from_slice(&output).expect("invalid JSON output");
+    let entries = json["data"]["entries"]
+        .as_array()
+        .expect("entries must be array");
+    let symlink = entries
+        .iter()
+        .find(|e| e["entry_type"] == "Symlink")
+        .expect("expected a Symlink entry in the listing");
+
+    assert_eq!(
+        symlink["symlink_target"].as_str(),
+        Some("target.txt"),
+        "symlink_target must equal the link target stored in the archive"
+    );
+}


### PR DESCRIPTION
## Summary

- `exarch list --json -l` was silently dropping `symlink_target` and `hardlink_target` from JSON output even though `exarch-core` populated them correctly after #343
- Root cause: the local `ManifestEntry` struct inside `format_manifest_long` in `exarch-cli/src/output/json.rs` was missing both fields
- Fix adds `symlink_target: Option<String>` and `hardlink_target: Option<String>` with `#[serde(skip_serializing_if = "Option::is_none")]`; fields are absent in JSON for non-symlink/non-hardlink entries
- Applies `skip_serializing_if = "Option::is_none"` consistently to all optional fields in the struct (`compressed_size`, `mode`, `modified`) for a uniform JSON schema

## Test plan

- [x] `test_list_json_long_symlink_target` — regression: builds a raw ZIP symlink fixture, runs `exarch list --json -l`, asserts `symlink_target == "target.txt"` in parsed JSON
- [x] `test_list_json_long_regular_file_omits_link_fields` — negative: asserts `symlink_target` and `hardlink_target` keys are absent for regular file entries (pins `skip_serializing_if` contract)
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` — 899/899 pass
- [x] `cargo clippy ... -- -D warnings` — clean
- [x] `cargo +nightly fmt --all -- --check` — clean

Closes #346