### PR TITLE
fix(cli): --quiet no longer suppresses --json output (#357)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `exarch create --quiet --json` now emits JSON to stdout instead of
+  suppressing it. `--quiet` no longer silences `--json` output for any
+  command (#357).
 - `exarch list --json -l` now includes `symlink_target` and `hardlink_target` in
   the JSON output for symlink and hardlink entries. Previously the fields were
   populated in `exarch-core` but silently dropped by the CLI JSON formatter (#346).

--- a/crates/exarch-cli/src/commands/create.rs
+++ b/crates/exarch-cli/src/commands/create.rs
@@ -50,9 +50,180 @@ pub fn execute(args: &CreateArgs, formatter: &dyn OutputFormatter, quiet: bool) 
             .with_context(|| format!("Failed to create archive: {}", args.output.display()))?
     };
 
-    if !quiet {
-        formatter.format_creation_result(&args.output, &report)?;
-    }
+    formatter.format_creation_result(&args.output, &report)?;
 
     Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::output::OutputFormatter;
+    use anyhow::Result;
+    use exarch_core::ArchiveManifest;
+    use exarch_core::CreationReport;
+    use exarch_core::ExtractionReport;
+    use exarch_core::VerificationReport;
+    use std::cell::Cell;
+    use std::path::Path;
+    use std::path::PathBuf;
+
+    struct SpyFormatter {
+        called: Cell<bool>,
+        quiet: bool,
+    }
+
+    impl SpyFormatter {
+        fn new(quiet: bool) -> Self {
+            Self {
+                called: Cell::new(false),
+                quiet,
+            }
+        }
+
+        fn was_called(&self) -> bool {
+            self.called.get()
+        }
+    }
+
+    impl OutputFormatter for SpyFormatter {
+        fn format_extraction_result(&self, _: &ExtractionReport) -> Result<()> {
+            Ok(())
+        }
+
+        fn format_creation_result(&self, _: &Path, _: &CreationReport) -> Result<()> {
+            if !self.quiet {
+                self.called.set(true);
+            }
+            Ok(())
+        }
+
+        fn format_manifest_short(&self, _: &ArchiveManifest) -> Result<()> {
+            Ok(())
+        }
+
+        fn format_manifest_long(&self, _: &ArchiveManifest, _: bool) -> Result<()> {
+            Ok(())
+        }
+
+        fn format_verification_report(&self, _: &VerificationReport) -> Result<()> {
+            Ok(())
+        }
+
+        fn format_error(&self, _: &str, _: &anyhow::Error) {}
+    }
+
+    /// `JsonFormatter` always calls `format_creation_result` regardless of
+    /// quiet.
+    struct AlwaysCallSpyFormatter {
+        called: Cell<bool>,
+    }
+
+    impl AlwaysCallSpyFormatter {
+        fn new() -> Self {
+            Self {
+                called: Cell::new(false),
+            }
+        }
+
+        fn was_called(&self) -> bool {
+            self.called.get()
+        }
+    }
+
+    impl OutputFormatter for AlwaysCallSpyFormatter {
+        fn format_extraction_result(&self, _: &ExtractionReport) -> Result<()> {
+            Ok(())
+        }
+
+        fn format_creation_result(&self, _: &Path, _: &CreationReport) -> Result<()> {
+            self.called.set(true);
+            Ok(())
+        }
+
+        fn format_manifest_short(&self, _: &ArchiveManifest) -> Result<()> {
+            Ok(())
+        }
+
+        fn format_manifest_long(&self, _: &ArchiveManifest, _: bool) -> Result<()> {
+            Ok(())
+        }
+
+        fn format_verification_report(&self, _: &VerificationReport) -> Result<()> {
+            Ok(())
+        }
+
+        fn format_error(&self, _: &str, _: &anyhow::Error) {}
+    }
+
+    fn make_args(output: PathBuf, source: PathBuf) -> CreateArgs {
+        CreateArgs {
+            output,
+            sources: vec![source],
+            compression_level: None,
+            follow_symlinks: false,
+            include_hidden: false,
+            exclude: vec![],
+            strip_prefix: None,
+            max_file_size: None,
+            preserve_permissions: true,
+            force: false,
+        }
+    }
+
+    // Regression test for issue #357: JSON formatter must emit output even when
+    // quiet=true.
+    #[test]
+    fn json_formatter_emits_when_quiet() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("hello.txt");
+        std::fs::write(&src, b"hello").unwrap();
+        let out = tmp.path().join("out.tar.gz");
+
+        let args = make_args(out, src);
+        let formatter = AlwaysCallSpyFormatter::new();
+
+        execute(&args, &formatter, true).unwrap();
+
+        assert!(
+            formatter.was_called(),
+            "format_creation_result must be called even when quiet=true (JSON mode)"
+        );
+    }
+
+    #[test]
+    fn json_formatter_emits_when_not_quiet() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("hello.txt");
+        std::fs::write(&src, b"hello").unwrap();
+        let out = tmp.path().join("out.tar.gz");
+
+        let args = make_args(out, src);
+        let formatter = AlwaysCallSpyFormatter::new();
+
+        execute(&args, &formatter, false).unwrap();
+
+        assert!(formatter.was_called());
+    }
+
+    // Human formatter with quiet=true must suppress output — SpyFormatter mirrors
+    // HumanFormatter behavior.
+    #[test]
+    fn human_formatter_suppresses_when_quiet() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("hello.txt");
+        std::fs::write(&src, b"hello").unwrap();
+        let out = tmp.path().join("out.tar.gz");
+
+        let args = make_args(out, src);
+        let formatter = SpyFormatter::new(true);
+
+        execute(&args, &formatter, true).unwrap();
+
+        assert!(
+            !formatter.was_called(),
+            "human formatter must not produce output when quiet=true"
+        );
+    }
 }

--- a/crates/exarch-cli/tests/cli_tests.rs
+++ b/crates/exarch-cli/tests/cli_tests.rs
@@ -1322,12 +1322,12 @@ fn test_create_json_output_structure_complete() {
     assert!(json["data"]["compression_ratio"].is_number());
 }
 
+// Regression test for issue #357: --json must never be silenced by --quiet.
 #[test]
-fn test_create_quiet_with_json_produces_no_output() {
+fn test_create_quiet_with_json_still_produces_output() {
     let temp = TempDir::new().expect("failed to create temp dir");
     let archive = temp.path().join("test.tar.gz");
 
-    // --quiet takes precedence, even with --json
     let output = exarch_cmd()
         .arg("--quiet")
         .arg("--json")
@@ -1340,8 +1340,11 @@ fn test_create_quiet_with_json_produces_no_output() {
         .stdout
         .clone();
 
-    // In quiet mode, should have no output
-    assert!(output.is_empty());
+    let json: serde_json::Value =
+        serde_json::from_slice(&output).expect("--quiet --json must emit valid JSON");
+    assert_eq!(json["operation"], "create");
+    assert_eq!(json["status"], "success");
+    assert!(json["data"]["files_added"].is_number());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Remove `if !quiet` guard around `formatter.format_creation_result` in `create.rs` — `--quiet` was silently discarding JSON output for `create` while `extract`, `list`, and `verify` emitted JSON unconditionally.
- Policy: `--quiet` suppresses human output; `--json` always emits JSON regardless of `--quiet`. All four commands now follow the same pattern.
- Update existing integration test that expected empty stdout under `--quiet --json` to assert valid JSON. Add 3 unit tests with spy formatters.
- Add `[Unreleased]` CHANGELOG entry.

Closes #357.

## Test plan

- [ ] `cargo nextest run -p exarch-cli --all-features` — 163 tests pass
- [ ] `exarch --quiet --json create out.tar.gz file.txt` → JSON on stdout
- [ ] `exarch --quiet create out.tar.gz file.txt` → no stdout (HumanFormatter quiet behavior preserved)
- [ ] `exarch --quiet --json extract/list/verify` → JSON on stdout (unchanged behavior confirmed)

## Follow-up

- Add integration tests for `extract/list/verify --quiet --json` to guard the invariant cross-command (M2 from review — tracked separately).