### PR TITLE
refactor(core): centralize absolute-path stripping in SafePath (#347, #348)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Absolute entry paths (e.g. `/etc/shadow`) and Windows drive/UNC paths (e.g. `C:\...`,
+  `\\server\share\...`) are now stripped centrally in `SafePath::validate_with_context` when
+  `allow_absolute_paths` is enabled, instead of in each format handler separately. The three
+  per-format pre-stripping workarounds in `tar.rs`, `zip.rs`, and `sevenz.rs` have been
+  removed. Also fixes bare-slash entries (`/`) returning `io::Error` instead of
+  `PathTraversalError` (#347, #348).
 - `exarch create --quiet --json` now emits JSON to stdout instead of
   suppressing it. `--quiet` no longer silences `--json` output for any
   command (#357).

--- a/crates/exarch-core/src/formats/sevenz.rs
+++ b/crates/exarch-core/src/formats/sevenz.rs
@@ -439,11 +439,7 @@ impl<R: Read + Seek> SevenZArchive<R> {
                           reader: &mut dyn Read,
                           _dest_dir: &PathBuf|
          -> std::result::Result<bool, sevenz_rust2::Error> {
-            let entry_path = strip_absolute_entry_name(&entry.name, config)
-                .map_err(|e| {
-                    sevenz_rust2::Error::Other(format!("path validation failed: {e}").into())
-                })?
-                .into_owned();
+            let entry_path = std::path::PathBuf::from(&entry.name);
             ctx.current_idx = ctx.current_idx.saturating_add(1);
             let idx = ctx.current_idx;
             ctx.progress
@@ -552,7 +548,7 @@ impl<R: Read + Seek> ArchiveFormat for SevenZArchive<R> {
         // - symlink detection: Not exposed, non-directory entries treated as files
         let mut prevalidator = EntryValidator::new(config, &dest);
         for entry in &self.entries {
-            let path = strip_absolute_entry_name(&entry.name, config)?;
+            let path = std::path::PathBuf::from(&entry.name);
             let entry_type = if entry.is_directory {
                 EntryType::Directory
             } else {
@@ -751,39 +747,6 @@ fn is_empty_sevenz_archive<R: Read + Seek>(err: &sevenz_rust2::Error, source: &m
     };
     let mut magic = [0u8; 6];
     source.read_exact(&mut magic).is_ok() && magic == SEVENZ_MAGIC
-}
-
-/// Strips the leading `/` from absolute entry names when `allow_absolute_paths`
-/// is enabled, preventing `PathBuf::join` from discarding the destination
-/// prefix.
-///
-/// Returns a `Cow<Path>`: borrowed when the name is already relative, owned
-/// when the leading slash is stripped. Returns `PathTraversal` if the stripped
-/// name is empty or still contains a `..` component.
-fn strip_absolute_entry_name<'a>(
-    name: &'a str,
-    config: &SecurityConfig,
-) -> Result<std::borrow::Cow<'a, Path>> {
-    let raw = Path::new(name);
-    if name.starts_with('/') && config.allowed.absolute_paths {
-        let stripped = name.trim_start_matches('/');
-        if stripped.is_empty() {
-            return Err(ArchiveError::PathTraversal {
-                path: raw.to_path_buf(),
-            });
-        }
-        let p = PathBuf::from(stripped);
-        if p.components()
-            .any(|c| matches!(c, std::path::Component::ParentDir))
-        {
-            return Err(ArchiveError::PathTraversal {
-                path: raw.to_path_buf(),
-            });
-        }
-        Ok(std::borrow::Cow::Owned(p))
-    } else {
-        Ok(std::borrow::Cow::Borrowed(raw))
-    }
 }
 
 /// Converts sevenz-rust2 errors to our `ArchiveError` type.
@@ -1539,49 +1502,6 @@ mod tests {
                 .unwrap();
         }
         writer.finish().unwrap().into_inner()
-    }
-
-    #[test]
-    fn test_strip_absolute_entry_name_relative_passthrough() {
-        let config = SecurityConfig::default();
-        let result = strip_absolute_entry_name("relative/path.txt", &config).unwrap();
-        assert_eq!(result.as_ref(), std::path::Path::new("relative/path.txt"));
-    }
-
-    #[test]
-    fn test_strip_absolute_entry_name_absolute_with_flag() {
-        let config = SecurityConfig::default().with_allow_absolute_paths(true);
-        let result = strip_absolute_entry_name("/etc/shadow", &config).unwrap();
-        assert_eq!(result.as_ref(), std::path::Path::new("etc/shadow"));
-    }
-
-    #[test]
-    fn test_strip_absolute_entry_name_absolute_without_flag() {
-        // Without the flag, absolute paths are passed through unchanged so that
-        // SafePath::validate can apply its own rejection logic.
-        let config = SecurityConfig::default();
-        let result = strip_absolute_entry_name("/etc/shadow", &config).unwrap();
-        assert_eq!(result.as_ref(), std::path::Path::new("/etc/shadow"));
-    }
-
-    #[test]
-    fn test_strip_absolute_entry_name_bare_slash_rejected() {
-        let config = SecurityConfig::default().with_allow_absolute_paths(true);
-        let result = strip_absolute_entry_name("/", &config);
-        assert!(
-            matches!(result, Err(ArchiveError::PathTraversal { .. })),
-            "bare slash must be rejected"
-        );
-    }
-
-    #[test]
-    fn test_strip_absolute_entry_name_traversal_after_root_rejected() {
-        let config = SecurityConfig::default().with_allow_absolute_paths(true);
-        let result = strip_absolute_entry_name("/../etc/passwd", &config);
-        assert!(
-            matches!(result, Err(ArchiveError::PathTraversal { .. })),
-            "traversal after root must be rejected"
-        );
     }
 
     #[test]

--- a/crates/exarch-core/src/formats/tar.rs
+++ b/crates/exarch-core/src/formats/tar.rs
@@ -207,31 +207,10 @@ impl<R: Read> TarArchive<R> {
             return Ok(None);
         }
 
-        let raw_path = entry
+        let path = entry
             .path()
             .map_err(|e| ArchiveError::InvalidArchive(format!("invalid path: {e}")))?
             .into_owned();
-
-        let path = if raw_path.to_str().is_some_and(|s| s.starts_with('/'))
-            && ctx.config.allowed.absolute_paths
-        {
-            let stripped = raw_path
-                .to_str()
-                .map(|s| s.trim_start_matches('/'))
-                .unwrap_or_default();
-            if stripped.is_empty() {
-                return Err(ArchiveError::PathTraversal { path: raw_path });
-            }
-            let p = std::path::PathBuf::from(stripped);
-            if p.components()
-                .any(|c| matches!(c, std::path::Component::ParentDir))
-            {
-                return Err(ArchiveError::PathTraversal { path: raw_path });
-            }
-            p
-        } else {
-            raw_path
-        };
 
         let entry_type = TarEntryAdapter::to_entry_type(&entry)?;
         let size = TarEntryAdapter::get_uncompressed_size(&entry);

--- a/crates/exarch-core/src/formats/zip.rs
+++ b/crates/exarch-core/src/formats/zip.rs
@@ -286,25 +286,7 @@ impl<R: Read + Seek> ZipArchive<R> {
             .into_owned();
         let path = match zip_file.enclosed_name() {
             Some(p) => p,
-            None if config.allowed.absolute_paths => {
-                let stripped = raw_name.trim_start_matches('/');
-                if stripped.is_empty() {
-                    return Err(ArchiveError::PathTraversal {
-                        path: PathBuf::from(&raw_name),
-                    });
-                }
-                let p = PathBuf::from(stripped);
-                // SafePath::validate will enforce the remaining security checks;
-                // we only need to pre-reject clear traversal here.
-                if p.components()
-                    .any(|c| matches!(c, std::path::Component::ParentDir))
-                {
-                    return Err(ArchiveError::PathTraversal {
-                        path: PathBuf::from(&raw_name),
-                    });
-                }
-                p
-            }
+            None if config.allowed.absolute_paths => PathBuf::from(&raw_name),
             None => {
                 return Err(ArchiveError::PathTraversal {
                     path: PathBuf::from(&raw_name),

--- a/crates/exarch-core/src/types/safe_path.rs
+++ b/crates/exarch-core/src/types/safe_path.rs
@@ -188,9 +188,19 @@ impl SafePath {
                             path: path.to_path_buf(),
                         });
                     }
-                    normalized.push(component);
+                    // Skip root/prefix so final_path stays relative; dest.join()
+                    // would otherwise discard dest entirely for absolute paths.
+                    needs_normalization = true;
                 }
             }
+        }
+
+        // Bare absolute paths like `/` or `C:\` produce an empty normalized
+        // path after stripping the root/prefix component. Reject them.
+        if needs_normalization && normalized.as_os_str().is_empty() && depth == 0 {
+            return Err(ArchiveError::PathTraversal {
+                path: path.to_path_buf(),
+            });
         }
 
         // Check path depth
@@ -434,12 +444,29 @@ mod tests {
         let mut config = SecurityConfig::default();
         config.allowed.absolute_paths = true;
 
-        // Create a temporary file to test with
-        let test_file = dest.as_path().join("test.txt");
-        std::fs::write(&test_file, "test").expect("failed to write test file");
+        // Verify that an external absolute path is stripped to a relative path
+        // so dest.join() resolves inside dest, not at the original absolute location.
+        let result = SafePath::validate(Path::new("/some/external/path"), &dest, &config);
+        assert!(
+            result.is_ok(),
+            "absolute path with flag should succeed: {result:?}"
+        );
+        let safe = result.expect("safe");
+        assert_eq!(safe.as_path(), Path::new("some/external/path"));
+    }
 
-        let result = SafePath::validate(&test_file, &dest, &config);
-        assert!(result.is_ok());
+    #[test]
+    #[cfg(unix)]
+    fn test_safe_path_bare_slash_rejected_when_absolute_allowed() {
+        let (_temp, dest) = create_test_dest();
+        let mut config = SecurityConfig::default();
+        config.allowed.absolute_paths = true;
+
+        let result = SafePath::validate(Path::new("/"), &dest, &config);
+        assert!(
+            matches!(result, Err(ArchiveError::PathTraversal { .. })),
+            "bare '/' must be rejected as PathTraversal even with allow_absolute_paths"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Moves the leading-root stripping logic from three per-format workarounds (`tar.rs`, `zip.rs`, `sevenz.rs`) into `SafePath::validate_with_context`
- `Component::RootDir` and `Component::Prefix(_)` are now skipped (not pushed to `normalized`) when `allow_absolute_paths=true`, keeping `final_path` relative so `dest.join(final_path)` resolves inside `dest`
- Windows drive/UNC prefixes (`C:\`, `\\server\share`) are handled by the same `Prefix(_)` arm, fixing #347
- A bare-slash guard (`final_path.is_empty() + depth==0`) preserves the previous `PathTraversal` error for entries that are nothing but a root dir

## Changes

| File | Change |
|------|--------|
| `exarch-core/src/types/safe_path.rs` | Centralized stripping + bare-slash guard + 2 new tests |
| `exarch-core/src/formats/tar.rs` | Removed 18-line pre-stripping block from `process_entry` |
| `exarch-core/src/formats/zip.rs` | Removed manual-stripping `None` arm from `process_entry` |
| `exarch-core/src/formats/sevenz.rs` | Removed `strip_absolute_entry_name` helper and call sites |
| `CHANGELOG.md` | Added `[Unreleased]` entry |

## Test plan

- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` — 911/911 pass
- [x] `cargo test --doc --workspace --all-features --exclude exarch-python --exclude exarch-node` — 98/98 pass
- [x] `cargo +nightly fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `test_safe_path_allow_absolute_when_configured` reworked to actually verify dest-containment
- [x] `test_safe_path_bare_slash_rejected_when_absolute_allowed` added for bare-slash guard

Closes #347, closes #348