### PR TITLE
fix(python): rename allow_* builder methods to with_allow_* prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `exarch create --quiet --json` now emits JSON to stdout instead of
   suppressing it. `--quiet` no longer silences `--json` output for any
   command (#357).
+- Node.js `SecurityConfig` JSDoc table now lists all 7 default `banned_path_components`
+  (`.git`, `.ssh`, `.gnupg`, `.aws`, `.kube`, `.docker`, `.env`); previously only `.git` and
+  `.ssh` were shown, which could mislead users into thinking the remaining five needed to be
+  added manually (#355).
 - `exarch list --json -l` now includes `symlink_target` and `hardlink_target` in
   the JSON output for symlink and hardlink entries. Previously the fields were
   populated in `exarch-core` but silently dropped by the CLI JSON formatter (#346).
@@ -35,6 +39,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now assert extracted file contents match the original source bytes (#335).
 
 ### Breaking Changes
+
+- **Python `SecurityConfig` builder methods** `allow_symlinks`, `allow_hardlinks`,
+  `allow_absolute_paths`, `allow_world_writable`, and `allow_solid_archives` have been renamed
+  to `with_allow_symlinks`, `with_allow_hardlinks`, `with_allow_absolute_paths`,
+  `with_allow_world_writable`, and `with_allow_solid_archives` to match the `with_` prefix
+  convention used by all other builder methods in the class. Update call sites by prepending
+  `with_` to each method name (#354).
 
 - **`ArchiveCreator::compression_level`** now returns `Result<Self, ArchiveError>` instead of
   `Self`. Call sites must propagate the error with `?` or handle it explicitly; passing an

--- a/crates/exarch-node/src/config.rs
+++ b/crates/exarch-node/src/config.rs
@@ -30,7 +30,7 @@ const MAX_COMPONENT_LENGTH: usize = 255;
 /// | `allow_world_writable` | false |
 /// | `preserve_permissions` | false |
 /// | `allowed_extensions` | empty (all allowed) |
-/// | `banned_path_components` | `.git`, `.ssh` |
+/// | `banned_path_components` | `.git`, `.ssh`, `.gnupg`, `.aws`, `.kube`, `.docker`, `.env` |
 #[napi]
 #[derive(Debug, Clone)]
 pub struct SecurityConfig {

--- a/crates/exarch-python/README.md
+++ b/crates/exarch-python/README.md
@@ -181,13 +181,14 @@ Builder-style security configuration.
 
 ```python
 config = exarch.SecurityConfig()
-config = config.max_file_size(100 * 1024 * 1024)        # 100 MB per file
-config = config.max_total_size(1024 * 1024 * 1024)      # 1 GB total
-config = config.max_file_count(10_000)                   # Max 10k files
-config = config.max_compression_ratio(50.0)              # Zip bomb threshold
-config = config.allowed_extensions([".txt", ".md"])      # Extension allowlist
-config = config.banned_path_components(["__MACOSX"])     # Skip components
-config = config.allow_solid_archives(True)               # Allow solid 7z archives
+config = config.with_max_file_size(100 * 1024 * 1024)   # 100 MB per file
+config = config.with_max_total_size(1024 * 1024 * 1024) # 1 GB total
+config = config.with_max_file_count(10_000)              # Max 10k files
+config = config.with_max_compression_ratio(50.0)        # Zip bomb threshold
+config = config.add_allowed_extension(".txt")            # Extension allowlist
+config = config.add_allowed_extension(".md")
+config = config.add_banned_component("__MACOSX")         # Skip components
+config = config.with_allow_solid_archives(True)          # Allow solid 7z archives
 ```
 
 ## Security Features

--- a/crates/exarch-python/exarch.pyi
+++ b/crates/exarch-python/exarch.pyi
@@ -57,23 +57,23 @@ class SecurityConfig:
         """Sets the maximum path depth."""
         ...
 
-    def allow_symlinks(self, allow: bool = True) -> SecurityConfig:
+    def with_allow_symlinks(self, allow: bool = True) -> SecurityConfig:
         """Allows or denies symlinks."""
         ...
 
-    def allow_hardlinks(self, allow: bool = True) -> SecurityConfig:
+    def with_allow_hardlinks(self, allow: bool = True) -> SecurityConfig:
         """Allows or denies hardlinks."""
         ...
 
-    def allow_absolute_paths(self, allow: bool = True) -> SecurityConfig:
+    def with_allow_absolute_paths(self, allow: bool = True) -> SecurityConfig:
         """Allows or denies absolute paths."""
         ...
 
-    def allow_world_writable(self, allow: bool = True) -> SecurityConfig:
+    def with_allow_world_writable(self, allow: bool = True) -> SecurityConfig:
         """Allows or denies world-writable files."""
         ...
 
-    def allow_solid_archives(self, allow: bool = True) -> SecurityConfig:
+    def with_allow_solid_archives(self, allow: bool = True) -> SecurityConfig:
         """Allows or denies solid 7z archives."""
         ...
 
@@ -81,7 +81,7 @@ class SecurityConfig:
         """
         Sets the maximum memory budget in bytes for decompressing a solid 7z block.
 
-        Only enforced when ``allow_solid_archives`` is ``True``. Raises
+        Only enforced when ``with_allow_solid_archives`` is called with ``True``. Raises
         ``ValueError`` if *size* is zero.
         """
         ...

--- a/crates/exarch-python/src/config.rs
+++ b/crates/exarch-python/src/config.rs
@@ -40,7 +40,7 @@ const MAX_COMPONENT_LENGTH: usize = 255;
 /// # Customize with builder pattern
 /// config = (SecurityConfig()
 ///     .with_max_file_size(100 * 1024 * 1024)
-///     .allow_symlinks(True))
+///     .with_allow_symlinks(True))
 ///
 /// # Use permissive configuration for trusted archives
 /// config = SecurityConfig.permissive()
@@ -126,28 +126,28 @@ impl PySecurityConfig {
 
     /// Allows or denies symlinks.
     #[pyo3(signature = (allow=true))]
-    fn allow_symlinks(mut slf: PyRefMut<'_, Self>, allow: bool) -> PyRefMut<'_, Self> {
+    fn with_allow_symlinks(mut slf: PyRefMut<'_, Self>, allow: bool) -> PyRefMut<'_, Self> {
         slf.inner.allowed.symlinks = allow;
         slf
     }
 
     /// Allows or denies hardlinks.
     #[pyo3(signature = (allow=true))]
-    fn allow_hardlinks(mut slf: PyRefMut<'_, Self>, allow: bool) -> PyRefMut<'_, Self> {
+    fn with_allow_hardlinks(mut slf: PyRefMut<'_, Self>, allow: bool) -> PyRefMut<'_, Self> {
         slf.inner.allowed.hardlinks = allow;
         slf
     }
 
     /// Allows or denies absolute paths.
     #[pyo3(signature = (allow=true))]
-    fn allow_absolute_paths(mut slf: PyRefMut<'_, Self>, allow: bool) -> PyRefMut<'_, Self> {
+    fn with_allow_absolute_paths(mut slf: PyRefMut<'_, Self>, allow: bool) -> PyRefMut<'_, Self> {
         slf.inner.allowed.absolute_paths = allow;
         slf
     }
 
     /// Allows or denies world-writable files.
     #[pyo3(signature = (allow=true))]
-    fn allow_world_writable(mut slf: PyRefMut<'_, Self>, allow: bool) -> PyRefMut<'_, Self> {
+    fn with_allow_world_writable(mut slf: PyRefMut<'_, Self>, allow: bool) -> PyRefMut<'_, Self> {
         slf.inner.allowed.world_writable = allow;
         slf
     }
@@ -158,7 +158,7 @@ impl PySecurityConfig {
     /// entry, which may allow a crafted archive to consume excessive
     /// memory. Disabled by default.
     #[pyo3(signature = (allow=true))]
-    fn allow_solid_archives(mut slf: PyRefMut<'_, Self>, allow: bool) -> PyRefMut<'_, Self> {
+    fn with_allow_solid_archives(mut slf: PyRefMut<'_, Self>, allow: bool) -> PyRefMut<'_, Self> {
         slf.inner.allow_solid_archives = allow;
         slf
     }

--- a/crates/exarch-python/tests/test_cve_regression.py
+++ b/crates/exarch-python/tests/test_cve_regression.py
@@ -47,7 +47,7 @@ def test_cve_symlink_escape(malicious_symlink_escape, temp_dir):
     # Test that even with symlinks enabled, escape is detected
     output_dir2 = temp_dir / "output2"
     output_dir2.mkdir()
-    config = exarch.SecurityConfig().allow_symlinks(True)
+    config = exarch.SecurityConfig().with_allow_symlinks(True)
 
     with pytest.raises(exarch.SymlinkEscapeError):
         exarch.extract_archive(malicious_symlink_escape, output_dir2, config)
@@ -100,7 +100,7 @@ def test_symlink_allowed_within_directory(temp_dir):
     output_dir.mkdir()
 
     # Allow symlinks within extraction directory
-    config = exarch.SecurityConfig().allow_symlinks(True)
+    config = exarch.SecurityConfig().with_allow_symlinks(True)
 
     report = exarch.extract_archive(archive_path, output_dir, config)
 
@@ -184,7 +184,7 @@ def test_hardlink_escape(malicious_hardlink_escape, temp_dir):
     output_dir2 = temp_dir / "output2"
     output_dir2.mkdir()
 
-    config = exarch.SecurityConfig().allow_hardlinks(True)
+    config = exarch.SecurityConfig().with_allow_hardlinks(True)
     with pytest.raises(exarch.HardlinkEscapeError):
         exarch.extract_archive(malicious_hardlink_escape, output_dir2, config)
 
@@ -229,7 +229,7 @@ def test_partial_extraction_preserves_symlink_escape_type(temp_dir):
 
     output_dir = temp_dir / "out"
     output_dir.mkdir()
-    config = exarch.SecurityConfig().allow_symlinks(True).allow_hardlinks(False)
+    config = exarch.SecurityConfig().with_allow_symlinks(True).with_allow_hardlinks(False)
 
     with pytest.raises(exarch.SymlinkEscapeError) as exc_info:
         exarch.extract_archive(archive, output_dir, config)
@@ -255,7 +255,7 @@ def test_partial_extraction_preserves_hardlink_escape_type(temp_dir):
 
     output_dir = temp_dir / "out"
     output_dir.mkdir()
-    config = exarch.SecurityConfig().allow_hardlinks(True)
+    config = exarch.SecurityConfig().with_allow_hardlinks(True)
 
     with pytest.raises(exarch.HardlinkEscapeError) as exc_info:
         exarch.extract_archive(archive, output_dir, config)

--- a/crates/exarch-python/tests/test_security_config.py
+++ b/crates/exarch-python/tests/test_security_config.py
@@ -24,7 +24,7 @@ class TestSecurityConfig:
         # config = (SecurityConfig()
         #     .with_max_file_size(100_000_000)
         #     .with_max_total_size(1_000_000_000)
-        #     .allow_symlinks(True))
+        #     .with_allow_symlinks(True))
         # assert config.max_file_size == 100_000_000
         # assert config.max_total_size == 1_000_000_000
 


### PR DESCRIPTION
## Summary

- Rename 5 `PySecurityConfig` builder methods in `exarch-python` to use the `with_` prefix already established by all other methods in the class (`allow_symlinks` → `with_allow_symlinks`, etc.), closing the naming inconsistency reported in #354
- Update all call sites: `tests/test_cve_regression.py`, `exarch.pyi` type stubs, `README.md` builder example
- Fix `exarch-node` JSDoc table so `banned_path_components` lists all 7 default components instead of the incomplete 2-item list from #355

## Breaking Change

Python users of `SecurityConfig` must rename calls to the affected methods:

| Old | New |
|-----|-----|
| `allow_symlinks(v)` | `with_allow_symlinks(v)` |
| `allow_hardlinks(v)` | `with_allow_hardlinks(v)` |
| `allow_absolute_paths(v)` | `with_allow_absolute_paths(v)` |
| `with_world_writable(v)` | `with_allow_world_writable(v)` |
| `allow_solid_archives(v)` | `with_allow_solid_archives(v)` |

Per project policy this breaking rename is intentional before v1.0.0.

## Test plan

- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` — 912/912 pass
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo +nightly fmt --all` — clean
- [x] No old `allow_*` method names remain in Python crate (verified by grep)
- [x] `exarch.pyi` stubs match runtime method names
- [x] Node JSDoc `banned_path_components` row matches `exarch-core` `Default` impl exactly (7 components)

Closes #354
Closes #355