### PR TITLE
release: v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-06-05
+
 ### Added
 
 - `detect_format` now falls back to magic-byte inspection when the file extension
@@ -77,8 +79,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   out-of-range level (0 or >9) now returns `ArchiveError::InvalidCompressionLevel` instead of
   silently clamping or panicking (#308).
 
-### Added
-
 - `extract` command now exposes three previously hidden `SecurityConfig` fields as CLI flags:
   `--max-path-depth <N>` (default 32), `--banned-component <COMPONENT>` (repeatable; replaces
   the default ban list when provided), and `--allow-absolute-paths` (flag). Operators can now
@@ -106,8 +106,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added integration tests for `ExtractionOptions::skip_duplicates`: covers `skip_duplicates=true` (first entry kept, duplicate skipped with warning) and `skip_duplicates=false` (second entry overwrites first) for TAR archives. Documents that the `zip` crate 8.x deduplicates entries at parse time, making the flag a no-op for ZIP (#302).
 - Added 7z integration tests for `skip_duplicates`: `skip_duplicates=true` keeps the first
   entry and records a warning; `skip_duplicates=false` overwrites with the last entry (#314).
-
-### Fixed
 
 - Python: `exarch.pyi` `SecurityConfig` and `CreationConfig` builder methods
   (`max_file_size`, `max_total_size`, `max_compression_ratio`, `max_file_count`,
@@ -202,8 +200,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   matching the post-#255 Rust API. Python exception hierarchy updated to include
   `UnknownFormatError(UnsupportedFormatError)` (#265, #264).
 
-### Changed
-
 - `creation/tar`: replace manual entry counter with `ProgressTracker`; add `ProgressTracker::callback()` accessor to enable byte-level progress in nested helpers without lifetime conflicts (#284).
 - `creation/zip`: same `ProgressTracker` wiring as tar, removing manual `idx + 1` counter (#284).
 - `creation/zip`: `create_zip_internal` now delegates to `create_zip_internal_with_progress` via `NoopProgress`, eliminating ~167 lines of duplicate traversal, compression-option, and file-add logic (#290).
@@ -225,8 +221,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   documenting that `ValidatedEntryType::Hardlink` is unreachable for any real ZIP entry (#272).
 - Removed `test_debug_zip_unix_mode` debug test that was permanently ignored.
 
-### Breaking Changes
-
 - **`ExtractionError::UnsupportedFormat`** has been removed. All format-detection failures now
   return `ExtractionError::UnknownFormat { path }`, which carries the path that could not be
   identified. Match arms on `UnsupportedFormat` must be updated to `UnknownFormat { .. }` (#255).
@@ -244,8 +238,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ExtractionError` as the catch-all. To detect whether output was partial, use
   `getattr(e, "files_extracted", None) is not None` (#251).
 
-### Added
-
 - Node.js: `SecurityConfig` now exposes `allowSolidArchives` getter, consistent with all other
   boolean permission getters (`allowSymlinks`, `allowHardlinks`, `allowAbsolutePaths`,
   `allowWorldWritable`) (#261).
@@ -260,8 +252,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Node.js: `extractArchiveWithProgress(archivePath, outputDir, config?, progress?)` async binding
   added, accepting an optional `ThreadsafeFunction` progress callback with signature
   `(path: string, total: bigint, current: bigint, bytesWritten: bigint) => void` (#263).
-
-### Fixed
 
 - CLI: `convert_extraction_error` now has explicit match arms for `InvalidConfiguration`,
   `SourceNotFound`, and `SourceNotAccessible`, each producing an actionable message with the
@@ -714,7 +704,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 64KB reusable copy buffers
 - LRU cache for symlink target resolution
 
-[Unreleased]: https://github.com/bug-ops/exarch/compare/v0.4.1...HEAD
+[Unreleased]: https://github.com/bug-ops/exarch/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/bug-ops/exarch/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/bug-ops/exarch/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/bug-ops/exarch/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/bug-ops/exarch/compare/v0.3.0...v0.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   out-of-range level (0 or >9) now returns `ArchiveError::InvalidCompressionLevel` instead of
   silently clamping or panicking (#308).
 
+### Added
+
 - `extract` command now exposes three previously hidden `SecurityConfig` fields as CLI flags:
   `--max-path-depth <N>` (default 32), `--banned-component <COMPONENT>` (repeatable; replaces
   the default ban list when provided), and `--allow-absolute-paths` (flag). Operators can now
@@ -106,6 +108,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added integration tests for `ExtractionOptions::skip_duplicates`: covers `skip_duplicates=true` (first entry kept, duplicate skipped with warning) and `skip_duplicates=false` (second entry overwrites first) for TAR archives. Documents that the `zip` crate 8.x deduplicates entries at parse time, making the flag a no-op for ZIP (#302).
 - Added 7z integration tests for `skip_duplicates`: `skip_duplicates=true` keeps the first
   entry and records a warning; `skip_duplicates=false` overwrites with the last entry (#314).
+
+### Fixed
 
 - Python: `exarch.pyi` `SecurityConfig` and `CreationConfig` builder methods
   (`max_file_size`, `max_total_size`, `max_compression_ratio`, `max_file_count`,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "exarch-cli"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -564,7 +564,7 @@ dependencies = [
 
 [[package]]
 name = "exarch-core"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "bzip2",
  "criterion",
@@ -587,7 +587,7 @@ dependencies = [
 
 [[package]]
 name = "exarch-node"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "exarch-core",
  "napi",
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "exarch-python"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "exarch-core",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.1"
+version = "0.5.0"
 authors = ["bug-ops"]
 edition = "2024"
 rust-version = "1.93.0"
@@ -19,7 +19,7 @@ keywords = ["archive", "extraction", "security", "tar", "zip"]
 categories = ["compression", "filesystem"]
 
 [workspace.dependencies]
-exarch-core = { path = "crates/exarch-core", version = "0.4.1" }
+exarch-core = { path = "crates/exarch-core", version = "0.5.0" }
 anyhow = "1.0"
 assert_cmd = "2.2"
 bzip2 = "0.6"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Memory-safe archive extraction and creation library with Python and Node.js bind
 
 ```toml
 [dependencies]
-exarch-core = "0.4"
+exarch-core = "0.5"
 ```
 
 > [!IMPORTANT]

--- a/crates/exarch-cli/README.md
+++ b/crates/exarch-cli/README.md
@@ -128,6 +128,9 @@ exarch extract --allow-symlinks trusted-source.tar
 | `--max-file-size` | - | Maximum single file size |
 | `--max-compression-ratio` | 100 | Maximum compression ratio (zip bomb protection) |
 | `--allowed-extensions` | — | Extract only entries whose extension is in the allowlist (repeatable; comma-separated values accepted; leading dots optional) |
+| `--max-path-depth` | 32 | Maximum path depth for extracted entries |
+| `--banned-component` | — | Banned path component (repeatable; replaces the default ban list when provided) |
+| `--allow-absolute-paths` | false | Allow entries with absolute paths (stripped to relative on extraction) |
 | `--allow-symlinks` | false | Allow symlinks (within extraction directory) |
 | `--allow-hardlinks` | false | Allow hardlinks (within extraction directory) |
 | `--preserve-permissions` | false | Preserve file permissions from archive |
@@ -175,6 +178,8 @@ exarch create -f backup.tar.gz ./src
 | `--include-hidden` | | Include hidden files |
 | `--exclude` | `-x` | Exclude pattern (repeatable) |
 | `--strip-prefix` | | Strip path prefix |
+| `--max-file-size` | — | Skip source files larger than this threshold (supports K/M/G/T suffixes) |
+| `--preserve-permissions` | true | Store Unix permissions in the archive; pass `--preserve-permissions=false` for a portable archive |
 | `--force` | `-f` | Overwrite existing file |
 | `--quiet` | `-q` | Suppress output |
 | `--json` | | Output JSON format |

--- a/crates/exarch-core/README.md
+++ b/crates/exarch-core/README.md
@@ -14,7 +14,7 @@ This crate is part of the [exarch](https://github.com/bug-ops/exarch) workspace.
 
 ```toml
 [dependencies]
-exarch-core = "0.4"
+exarch-core = "0.5"
 ```
 
 > [!IMPORTANT]
@@ -64,9 +64,6 @@ let report = ArchiveBuilder::new()
     .output_dir("/output/path")
     .extract()?;
 ```
-
-> [!WARNING]
-> **Breaking change in v0.4.0:** `Archive::open` now returns `Self` directly instead of `Result<Self>`. Drop the `?` or `.unwrap()` at call sites; I/O errors now surface on `extract()` instead.
 
 ## Security Features
 

--- a/crates/exarch-node/README.md
+++ b/crates/exarch-node/README.md
@@ -235,8 +235,6 @@ The library provides built-in protection against:
 
 **Note:** 7z creation is not yet supported. Solid and encrypted 7z archives are rejected for security reasons. Unix symlinks inside 7z archives are reported as regular files (sevenz-rust2 API limitation).
 
-**Note:** Since v0.4.0, partial extraction failures return the `ExtractionReport` accumulated up to the failure point without the inner error text being duplicated, and the report is now correctly delivered across the FFI boundary instead of being dropped early.
-
 ## Comparison with tar-fs
 
 ```javascript

--- a/crates/exarch-node/package.json
+++ b/crates/exarch-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exarch-rs",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Memory-safe archive extraction library with built-in security validation",
   "main": "index.js",
   "types": "index.d.ts",

--- a/crates/exarch-python/README.md
+++ b/crates/exarch-python/README.md
@@ -85,7 +85,7 @@ result = exarch.extract_archive(archive, output)
 import exarch
 
 config = exarch.SecurityConfig()
-config = config.max_file_size(100 * 1024 * 1024)  # 100 MB
+config = config.with_max_file_size(100 * 1024 * 1024)  # 100 MB
 
 result = exarch.extract_archive("archive.tar.gz", "/output", config)
 ```

--- a/crates/exarch-python/pyproject.toml
+++ b/crates/exarch-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exarch"
-version = "0.4.1"
+version = "0.5.0"
 description = "Memory-safe archive extraction library with built-in security validation"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -22,11 +22,11 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Rust",
     "Topic :: Security",
@@ -59,7 +59,7 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 strict = true
 disallow_untyped_defs = true
 

--- a/specs/001-security-pipeline/spec.md
+++ b/specs/001-security-pipeline/spec.md
@@ -176,6 +176,23 @@ THEN the written file has those bits cleared; ValidatedEntry.mode reflects the s
 | `HardlinkTracker` | Records all file paths seen in this archive to validate hardlink targets | `seen: HashSet<PathBuf>` |
 | `DestDir` | Canonicalized output directory; used as the trust boundary for symlink/hardlink validation | Wraps `PathBuf` |
 
+> [!note] v0.4.1 API changes
+> `sanitize_permissions` return type changed from `Result<u32>` to `u32` — the function
+> never fails; callers no longer need `?` or `.unwrap()`.
+> The `_path: &Path` parameter previously accepted by `sanitize_permissions` has been
+> removed; call sites must omit that argument.
+> All security primitives (`validate_path`, `validate_symlink`, `sanitize_permissions`,
+> `validate_compression_ratio`, `QuotaTracker`, `HardlinkTracker`) are now `pub(crate)`;
+> external benchmarks or integration tests that reference them directly must add
+> `--features testing`.
+
+> [!note] v0.5.0: centralized absolute-path stripping
+> Absolute entry paths and Windows drive/UNC paths (e.g. `C:\...`, `\\server\share\...`) are
+> now stripped centrally inside `SafePath::validate_with_context` when `allow_absolute_paths`
+> is enabled. The per-format pre-stripping workarounds that previously existed in `tar.rs`,
+> `zip.rs`, and `sevenz.rs` have been removed. Bare-slash entries (`/`) now return
+> `PathTraversalError` instead of `io::Error`.
+
 ## 6. Edge Cases and Error Handling
 
 | Scenario | Expected Behavior |

--- a/specs/002-format-handlers/spec.md
+++ b/specs/002-format-handlers/spec.md
@@ -48,7 +48,6 @@ using both file extension and a fixed set of ZIP-family aliases.
 - Archive encryption or signing
 - 7z archive creation (extraction only — `FormatCreator` not implemented for 7z)
 - Streaming/incremental extraction over network (local files only)
-- Magic byte detection (format is determined from extension only)
 
 ## 2. User Stories
 
@@ -128,14 +127,26 @@ THEN extraction fails before decompressing the solid block
 ### US-006: Format Detection
 
 AS A developer
-I WANT the correct handler selected automatically from the archive extension
-SO THAT I do not need to specify the format explicitly
+I WANT the correct handler selected automatically from the archive path
+SO THAT I do not need to specify the format explicitly, even for files with missing or ambiguous extensions
 
 **Acceptance criteria:**
 ```
 GIVEN an archive path with an unrecognized extension
 WHEN any archive operation is called
 THEN ArchiveError::UnknownFormat { path } is returned immediately
+```
+
+```
+GIVEN an archive whose extension is absent, unrecognized, or contradicts the file content
+WHEN any archive operation is called
+THEN detect_format falls back to magic-byte inspection and selects the correct handler
+```
+
+```
+GIVEN an archive where magic bytes and extension disagree
+WHEN any archive operation is called
+THEN magic bytes take precedence over the extension
 ```
 
 ## 3. Functional Requirements
@@ -145,7 +156,7 @@ THEN ArchiveError::UnknownFormat { path } is returned immediately
 | FR-020 | WHEN an archive path has extension `.tar`, `.tgz`, `.tar.gz`, `.tar.bz2`, `.tbz`, `.tbz2`, `.tar.xz`, `.txz`, `.tar.zst`, `.tzst`, THE SYSTEM SHALL extract it as a TAR archive with the appropriate decompressor | must |
 | FR-021 | WHEN an archive path has extension `.zip` or any ZIP-family alias, THE SYSTEM SHALL extract it as a ZIP archive | must |
 | FR-022 | WHEN an archive path has extension `.7z`, THE SYSTEM SHALL extract it using the 7z handler | must |
-| FR-023 | WHEN format detection finds an unrecognized or ambiguous extension (e.g. bare `.gz` without `.tar` stem), THE SYSTEM SHALL return `ArchiveError::UnknownFormat { path }` | must |
+| FR-023 | WHEN format detection cannot identify an archive via extension, THE SYSTEM SHALL fall back to magic-byte inspection (ZIP local-file header / EOCD, GZIP, BZ2, XZ, Zstd, 7z, TAR USTAR); when magic bytes and extension disagree, magic takes precedence; if neither resolves a format, THE SYSTEM SHALL return `ArchiveError::UnknownFormat { path }` | must |
 | FR-024 | WHEN creating archives, THE SYSTEM SHALL support TAR (all compression variants) and ZIP; 7z creation SHALL return `InvalidConfiguration` | must |
 | FR-025 | WHEN creating archives for ZIP-family aliases without an explicit `CreationConfig::format` override, THE SYSTEM SHALL return `ArchiveError::InvalidArchive` with an explanation | should |
 | FR-026 | WHEN a 7z archive is solid and `allow_solid_archives` is false, THE SYSTEM SHALL reject extraction before decompressing the solid block | must |
@@ -189,10 +200,14 @@ THEN ArchiveError::UnknownFormat { path } is returned immediately
 | `.zip` | `Zip` |
 | `.jar`, `.war`, `.ear`, `.nar`, `.nbm`, `.apk`, `.aab`, `.ipa`, `.appx`, `.msix`, `.whl`, `.vsix`, `.xpi`, `.epub` | `Zip` (extraction) / error (creation) |
 | `.7z` | `SevenZ` |
-| `.gz` (no `.tar` stem), anything else | `UnknownFormat { path }` |
+| `.gz` (no `.tar` stem), anything else | Try magic-byte fallback; `UnknownFormat { path }` if magic also fails |
 
-> [!note]
-> Format detection is extension-based, case-insensitive. Magic byte detection is NOT currently implemented.
+> [!note] v0.5.0: magic-byte fallback
+> `detect_format` now falls back to magic-byte inspection when the file extension is absent,
+> unrecognised, or contradicts the file content. Seven signatures are recognised: ZIP (local-file
+> header, EOCD, split-archive marker), GZIP, BZ2, XZ, Zstd, 7z, and TAR USTAR. When magic bytes
+> and extension disagree, magic takes precedence. Archive creation (`determine_creation_format`)
+> remains extension-only so stale on-disk bytes cannot override the caller's intent.
 
 ### Trait Signatures
 
@@ -265,7 +280,11 @@ FormatCreator:
 ## 9. Open Questions
 
 - [NEEDS CLARIFICATION: Is there a plan to support 7z creation in a future version, or is read-only permanently by design?]
-- [NEEDS CLARIFICATION: Should magic byte detection be added alongside extension detection for robustness?]
+
+> [!note] Resolved in v0.5.0
+> Magic-byte detection has been implemented alongside extension detection. `detect_format` now
+> uses both extension and a magic-byte fallback (#353). `determine_creation_format` (used during
+> archive creation) remains extension-only by design.
 
 ## 10. See Also
 

--- a/specs/003-config-api/spec.md
+++ b/specs/003-config-api/spec.md
@@ -94,10 +94,14 @@ SO THAT I can produce well-formed archives without manual format handling
 
 **Acceptance criteria:**
 ```
-GIVEN CreationConfig::default().with_compression_level(9).with_exclude_patterns(vec!["*.log"])
+GIVEN CreationConfig::default().with_compression_level(9)?.with_exclude_patterns(vec!["*.log"])
 WHEN create_archive() is called
 THEN all .log files are excluded and maximum compression is applied
 ```
+
+> [!note] `with_compression_level` returns `Result`
+> Since v0.4.1 / v0.5.0, `with_compression_level` returns `Result<Self, ArchiveError>`.
+> Builder chains must propagate the error with `?` before chaining further methods.
 
 ### US-005: Atomic Extraction
 
@@ -119,7 +123,7 @@ THEN no files are present in the output directory; the temp dir is cleaned up
 | FR-030 | `SecurityConfig` SHALL expose 15 fluent builder methods: `with_max_file_size`, `with_max_total_size`, `with_max_compression_ratio`, `with_max_file_count`, `with_max_path_depth`, `with_allowed`, `with_allow_symlinks`, `with_allow_hardlinks`, `with_allow_absolute_paths`, `with_allow_world_writable`, `with_preserve_permissions`, `with_allowed_extensions`, `with_banned_path_components`, `with_allow_solid_archives`, `with_max_solid_block_memory`; each returns `Self` | must |
 | FR-031 | `SecurityConfig`, `AllowedFeatures`, and `ExtractionOptions` SHALL be annotated `#[non_exhaustive]`; external crates must use `Default::default()` plus builder methods — struct literal construction is a compile error | must |
 | FR-032 | `SecurityConfig::validate()` SHALL return `InvalidConfiguration` if: any numeric limit is zero (`max_file_size`, `max_total_size`, `max_file_count`, `max_path_depth`, `max_solid_block_memory`), or `max_compression_ratio` is zero, negative, or NaN | must |
-| FR-033 | `CreationConfig` SHALL support: `follow_symlinks`, `include_hidden`, `max_file_size`, `exclude_patterns` (glob), `strip_prefix`, `compression_level` (1–9), `preserve_permissions`, `format` override | must |
+| FR-033 | `CreationConfig` SHALL support: `follow_symlinks`, `include_hidden`, `max_file_size`, `exclude_patterns` (glob), `strip_prefix`, `compression_level` (1–9), `preserve_permissions`, `format` override; `with_compression_level` returns `Result<Self, ArchiveError>` — callers must propagate the error with `?`; passing a level outside 1–9 returns `ArchiveError::InvalidCompressionLevel` instead of panicking | must |
 | FR-034 | `ExtractionOptions` SHALL support: `atomic` (temp-dir + rename) via `with_atomic`, `skip_duplicates` (default true) via `with_skip_duplicates` | must |
 | FR-035 | WHEN `ExtractionOptions::atomic` is true, THE SYSTEM SHALL extract to a temp dir in the same parent as the output directory and atomically rename on success | must |
 | FR-036 | WHEN atomic extraction fails, THE SYSTEM SHALL delete the temp dir before returning the error | must |
@@ -170,7 +174,7 @@ THEN no files are present in the output directory; the temp dir is cleaned up
 |----------|-------------------|
 | `SecurityConfig` with zero `max_file_size`, `max_total_size`, `max_path_depth`, `max_file_count`, or `max_solid_block_memory` | `validate()` returns `InvalidConfiguration` |
 | `SecurityConfig` with `max_compression_ratio` of 0.0, negative, or NaN | `validate()` returns `InvalidConfiguration` |
-| `compression_level` outside 1–9 | `CreationConfig` builder panics or returns error at construction |
+| `compression_level` outside 1–9 (0 or > 9) | `ArchiveCreator::compression_level` (and `CreationConfig::with_compression_level`) returns `Err(ArchiveError::InvalidCompressionLevel)`; callers must handle with `?` or explicit match |
 | `atomic = true` and output on a different filesystem than temp dir | `fs::rename` may fail; caller receives `ArchiveError::Io` |
 | `skip_duplicates = false` and duplicate entry | `ArchiveError::InvalidArchive` (duplicate entry) |
 | Atomic extraction fails mid-archive | Temp dir deleted; `ArchiveError` returned; no files in output dir |
@@ -203,8 +207,12 @@ THEN no files are present in the output directory; the temp dir is cleaned up
 
 ## 9. Open Questions
 
-- [NEEDS CLARIFICATION: Should `CreationConfig::compression_level` validate range at construction (panic/error) or defer to the compression backend?]
 - [NEEDS CLARIFICATION: Should `ExtractionOptions` include a `max_concurrency` field for future parallel extraction?]
+
+> [!note] Resolved in v0.4.1 and v0.5.0
+> `CreationConfig::with_compression_level` (and `ArchiveCreator::compression_level`) now returns
+> `Result<Self, ArchiveError>` rather than `Self`. Passing a level of 0 or > 9 returns
+> `ArchiveError::InvalidCompressionLevel`; the panic at the former call site is eliminated (#257, #308).
 
 ## 10. See Also
 

--- a/specs/005-cli/spec.md
+++ b/specs/005-cli/spec.md
@@ -140,17 +140,19 @@ THEN stdout contains valid JSON with all report fields; stderr contains no progr
 | FR-060 | THE CLI SHALL provide subcommands: `extract`, `create`, `list`, `verify`, `completion` | must |
 | FR-061 | THE CLI SHALL support global flags: `--verbose`, `--quiet`, `--json` | must |
 | FR-062 | WHEN `--json` is set, THE CLI SHALL output machine-readable JSON to stdout; human-readable text and progress output SHALL go to stderr | must |
-| FR-063 | `extract` SHALL support: `--max-files N`, `--max-total-size SIZE` (K/M/G/T suffixes), `--max-file-size SIZE`, `--max-compression-ratio N`, `--allow-symlinks`, `--allow-hardlinks`, `--allow-solid-archives`, `--allow-world-writable`, `--preserve-permissions`, `--force`, `--atomic` | must |
-| FR-064 | `create` SHALL support: `-l/--compression-level 1-9`, `--follow-symlinks`, `--include-hidden`, `-x/--exclude PATTERN` (repeatable glob), `--strip-prefix PREFIX`, `-f/--force` | must |
-| FR-065 | `list` and `verify` SHALL support: `-l/--long`, `-H/--human-readable`, `--max-files N`, `--max-total-size SIZE`, `--allow-solid-archives` | must |
+| FR-063 | `extract` SHALL support: `--max-files N`, `--max-total-size SIZE` (K/M/G/T suffixes), `--max-file-size SIZE`, `--max-compression-ratio N`, `--allow-symlinks`, `--allow-hardlinks`, `--allow-solid-archives`, `--allow-world-writable`, `--preserve-permissions`, `--force`, `--atomic`, `--max-path-depth N` (default 32), `--banned-component COMPONENT` (repeatable; replaces the default ban list when provided), `--allow-absolute-paths` (flag; also applies to the listing pre-pass) | must |
+| FR-064 | `create` SHALL support: `-l/--compression-level 1-9`, `--follow-symlinks`, `--include-hidden`, `-x/--exclude PATTERN` (repeatable glob), `--strip-prefix PREFIX`, `-f/--force`, `--max-file-size SIZE` (K/M/G/T suffixes; skips source files larger than threshold), `--preserve-permissions BOOL` (default true; pass `--preserve-permissions=false` for portable archive without Unix permission bits) | must |
+| FR-065 | `list` and `verify` SHALL support: `-l/--long`, `-H/--human-readable`, `--max-files N`, `--max-total-size SIZE`, `--allow-solid-archives`, `--allow-absolute-paths` | must |
 | FR-066 | `completion <SHELL>` SHALL generate shell completion scripts for bash, zsh, fish, powershell, and elvish; output goes to stdout for piping into the appropriate completions directory | must |
 | FR-067 | WHEN extraction or creation fails, THE CLI SHALL exit with a non-zero exit code and print the error to stderr | must |
-| FR-068 | WHEN `--quiet` is set, THE CLI SHALL suppress progress bars and informational output; only errors go to stderr | must |
+| FR-068 | WHEN `--quiet` is set, THE CLI SHALL suppress progress bars and informational output; only errors go to stderr; `--quiet` SHALL NOT suppress `--json` output — `--json` always emits to stdout regardless of `--quiet` | must |
 | FR-069 | WHEN `--verbose` is set, THE CLI SHALL print one line per extracted entry to stderr including entry type indicator (`f`/`d`/`l`), uncompressed size, and relative path; `--quiet` takes precedence when both are set | must |
 | FR-070 | THE CLI progress bar SHALL use `indicatif` in human mode and be suppressed in `--json` and `--quiet` modes | must |
 | FR-071 | Human-readable output SHALL use SI suffixes (K, M, G) for byte counts when `-H/--human-readable` is set | should |
 | FR-072 | WHEN `--allow-symlinks` is already active and a symlink escape is blocked, THE CLI SHALL NOT emit the `--allow-symlinks` hint; the hint is only relevant when symlinks are not yet enabled | must |
 | FR-073 | WHEN `--json` is used, the JSON `message` field for `PartialExtraction`, `PathTraversal`, `SymlinkEscape`, `HardlinkEscape`, `QuotaExceeded`, and `ZipBomb` errors SHALL NOT repeat inner error text that already appears in the structured fields | must |
+| FR-074 | `verify` SHALL support `--strict` flag: when set, a `VerificationReport` with `Warning` status causes the process to exit with code 2 instead of 0; without the flag, exit 0 on warnings is unchanged | must |
+| FR-075 | WHEN `list -l` or `list --json -l` is run and an entry is a symlink or hardlink, THE CLI SHALL include the target path in the output; text format: `l755  0  link.txt -> target.txt`; JSON format: `symlink_target` and `hardlink_target` fields populated | must |
 
 ## 4. Non-Functional Requirements
 
@@ -168,8 +170,8 @@ THEN stdout contains valid JSON with all report fields; stderr contains no progr
 |--------|-------------|----------------|
 | `Cli` | Root clap struct | Global flags (`--verbose`, `--quiet`, `--json`), `Commands` enum |
 | `Commands` | Enum of subcommands | `Extract(ExtractArgs)`, `Create(CreateArgs)`, `List(ListArgs)`, `Verify(VerifyArgs)`, `Completion(CompletionArgs)` |
-| `ExtractArgs` | Arguments for `extract` subcommand | `archive`, `output_dir`, security overrides, `--force`, `--atomic` |
-| `CreateArgs` | Arguments for `create` subcommand | `output`, `sources`, creation options |
+| `ExtractArgs` | Arguments for `extract` subcommand | `archive`, `output_dir`, security overrides, `--force`, `--atomic`, `--max-path-depth`, `--banned-component`, `--allow-absolute-paths` |
+| `CreateArgs` | Arguments for `create` subcommand | `output`, `sources`, creation options, `--max-file-size`, `--preserve-permissions` |
 | `ListArgs` | Arguments for `list` subcommand | `archive`, display options |
 | `VerifyArgs` | Arguments for `verify` subcommand | `archive`, inspection options |
 | `OutputFormatter` | Trait for human vs JSON output | Methods: `print_extraction_report`, `print_creation_report`, `print_manifest`, `print_verification_report` |
@@ -184,17 +186,21 @@ exarch extract <ARCHIVE> [OUTPUT_DIR]
     [--max-compression-ratio N] [--allow-symlinks] [--allow-hardlinks]
     [--allow-solid-archives] [--allow-world-writable]
     [--preserve-permissions] [--force] [--atomic]
+    [--max-path-depth N] [--banned-component COMPONENT]... [--allow-absolute-paths]
 
 exarch create <OUTPUT> <SOURCE>...
     [-l/--compression-level 1-9] [--follow-symlinks] [--include-hidden]
     [-x/--exclude PATTERN]... [--strip-prefix PREFIX] [-f/--force]
+    [--max-file-size SIZE] [--preserve-permissions=BOOL]
 
 exarch list <ARCHIVE>
     [-l/--long] [-H/--human-readable]
     [--max-files N] [--max-total-size SIZE] [--allow-solid-archives]
+    [--allow-absolute-paths]
 
 exarch verify <ARCHIVE>
     [--max-files N] [--max-total-size SIZE] [--allow-solid-archives]
+    [--strict]
 
 exarch completion <SHELL>    # bash | zsh | fish | powershell | elvish  (output to stdout)
 ```
@@ -206,7 +212,8 @@ exarch completion <SHELL>    # bash | zsh | fish | powershell | elvish  (output 
 | Archive does not exist | Error printed to stderr; exit code non-zero |
 | Output directory does not exist | Created automatically (unless `--force` is required) |
 | Extraction fails (security violation) | Error with variant name printed to stderr; exit code non-zero |
-| `--json` and `--quiet` combined | JSON on stdout; nothing on stderr |
+| `--json` and `--quiet` combined | JSON on stdout (never suppressed by `--quiet`); nothing on stderr |
+| `verify --strict` with Warning report | Exit code 2 (was 0 without `--strict`) |
 | SIZE suffix parsing (e.g. `--max-total-size 500M`) | K=1024, M=1024², G=1024³, T=1024⁴ |
 | `completion` for unsupported shell | Error; exit code non-zero |
 | `verify` on archive with issues | Issues printed; exit code non-zero when status is Fail |

--- a/specs/006-python-bindings/spec.md
+++ b/specs/006-python-bindings/spec.md
@@ -121,7 +121,7 @@ SO THAT I can customize security limits in idiomatic Python
 
 **Acceptance criteria:**
 ```
-GIVEN SecurityConfig().max_file_size(200 * 1024 * 1024).allow_symlinks(True)
+GIVEN SecurityConfig().with_max_file_size(200 * 1024 * 1024).with_allow_symlinks(True)
 WHEN passed to extract_archive()
 THEN extraction respects those settings
 ```
@@ -130,7 +130,7 @@ THEN extraction respects those settings
 
 | ID | Requirement | Priority |
 |----|------------|----------|
-| FR-070 | THE SYSTEM SHALL expose Python functions: `extract_archive`, `create_archive`, `create_archive_with_progress`, `list_archive`, `verify_archive` | must |
+| FR-070 | THE SYSTEM SHALL expose Python functions: `extract_archive`, `extract_archive_with_progress`, `create_archive`, `create_archive_with_progress`, `list_archive`, `verify_archive` | must |
 | FR-071 | ALL Python functions SHALL accept `str` or `pathlib.Path` for path arguments | must |
 | FR-072 | WHEN paths contain null bytes or exceed 4096 bytes, THE SYSTEM SHALL raise `ValueError` at the Python boundary before calling into Rust | must |
 | FR-073 | WHEN no Python progress callback is provided, THE SYSTEM SHALL release the GIL during extraction/creation | must |
@@ -154,7 +154,7 @@ THEN extraction respects those settings
 
 | Entity | Description | Key Attributes |
 |--------|-------------|----------------|
-| `PySecurityConfig` | Python class wrapping `SecurityConfig` | Same fluent builder methods: `max_file_size()`, `allow_symlinks()`, etc. |
+| `PySecurityConfig` | Python class wrapping `SecurityConfig` | Fluent builder methods all use `with_` prefix: `with_max_file_size()`, `with_allow_symlinks()`, `with_allow_hardlinks()`, `with_allow_absolute_paths()`, `with_allow_world_writable()`, `with_allow_solid_archives()`, etc.; scalar getters (`max_file_size`, `max_total_size`, etc.) return values directly |
 | `PyCreationConfig` | Python class wrapping `CreationConfig` | Same fluent builder methods |
 | `PyExtractionReport` | Python class wrapping `ExtractionReport` | `files_extracted`, `bytes_written`, `duration`, `warnings` |
 | `PyCreationReport` | Python class wrapping `CreationReport` | `files_added`, `bytes_written`, `duration` |
@@ -165,18 +165,26 @@ THEN extraction respects those settings
 ### Python Exception Hierarchy
 
 ```
-ExarchError(Exception)
-  PathTraversalError(ExarchError)      # may carry files_extracted, bytes_written
-  SymlinkEscapeError(ExarchError)      # may carry files_extracted, bytes_written
-  HardlinkEscapeError(ExarchError)     # may carry files_extracted, bytes_written
-  ZipBombError(ExarchError)            # may carry files_extracted, bytes_written
-  QuotaExceededError(ExarchError)      # may carry files_extracted, bytes_written
-  SecurityViolationError(ExarchError)  # may carry files_extracted, bytes_written
-  InvalidPermissionsError(ExarchError) # may carry files_extracted, bytes_written
-  UnsupportedFormatError(ExarchError)
-    UnknownFormatError(UnsupportedFormatError)
-  InvalidArchiveError(ExarchError)
+ExarchError(Exception)           # catch-all alias; same class as ArchiveError
+ArchiveError(Exception)          # base exception (renamed from ExtractionError in v0.4.1)
+  PathTraversalError(ArchiveError)      # may carry files_extracted, bytes_written
+  SymlinkEscapeError(ArchiveError)      # may carry files_extracted, bytes_written
+  HardlinkEscapeError(ArchiveError)     # may carry files_extracted, bytes_written
+  ZipBombError(ArchiveError)            # may carry files_extracted, bytes_written
+  QuotaExceededError(ArchiveError)      # may carry files_extracted, bytes_written
+  SecurityViolationError(ArchiveError)  # may carry files_extracted, bytes_written
+  InvalidPermissionsError(ArchiveError) # may carry files_extracted, bytes_written
+  UnsupportedFormatError(ArchiveError)
+    UnknownFormatError(UnsupportedFormatError)  # raised for CoreError::UnknownFormat
+  InvalidArchiveError(ArchiveError)
 ```
+
+> [!note] v0.4.1: error rename and `UnknownFormatError`
+> The Python base exception is now `exarch.ArchiveError` (was `exarch.ExtractionError`).
+> `UnknownFormatError` is a distinct subclass of `UnsupportedFormatError`, raised when the
+> archive format cannot be identified from path or magic bytes. Callers catching the broader
+> `UnsupportedFormatError` continue to work unchanged; those that need to distinguish "format
+> unknown" from "format known but unsupported" can catch the narrower type (#260).
 
 The `files_extracted` and `bytes_written` attributes are present on the raised
 exception when `exarch-core` wraps the inner error in `CoreError::PartialExtraction`
@@ -202,12 +210,37 @@ Use `hasattr(e, "files_extracted")` to detect whether a partial extraction occur
 ```python
 # Module: exarch
 
-def extract_archive(archive_path, output_dir, config=None) -> ExtractionReport
+def extract_archive(archive_path, output_dir, config=None, options=None) -> ExtractionReport
+def extract_archive_with_progress(archive_path, output_dir, config=None, progress=None) -> ExtractionReport
+    # GIL held when progress callback is provided; released otherwise
 def create_archive(output_path, sources, config=None) -> CreationReport
 def create_archive_with_progress(output_path, sources, config=None, progress=None) -> CreationReport
 def list_archive(archive_path, config=None) -> ArchiveManifest
 def verify_archive(archive_path, config=None) -> VerificationReport
+
+class ExtractionOptions:
+    def with_atomic(self, atomic: bool = True) -> ExtractionOptions
+    def with_skip_duplicates(self, skip: bool = True) -> ExtractionOptions
+    @property
+    def atomic(self) -> bool
+    @atomic.setter
+    def atomic(self, value: bool) -> None
+    @property
+    def skip_duplicates(self) -> bool
 ```
+
+> [!note] v0.5.0: `ExtractionOptions` and `extract_archive_with_progress` added
+> Both `extract_archive` and `extract_archive_with_progress` accept an optional `options`
+> parameter of type `ExtractionOptions`. `ExtractionOptions.atomic` triggers staging-directory
+> extraction with atomic rename; `ExtractionOptions.skip_duplicates` (default `True`) skips
+> duplicate entries. `with_atomic` and `with_skip_duplicates` are the fluent builder methods.
+
+> [!note] v0.5.0: builder method naming
+> All Python `SecurityConfig` builder methods that previously omitted `with_` (`allow_symlinks`,
+> `allow_hardlinks`, `allow_absolute_paths`, `allow_world_writable`, `allow_solid_archives`)
+> have been renamed to `with_allow_symlinks`, `with_allow_hardlinks`, `with_allow_absolute_paths`,
+> `with_allow_world_writable`, `with_allow_solid_archives` to match the `with_` prefix
+> convention. Update all call sites accordingly (#354).
 
 ## 6. Edge Cases and Error Handling
 
@@ -255,7 +288,10 @@ def verify_archive(archive_path, config=None) -> VerificationReport
 ## 9. Open Questions
 
 - [NEEDS CLARIFICATION: Should an async Python interface (asyncio) be provided via `pyo3-asyncio` in a future version?]
-- [NEEDS CLARIFICATION: What Python version range does the abi3 build target? (e.g., 3.8+)]
+
+> [!note] Resolved in v0.3.1
+> Python version range: minimum Python 3.10. Python 3.9 support was dropped when it reached
+> EOL in October 2025. The abi3 wheel covers 3.10–3.14+.
 
 ## 10. See Also
 

--- a/specs/007-node-bindings/spec.md
+++ b/specs/007-node-bindings/spec.md
@@ -45,7 +45,6 @@ named JavaScript error types, and TypeScript type definitions.
 ### Out of Scope
 
 - Streaming Node.js readable/writable interfaces
-- Progress callbacks from Node.js (no equivalent of `PyProgressAdapter`)
 - Electron or browser support (Node.js native addon only)
 - CommonJS-only distribution (ESM and CJS both supported by napi-rs)
 
@@ -126,12 +125,15 @@ THEN extraction respects those settings
 
 | ID | Requirement | Priority |
 |----|------------|----------|
-| FR-080 | THE SYSTEM SHALL expose async Node.js functions returning Promises: `extractArchive`, `createArchive`, `listArchive`, `verifyArchive` | must |
+| FR-080 | THE SYSTEM SHALL expose async Node.js functions returning Promises: `extractArchive`, `extractArchiveWithProgress`, `createArchive`, `listArchive`, `verifyArchive` | must |
 | FR-081 | ALL async operations SHALL run on the libuv thread pool, not the main event loop thread | must |
 | FR-082 | WHEN paths contain null bytes or exceed 4096 bytes, THE SYSTEM SHALL throw a synchronous JavaScript Error before spawning a thread | must |
 | FR-083 | Rust `ArchiveError` variants SHALL map to named JavaScript Error types; when `PartialExtraction` wraps an inner error, the error message SHALL begin with the specific inner error code (e.g. `SYMLINK_ESCAPE`, `QUOTA_EXCEEDED`) and SHALL append `filesExtracted` and `bytesWritten` fields for caller inspection | must |
-| FR-084 | `SecurityConfig` and `CreationConfig` SHALL be exposed as JavaScript classes with fluent builder methods | must |
+| FR-084 | `SecurityConfig` and `CreationConfig` SHALL be exposed as JavaScript classes with fluent builder methods; `SecurityConfig` SHALL expose `allowSolidArchives` getter consistent with `allowSymlinks`, `allowHardlinks`, `allowAbsolutePaths`, `allowWorldWritable` | must |
 | FR-085 | `ExtractionReport`, `CreationReport`, `ArchiveManifest`, and `VerificationReport` SHALL be exposed as JavaScript objects with typed fields | must |
+| FR-088 | `ExtractionOptions` SHALL be exposed as a JavaScript class with builder methods `withAtomic(bool?)` and `withSkipDuplicates(bool?)`; both `extractArchive` and `extractArchiveWithProgress` SHALL accept an optional `options` parameter | must |
+| FR-089 | ALL async operations SHALL wrap the core call with `catch_unwind` inside `spawn_blocking`; panics in `exarch-core` SHALL be converted to JavaScript errors and SHALL NOT abort the Node.js process | must |
+| FR-090 | `extractArchiveWithProgress(archivePath, outputDir, config?, progress?)` SHALL accept an optional `ThreadsafeFunction` callback with signature `(path: string, total: number, current: number, bytesWritten: number) => void`; numeric callback arguments are `number` (not `bigint`) | must |
 | FR-086 | napi-rs SHALL generate TypeScript `.d.ts` files for all exported functions and classes | must |
 | FR-087 | ALL path arguments SHALL accept `string` type in JavaScript | must |
 
@@ -163,7 +165,15 @@ THEN extraction respects those settings
 function extractArchive(
     archivePath: string,
     outputDir: string,
-    config?: SecurityConfig
+    config?: SecurityConfig,
+    options?: ExtractionOptions
+): Promise<ExtractionReport>
+
+function extractArchiveWithProgress(
+    archivePath: string,
+    outputDir: string,
+    config?: SecurityConfig,
+    progress?: (path: string, total: number, current: number, bytesWritten: number) => void
 ): Promise<ExtractionReport>
 
 function createArchive(
@@ -191,6 +201,14 @@ class SecurityConfig {
     allowSymlinks(allow: boolean): this
     allowHardlinks(allow: boolean): this
     allowSolidArchives(allow: boolean): this
+    setMaxSolidBlockMemory(size: number): this
+    // Getters (boolean)
+    get allowSymlinks(): boolean
+    get allowHardlinks(): boolean
+    get allowAbsolutePaths(): boolean
+    get allowWorldWritable(): boolean
+    get allowSolidArchives(): boolean
+    get maxSolidBlockMemory(): number
 }
 
 class CreationConfig {
@@ -200,7 +218,19 @@ class CreationConfig {
     exclude(pattern: string): this
     stripPrefix(prefix: string): this
 }
+
+class ExtractionOptions {
+    withAtomic(atomic?: boolean): this
+    withSkipDuplicates(skip?: boolean): this
+    get atomic(): boolean
+}
 ```
+
+> [!note] v0.5.0: `ExtractionOptions` and `extractArchiveWithProgress`
+> Both functions now accept an optional `ExtractionOptions` parameter. The progress callback
+> arguments (`total`, `current`, `bytesWritten`) are `number` (NAPI-RS maps `i64` to `number`),
+> not `bigint`. `index.d.ts` is committed to the repository so TypeScript consumers have correct
+> types without building from source.
 
 ### JavaScript Error Mapping
 
@@ -259,8 +289,8 @@ class CreationConfig {
 
 ### Ask First
 - Adding new async functions not yet in `exarch-core`
-- Adding progress callback support for Node.js (requires careful GIL/event-loop design)
 - Changing the TypeScript interface (breaking change for downstream consumers)
+- Expanding `ThreadsafeFunction` callback signature (breaks callers)
 
 ### Never
 - Block the Node.js event loop with synchronous Rust I/O
@@ -270,8 +300,13 @@ class CreationConfig {
 ## 9. Open Questions
 
 - [NEEDS CLARIFICATION: What is the minimum supported Node.js version? (LTS policy — 18+, 20+?)]
-- [NEEDS CLARIFICATION: Should progress callbacks be supported from Node.js? Requires thread-safe channel from Rust back to JS event loop.]
 - [NEEDS CLARIFICATION: Should empty `sources` array in `createArchive` produce an empty archive or reject with an error?]
+
+> [!note] Resolved in v0.4.1
+> Progress callbacks for Node.js are now supported. `extractArchiveWithProgress` accepts an
+> optional `ThreadsafeFunction` callback with signature
+> `(path: string, total: number, current: number, bytesWritten: number) => void` (#263).
+> Numeric arguments are `number`, not `bigint` — corrected in #326.
 
 ## 10. See Also
 
@@ -279,5 +314,5 @@ class CreationConfig {
 - [[MOC-specs]] — all specifications
 - [[001-security-pipeline/spec]] — security pipeline invoked by Node.js bindings
 - [[003-config-api/spec]] — `SecurityConfig` and `CreationConfig` types
-- [[004-progress-tracking/spec]] — `ProgressCallback` (currently no Node.js callback support)
+- [[004-progress-tracking/spec]] — `ProgressCallback` and `NodeProgressAdapter` (progress callbacks supported via `ThreadsafeFunction` since v0.4.1)
 - [[001-exarch-system/spec]] — original monolithic spec (archived)

--- a/specs/MOC-specs.md
+++ b/specs/MOC-specs.md
@@ -19,13 +19,13 @@ status: moc
 
 | ID | Feature | Phase | Status | Tasks |
 |----|---------|-------|--------|-------|
-| 001 | [[001-security-pipeline/spec\|Security Pipeline]] | tasks | done (v0.4.0) | [[001-security-pipeline/tasks\|none open]] |
-| 002 | [[002-format-handlers/spec\|Format Handlers]] | tasks | done (v0.4.0) | [[002-format-handlers/tasks\|none open]] |
-| 003 | [[003-config-api/spec\|Configuration API]] | tasks | done | [[003-config-api/tasks\|none]] |
-| 004 | [[004-progress-tracking/spec\|Progress Tracking]] | tasks | done | [[004-progress-tracking/tasks\|none]] |
-| 005 | [[005-cli/spec\|CLI]] | tasks | done (v0.4.0) | [[005-cli/tasks\|none open]] |
-| 006 | [[006-python-bindings/spec\|Python Bindings]] | tasks | done | [[006-python-bindings/tasks\|none]] |
-| 007 | [[007-node-bindings/spec\|Node.js Bindings]] | tasks | done | [[007-node-bindings/tasks\|none]] |
+| 001 | [[001-security-pipeline/spec\|Security Pipeline]] | tasks | current (v0.5.0) | [[001-security-pipeline/tasks\|none open]] |
+| 002 | [[002-format-handlers/spec\|Format Handlers]] | tasks | current (v0.5.0) | [[002-format-handlers/tasks\|none open]] |
+| 003 | [[003-config-api/spec\|Configuration API]] | tasks | current (v0.5.0) | [[003-config-api/tasks\|none]] |
+| 004 | [[004-progress-tracking/spec\|Progress Tracking]] | tasks | current (v0.5.0) | [[004-progress-tracking/tasks\|none]] |
+| 005 | [[005-cli/spec\|CLI]] | tasks | current (v0.5.0) | [[005-cli/tasks\|none open]] |
+| 006 | [[006-python-bindings/spec\|Python Bindings]] | tasks | current (v0.5.0) | [[006-python-bindings/tasks\|none]] |
+| 007 | [[007-node-bindings/spec\|Node.js Bindings]] | tasks | current (v0.5.0) | [[007-node-bindings/tasks\|none]] |
 
 ## Completed Specs
 

--- a/specs/constitution.md
+++ b/specs/constitution.md
@@ -5,6 +5,7 @@ tags:
   - sdd
   - constitution
 created: 2026-05-20
+updated: 2026-06-05
 status: permanent
 ---
 
@@ -29,7 +30,7 @@ status: permanent
 - CLI: `clap` 4.x with derive macros
 - Python bindings: `pyo3` 0.28, `maturin`, GIL released during I/O
 - Node.js bindings: `napi-rs` 3.x, async Promises via tokio thread pool
-- Compression: `flate2` (gz), `bzip2` (bz2), `xz2` (xz, static), `zstd` (zst), `zip` 8.x, `sevenz-rust2` (7z)
+- Compression: `flate2` (gz), `bzip2` (bz2), `xz2` (xz, static), `zstd` (zst), `zip` 9.0.0-pre2, `sevenz-rust2` (7z)
 - Testing: `cargo nextest`, `proptest` for property-based tests, `criterion` + `dhat` for benchmarks
 
 ## III. Testing (NON-NEGOTIABLE)
@@ -56,6 +57,10 @@ status: permanent
 - Default limits: 50 MB per file, 500 MB total, 100× compression ratio, 10,000 files, depth 32
 - Path component matching is case-insensitive to prevent bypass on case-insensitive filesystems
 - Security issues detected during `verify_archive` are reported in `VerificationReport.issues`, not propagated as errors (complete picture for the caller)
+- `ValidationReport` is re-exported at crate root as `exarch_core::ValidationReport` (v0.4.1)
+- The error type covering all archive operations is `ArchiveError` (renamed from `ExtractionError` in v0.4.1); all public API surfaces use this name
+- Security primitives (`validate_path`, `validate_symlink`, `sanitize_permissions`, `validate_compression_ratio`, `QuotaTracker`, `HardlinkTracker`) are `pub(crate)` and not part of the public API; external tests must use `--features testing`
+- Absolute-path stripping for entries with `allow_absolute_paths` enabled is performed centrally in `SafePath::validate_with_context`, not in per-format handlers (v0.5.0)
 
 ## VI. Performance
 


### PR DESCRIPTION
## Summary

- Bump version from 0.4.1 to 0.5.0 across all workspace manifests
- Finalize CHANGELOG.md: move `[Unreleased]` content into `[0.5.0] - 2026-06-05` section, compact duplicate section headers
- Update installation version references in all README files (`"0.4"` → `"0.5"`)
- Fix stale Python `SecurityConfig` example (`.max_file_size` → `.with_max_file_size`)
- Add new CLI flags to exarch-cli README: `--max-path-depth`, `--banned-component`, `--allow-absolute-paths` (extract); `--max-file-size`, `--preserve-permissions` (create)
- Remove outdated `Archive::open` breaking-change warning from exarch-core README
- Update `pyproject.toml` classifiers: drop Python 3.9 (EOL), add Python 3.14; update mypy target to 3.10
- Update `package.json` version to 0.5.0

## Checklist

- [x] Version updated in all manifests (workspace, pyproject.toml, package.json)
- [x] CHANGELOG.md has release section with date and no duplicate headers
- [x] All README files reflect new version and current API
- [x] Python classifiers updated (3.10–3.14)
- [x] All CI checks pass (927 tests, clippy, fmt, 98 doc-tests)
- [ ] Ready for tagging after merge