### PR TITLE
fix: unblock CI for dependabot minor-and-patch bump (#379)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,9 +433,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/exarch-node/src/error.rs
+++ b/crates/exarch-node/src/error.rs
@@ -385,7 +385,7 @@ mod tests {
         };
 
         let napi_err = convert_error(err);
-        let msg = napi_err.reason.clone();
+        let msg = &napi_err.reason;
         // Must carry the specific error code, not the generic PARTIAL_EXTRACTION
         // prefix.
         assert!(


### PR DESCRIPTION
## Summary
- Clippy on the current stable toolchain flags `napi_err.reason.clone()` in `error.rs` test as a redundant clone, since the value isn't reused afterward
- `cargo-deny` now flags RUSTSEC-2026-0204 in `crossbeam-epoch` 0.9.18, pulled in transitively through criterion's dev-dependency chain; bumped to 0.9.20
- Both issues currently block CI on #379 (dependabot minor-and-patch bump) and would block any other PR today, unrelated to the dependency changes in #379 itself

## Test plan
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node`
- [x] `cargo test --doc --workspace --all-features --exclude exarch-python`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace --exclude exarch-python`
- [x] `cargo deny check`