### PR TITLE
feat(cli): add exarch-cli skill and release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,6 +191,111 @@ jobs:
           path: crates/exarch-python/wheels/*.whl
           retention-days: 7
 
+  # Build exarch-cli binaries for multiple platforms
+  build-cli-binaries:
+    name: Build CLI Binary (${{ matrix.platform.name }})
+    needs: validate
+    runs-on: ${{ matrix.platform.os }}
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          # Linux x86_64
+          - name: linux-x86_64
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            archive: tar.gz
+
+          # Linux aarch64
+          - name: linux-aarch64
+            os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            archive: tar.gz
+
+          # macOS x86_64
+          - name: macos-x86_64
+            os: macos-15-intel
+            target: x86_64-apple-darwin
+            archive: tar.gz
+
+          # macOS aarch64 (Apple Silicon)
+          - name: macos-aarch64
+            os: macos-latest
+            target: aarch64-apple-darwin
+            archive: tar.gz
+
+          # Windows x86_64
+          - name: windows-x86_64
+            os: windows-latest
+            target: x86_64-pc-windows-msvc
+            archive: zip
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.platform.target }}
+
+      - name: Setup cross-compilation (Linux aarch64)
+        if: matrix.platform.name == 'linux-aarch64'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+
+      - name: Cache Cargo dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "cli-${{ matrix.platform.name }}"
+
+      - name: Build exarch-cli
+        run: cargo build -p exarch-cli --release --target ${{ matrix.platform.target }}
+
+      - name: Package archive (Unix)
+        if: matrix.platform.archive == 'tar.gz'
+        run: |
+          VERSION="${{ needs.validate.outputs.version }}"
+          NAME="exarch-${VERSION}-${{ matrix.platform.target }}"
+          STAGE="$(mktemp -d)/${NAME}"
+          mkdir -p "$STAGE"
+          cp "target/${{ matrix.platform.target }}/release/exarch" "$STAGE/"
+          cp LICENSE-MIT LICENSE-APACHE README.md "$STAGE/"
+          tar -C "$(dirname "$STAGE")" -czf "${NAME}.tar.gz" "${NAME}"
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "${NAME}.tar.gz" > "${NAME}.tar.gz.sha256"
+          else
+            shasum -a 256 "${NAME}.tar.gz" > "${NAME}.tar.gz.sha256"
+          fi
+
+      - name: Package archive (Windows)
+        if: matrix.platform.archive == 'zip'
+        shell: pwsh
+        run: |
+          $Version = "${{ needs.validate.outputs.version }}"
+          $Name = "exarch-$Version-${{ matrix.platform.target }}"
+          $Stage = Join-Path $Env:RUNNER_TEMP $Name
+          New-Item -ItemType Directory -Path $Stage | Out-Null
+          Copy-Item "target/${{ matrix.platform.target }}/release/exarch.exe" -Destination $Stage
+          Copy-Item LICENSE-MIT, LICENSE-APACHE, README.md -Destination $Stage
+          Compress-Archive -Path $Stage -DestinationPath "$Name.zip"
+          (Get-FileHash "$Name.zip" -Algorithm SHA256).Hash.ToLower() + "  $Name.zip" | Out-File -Encoding ascii "$Name.zip.sha256"
+
+      - name: Upload CLI archive
+        uses: actions/upload-artifact@v7
+        with:
+          name: cli-${{ matrix.platform.name }}
+          path: |
+            exarch-*.tar.gz
+            exarch-*.tar.gz.sha256
+            exarch-*.zip
+            exarch-*.zip.sha256
+          retention-days: 7
+
   # Publish Python wheels to PyPI using Trusted Publishing (OIDC)
   # Setup: https://docs.pypi.org/trusted-publishers/adding-a-publisher/
   publish-python:
@@ -360,7 +465,7 @@ jobs:
   # Create GitHub Release with artifacts
   github-release:
     name: Create GitHub Release
-    needs: [validate, publish-crates, publish-python, publish-node]
+    needs: [validate, publish-crates, publish-python, publish-node, build-cli-binaries]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -380,6 +485,13 @@ jobs:
         with:
           path: release-artifacts/node
           pattern: bindings-*
+
+      - name: Download CLI binaries
+        uses: actions/download-artifact@v8
+        with:
+          path: release-artifacts/cli
+          pattern: cli-*
+          merge-multiple: true
 
       - name: Generate changelog
         id: changelog
@@ -420,10 +532,20 @@ jobs:
           npm install exarch-rs@$VERSION
           \`\`\`
 
+          ### Rust CLI
+          \`\`\`bash
+          cargo install exarch-cli
+          \`\`\`
+          Or download a prebuilt \`exarch-$VERSION-<target>\` archive from this release's assets
+          (or run \`curl -fsSL https://raw.githubusercontent.com/bug-ops/exarch/main/scripts/install.sh | sh\`),
+          both of which skip the Rust toolchain requirement.
+
           ## Artifacts
 
           - Python wheels for Linux (x86_64, aarch64), Linux musl (x86_64, aarch64), macOS (x86_64, aarch64), Windows (x86_64)
           - Node.js native addons for Linux (x86_64, aarch64), macOS (x86_64, aarch64), Windows (x86_64)
+          - CLI binaries for Linux (x86_64, aarch64), macOS (x86_64, aarch64), Windows (x86_64) as
+            \`exarch-$VERSION-<target>.tar.gz\` / \`.zip\` with \`.sha256\` checksums, plus \`install.sh\`
           - Published to [crates.io](https://crates.io/crates/exarch-core), [PyPI](https://pypi.org/project/exarch), and [npm](https://www.npmjs.com/package/exarch-rs)
           EOF
 
@@ -437,6 +559,11 @@ jobs:
           files: |
             release-artifacts/python/*.whl
             release-artifacts/node/**/*.node
+            release-artifacts/cli/*.tar.gz
+            release-artifacts/cli/*.tar.gz.sha256
+            release-artifacts/cli/*.zip
+            release-artifacts/cli/*.zip.sha256
+            scripts/install.sh
           token: ${{ secrets.GITHUB_TOKEN }}
 
   # Final success check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **CLI binary releases**: `exarch-cli` release binaries are now built and attached to every
+  GitHub release for Linux (x86_64, aarch64), macOS (x86_64, aarch64), and Windows (x86_64) as
+  `exarch-<version>-<target>.tar.gz` / `.zip` archives with `.sha256` checksums.
+- **`scripts/install.sh`**: a POSIX-sh installer that downloads, checksum-verifies, and installs
+  the correct prebuilt `exarch` binary for the host platform. Also attached to every release.
+- `skills/exarch-cli/SKILL.md` now documents both install methods above as secondary alternatives
+  to `cargo install exarch-cli`.
+
 ## [0.5.1] - 2026-07-09
 
 ### Fixed

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+# Installs the exarch CLI from a GitHub release. Meant to be run via:
+#   curl -fsSL https://raw.githubusercontent.com/bug-ops/exarch/main/scripts/install.sh | sh
+set -eu
+
+REPO="bug-ops/exarch"
+INSTALL_DIR="${EXARCH_INSTALL_DIR:-$HOME/.local/bin}"
+
+log() { printf '%s\n' "$*" >&2; }
+die() {
+  log "error: $*"
+  exit 1
+}
+
+command -v curl >/dev/null 2>&1 || die "curl is required but not found"
+command -v tar >/dev/null 2>&1 || die "tar is required but not found"
+
+detect_os() {
+  case "$(uname -s)" in
+    Linux) echo linux ;;
+    Darwin) echo darwin ;;
+    *) die "unsupported OS: $(uname -s)" ;;
+  esac
+}
+
+detect_arch() {
+  arch="$(uname -m)"
+  case "$arch" in
+    x86_64 | amd64) echo x86_64 ;;
+    arm64 | aarch64) echo aarch64 ;;
+    *) die "unsupported architecture: $arch" ;;
+  esac
+}
+
+os="$(detect_os)"
+arch="$(detect_arch)"
+
+case "$os-$arch" in
+  linux-x86_64) target="x86_64-unknown-linux-gnu" ;;
+  linux-aarch64) target="aarch64-unknown-linux-gnu" ;;
+  darwin-x86_64) target="x86_64-apple-darwin" ;;
+  darwin-aarch64) target="aarch64-apple-darwin" ;;
+  *) die "no prebuilt exarch binary for $os-$arch" ;;
+esac
+
+version="${EXARCH_VERSION:-}"
+if [ -z "$version" ]; then
+  version="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+    | grep '"tag_name"' | head -n1 | sed -E 's/.*"v?([^"]+)".*/\1/')"
+  [ -n "$version" ] || die "failed to resolve latest release version"
+fi
+
+archive="exarch-${version}-${target}.tar.gz"
+base_url="https://github.com/${REPO}/releases/download/v${version}"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+log "Downloading ${archive} (v${version})..."
+curl -fsSL -o "${tmp_dir}/${archive}" "${base_url}/${archive}"
+curl -fsSL -o "${tmp_dir}/${archive}.sha256" "${base_url}/${archive}.sha256"
+
+log "Verifying checksum..."
+(
+  cd "$tmp_dir"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -c "${archive}.sha256"
+  elif command -v shasum >/dev/null 2>&1; then
+    checksum="$(cut -d ' ' -f1 "${archive}.sha256")"
+    echo "${checksum}  ${archive}" | shasum -a 256 -c -
+  else
+    die "no sha256sum or shasum available to verify the download"
+  fi
+) || die "checksum verification failed, aborting install"
+
+log "Extracting..."
+tar -xzf "${tmp_dir}/${archive}" -C "$tmp_dir"
+
+mkdir -p "$INSTALL_DIR"
+cp "${tmp_dir}/exarch-${version}-${target}/exarch" "${INSTALL_DIR}/exarch"
+chmod +x "${INSTALL_DIR}/exarch"
+
+log "Installed exarch v${version} to ${INSTALL_DIR}/exarch"
+
+case ":$PATH:" in
+  *":${INSTALL_DIR}:"*) ;;
+  *) log "note: ${INSTALL_DIR} is not on your PATH, add it to use 'exarch' directly" ;;
+esac

--- a/skills/exarch-cli/SKILL.md
+++ b/skills/exarch-cli/SKILL.md
@@ -20,17 +20,54 @@ job, not a bug to route around (see "Do not reach for `--allow-*` reflexively" b
 
 ## Install
 
+First check whether a Rust toolchain is present: `command -v cargo`.
+
+**`cargo` available (recommended):**
+
 ```bash
 cargo install exarch-cli
 ```
 
-This installs a binary named `exarch` (not `exarch-cli`). Inside this workspace, use the debug
-build instead:
+This installs a binary named `exarch` (not `exarch-cli`) and is the fastest path to a working
+binary since it doesn't require identifying the target triple. Inside this workspace, use the
+debug build instead:
 
 ```bash
 cargo build -p exarch-cli
 ./target/debug/exarch --help
 ```
+
+**`cargo` NOT available:**
+
+*Linux / macOS* — run the install script, no toolchain required, checksum-verified:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/bug-ops/exarch/main/scripts/install.sh | sh
+```
+
+Installs to `~/.local/bin` (override with `EXARCH_INSTALL_DIR`). If the script itself can't run
+(e.g. a restricted shell), fall back to a manual download: get `exarch-<version>-<target>.tar.gz`
+plus its `.sha256` from [GitHub Releases](https://github.com/bug-ops/exarch/releases) —
+`<target>` is `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, `x86_64-apple-darwin`, or
+`aarch64-apple-darwin` — then verify and extract:
+
+```bash
+sha256sum -c exarch-<version>-<target>.tar.gz.sha256   # macOS: shasum -a 256 -c
+tar -xzf exarch-<version>-<target>.tar.gz
+```
+
+*Windows* — no install script; download `exarch-<version>-x86_64-pc-windows-msvc.zip` plus its
+`.sha256` from [GitHub Releases](https://github.com/bug-ops/exarch/releases), then verify and
+extract in PowerShell:
+
+```powershell
+(Get-FileHash exarch-<version>-x86_64-pc-windows-msvc.zip -Algorithm SHA256).Hash
+# compare (case-insensitively) against the hash in the .sha256 file, then:
+Expand-Archive exarch-<version>-x86_64-pc-windows-msvc.zip -DestinationPath .
+```
+
+`CertUtil -hashfile exarch-<version>-x86_64-pc-windows-msvc.zip SHA256` is an equivalent,
+cmd-only alternative to `Get-FileHash`.
 
 ## Global flags
 

--- a/skills/exarch-cli/SKILL.md
+++ b/skills/exarch-cli/SKILL.md
@@ -1,0 +1,276 @@
+---
+name: exarch-cli
+description: Extract, create, list, and verify TAR (plus gz/bz2/xz/zst), ZIP, and 7z archives securely using the `exarch` CLI. Use whenever a task involves unpacking or building archives, especially from untrusted sources — exarch blocks path traversal, symlink/hardlink escapes, zip bombs, and oversized archives by default, and reports rejections as structured errors instead of silently succeeding.
+license: MIT OR Apache-2.0
+compatibility: Requires the `exarch` binary (cargo install exarch-cli, or build from this workspace with cargo build -p exarch-cli). MSRV 1.93.0 if building from source.
+metadata:
+  author: bug-ops
+  version: "0.5.1"
+---
+
+# exarch CLI
+
+`exarch` is a security-first archive tool. It extracts, creates, lists, and verifies TAR
+(plain, `.gz`, `.bz2`, `.xz`, `.zst`), ZIP, and 7z archives. Every extraction runs through a
+validation pipeline that is deny-by-default: path traversal, symlink/hardlink escapes outside
+the destination directory, zip bombs (excessive compression ratio), oversized files/archives,
+and unsafe permission bits (setuid/setgid, world-writable) are all rejected unless explicitly
+allowed. If an extraction fails with a security-related error, treat that as the tool doing its
+job, not a bug to route around (see "Do not reach for `--allow-*` reflexively" below).
+
+## Install
+
+```bash
+cargo install exarch-cli
+```
+
+This installs a binary named `exarch` (not `exarch-cli`). Inside this workspace, use the debug
+build instead:
+
+```bash
+cargo build -p exarch-cli
+./target/debug/exarch --help
+```
+
+## Global flags
+
+Available on every subcommand:
+
+| Flag | Effect |
+|---|---|
+| `-v, --verbose` | Verbose output. Conflicts with `--quiet`. |
+| `-q, --quiet` | Suppress non-error output. Conflicts with `--verbose`. |
+| `-j, --json` | Emit a machine-readable JSON envelope instead of human-readable text (see below). Always prefer this when parsing output programmatically. |
+
+## Subcommands
+
+### `extract <ARCHIVE> [OUTPUT_DIR]`
+
+```bash
+exarch extract archive.tar.gz ./out --json
+```
+
+`OUTPUT_DIR` defaults to the **current directory** if omitted — always pass an explicit output
+directory rather than relying on the default, so extraction is predictable and easy to clean up.
+
+Key flags (all optional):
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--force` | off | Overwrite existing files at the destination. |
+| `--atomic` | off | Extract to a temp dir, rename into place on success, clean up on failure. With `--force`, the pre-existing destination is removed only after successful extraction (right before rename), minimizing the window with no valid data. |
+| `--preserve-permissions` | off | Preserve file permissions from the archive (setuid/setgid are still stripped regardless). |
+| `--max-files` | 10000 | Max number of entries to extract. |
+| `--max-total-size` | 500 MB | Max cumulative extracted size. Accepts `K`/`M`/`G`/`T` suffixes, e.g. `2G`. |
+| `--max-file-size` | 50 MB | Max size of any single extracted file. Same suffix syntax. |
+| `--max-compression-ratio` | 100 | Max uncompressed/compressed ratio before an entry is treated as a zip bomb. |
+| `--max-path-depth` | 32 | Max path component depth allowed per entry. |
+| `--allowed-extensions <EXT>` | all allowed | Restrict extraction to matching extensions. Repeatable or comma-separated (`txt,pdf`); leading dot optional, case-insensitive. |
+| `--allow-symlinks` | off | Allow symlinks that resolve within the extraction directory. |
+| `--allow-hardlinks` | off | Allow hardlinks that resolve within the extraction directory. |
+| `--allow-absolute-paths` | off | Allow archive entries with absolute paths. |
+| `--allow-world-writable` | off | Allow files with world-writable (mode `0o002`) permission bits. |
+| `--allow-solid-archives` | off | Allow solid 7z archives (see Security model below). |
+| `--banned-component <COMPONENT>` | see below | Block entries whose path contains this component. **Replaces** the default list — see warning below. Repeatable. |
+
+> [!WARNING]
+> **`--banned-component` REPLACES the default ban list, it does not append to it.** The default
+> blocks path components `.git`, `.ssh`, `.gnupg`, `.aws`, `.kube`, `.docker`, `.env`. Passing
+> `--banned-component foo` drops ALL of those defaults and blocks only `foo` — silently letting
+> `.ssh`, `.aws`, etc. through. If you need one extra banned component, repeat the flag with the
+> full desired set, not just the addition: `--banned-component .git --banned-component .ssh
+> --banned-component .gnupg --banned-component .aws --banned-component .kube --banned-component
+> .docker --banned-component .env --banned-component foo`. Passing an empty value disables all
+> banning.
+
+### `create <OUTPUT> <SOURCE>...`
+
+```bash
+exarch create out.tar.gz src/ --json
+```
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `-f, --force` | off | Overwrite `OUTPUT` if it already exists. |
+| `-l, --compression-level <1-9>` | format default | Compression level. |
+| `-x, --exclude <PATTERN>` | none | Glob exclude pattern; repeatable. |
+| `--strip-prefix <PREFIX>` | none | Strip a path prefix from entry names. |
+| `--include-hidden` | off | Include dotfiles/hidden entries. |
+| `--follow-symlinks` | off | Follow symlinks when walking source trees (stores target contents, not the link). |
+| `--max-file-size <BYTES>` | none | Skip source files larger than this (`K`/`M`/`G`/`T` suffixes). |
+| `--preserve-permissions[=true\|false]` | `true` | Preserve platform permission bits. Pass `--preserve-permissions=false` for a portable, permission-agnostic archive. |
+
+`exarch` refuses to *create* 7z archives (7z is extract-only) and refuses to create archives
+under ZIP-family extensions that carry extra format semantics: `.jar`, `.war`, `.ear`, `.nar`,
+`.nbm`, `.apk`, `.aab`, `.ipa`, `.appx`, `.msix`, `.whl`, `.vsix`, `.xpi`, `.epub` — use plain
+`.zip` for those cases.
+
+### `list <ARCHIVE>`
+
+```bash
+exarch list archive.zip -l -H --json
+```
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `-l, --long` | off | Detailed per-entry info (type, size, mode, timestamps, link targets). |
+| `-H, --human-readable` | off | Human-readable sizes in text mode (ignored in `--json` mode, which always emits raw byte counts). |
+| `--max-files` | 10000 | Hard limit on entries scanned; listing fails with `QuotaExceeded` past this count, it does not truncate. |
+| `--max-total-size` | 500 MB | Hard limit on cumulative listed size; listing fails with `QuotaExceeded` past this size. Raise it explicitly for larger archives. |
+| `--allow-solid-archives` | off | Allow listing solid 7z archives (higher memory use). |
+
+### `verify <ARCHIVE>`
+
+```bash
+exarch verify archive.tar.gz --check-integrity --check-security --json
+```
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--check-integrity` | off | Validate checksums/structure. |
+| `--check-security` | off | Run the security validation pipeline (path traversal, symlink/hardlink, permissions) without extracting. |
+| `--strict` | off | Treat any warning-level finding as an error and exit with status `2` instead of `0`. |
+| `--max-files` / `--max-total-size` / `--allow-solid-archives` | same as `list` (10000 / 500 MB / off) | Same hard-limit semantics as `list` — verification fails with `QuotaExceeded` past these caps, it does not skip entries. |
+
+Run `verify` before `extract` on any archive from an untrusted source to inspect issues without
+writing anything to disk. Archives over 500 MB need `--max-total-size` raised explicitly or
+`verify` will fail with `QuotaExceeded` before it can report anything else.
+
+> [!WARNING]
+> **When the archive has `status: "FAIL"`, `verify --json` prints TWO concatenated top-level
+> JSON objects to stdout, not one.** Verified live (with and without `--strict`) on an archive
+> containing a bare symlink entry: stdout contains a `status: "success"` envelope with the full
+> report (`data.status: "FAIL"`, findings in `data.issues`), immediately followed by a second
+> `status: "error"` envelope (`error.kind: "Error"`, generic message `"Archive verification
+> failed"`). The process exits `1` in both cases. A naive `json.loads(stdout)` will fail on this
+> output — split on the `}\n{` boundary, or use a streaming/multi-document JSON parser, and treat
+> the first object's `data` as the authoritative report.
+
+### `completion <SHELL>`
+
+```bash
+exarch completion zsh > ~/.zsh/completions/_exarch
+```
+
+Valid `<SHELL>` values (case-sensitive, exact set): `bash`, `elvish`, `fish`, `powershell`, `zsh`.
+
+## Do not reach for `--allow-*` reflexively
+
+`--allow-symlinks`, `--allow-hardlinks`, `--allow-absolute-paths`, `--allow-world-writable`,
+`--allow-solid-archives`, and `--force` all weaken a default-deny security check. When an
+extraction fails with `SymlinkEscape`, `HardlinkEscape`, `PathTraversal`, `ZipBomb`,
+`InvalidPermissions`, or `SecurityViolation`, that is the validator correctly rejecting
+something dangerous — **do not add the matching `--allow-*` flag just to make the command
+succeed.** Only add it when the archive's origin and contents are already known to be trusted,
+and prefer re-running just `verify --check-security` first to see the full list of findings
+before deciding. `--force` (extract/create) and `--atomic` (extract) are safe to use more
+liberally since they affect overwrite behavior, not path/link/permission validation.
+
+## `--json` output envelope
+
+Every subcommand's `--json` output uses the same envelope:
+
+```jsonc
+// success
+{
+  "operation": "extract" | "create" | "list" | "verify",
+  "status": "success",
+  "data": { /* per-command payload, see below */ }
+}
+
+// error
+{
+  "operation": "extract" | "create" | "list" | "verify",
+  "status": "error",
+  "error": {
+    "kind": "PathTraversal",   // see full enum below
+    "message": "..."
+  }
+}
+```
+
+`data` is absent on error, `error` is absent on success.
+
+For `extract`, when some files were already written before a mid-archive failure, the JSON
+schema has a structured `error.partial_report` field defined for exactly this case — but as of
+0.5.1 it is never actually populated; verified live against a two-entry archive where the first
+entry extracts and the second exceeds `--max-file-size`. The partial-progress counts are instead
+embedded as free text inside `error.message`, prefixed `"WARNING: Extraction was stopped. N
+items (X files, Y directories, Z symlinks) were written to disk before the error."`. Parse that
+prefix (or just treat any `error.message` starting with `"WARNING:"` as "some data was written")
+if you need this information — do not branch on an `error.partial_report` object appearing.
+
+### Verified examples
+
+Success (`extract`):
+
+```json
+{
+  "operation": "extract",
+  "status": "success",
+  "data": {
+    "files_extracted": 1,
+    "directories_created": 0,
+    "symlinks_created": 0,
+    "bytes_written": 6,
+    "duration_ms": 0
+  }
+}
+```
+
+Error (`extract`, path traversal):
+
+```json
+{
+  "operation": "extract",
+  "status": "error",
+  "error": {
+    "kind": "PathTraversal",
+    "message": "failed to list archive: evil.tar: path traversal detected: ../../etc/passwd"
+  }
+}
+```
+
+Error (`extract`, mid-archive quota failure with partial progress — note there is no
+`partial_report` field, only the `"WARNING:"`-prefixed text in `message`):
+
+```json
+{
+  "operation": "extract",
+  "status": "error",
+  "error": {
+    "kind": "QuotaExceeded",
+    "message": "WARNING: Extraction was stopped. 1 items (1 files, 0 directories, 0 symlinks) were written to disk before the error.\nHINT: Inspect or remove the output directory before re-running.: quota exceeded: single file size (100 > 10)"
+  }
+}
+```
+
+### `error.kind` enum
+
+`IoError`, `InvalidArchive`, `PathTraversal`, `SymlinkEscape`, `HardlinkEscape`, `ZipBomb`,
+`InvalidPermissions`, `QuotaExceeded`, `SecurityViolation`, `SourceNotFound`,
+`SourceNotAccessible`, `OutputExists`, `InvalidCompressionLevel`, `UnknownFormat`,
+`InvalidConfiguration`, or the generic `Error` fallback for failures that don't originate from
+the archive validation pipeline (e.g. unexpected I/O outside archive handling). Branch on this
+field rather than parsing `message`, which is a free-text, human-oriented string and not stable
+across versions.
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Success. |
+| `1` | Operation failed (see `error.kind` in JSON mode, or stderr in text mode). |
+| `2` | `verify --strict` only: the archive is otherwise valid but has warning-level findings, treated as failure because `--strict` was passed. |
+
+## Security model (context, not a full manual)
+
+Default `SecurityConfig` limits: 50 MB per file, 500 MB total extracted size, 100x max
+compression ratio, 10,000 max files, 32 max path depth. All symlinks, hardlinks, absolute
+paths, and world-writable files are rejected unless explicitly allowed. setuid/setgid bits are
+always stripped on Unix regardless of `--preserve-permissions`. Solid 7z archives (multiple
+files compressed as one block) are rejected by default because extracting even one file
+requires decompressing the whole block into memory — a memory-exhaustion vector; enable
+`--allow-solid-archives` only for trusted archives, and consider it isn't a substitute for
+enough free memory. If an operation is rejected for one of these reasons, that's the security
+pipeline working as intended, not a defect to work around by default.


### PR DESCRIPTION
## Summary
- Adds `skills/exarch-cli/SKILL.md`, an Agent Skill (per the [agentskills.io specification](https://agentskills.io/specification)) documenting installation and usage of the `exarch` CLI for AI coding agents. Covers installation, every subcommand (`extract`, `create`, `list`, `verify`, `completion`) with flags and defaults verified against source, the `--json` output envelope with the full `error.kind` enum, exit codes, the security model, and explicit anti-reflex guidance against `--allow-*` bypass flags. Also documents two real, currently-unpatched CLI behaviors discovered during review rather than papering over them (tracked as #386 and #387).
- Adds a `build-cli-binaries` job to `.github/workflows/release.yml` that cross-compiles `exarch-cli` for Linux (x86_64/aarch64), macOS (x86_64/aarch64), and Windows (x86_64), packages each as a checksummed archive, and attaches them to the GitHub release.
- Adds `scripts/install.sh`, a POSIX installer that resolves the latest (or a pinned) release, downloads the matching archive, verifies its SHA256 checksum before extracting, and installs `exarch` to `~/.local/bin` — no Rust toolchain required. Also attached to each release.
- Updates the skill's Install section to document both paths (`cargo install`, prebuilt binary / install script), gated on Rust toolchain availability (`command -v cargo`) and split by OS where the commands genuinely differ (Linux/macOS vs. Windows extraction and checksum verification).
- Updates `CHANGELOG.md` `[Unreleased]`.

## Test plan
- [x] All documented `exarch` commands/flags executed live against a locally built binary
- [x] `--json` envelope examples captured from real output (success, path-traversal error, partial-extraction error)
- [x] `--banned-component` replace-semantics, completion shells, and quota defaults verified live
- [x] Security-relevant claims independently audited, 0 blocking issues
- [x] `.github/workflows/release.yml` validated with `fy validate`/`fy parse` (0 errors); artifact upload/download name-pattern matching verified by hand since the workflow can't be dry-run without a tag push
- [x] `scripts/install.sh` passes `shellcheck -s sh`; supply-chain audit (checksum-before-extract, HTTPS-only, no unverified code execution) passed with 0 critical/high findings
- [x] Frontmatter and file layout verified against the live agentskills.io spec