### PR TITLE
fix(cli): correct json output for verify FAIL and extract partial_report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `skills/exarch-cli/SKILL.md` now documents both install methods above as secondary alternatives
   to `cargo install exarch-cli`.
 
+### Fixed
+
+- **`verify --json` printed two concatenated top-level JSON documents on FAIL (#387)**: the
+  verification report (with `data.status == "FAIL"`) was always printed, and then the command
+  bailed with an error that `main`'s top-level handler also serialized to stdout, breaking
+  single-document JSON parsing. `verify::execute` now returns a sentinel error that `main`
+  recognizes and skips re-printing in `--json` mode; human-readable output still prints the
+  "Archive verification failed" message on stderr as before. The command still exits non-zero
+  on FAIL in both modes.
+- **`extract --json` never populated `error.partial_report` (#386)**: `format_error` looked up
+  `PartialExtractionContext` via `error.chain().find_map(downcast_ref)`, which never matches
+  because `anyhow::Error::context(...)` requires a direct top-level `downcast_ref` to see
+  through the context wrapper. Switched to `error.downcast_ref::<PartialExtractionContext>()`,
+  so partial extraction progress is now correctly reported in JSON error output.
+
 ## [0.5.1] - 2026-07-09
 
 ### Fixed

--- a/crates/exarch-cli/src/commands/verify.rs
+++ b/crates/exarch-cli/src/commands/verify.rs
@@ -2,9 +2,9 @@
 
 use crate::cli::VerifyArgs;
 use crate::error::StrictWarning;
+use crate::error::VerificationFailed;
 use crate::output::OutputFormatter;
 use anyhow::Result;
-use anyhow::bail;
 use exarch_core::SecurityConfig;
 use exarch_core::VerificationStatus;
 use exarch_core::verify_archive;
@@ -27,8 +27,6 @@ pub fn execute(args: &VerifyArgs, formatter: &dyn OutputFormatter) -> Result<()>
             }
             Ok(())
         }
-        VerificationStatus::Fail => {
-            bail!("Archive verification failed")
-        }
+        VerificationStatus::Fail => Err(anyhow::Error::new(VerificationFailed)),
     }
 }

--- a/crates/exarch-cli/src/error.rs
+++ b/crates/exarch-cli/src/error.rs
@@ -24,6 +24,26 @@ impl fmt::Display for StrictWarning {
 
 impl std::error::Error for StrictWarning {}
 
+/// Sentinel error returned by `verify::execute` when the verification report
+/// has `Fail` status.
+///
+/// The verification report itself (already emitted by the formatter, with
+/// `data.status == "FAIL"` in JSON mode) fully describes the failure, so
+/// `main` must not print a second error envelope for `--json` output — doing
+/// so would emit two concatenated top-level JSON documents on stdout. For
+/// human-readable output, `main` still prints this sentinel via
+/// `format_error` and exits non-zero, matching prior behavior.
+#[derive(Debug)]
+pub struct VerificationFailed;
+
+impl fmt::Display for VerificationFailed {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("Archive verification failed")
+    }
+}
+
+impl std::error::Error for VerificationFailed {}
+
 /// Carrier for partial-extraction progress embedded in the anyhow error chain.
 ///
 /// `ArchiveError::PartialExtraction` uses `#[error("{source}")]` with

--- a/crates/exarch-cli/src/main.rs
+++ b/crates/exarch-cli/src/main.rs
@@ -9,6 +9,7 @@ mod progress;
 
 use clap::Parser;
 use error::StrictWarning;
+use error::VerificationFailed;
 use output::OutputFormatter;
 use std::process;
 
@@ -39,6 +40,17 @@ fn main() {
     if let Err(err) = result {
         if err.is::<StrictWarning>() {
             process::exit(2);
+        }
+        // The verification report (already emitted by the formatter) fully
+        // describes a Fail status. In --json mode, printing a second error
+        // envelope here would produce two concatenated top-level JSON
+        // documents on stdout, so it's skipped; human-readable output still
+        // gets the error message on stderr.
+        if err.is::<VerificationFailed>() {
+            if !cli.json {
+                formatter.format_error(operation, &err);
+            }
+            process::exit(1);
         }
         formatter.format_error(operation, &err);
         process::exit(1);

--- a/crates/exarch-cli/src/output/json.rs
+++ b/crates/exarch-cli/src/output/json.rs
@@ -110,18 +110,21 @@ impl OutputFormatter for JsonFormatter {
         let kind = extraction_err.map_or_else(|| "Error".to_string(), extraction_error_kind);
         let message = format!("{error:#}");
 
-        // PartialExtraction is converted by convert_extraction_error into a chain
-        // of PartialExtractionContext → inner ArchiveError, so the partial
-        // report is carried by PartialExtractionContext, not by ArchiveError.
-        let partial_report = error
-            .chain()
-            .find_map(|e| e.downcast_ref::<PartialExtractionContext>())
-            .map(|ctx| JsonPartialReport {
-                files_extracted: ctx.report.files_extracted,
-                directories_created: ctx.report.directories_created,
-                symlinks_created: ctx.report.symlinks_created,
-                bytes_written: ctx.report.bytes_written,
-            });
+        // PartialExtraction is converted by convert_extraction_error into a
+        // PartialExtractionContext attached via `.context()`, so the partial
+        // report must be recovered with a direct top-level downcast: anyhow
+        // sees through `.context()` layers for the context type itself, but
+        // `.chain()` yields the wrapper's Display/Debug impl, never the
+        // context value, so `.chain().find_map(downcast_ref)` never matches.
+        let partial_report =
+            error
+                .downcast_ref::<PartialExtractionContext>()
+                .map(|ctx| JsonPartialReport {
+                    files_extracted: ctx.report.files_extracted,
+                    directories_created: ctx.report.directories_created,
+                    symlinks_created: ctx.report.symlinks_created,
+                    bytes_written: ctx.report.bytes_written,
+                });
 
         let output = if let Some(pr) = partial_report {
             JsonOutput::<()>::error_with_partial(operation, kind, message, pr)

--- a/crates/exarch-cli/tests/cli_tests.rs
+++ b/crates/exarch-cli/tests/cli_tests.rs
@@ -1176,6 +1176,181 @@ fn test_verify_archive_json_output() {
     assert!(json["data"]["security_status"].is_string());
 }
 
+/// Builds a tar.gz archive at `path` containing one symlink entry pointing
+/// outside the extraction root. Verification rejects the symlink, producing a
+/// `VerificationStatus::Fail` report.
+fn create_symlink_escape_tar_gz(path: &std::path::Path) {
+    use flate2::Compression;
+    use flate2::write::GzEncoder;
+
+    let file = std::fs::File::create(path).expect("create archive");
+    let gz = GzEncoder::new(file, Compression::default());
+    let mut builder = tar::Builder::new(gz);
+    let mut header = tar::Header::new_gnu();
+    header.set_size(0);
+    header.set_entry_type(tar::EntryType::Symlink);
+    header.set_path("evil_link").expect("set path");
+    header.set_link_name("/etc/passwd").expect("set link name");
+    header.set_cksum();
+    builder
+        .append_data(&mut header, "evil_link", std::io::empty())
+        .expect("append entry");
+    let gz = builder.into_inner().expect("get gz encoder");
+    gz.finish().expect("finish gzip stream");
+}
+
+/// Regression test for issue #387: `verify --json` on a FAIL-status archive
+/// must print exactly one top-level JSON document, and the process must still
+/// exit non-zero.
+#[test]
+fn test_verify_json_fail_prints_single_document() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let archive_path = temp.path().join("symlink_escape.tar.gz");
+    create_symlink_escape_tar_gz(&archive_path);
+
+    let output = exarch_cmd()
+        .arg("verify")
+        .arg("--json")
+        .arg(&archive_path)
+        .assert()
+        .failure()
+        .code(1)
+        .get_output()
+        .stdout
+        .clone();
+
+    let stdout = std::str::from_utf8(&output).expect("stdout is not valid UTF-8");
+    let mut deserializer =
+        serde_json::Deserializer::from_str(stdout).into_iter::<serde_json::Value>();
+    let first = deserializer
+        .next()
+        .expect("expected at least one JSON document")
+        .expect("first JSON document is invalid");
+    assert!(
+        deserializer.next().is_none(),
+        "stdout must contain exactly one top-level JSON document, got extra trailing data: {stdout}"
+    );
+
+    assert_eq!(first["operation"], "verify");
+    assert_eq!(first["status"], "success");
+    assert_eq!(first["data"]["status"], "FAIL");
+}
+
+/// Regression test for issue #387: the human-readable path must still print
+/// an error message on stderr and exit non-zero for a FAIL-status archive.
+#[test]
+fn test_verify_fail_human_readable_prints_error() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let archive_path = temp.path().join("symlink_escape.tar.gz");
+    create_symlink_escape_tar_gz(&archive_path);
+
+    exarch_cmd()
+        .arg("verify")
+        .arg(&archive_path)
+        .assert()
+        .failure()
+        .code(1)
+        .stderr(predicate::str::contains("Archive verification failed"));
+}
+
+/// Regression test for issue #386: `extract --json` must populate the
+/// structured `error.partial_report` field when extraction is stopped
+/// mid-archive after some entries were already written.
+#[test]
+fn test_extract_json_partial_report_populated() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let archive_path = temp.path().join("partial.tar.gz");
+
+    {
+        use flate2::Compression;
+        use flate2::write::GzEncoder;
+
+        let file = std::fs::File::create(&archive_path).expect("create archive");
+        let gz = GzEncoder::new(file, Compression::default());
+        let mut builder = tar::Builder::new(gz);
+        builder
+            .append_data(
+                &mut {
+                    let mut h = tar::Header::new_gnu();
+                    h.set_size(4);
+                    h.set_mode(0o644);
+                    h.set_cksum();
+                    h
+                },
+                "small.txt",
+                &b"data"[..],
+            )
+            .expect("append small entry");
+        let big = vec![0_u8; 2_000_000];
+        builder
+            .append_data(
+                &mut {
+                    let mut h = tar::Header::new_gnu();
+                    h.set_size(big.len() as u64);
+                    h.set_mode(0o644);
+                    h.set_cksum();
+                    h
+                },
+                "big.bin",
+                big.as_slice(),
+            )
+            .expect("append big entry");
+        let gz = builder.into_inner().expect("get gz encoder");
+        gz.finish().expect("finish gzip stream");
+    }
+
+    let output_dir = temp.path().join("out");
+    let output = exarch_cmd()
+        .arg("extract")
+        .arg("--json")
+        .arg("--max-file-size")
+        .arg("1000000")
+        .arg(&archive_path)
+        .arg(&output_dir)
+        .assert()
+        .failure()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json: serde_json::Value = serde_json::from_slice(&output).expect("invalid JSON output");
+    assert_eq!(json["status"], "error");
+    let partial_report = &json["error"]["partial_report"];
+    assert!(
+        !partial_report.is_null(),
+        "error.partial_report must be populated, got: {json}"
+    );
+    assert!(partial_report["files_extracted"].as_u64().unwrap() >= 1);
+}
+
+/// Regression test for issue #386: `error.partial_report` must stay
+/// absent/null for failures that never wrote anything to disk. Guards
+/// against a broken fix that always populates `partial_report` regardless
+/// of whether extraction actually made progress.
+#[test]
+fn test_extract_json_partial_report_absent_when_nothing_extracted() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let output_dir = temp.path().join("out");
+
+    let output = exarch_cmd()
+        .arg("extract")
+        .arg("--json")
+        .arg("nonexistent.tar.gz")
+        .arg(&output_dir)
+        .assert()
+        .failure()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json: serde_json::Value = serde_json::from_slice(&output).expect("invalid JSON output");
+    assert_eq!(json["status"], "error");
+    assert!(
+        json["error"]["partial_report"].is_null(),
+        "error.partial_report must be absent/null when no entries were extracted, got: {json}"
+    );
+}
+
 #[test]
 fn test_global_verbose_flag() {
     let temp = TempDir::new().expect("failed to create temp dir");

--- a/skills/exarch-cli/SKILL.md
+++ b/skills/exarch-cli/SKILL.md
@@ -173,15 +173,11 @@ Run `verify` before `extract` on any archive from an untrusted source to inspect
 writing anything to disk. Archives over 500 MB need `--max-total-size` raised explicitly or
 `verify` will fail with `QuotaExceeded` before it can report anything else.
 
-> [!WARNING]
-> **When the archive has `status: "FAIL"`, `verify --json` prints TWO concatenated top-level
-> JSON objects to stdout, not one.** Verified live (with and without `--strict`) on an archive
-> containing a bare symlink entry: stdout contains a `status: "success"` envelope with the full
-> report (`data.status: "FAIL"`, findings in `data.issues`), immediately followed by a second
-> `status: "error"` envelope (`error.kind: "Error"`, generic message `"Archive verification
-> failed"`). The process exits `1` in both cases. A naive `json.loads(stdout)` will fail on this
-> output — split on the `}\n{` boundary, or use a streaming/multi-document JSON parser, and treat
-> the first object's `data` as the authoritative report.
+When the archive has `status: "FAIL"`, `verify --json` prints exactly one top-level JSON
+document to stdout — a `status: "success"` envelope carrying the full report (`data.status:
+"FAIL"`, findings in `data.issues`). Verified live on an archive containing a bare symlink
+entry: a single valid JSON document, parseable with a plain `json.loads(stdout)`. The process
+still exits `1` for a FAIL status.
 
 ### `completion <SHELL>`
 
@@ -228,14 +224,17 @@ Every subcommand's `--json` output uses the same envelope:
 
 `data` is absent on error, `error` is absent on success.
 
-For `extract`, when some files were already written before a mid-archive failure, the JSON
-schema has a structured `error.partial_report` field defined for exactly this case — but as of
-0.5.1 it is never actually populated; verified live against a two-entry archive where the first
-entry extracts and the second exceeds `--max-file-size`. The partial-progress counts are instead
-embedded as free text inside `error.message`, prefixed `"WARNING: Extraction was stopped. N
-items (X files, Y directories, Z symlinks) were written to disk before the error."`. Parse that
-prefix (or just treat any `error.message` starting with `"WARNING:"` as "some data was written")
-if you need this information — do not branch on an `error.partial_report` object appearing.
+**`verify` is the one exception to "top-level `status` tells you whether it worked":** a FAIL-status
+archive still yields a `status: "success"` envelope (the verification *ran* successfully — it just
+found the archive unsafe), with the outcome in `data.status` (`"PASS"` / `"WARNING"` / `"FAIL"`).
+For `verify`, branch on `data.status` (or the process exit code), not on top-level `status`.
+
+For `extract`, when some files were already written before a mid-archive failure, `error` carries
+a structured `error.partial_report` object (`files_extracted`, `directories_created`,
+`symlinks_created`, `bytes_written`). Verified live against a two-entry archive where the first
+entry extracts and the second exceeds `--max-file-size`. The same progress counts also appear as
+free text inside `error.message` (prefixed `"WARNING: Extraction was stopped. ..."`) — prefer the
+structured `error.partial_report` field over parsing that text.
 
 ### Verified examples
 
@@ -268,8 +267,8 @@ Error (`extract`, path traversal):
 }
 ```
 
-Error (`extract`, mid-archive quota failure with partial progress — note there is no
-`partial_report` field, only the `"WARNING:"`-prefixed text in `message`):
+Error (`extract`, mid-archive quota failure with partial progress — note the structured
+`error.partial_report` field):
 
 ```json
 {
@@ -277,7 +276,13 @@ Error (`extract`, mid-archive quota failure with partial progress — note there
   "status": "error",
   "error": {
     "kind": "QuotaExceeded",
-    "message": "WARNING: Extraction was stopped. 1 items (1 files, 0 directories, 0 symlinks) were written to disk before the error.\nHINT: Inspect or remove the output directory before re-running.: quota exceeded: single file size (100 > 10)"
+    "message": "WARNING: Extraction was stopped. 1 items (1 files, 0 directories, 0 symlinks) were written to disk before the error.\nHINT: Inspect or remove the output directory before re-running.: quota exceeded: single file size (2000000 > 1000000)",
+    "partial_report": {
+      "files_extracted": 1,
+      "directories_created": 0,
+      "symlinks_created": 0,
+      "bytes_written": 4
+    }
   }
 }
 ```
@@ -297,7 +302,7 @@ across versions.
 | Code | Meaning |
 |---|---|
 | `0` | Success. |
-| `1` | Operation failed (see `error.kind` in JSON mode, or stderr in text mode). |
+| `1` | Operation failed (see `error.kind` in JSON mode, or stderr in text mode). **Exception:** `verify --json` on a FAIL-status archive also exits `1`, but prints a `status: "success"` envelope with `data.status: "FAIL"` — there is no `error` object in this case. Check `data.status`, not top-level `status`, for `verify`. |
 | `2` | `verify --strict` only: the archive is otherwise valid but has warning-level findings, treated as failure because `--strict` was passed. |
 
 ## Security model (context, not a full manual)


### PR DESCRIPTION
## Summary

- `verify --json` printed two concatenated top-level JSON documents on a FAIL status result, breaking single-document JSON parsing for scripted/agent consumers. `verify::execute` now returns a sentinel error that `main`'s handler recognizes and skips re-printing in `--json` mode; human-readable output and exit codes (non-zero on FAIL) are unchanged.
- `extract --json` never populated the documented `error.partial_report` field on partial-extraction failures, because the lookup traversed `error.chain()` with `downcast_ref`, which cannot see through anyhow's `.context()` wrapper. Switched to a direct `downcast_ref` on the top-level error.
- Both fixes were validated live against the built binary, plus 4 new regression tests (one negative test guarding against an "always populate partial_report" false fix).
- `skills/exarch-cli/SKILL.md` updated: removed the two now-fixed known-broken warning callouts, corrected exit-code table and envelope-schema notes, fixed a stale example value.

Closes #387
Closes #386

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node`
- [x] `cargo test --doc --workspace --all-features` (exarch-cli/exarch-core doctests pass; exarch-python doctest failure is a pre-existing local libpython-linking issue, unrelated to this diff)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --all-features --workspace`
- [x] Live repro of both original bugs confirmed fixed against `target/debug/exarch`
- [x] Independent adversarial critique (verdict: minor, no blocking defects) and code review (verdict: approved)