### PR TITLE
fix(core): route list_archive() quota checks through QuotaTracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the writer/encoder is fully flushed and finished, for ZIP and all TAR variants (including plain
   `.tar`). `compression_ratio()` and `compression_percentage()` now reflect real compression
   results. The now-unused `crate::io::CountingWriter` (crate-internal only) was removed.
+- **`list_archive()` re-implemented quota checks instead of reusing `QuotaTracker` (#396)**:
+  the three per-format listing functions in `exarch-core`'s `inspection::list` module each
+  duplicated total-size and file-count quota logic inline, independently of the `QuotaTracker`
+  used by extraction. This duplicate implementation was weaker than the original: it never
+  checked `max_file_size` per entry, and computed the running total-size check with unchecked
+  `+` instead of `checked_add`, so a crafted archive with entry sizes near `u64::MAX` could wrap
+  `total_size` in a release build and silently bypass `max_total_size` during listing. All three
+  listing functions (TAR, ZIP, 7z) now route every entry through the same `QuotaTracker` used by
+  extraction, closing both gaps. This does not make listing and extraction fully equivalent:
+  extraction's `QuotaTracker` only records `EntryType::File`, while listing records every entry
+  type (directories, symlinks, hardlinks too) — a pre-existing, unrelated divergence.
+
+  **BREAKING CHANGE:** `list_archive()` and `verify_archive()` — and by extension the `list`/
+  `verify` CLI subcommands and the `exarch-python`/`exarch-node` bindings — now reject any single
+  entry larger than `max_file_size` (default 50 MB) during listing; previously only file count
+  and total size were enforced there. `list`/`verify` gain a new `--max-file-size` CLI flag
+  (mirroring `extract`/`create`) to raise this limit; there was previously no way to configure it
+  for these two commands. `verify_archive()`'s internal pre-flight listing pass keeps
+  `max_file_size` unlimited so an oversized entry still surfaces as a `VerificationIssue`
+  (`Fail` status with an itemized report) via the existing per-entry check in `verify_entry`,
+  rather than aborting before any report exists — `verify`'s "report, don't hard-fail" contract
+  is preserved.
+
+### Changed
+
+- **Deduplicated `PartialExtraction` error-wrapping logic across format handlers (#394)**: the
+  "wrap the error in `ArchiveError::PartialExtraction` if the report recorded any processed
+  items, otherwise return it as-is" pattern was copy-pasted five times across `tar.rs`, `zip.rs`,
+  and `sevenz.rs`. Consolidated into `ArchiveError::partial_or()`; behavior-equivalent at all
+  current call sites (each site returns the error immediately afterwards, so evaluating
+  `std::mem::take(report)` unconditionally rather than only inside the `total_items() > 0` branch
+  is unobservable).
 
 ## [0.5.2] - 2026-07-27
 

--- a/crates/exarch-cli/src/cli.rs
+++ b/crates/exarch-cli/src/cli.rs
@@ -199,6 +199,10 @@ pub struct ListArgs {
     #[arg(long, value_parser = parse_byte_size)]
     pub max_total_size: Option<u64>,
 
+    /// Maximum size of any single entry in bytes (supports K, M, G, T suffixes)
+    #[arg(long, value_parser = parse_byte_size)]
+    pub max_file_size: Option<u64>,
+
     /// Allow solid 7z archives (higher memory usage during listing)
     #[arg(long)]
     pub allow_solid_archives: bool,
@@ -225,6 +229,10 @@ pub struct VerifyArgs {
     /// Maximum total size of entries in bytes (supports K, M, G, T suffixes)
     #[arg(long, value_parser = parse_byte_size)]
     pub max_total_size: Option<u64>,
+
+    /// Maximum size of any single entry in bytes (supports K, M, G, T suffixes)
+    #[arg(long, value_parser = parse_byte_size)]
+    pub max_file_size: Option<u64>,
 
     /// Allow solid 7z archives (higher memory usage during verification)
     #[arg(long)]
@@ -431,6 +439,24 @@ mod tests {
             panic!("expected verify command");
         };
         assert_eq!(args.max_total_size, Some(500 * 1024 * 1024));
+    }
+
+    #[test]
+    fn test_list_args_max_file_size_override() {
+        let cli = Cli::parse_from(["exarch", "list", "--max-file-size", "100M", "archive.zip"]);
+        let Commands::List(args) = cli.command else {
+            panic!("expected list command");
+        };
+        assert_eq!(args.max_file_size, Some(100 * 1024 * 1024));
+    }
+
+    #[test]
+    fn test_verify_args_max_file_size_override() {
+        let cli = Cli::parse_from(["exarch", "verify", "--max-file-size", "100M", "archive.zip"]);
+        let Commands::Verify(args) = cli.command else {
+            panic!("expected verify command");
+        };
+        assert_eq!(args.max_file_size, Some(100 * 1024 * 1024));
     }
 
     #[test]

--- a/crates/exarch-cli/src/commands/list.rs
+++ b/crates/exarch-cli/src/commands/list.rs
@@ -10,6 +10,7 @@ pub fn execute(args: &ListArgs, formatter: &dyn OutputFormatter) -> Result<()> {
     let config = SecurityConfig::default()
         .with_max_file_count(args.max_files)
         .with_max_total_size(args.max_total_size.unwrap_or(500 * 1024 * 1024))
+        .with_max_file_size(args.max_file_size.unwrap_or(50 * 1024 * 1024))
         .with_allow_solid_archives(args.allow_solid_archives);
 
     // List archive

--- a/crates/exarch-cli/src/commands/verify.rs
+++ b/crates/exarch-cli/src/commands/verify.rs
@@ -13,6 +13,7 @@ pub fn execute(args: &VerifyArgs, formatter: &dyn OutputFormatter) -> Result<()>
     let config = SecurityConfig::default()
         .with_max_file_count(args.max_files)
         .with_max_total_size(args.max_total_size.unwrap_or(500 * 1024 * 1024))
+        .with_max_file_size(args.max_file_size.unwrap_or(50 * 1024 * 1024))
         .with_allow_solid_archives(args.allow_solid_archives);
 
     let report = verify_archive(&args.archive, &config)?;

--- a/crates/exarch-cli/tests/cli_tests.rs
+++ b/crates/exarch-cli/tests/cli_tests.rs
@@ -1039,6 +1039,98 @@ fn test_list_archive_json_output() {
     assert!(json["data"]["total_entries"].is_number());
 }
 
+/// Builds a tar.gz archive at `path` containing one file of `size` bytes.
+fn create_sized_tar_gz(path: &std::path::Path, size: usize) {
+    use flate2::Compression;
+    use flate2::write::GzEncoder;
+
+    let file = std::fs::File::create(path).expect("create archive");
+    let gz = GzEncoder::new(file, Compression::default());
+    let mut builder = tar::Builder::new(gz);
+    let data = vec![0u8; size];
+    let mut header = tar::Header::new_gnu();
+    header.set_size(data.len() as u64);
+    header.set_mode(0o644);
+    header.set_path("big.bin").expect("set path");
+    header.set_cksum();
+    builder
+        .append_data(&mut header, "big.bin", &data[..])
+        .expect("append entry");
+    let gz = builder.into_inner().expect("get gz encoder");
+    gz.finish().expect("finish gzip stream");
+}
+
+/// Regression test: `list` must respect a caller-supplied `--max-file-size`,
+/// not just the compiled-in 50MB default — previously `list`/`verify` had no
+/// flag to raise or lower this cap, unlike `extract`/`create`.
+#[test]
+fn test_list_max_file_size_flag_enforced_and_configurable() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let archive_path = temp.path().join("oversized.tar.gz");
+    create_sized_tar_gz(&archive_path, 1000);
+
+    // Below the entry's size: list must reject with QuotaExceeded.
+    let output = exarch_cmd()
+        .arg("list")
+        .arg("--json")
+        .arg("--max-file-size")
+        .arg("500")
+        .arg(&archive_path)
+        .assert()
+        .failure()
+        .get_output()
+        .stdout
+        .clone();
+    let json: serde_json::Value = serde_json::from_slice(&output).expect("invalid JSON output");
+    assert_eq!(json["status"], "error");
+    assert_eq!(json["error"]["kind"], "QuotaExceeded");
+
+    // Above the entry's size: list must succeed.
+    exarch_cmd()
+        .arg("list")
+        .arg("--max-file-size")
+        .arg("2000")
+        .arg(&archive_path)
+        .assert()
+        .success();
+}
+
+/// Regression test: an oversized entry must degrade `verify` to a graceful
+/// Fail-status report (with the violation itemized as an issue), not a bare
+/// error — `verify`'s internal pre-flight listing pass keeps `max_file_size`
+/// unlimited precisely so this stays a report, not a hard failure.
+#[test]
+fn test_verify_oversized_entry_produces_fail_report_not_error() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let archive_path = temp.path().join("oversized.tar.gz");
+    create_sized_tar_gz(&archive_path, 1000);
+
+    let output = exarch_cmd()
+        .arg("verify")
+        .arg("--json")
+        .arg("--check-security")
+        .arg("--max-file-size")
+        .arg("500")
+        .arg(&archive_path)
+        .assert()
+        .failure()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json: serde_json::Value = serde_json::from_slice(&output).expect("invalid JSON output");
+    assert_eq!(
+        json["status"], "success",
+        "verify's envelope status must stay success even when data.status is FAIL"
+    );
+    assert_eq!(json["data"]["status"], "FAIL");
+    let issues = json["data"]["issues"].as_array().expect("issues array");
+    assert!(
+        issues.iter().any(|i| i["category"] == "Quota Exceeded"),
+        "expected a QuotaExceeded issue in the report, got: {json}"
+    );
+}
+
 #[test]
 fn test_verify_archive_safe() {
     exarch_cmd()
@@ -1256,6 +1348,13 @@ fn test_verify_fail_human_readable_prints_error() {
 /// Regression test for issue #386: `extract --json` must populate the
 /// structured `error.partial_report` field when extraction is stopped
 /// mid-archive after some entries were already written.
+///
+/// Uses a symlink entry (rejected only during extraction, since
+/// `allow_symlinks` defaults to false) rather than an oversized entry: since
+/// issue #396, `list` enforces `max_file_size` during the CLI's pre-flight
+/// `list_archive()` call (see `extract.rs`'s `list_config`), so an oversized
+/// entry is now rejected before extraction ever starts and would never produce
+/// a partial report.
 #[test]
 fn test_extract_json_partial_report_populated() {
     let temp = TempDir::new().expect("failed to create temp dir");
@@ -1281,20 +1380,14 @@ fn test_extract_json_partial_report_populated() {
                 &b"data"[..],
             )
             .expect("append small entry");
-        let big = vec![0_u8; 2_000_000];
+        let mut link_header = tar::Header::new_gnu();
+        link_header.set_size(0);
+        link_header.set_entry_type(tar::EntryType::Symlink);
+        link_header.set_mode(0o777);
+        link_header.set_cksum();
         builder
-            .append_data(
-                &mut {
-                    let mut h = tar::Header::new_gnu();
-                    h.set_size(big.len() as u64);
-                    h.set_mode(0o644);
-                    h.set_cksum();
-                    h
-                },
-                "big.bin",
-                big.as_slice(),
-            )
-            .expect("append big entry");
+            .append_link(&mut link_header, "link", "target.txt")
+            .expect("append symlink entry");
         let gz = builder.into_inner().expect("get gz encoder");
         gz.finish().expect("finish gzip stream");
     }
@@ -1303,8 +1396,6 @@ fn test_extract_json_partial_report_populated() {
     let output = exarch_cmd()
         .arg("extract")
         .arg("--json")
-        .arg("--max-file-size")
-        .arg("1000000")
         .arg(&archive_path)
         .arg(&output_dir)
         .assert()

--- a/crates/exarch-core/src/api.rs
+++ b/crates/exarch-core/src/api.rs
@@ -521,7 +521,7 @@ fn creator_for_format(
 /// Returns error if:
 /// - Archive file cannot be opened
 /// - Archive format is unsupported or corrupted
-/// - Quota limits exceeded (file count, total size)
+/// - Quota limits exceeded (file count, total size, single file size)
 ///
 /// # Examples
 ///

--- a/crates/exarch-core/src/error/types.rs
+++ b/crates/exarch-core/src/error/types.rs
@@ -297,6 +297,25 @@ impl ArchiveError {
             _ => None,
         }
     }
+
+    /// Wraps `err` in [`Self::PartialExtraction`] if `report` recorded any
+    /// processed items, otherwise returns `err` unchanged.
+    ///
+    /// Format handlers call this at every point where extraction can fail
+    /// mid-archive, so callers can distinguish "nothing was written" from
+    /// "extraction stopped partway through" without each handler
+    /// reimplementing the same check.
+    #[must_use]
+    pub(crate) fn partial_or(report: crate::ExtractionReport, err: Self) -> Self {
+        if report.total_items() > 0 {
+            Self::PartialExtraction {
+                source: Box::new(err),
+                report,
+            }
+        } else {
+            err
+        }
+    }
 }
 
 #[cfg(test)]
@@ -672,6 +691,35 @@ mod tests {
             report: ExtractionReport::new(),
         };
         assert!(err.is_recoverable());
+    }
+
+    #[test]
+    fn test_partial_or_wraps_when_report_has_items() {
+        use crate::ExtractionReport;
+
+        let mut report = ExtractionReport::new();
+        report.files_extracted = 1;
+        let err = ArchiveError::InvalidArchive("bad entry".into());
+
+        let result = ArchiveError::partial_or(report, err);
+        assert!(
+            matches!(result, ArchiveError::PartialExtraction { .. }),
+            "expected PartialExtraction when report has processed items, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_partial_or_passes_through_when_report_empty() {
+        use crate::ExtractionReport;
+
+        let report = ExtractionReport::new();
+        let err = ArchiveError::InvalidArchive("bad entry".into());
+
+        let result = ArchiveError::partial_or(report, err);
+        assert!(
+            matches!(result, ArchiveError::InvalidArchive(_)),
+            "expected the original error unwrapped when report is empty, got: {result:?}"
+        );
     }
 
     #[test]

--- a/crates/exarch-core/src/formats/sevenz.rs
+++ b/crates/exarch-core/src/formats/sevenz.rs
@@ -490,14 +490,7 @@ impl<R: Read + Seek> SevenZArchive<R> {
             Ok(()) => return Ok(accumulated),
             Err(e) => ArchiveError::from(e),
         };
-        if accumulated.total_items() > 0 {
-            Err(ArchiveError::PartialExtraction {
-                source: Box::new(e),
-                report: accumulated,
-            })
-        } else {
-            Err(e)
-        }
+        Err(ArchiveError::partial_or(accumulated, e))
     }
 }
 
@@ -619,7 +612,9 @@ impl<R: Read + Seek> ArchiveFormat for SevenZArchive<R> {
 
     fn verify(&mut self, config: &SecurityConfig) -> Result<crate::inspection::VerificationReport> {
         config.validate()?;
-        let manifest = self.list(config)?;
+        let manifest = self.list(&crate::inspection::verify::listing_config_for_verify(
+            config,
+        ))?;
         crate::inspection::verify::verify_manifest(&manifest, config)
     }
 

--- a/crates/exarch-core/src/formats/tar.rs
+++ b/crates/exarch-core/src/formats/tar.rs
@@ -390,14 +390,7 @@ impl<R: Read> ArchiveFormat for TarArchive<R> {
         for entry_result in entries {
             let entry = entry_result.map_err(|e| {
                 let raw = ArchiveError::InvalidArchive(format!("failed to read entry: {e}"));
-                if ctx.report.total_items() > 0 {
-                    ArchiveError::PartialExtraction {
-                        source: Box::new(raw),
-                        report: std::mem::take(ctx.report),
-                    }
-                } else {
-                    raw
-                }
+                ArchiveError::partial_or(std::mem::take(ctx.report), raw)
             })?;
 
             // TAR is streaming: total entry count is not known upfront, so pass 0.
@@ -420,14 +413,7 @@ impl<R: Read> ArchiveFormat for TarArchive<R> {
                 }
                 Err(e) => {
                     ctx.progress.on_entry_complete(&entry_path);
-                    return Err(if ctx.report.total_items() > 0 {
-                        ArchiveError::PartialExtraction {
-                            source: Box::new(e),
-                            report: std::mem::take(ctx.report),
-                        }
-                    } else {
-                        e
-                    });
+                    return Err(ArchiveError::partial_or(std::mem::take(ctx.report), e));
                 }
             }
         }
@@ -435,14 +421,7 @@ impl<R: Read> ArchiveFormat for TarArchive<R> {
         // Two-pass extraction: create hardlinks after all target files exist
         for hardlink_info in &hardlinks {
             if let Err(e) = Self::create_hardlink(hardlink_info, &mut ctx) {
-                return Err(if ctx.report.total_items() > 0 {
-                    ArchiveError::PartialExtraction {
-                        source: Box::new(e),
-                        report: std::mem::take(ctx.report),
-                    }
-                } else {
-                    e
-                });
+                return Err(ArchiveError::partial_or(std::mem::take(ctx.report), e));
             }
         }
 
@@ -485,7 +464,9 @@ impl<R: Read> ArchiveFormat for TarArchive<R> {
     }
 
     fn verify(&mut self, config: &SecurityConfig) -> Result<crate::inspection::VerificationReport> {
-        let manifest = self.list(config)?;
+        let manifest = self.list(&crate::inspection::verify::listing_config_for_verify(
+            config,
+        ))?;
         crate::inspection::verify::verify_manifest(&manifest, config)
     }
 

--- a/crates/exarch-core/src/formats/zip.rs
+++ b/crates/exarch-core/src/formats/zip.rs
@@ -481,14 +481,7 @@ impl<R: Read + Seek> ArchiveFormat for ZipArchive<R> {
 
             if let Err(e) = result {
                 drop(guard);
-                return Err(if report.total_items() > 0 {
-                    ArchiveError::PartialExtraction {
-                        source: Box::new(e),
-                        report: std::mem::take(&mut report),
-                    }
-                } else {
-                    e
-                });
+                return Err(ArchiveError::partial_or(std::mem::take(&mut report), e));
             }
             guard.complete();
         }
@@ -505,7 +498,9 @@ impl<R: Read + Seek> ArchiveFormat for ZipArchive<R> {
     }
 
     fn verify(&mut self, config: &SecurityConfig) -> Result<crate::inspection::VerificationReport> {
-        let manifest = self.list(config)?;
+        let manifest = self.list(&crate::inspection::verify::listing_config_for_verify(
+            config,
+        ))?;
         crate::inspection::verify::verify_manifest(&manifest, config)
     }
 

--- a/crates/exarch-core/src/inspection/list.rs
+++ b/crates/exarch-core/src/inspection/list.rs
@@ -14,6 +14,7 @@ use flate2::read::GzDecoder;
 use crate::ArchiveError;
 use crate::Result;
 use crate::SecurityConfig;
+#[cfg(test)]
 use crate::error::QuotaResource;
 use crate::formats::common::normalize_entry_name;
 use crate::formats::detect::ArchiveType;
@@ -23,6 +24,7 @@ use crate::formats::zip::zip_mode_is_symlink;
 use crate::inspection::manifest::ArchiveEntry;
 use crate::inspection::manifest::ArchiveManifest;
 use crate::inspection::manifest::ManifestEntryType;
+use crate::security::quota::QuotaTracker;
 
 /// Lists archive contents without extracting.
 ///
@@ -39,7 +41,7 @@ use crate::inspection::manifest::ManifestEntryType;
 /// Returns error if:
 /// - Archive file cannot be opened
 /// - Archive format is unsupported or corrupted
-/// - Quota limits exceeded (file count, total size)
+/// - Quota limits exceeded (file count, total size, single file size)
 ///
 /// # Examples
 ///
@@ -148,6 +150,7 @@ fn list_tar_entries<R: std::io::Read>(
     config: &SecurityConfig,
 ) -> Result<ArchiveManifest> {
     let mut manifest = ArchiveManifest::new(format);
+    let mut quota = QuotaTracker::new();
 
     let entries = archive
         .entries()
@@ -162,15 +165,15 @@ fn list_tar_entries<R: std::io::Read>(
             continue;
         }
 
-        // Check file count quota
-        if manifest.total_entries >= config.max_file_count {
-            return Err(ArchiveError::QuotaExceeded {
-                resource: QuotaResource::FileCount {
-                    current: manifest.total_entries + 1,
-                    max: config.max_file_count,
-                },
-            });
-        }
+        let size = entry.size();
+
+        // Route through the same QuotaTracker used by extraction: per-file
+        // size, file count, and total size (with checked arithmetic) are all
+        // enforced here using the same logic. Note this doesn't make listing
+        // and extraction fully equivalent — extraction's QuotaTracker only
+        // records EntryType::File, while listing records every entry type
+        // (directories, symlinks, hardlinks too), a pre-existing divergence.
+        quota.record_file(size, config)?;
 
         let path = entry
             .path()
@@ -182,7 +185,6 @@ fn list_tar_entries<R: std::io::Read>(
         }
 
         let entry_type = convert_tar_entry_type(&entry)?;
-        let size = entry.size();
         let mode = entry.header().mode().ok();
         let modified =
             entry.header().mtime().ok().and_then(|t| {
@@ -215,16 +217,6 @@ fn list_tar_entries<R: std::io::Read>(
             symlink_target,
             hardlink_target,
         };
-
-        // Check total size quota
-        if manifest.total_size + archive_entry.size > config.max_total_size {
-            return Err(ArchiveError::QuotaExceeded {
-                resource: QuotaResource::TotalSize {
-                    current: manifest.total_size + archive_entry.size,
-                    max: config.max_total_size,
-                },
-            });
-        }
 
         manifest.add_entry(archive_entry);
     }
@@ -264,17 +256,9 @@ pub(crate) fn list_zip_reader<R: Read + Seek>(
     config: &SecurityConfig,
 ) -> Result<ArchiveManifest> {
     let mut manifest = ArchiveManifest::new(ArchiveType::Zip);
+    let mut quota = QuotaTracker::new();
 
     for i in 0..archive.len() {
-        if manifest.total_entries >= config.max_file_count {
-            return Err(ArchiveError::QuotaExceeded {
-                resource: QuotaResource::FileCount {
-                    current: manifest.total_entries + 1,
-                    max: config.max_file_count,
-                },
-            });
-        }
-
         let entry = archive.by_index(i).map_err(|e| {
             if e.to_string().contains("Password required to decrypt file") {
                 return ArchiveError::SecurityViolation {
@@ -289,6 +273,14 @@ pub(crate) fn list_zip_reader<R: Read + Seek>(
                 reason: "archive is password-protected".into(),
             });
         }
+
+        // Route through the same QuotaTracker used by extraction: per-file
+        // size, file count, and total size (with checked arithmetic) are all
+        // enforced here using the same logic. Note this doesn't make listing
+        // and extraction fully equivalent — extraction's QuotaTracker only
+        // records EntryType::File, while listing records every entry type
+        // (directories, symlinks, hardlinks too), a pre-existing divergence.
+        quota.record_file(entry.size(), config)?;
 
         let raw_name = entry
             .name()
@@ -353,15 +345,6 @@ pub(crate) fn list_zip_reader<R: Read + Seek>(
             symlink_target,
             hardlink_target: None,
         };
-
-        if manifest.total_size + archive_entry.size > config.max_total_size {
-            return Err(ArchiveError::QuotaExceeded {
-                resource: QuotaResource::TotalSize {
-                    current: manifest.total_size + archive_entry.size,
-                    max: config.max_total_size,
-                },
-            });
-        }
 
         manifest.add_entry(archive_entry);
     }
@@ -438,20 +421,20 @@ fn list_sevenz_archive(
     config: &SecurityConfig,
 ) -> Result<ArchiveManifest> {
     let mut manifest = ArchiveManifest::new(ArchiveType::SevenZ);
+    let mut quota = QuotaTracker::new();
 
     for entry in &archive.files {
         if entry.is_anti_item {
             continue;
         }
 
-        if manifest.total_entries >= config.max_file_count {
-            return Err(ArchiveError::QuotaExceeded {
-                resource: QuotaResource::FileCount {
-                    current: manifest.total_entries + 1,
-                    max: config.max_file_count,
-                },
-            });
-        }
+        // Route through the same QuotaTracker used by extraction: per-file
+        // size, file count, and total size (with checked arithmetic) are all
+        // enforced here using the same logic. Note this doesn't make listing
+        // and extraction fully equivalent — extraction's QuotaTracker only
+        // records EntryType::File, while listing records every entry type
+        // (directories, symlinks, hardlinks too), a pre-existing divergence.
+        quota.record_file(entry.size, config)?;
 
         let path = PathBuf::from(normalize_entry_name(&entry.name));
 
@@ -483,15 +466,6 @@ fn list_sevenz_archive(
             symlink_target: None,
             hardlink_target: None,
         };
-
-        if manifest.total_size + archive_entry.size > config.max_total_size {
-            return Err(ArchiveError::QuotaExceeded {
-                resource: QuotaResource::TotalSize {
-                    current: manifest.total_size + archive_entry.size,
-                    max: config.max_total_size,
-                },
-            });
-        }
 
         manifest.add_entry(archive_entry);
     }
@@ -2002,6 +1976,209 @@ mod tests {
         assert!(
             matches!(result, Err(ArchiveError::PathTraversal { .. })),
             "traversal inside absolute path must still be rejected, got: {result:?}"
+        );
+    }
+
+    // --- Regression tests for #396: list_archive() must route through
+    // QuotaTracker instead of reimplementing quota checks ---
+
+    #[test]
+    fn test_list_tar_quota_exceeded_file_size() {
+        // Previously list_tar_entries never checked max_file_size per entry —
+        // only max_file_count/max_total_size. A single oversized entry must now
+        // be rejected even when total size and file count are within limits.
+        let mut temp_file = NamedTempFile::with_suffix(".tar").unwrap();
+        let mut builder = tar::Builder::new(Vec::new());
+
+        let data = vec![0u8; 1000];
+        let mut header = tar::Header::new_gnu();
+        header.set_path("big.bin").unwrap();
+        header.set_size(data.len() as u64);
+        header.set_cksum();
+        builder.append(&header, &data[..]).unwrap();
+
+        let archive_data = builder.into_inner().unwrap();
+        temp_file.write_all(&archive_data).unwrap();
+        temp_file.flush().unwrap();
+
+        let config = SecurityConfig {
+            max_file_size: 500,
+            ..Default::default()
+        };
+        let result = list_archive(temp_file.path(), &config);
+        assert!(
+            matches!(
+                result,
+                Err(ArchiveError::QuotaExceeded {
+                    resource: QuotaResource::FileSize {
+                        size: 1000,
+                        max: 500
+                    }
+                })
+            ),
+            "expected FileSize quota error, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_list_zip_quota_exceeded_file_size() {
+        let temp_file = NamedTempFile::with_suffix(".zip").unwrap();
+        let file = std::fs::File::create(temp_file.path()).unwrap();
+        let mut zip = zip::ZipWriter::new(file);
+        let options = zip::write::SimpleFileOptions::default()
+            .compression_method(zip::CompressionMethod::Stored);
+        zip.start_file("big.bin", options).unwrap();
+        zip.write_all(&vec![0u8; 1000]).unwrap();
+        zip.finish().unwrap();
+
+        let config = SecurityConfig {
+            max_file_size: 500,
+            ..Default::default()
+        };
+        let result = list_archive(temp_file.path(), &config);
+        assert!(
+            matches!(
+                result,
+                Err(ArchiveError::QuotaExceeded {
+                    resource: QuotaResource::FileSize {
+                        size: 1000,
+                        max: 500
+                    }
+                })
+            ),
+            "expected FileSize quota error, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_list_sevenz_quota_exceeded_file_size() {
+        let data = vec![0u8; 1000];
+        let archive_bytes = make_sevenz_archive(&[("big.bin", &data)]);
+        let mut temp_file = NamedTempFile::with_suffix(".7z").unwrap();
+        temp_file.write_all(&archive_bytes).unwrap();
+        temp_file.flush().unwrap();
+
+        let config = SecurityConfig {
+            max_file_size: 500,
+            ..Default::default()
+        };
+        let result = list_archive(temp_file.path(), &config);
+        assert!(
+            matches!(
+                result,
+                Err(ArchiveError::QuotaExceeded {
+                    resource: QuotaResource::FileSize {
+                        size: 1000,
+                        max: 500
+                    }
+                })
+            ),
+            "expected FileSize quota error, got: {result:?}"
+        );
+    }
+
+    /// Builds a raw ZIP archive whose central directory declares entry sizes
+    /// via the ZIP64 extended-information extra field (id `0x0001`),
+    /// independent of the actual (empty) local file data. This lets tests
+    /// exercise declared sizes that would be implausible to back with real
+    /// bytes (e.g. near `u64::MAX`), which is exactly what `QuotaTracker`'s
+    /// checked arithmetic must guard against.
+    #[allow(clippy::cast_possible_truncation)]
+    fn zip_with_zip64_declared_sizes(entries: &[(&str, u64)]) -> Vec<u8> {
+        let mut buf: Vec<u8> = Vec::new();
+        let mut central_entries: Vec<Vec<u8>> = Vec::new();
+
+        for (name, declared_size) in entries {
+            let name_bytes = name.as_bytes();
+            let name_len = name_bytes.len() as u16;
+            let local_offset = buf.len() as u32;
+
+            // Local file header: empty stored entry, real size 0.
+            buf.extend_from_slice(b"PK\x03\x04");
+            buf.extend_from_slice(&20u16.to_le_bytes()); // version needed
+            buf.extend_from_slice(&0u16.to_le_bytes()); // flags
+            buf.extend_from_slice(&0u16.to_le_bytes()); // compression: stored
+            buf.extend_from_slice(&0u16.to_le_bytes()); // mod time
+            buf.extend_from_slice(&0u16.to_le_bytes()); // mod date
+            buf.extend_from_slice(&0u32.to_le_bytes()); // crc32
+            buf.extend_from_slice(&0u32.to_le_bytes()); // compressed size
+            buf.extend_from_slice(&0u32.to_le_bytes()); // uncompressed size
+            buf.extend_from_slice(&name_len.to_le_bytes());
+            buf.extend_from_slice(&0u16.to_le_bytes()); // extra field length
+            buf.extend_from_slice(name_bytes);
+
+            // Central directory entry: sizes forced to the ZIP64 sentinel with
+            // the real (lying) sizes carried in a ZIP64 extra field.
+            let mut central: Vec<u8> = Vec::new();
+            central.extend_from_slice(b"PK\x01\x02");
+            central.extend_from_slice(&0x032du16.to_le_bytes()); // version made by: Unix, 4.5
+            central.extend_from_slice(&45u16.to_le_bytes()); // version needed: 4.5 (ZIP64)
+            central.extend_from_slice(&0u16.to_le_bytes()); // flags
+            central.extend_from_slice(&0u16.to_le_bytes()); // compression
+            central.extend_from_slice(&0u16.to_le_bytes()); // mod time
+            central.extend_from_slice(&0u16.to_le_bytes()); // mod date
+            central.extend_from_slice(&0u32.to_le_bytes()); // crc32
+            central.extend_from_slice(&0xFFFF_FFFFu32.to_le_bytes()); // compressed size sentinel
+            central.extend_from_slice(&0xFFFF_FFFFu32.to_le_bytes()); // uncompressed size sentinel
+            central.extend_from_slice(&name_len.to_le_bytes());
+            central.extend_from_slice(&20u16.to_le_bytes()); // extra field length (4 hdr + 16 data)
+            central.extend_from_slice(&0u16.to_le_bytes()); // comment length
+            central.extend_from_slice(&0u16.to_le_bytes()); // disk number start
+            central.extend_from_slice(&0u16.to_le_bytes()); // internal attributes
+            central.extend_from_slice(&0u32.to_le_bytes()); // external attributes
+            central.extend_from_slice(&local_offset.to_le_bytes());
+            central.extend_from_slice(name_bytes);
+            central.extend_from_slice(&1u16.to_le_bytes()); // ZIP64 extra field id
+            central.extend_from_slice(&16u16.to_le_bytes()); // ZIP64 extra field data size
+            central.extend_from_slice(&declared_size.to_le_bytes()); // uncompressed size
+            central.extend_from_slice(&declared_size.to_le_bytes()); // compressed size
+
+            central_entries.push(central);
+        }
+
+        let central_offset = buf.len() as u32;
+        for central in &central_entries {
+            buf.extend_from_slice(central);
+        }
+        let central_size = (buf.len() as u32) - central_offset;
+
+        buf.extend_from_slice(b"PK\x05\x06");
+        buf.extend_from_slice(&0u16.to_le_bytes()); // disk number
+        buf.extend_from_slice(&0u16.to_le_bytes()); // disk with central dir
+        buf.extend_from_slice(&(entries.len() as u16).to_le_bytes());
+        buf.extend_from_slice(&(entries.len() as u16).to_le_bytes());
+        buf.extend_from_slice(&central_size.to_le_bytes());
+        buf.extend_from_slice(&central_offset.to_le_bytes());
+        buf.extend_from_slice(&0u16.to_le_bytes()); // comment length
+        buf
+    }
+
+    #[test]
+    fn test_list_zip_total_size_overflow_rejected_not_wrapped() {
+        // Two entries whose declared sizes sum past u64::MAX. With unchecked
+        // addition (the pre-fix behaviour) `total_size` would silently wrap
+        // and bypass max_total_size entirely. QuotaTracker's checked_add must
+        // reject this with IntegerOverflow instead.
+        use std::io::Cursor;
+
+        let zip_bytes = zip_with_zip64_declared_sizes(&[("a.bin", u64::MAX - 100), ("b.bin", 200)]);
+        let mut archive = zip::ZipArchive::new(Cursor::new(zip_bytes)).unwrap();
+
+        let config = SecurityConfig {
+            max_file_size: u64::MAX,
+            max_file_count: usize::MAX,
+            max_total_size: u64::MAX,
+            ..Default::default()
+        };
+        let result = list_zip_reader(&mut archive, &config);
+        assert!(
+            matches!(
+                result,
+                Err(ArchiveError::QuotaExceeded {
+                    resource: QuotaResource::IntegerOverflow
+                })
+            ),
+            "expected IntegerOverflow quota error instead of a silently wrapped total, got: {result:?}"
         );
     }
 }

--- a/crates/exarch-core/src/inspection/verify.rs
+++ b/crates/exarch-core/src/inspection/verify.rs
@@ -115,8 +115,20 @@ pub fn verify_archive<P: AsRef<Path>>(
     config: &SecurityConfig,
 ) -> Result<VerificationReport> {
     config.validate()?;
-    let manifest = list_archive(archive_path, config)?;
+    let manifest = list_archive(archive_path, &listing_config_for_verify(config))?;
     verify_manifest(&manifest, config)
+}
+
+/// Returns a config variant for the pre-flight listing step that feeds
+/// `verify_manifest`, with `max_file_size` relaxed to unlimited.
+///
+/// `verify` is a read-only, report-based operation: an oversized entry is
+/// meant to surface as a `VerificationIssue` from `verify_entry` (which
+/// re-checks the real `config` against every manifest entry), not abort the
+/// listing step before any report exists. `max_file_count` and
+/// `max_total_size` are left untouched, matching prior behavior.
+pub(crate) fn listing_config_for_verify(config: &SecurityConfig) -> SecurityConfig {
+    config.clone().with_max_file_size(u64::MAX)
 }
 
 fn verify_entry(
@@ -424,6 +436,68 @@ mod tests {
             report.issues.is_empty(),
             "Safe archive should have no issues"
         );
+    }
+
+    // Regression test: verify_archive() must report an oversized entry as a
+    // graceful VerificationIssue (Fail status with an itemized report), not
+    // abort with a bare error during its internal pre-flight list_archive()
+    // call. Before listing_config_for_verify() existed, list_archive()
+    // enforcing max_file_size (#396) made this scenario an Err with no
+    // report, bypassing verify_entry's existing FileSize handling.
+    #[test]
+    fn test_verify_archive_oversized_entry_reports_issue_not_error() {
+        let mut temp_file = NamedTempFile::with_suffix(".tar").unwrap();
+        let mut builder = tar::Builder::new(Vec::new());
+
+        let data = vec![0u8; 1000];
+        let mut header = tar::Header::new_gnu();
+        header.set_path("big.bin").unwrap();
+        header.set_size(data.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder.append(&header, &data[..]).unwrap();
+
+        let archive_data = builder.into_inner().unwrap();
+        temp_file.write_all(&archive_data).unwrap();
+        temp_file.flush().unwrap();
+
+        let config = SecurityConfig {
+            max_file_size: 500,
+            ..Default::default()
+        };
+        let report = verify_archive(temp_file.path(), &config)
+            .expect("verify_archive must report oversized entries, not error out");
+
+        assert_eq!(
+            report.status,
+            VerificationStatus::Fail,
+            "oversized entry must fail verification via a report, not a hard error"
+        );
+        assert_eq!(report.suspicious_entries, 1);
+        assert!(
+            report.issues.iter().any(|i| {
+                i.severity == IssueSeverity::High
+                    && i.category == IssueCategory::QuotaExceeded
+                    && i.message.contains("single file size")
+            }),
+            "expected a High-severity QuotaExceeded FileSize issue, got: {:?}",
+            report.issues
+        );
+    }
+
+    #[test]
+    fn test_listing_config_for_verify_relaxes_only_max_file_size() {
+        let config = SecurityConfig {
+            max_file_size: 1000,
+            max_total_size: 2000,
+            max_file_count: 3,
+            ..Default::default()
+        };
+        let listing_config = listing_config_for_verify(&config);
+
+        assert_eq!(listing_config.max_file_size, u64::MAX);
+        assert_eq!(listing_config.max_total_size, config.max_total_size);
+        assert_eq!(listing_config.max_file_count, config.max_file_count);
     }
 
     // Note: Full CVE regression tests for path traversal require real malicious

--- a/skills/exarch-cli/SKILL.md
+++ b/skills/exarch-cli/SKILL.md
@@ -154,7 +154,12 @@ exarch list archive.zip -l -H --json
 | `-H, --human-readable` | off | Human-readable sizes in text mode (ignored in `--json` mode, which always emits raw byte counts). |
 | `--max-files` | 10000 | Hard limit on entries scanned; listing fails with `QuotaExceeded` past this count, it does not truncate. |
 | `--max-total-size` | 500 MB | Hard limit on cumulative listed size; listing fails with `QuotaExceeded` past this size. Raise it explicitly for larger archives. |
+| `--max-file-size` | 50 MB | Hard limit on any single entry's size; listing fails with `QuotaExceeded` (`FileSize`) past this size. Raise it explicitly for archives with large individual files. |
 | `--allow-solid-archives` | off | Allow listing solid 7z archives (higher memory use). |
+
+Verified live: a 51 MB tar entry fails `exarch list` with
+`"quota exceeded: single file size (53477376 > 52428800)"` at the 50 MB default, and succeeds
+once `--max-file-size 100M` is passed.
 
 ### `verify <ARCHIVE>`
 
@@ -167,11 +172,21 @@ exarch verify archive.tar.gz --check-integrity --check-security --json
 | `--check-integrity` | off | Validate checksums/structure. |
 | `--check-security` | off | Run the security validation pipeline (path traversal, symlink/hardlink, permissions) without extracting. |
 | `--strict` | off | Treat any warning-level finding as an error and exit with status `2` instead of `0`. |
-| `--max-files` / `--max-total-size` / `--allow-solid-archives` | same as `list` (10000 / 500 MB / off) | Same hard-limit semantics as `list` — verification fails with `QuotaExceeded` past these caps, it does not skip entries. |
+| `--max-files` / `--max-total-size` / `--max-file-size` / `--allow-solid-archives` | same as `list` (10000 / 500 MB / 50 MB / off) | Same hard-limit semantics as `list` for file count and total size — verification fails with `QuotaExceeded` past those two caps, it does not skip entries. |
 
 Run `verify` before `extract` on any archive from an untrusted source to inspect issues without
 writing anything to disk. Archives over 500 MB need `--max-total-size` raised explicitly or
 `verify` will fail with `QuotaExceeded` before it can report anything else.
+
+`--max-file-size` is the one exception to "fails with `QuotaExceeded`": an entry over this cap
+does **not** abort `verify` early. `verify`'s internal pre-flight listing pass always allows
+entries of any size through, then re-checks the real `--max-file-size` per entry and records a
+violation as a `HIGH`-severity `QuotaExceeded` issue, same as any other security finding —
+`data.status` becomes `"FAIL"` with the issue itemized, `status` (the envelope) stays
+`"success"`, same as the `verify` "one exception" rule described under `--json` output envelope
+below. Verified live: a 51 MB tar entry against the 50 MB default produces `data.status: "FAIL"`
+with one `HIGH` `"Quota Exceeded"` issue and exit code `1`; the same command with
+`--max-file-size 100M` produces `data.status: "PASS"` and exit code `0`.
 
 When the archive has `status: "FAIL"`, `verify --json` prints exactly one top-level JSON
 document to stdout — a `status: "success"` envelope carrying the full report (`data.status:
@@ -232,9 +247,17 @@ For `verify`, branch on `data.status` (or the process exit code), not on top-lev
 For `extract`, when some files were already written before a mid-archive failure, `error` carries
 a structured `error.partial_report` object (`files_extracted`, `directories_created`,
 `symlinks_created`, `bytes_written`). Verified live against a two-entry archive where the first
-entry extracts and the second exceeds `--max-file-size`. The same progress counts also appear as
-free text inside `error.message` (prefixed `"WARNING: Extraction was stopped. ..."`) — prefer the
-structured `error.partial_report` field over parsing that text.
+entry extracts and the second is a symlink rejected by the (default-off) `--allow-symlinks`
+check. The same progress counts also appear as free text inside `error.message` (prefixed
+`"WARNING: Extraction was stopped. ..."`) — prefer the structured `error.partial_report` field
+over parsing that text.
+
+Note: `extract` always lists the archive first (`list_archive()`, sharing `--max-file-count`,
+`--max-total-size`, and `--max-file-size` with the extraction config) to detect output
+conflicts and size the progress bar. Quota violations (file count, total size, per-file size)
+are therefore caught during this pre-flight pass and reported as a plain error with **no**
+`partial_report`, since extraction never starts. Only checks that require the real destination
+directory — symlink/hardlink escape — can still produce a mid-archive partial extraction.
 
 ### Verified examples
 
@@ -267,16 +290,17 @@ Error (`extract`, path traversal):
 }
 ```
 
-Error (`extract`, mid-archive quota failure with partial progress — note the structured
-`error.partial_report` field):
+Error (`extract`, mid-archive security failure with partial progress — note the structured
+`error.partial_report` field; the archive's first entry extracts, then a symlink entry is
+rejected because `--allow-symlinks` was not passed):
 
 ```json
 {
   "operation": "extract",
   "status": "error",
   "error": {
-    "kind": "QuotaExceeded",
-    "message": "WARNING: Extraction was stopped. 1 items (1 files, 0 directories, 0 symlinks) were written to disk before the error.\nHINT: Inspect or remove the output directory before re-running.: quota exceeded: single file size (2000000 > 1000000)",
+    "kind": "SecurityViolation",
+    "message": "WARNING: Extraction was stopped. 1 items (1 files, 0 directories, 0 symlinks) were written to disk before the error.\nHINT: Inspect or remove the output directory before re-running.: operation denied by security policy: symlinks not allowed",
     "partial_report": {
       "files_extracted": 1,
       "directories_created": 0,


### PR DESCRIPTION
## Summary

- `list_archive()` reimplemented total-size/file-count quota checks inline in each per-format listing function, independently of the `QuotaTracker` used by extraction. The duplicate logic never checked `max_file_size` per entry and used unchecked `u64` addition for the running total, so a crafted archive with entry sizes near `u64::MAX` could wrap the total and silently bypass `max_total_size` in a release build. All three listing paths (TAR, ZIP, 7z) now route every entry through `QuotaTracker::record_file()`, matching extraction.
- `list`/`verify` gain a `--max-file-size` CLI flag (mirroring `extract`/`create`) since they previously had no way to raise the now-enforced per-file limit.
- `verify_archive()`'s internal pre-flight listing pass keeps `max_file_size` unbounded so an oversized entry still surfaces as a graceful `VerificationIssue` (`Fail` status, itemized report) instead of aborting before any report exists.
- Consolidated the five copy-pasted `PartialExtraction` error-wrapping blocks across `tar.rs`/`zip.rs`/`sevenz.rs` into `ArchiveError::partial_or()` — no behavior change.

**BREAKING CHANGE:** `list_archive()`/`verify_archive()` (Rust API, CLI, Python, Node bindings) now reject any entry larger than `max_file_size` during listing, where previously only file count and total size were enforced.

Fixes #396
Fixes #394

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` (948 passed)
- [x] `cargo test --doc --workspace --all-features` (exarch-python excluded — pre-existing pyo3 linker error on this machine, confirmed present on `main` too)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace`
- [x] New regression tests: per-format (tar/zip/7z) `max_file_size` enforcement on listing, ZIP64-crafted `u64` overflow rejection, `ArchiveError::partial_or` unit tests, CLI arg-parse and integration tests for the new `--max-file-size` flag on `list`/`verify`
- [x] Live-verified: a 60 MB single-file archive is rejected by `list`/`verify` by default and succeeds with `--max-file-size`; `verify --json` on an oversized entry returns an itemized `Fail` report instead of a bare error