### PR TITLE
fix(cli): stop duplicating SecurityViolation reason text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`Fail` status with an itemized report) via the existing per-entry check in `verify_entry`,
   rather than aborting before any report exists — `verify`'s "report, don't hard-fail" contract
   is preserved.
+- **`SecurityViolation` error text was duplicated for pre-extraction violations (#403)**:
+  `convert_extraction_error` in `exarch-cli` rebuilt the wrapped `ArchiveError`'s own Display
+  text as anyhow context, so the reason (e.g. "banned path component: .git") appeared twice in
+  both `--json` and human text output whenever a violation was caught during listing/
+  pre-validation (banned path components, disallowed symlinks/hardlinks, disallowed solid 7z
+  archives). The reason now appears exactly once, and the CLI's own context adds a hint naming
+  the actual policy flags (`--allow-symlinks`, `--allow-hardlinks`, `--allow-solid-archives`,
+  `--banned-component`) instead of repeating the source error's text.
 
 ### Changed
 

--- a/crates/exarch-cli/src/error.rs
+++ b/crates/exarch-cli/src/error.rs
@@ -173,9 +173,12 @@ pub fn convert_extraction_error(
         ArchiveError::InvalidCompressionLevel { level } => {
             format!("Invalid compression level {level}: must be between 1 and 9.")
         }
-        ArchiveError::SecurityViolation { reason } => {
-            format!("Operation denied by security policy: {reason}")
-        }
+        ArchiveError::SecurityViolation { .. } => format!(
+            "Security violation while processing '{}'\n\
+             HINT: If this archive is from a trusted source, relax the relevant policy flag \
+             (--allow-symlinks, --allow-hardlinks, --allow-solid-archives, --banned-component).",
+            archive.display(),
+        ),
     };
     anyhow::Error::from(err).context(context)
 }
@@ -364,20 +367,37 @@ mod tests {
     }
 
     #[test]
-    fn test_security_violation_contains_reason() {
+    fn test_security_violation_reason_appears_exactly_once() {
         let err = ArchiveError::SecurityViolation {
             reason: "absolute path detected".to_string(),
         };
         let converted = convert_extraction_error(err, Path::new("archive.tar.gz"), false);
         let msg = format!("{converted:#}");
-        assert!(
-            msg.contains("absolute path detected"),
-            "reason missing: {msg}"
+        assert_eq!(
+            msg.matches("absolute path detected").count(),
+            1,
+            "reason should appear exactly once, got: {msg}"
         );
-        assert!(
-            msg.contains("security policy"),
-            "policy text missing: {msg}"
-        );
+    }
+
+    #[test]
+    fn test_security_violation_hint_names_policy_flags() {
+        // These assertions target text the CLI itself authors (the anyhow
+        // context), not the wrapped `ArchiveError`'s own Display, so the test
+        // fails if the HINT regresses to generic wording again.
+        let err = ArchiveError::SecurityViolation {
+            reason: "banned path component: .git".to_string(),
+        };
+        let converted = convert_extraction_error(err, Path::new("archive.tar.gz"), false);
+        let msg = format!("{converted:#}");
+        for flag in [
+            "--allow-symlinks",
+            "--allow-hardlinks",
+            "--allow-solid-archives",
+            "--banned-component",
+        ] {
+            assert!(msg.contains(flag), "HINT missing flag {flag}: {msg}");
+        }
     }
 
     #[test]

--- a/crates/exarch-cli/tests/cli_tests.rs
+++ b/crates/exarch-cli/tests/cli_tests.rs
@@ -2137,3 +2137,94 @@ fn test_list_json_long_regular_file_omits_link_fields() {
         "regular file entry must not contain hardlink_target key"
     );
 }
+
+/// Builds a tar.gz archive at `path` containing one file entry nested under
+/// `component`, so a `--banned-component` flag matching `component` triggers
+/// `ArchiveError::SecurityViolation` during extraction.
+fn create_tar_gz_with_component(path: &std::path::Path, component: &str) {
+    use flate2::Compression;
+    use flate2::write::GzEncoder;
+
+    let file = std::fs::File::create(path).expect("create archive");
+    let gz = GzEncoder::new(file, Compression::default());
+    let mut builder = tar::Builder::new(gz);
+    let data = b"payload";
+    let entry_path = format!("{component}/file.txt");
+    let mut header = tar::Header::new_gnu();
+    header.set_size(data.len() as u64);
+    header.set_mode(0o644);
+    header.set_path(&entry_path).expect("set path");
+    header.set_cksum();
+    builder
+        .append_data(&mut header, &entry_path, &data[..])
+        .expect("append entry");
+    let gz = builder.into_inner().expect("get gz encoder");
+    gz.finish().expect("finish gzip stream");
+}
+
+/// Regression test for issue #403: the `SecurityViolation` reason must appear
+/// exactly once in `--json` output, not doubled by redundant anyhow context.
+#[test]
+fn test_extract_security_violation_json_reason_appears_once() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let archive_path = temp.path().join("banned.tar.gz");
+    create_tar_gz_with_component(&archive_path, ".customdir");
+    let out_dir = temp.path().join("out");
+    std::fs::create_dir_all(&out_dir).expect("create out dir");
+
+    let output = exarch_cmd()
+        .arg("extract")
+        .arg(&archive_path)
+        .arg(&out_dir)
+        .arg("--banned-component")
+        .arg(".customdir")
+        .arg("--json")
+        .assert()
+        .failure()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json: serde_json::Value = serde_json::from_slice(&output).expect("invalid JSON output");
+    assert_eq!(json["status"], "error");
+    assert_eq!(json["error"]["kind"], "SecurityViolation");
+    let message = json["error"]["message"]
+        .as_str()
+        .expect("error.message must be a string");
+    assert_eq!(
+        message.matches("banned path component: .customdir").count(),
+        1,
+        "reason should appear exactly once, got: {message}"
+    );
+}
+
+/// Regression test for issue #403: same duplication check as
+/// [`test_extract_security_violation_json_reason_appears_once`], for the
+/// human-readable (non-JSON) output path.
+#[test]
+fn test_extract_security_violation_text_reason_appears_once() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let archive_path = temp.path().join("banned.tar.gz");
+    create_tar_gz_with_component(&archive_path, ".customdir");
+    let out_dir = temp.path().join("out");
+    std::fs::create_dir_all(&out_dir).expect("create out dir");
+
+    let output = exarch_cmd()
+        .arg("extract")
+        .arg(&archive_path)
+        .arg(&out_dir)
+        .arg("--banned-component")
+        .arg(".customdir")
+        .assert()
+        .failure()
+        .get_output()
+        .stderr
+        .clone();
+
+    let stderr = std::str::from_utf8(&output).expect("stderr is not valid UTF-8");
+    assert_eq!(
+        stderr.matches("banned path component: .customdir").count(),
+        1,
+        "reason should appear exactly once, got: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary
- `convert_extraction_error` in `exarch-cli` rebuilt the wrapped `ArchiveError`'s own Display text as anyhow context, so the reason (e.g. "banned path component: .git") appeared twice in both `--json` and human text output for every `SecurityViolation` caught during listing/pre-validation.
- The reason now surfaces exactly once via anyhow's source chain; the CLI's own context adds a hint naming the actual policy flags (`--allow-symlinks`, `--allow-hardlinks`, `--allow-solid-archives`, `--banned-component`) instead of repeating the source error's text.
- Added regression tests: two CLI integration tests asserting the reason appears exactly once (JSON and text modes), plus a unit test asserting the HINT names the real policy flags.

Closes #403

## Test plan
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` (961/961 passed)
- [x] `cargo test --doc -p exarch-core -p exarch-cli --all-features` (98/98 passed; workspace-wide doctest run is blocked only by a pre-existing, unrelated macOS `exarch-python` PyO3 linking issue)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace`
- [x] Manually reproduced the original duplication and confirmed the fix with the built binary (`--banned-component .customdir`, both `--json` and text output)