### PR TITLE
fix(bindings): dedupe boundary path validation, fix unsafe and stale docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   archives). The reason now appears exactly once, and the CLI's own context adds a hint naming
   the actual policy flags (`--allow-symlinks`, `--allow-hardlinks`, `--allow-solid-archives`,
   `--banned-component`) instead of repeating the source error's text.
+- **Redundant `unsafe impl Send` on `PyProgressAdapter` in `exarch-python` (#405)**: pyo3 0.29's
+  `Py<T>` is `Send` for all `T` unconditionally, so `PyProgressAdapter { callback: Py<PyAny>, .. }`
+  already auto-derives `Send`. Removed the manual `unsafe impl Send` block; no `unsafe` code was
+  actually required.
+- **Stale generated `exarch-node/index.d.ts` (#404)**: the napi-rs generated type declarations
+  still listed only 2 of the 7 default `banned_path_components` entries in the `SecurityConfig`
+  doc comment table, out of sync with the Rust source. Regenerated via `napi build`.
 
 ### Changed
 
@@ -87,6 +94,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   current call sites (each site returns the error immediately afterwards, so evaluating
   `std::mem::take(report)` unconditionally rather than only inside the `total_items() > 0` branch
   is unobservable).
+- **Deduplicated FFI boundary path validation between `exarch-python` and `exarch-node` (#406)**:
+  both bindings independently rejected null bytes and paths over 4096 bytes for raw path strings
+  supplied by callers, and the two implementations had drifted (a full-scan fold vs. a
+  short-circuiting `contains` for the null-byte check, and no consistent check order). Both now
+  call the new `exarch_core::validate_raw_path_str()`, which owns `MAX_PATH_LENGTH`, checks length
+  before scanning for a null byte (rejecting oversized input in O(1) before the O(n) scan runs),
+  and returns `ArchiveError::SecurityViolation`. Each binding routes that error through its
+  existing `convert_error()` — the same converter used for every other security rejection — instead
+  of hand-rolling a bespoke exception. This changes the concrete exception raised for null-byte and
+  path-length rejections: Python now raises `SecurityViolationError` (previously a bare
+  `ValueError`) and Node.js error messages now carry the `SECURITY_VIOLATION:` code prefix
+  (previously unprefixed). Both were already documented as possible outcomes of these checks;
+  acceptable pre-1.0 per the project's no-backward-compatibility policy.
 
 ## [0.5.2] - 2026-07-27
 

--- a/crates/exarch-core/src/lib.rs
+++ b/crates/exarch-core/src/lib.rs
@@ -76,6 +76,12 @@ pub use inspection::VerificationStatus;
 /// Summary statistics produced by the validation pipeline; see
 /// [`security::ValidationReport`].
 pub use security::ValidationReport;
+/// Maximum length, in bytes, of a raw path string accepted at the FFI
+/// boundary. Shared by `exarch-python` and `exarch-node`.
+pub use security::boundary::MAX_PATH_LENGTH;
+/// Validates a raw, caller-supplied path string before it enters the
+/// archive pipeline. Shared by `exarch-python` and `exarch-node`.
+pub use security::boundary::validate_raw_path_str;
 
 // Re-export types module for easier access
 pub use types::DestDir;

--- a/crates/exarch-core/src/security/boundary.rs
+++ b/crates/exarch-core/src/security/boundary.rs
@@ -1,0 +1,142 @@
+//! Raw path string validation shared by FFI bindings.
+//!
+//! Both `exarch-python` and `exarch-node` accept archive/output paths as
+//! plain strings from their host language before any `Path`, `DestDir`, or
+//! `SecurityConfig` exists to run them through [`super::path::validate_path`].
+//! This module centralizes that pre-flight check so the two bindings cannot
+//! drift on what counts as a well-formed path string.
+
+use crate::error::ArchiveError;
+use crate::error::Result;
+
+/// Maximum length, in bytes, of a raw path string accepted at the FFI
+/// boundary.
+///
+/// Linux and macOS define `PATH_MAX` as 4096 bytes. Bindings enforce the
+/// same ceiling on every platform so behavior does not vary by OS and
+/// pathological inputs are rejected before reaching the archive pipeline.
+pub const MAX_PATH_LENGTH: usize = 4096;
+
+/// Validates a raw, caller-supplied path string before it enters the
+/// archive pipeline.
+///
+/// This is the shared boundary check for `exarch-python` and `exarch-node`:
+/// reject overlong strings and null bytes before doing anything else with
+/// them. It intentionally does not perform traversal, symlink, or
+/// destination-boundary checks — those require a `Path`, a `DestDir`, and a
+/// `SecurityConfig`, and are handled later by
+/// [`super::path::validate_path`].
+///
+/// # Check order
+///
+/// Length is checked before scanning for a null byte: `.len()` is an O(1)
+/// lookup, so an oversized input is rejected without ever running the
+/// O(n) null-byte scan below it — this serves the length check's own
+/// `DoS`-prevention purpose.
+///
+/// # Null-byte detection
+///
+/// Uses [`str::contains`], which short-circuits on the first null byte.
+/// This check validates the *format* of caller-supplied input (is this a
+/// well-formed path string?) rather than comparing one secret against
+/// another, so there is no timing side channel to defend against and
+/// short-circuiting is safe.
+///
+/// # Errors
+///
+/// Returns [`ArchiveError::SecurityViolation`] if `path` contains a null
+/// byte or exceeds [`MAX_PATH_LENGTH`] bytes.
+///
+/// # Examples
+///
+/// ```
+/// use exarch_core::validate_raw_path_str;
+///
+/// assert!(validate_raw_path_str("archive.tar.gz").is_ok());
+/// assert!(validate_raw_path_str("bad\0path").is_err());
+/// assert!(validate_raw_path_str(&"x".repeat(5000)).is_err());
+/// ```
+pub fn validate_raw_path_str(path: &str) -> Result<()> {
+    if path.len() > MAX_PATH_LENGTH {
+        return Err(ArchiveError::SecurityViolation {
+            reason: format!(
+                "path exceeds maximum length of {MAX_PATH_LENGTH} bytes (got {} bytes)",
+                path.len()
+            ),
+        });
+    }
+
+    if path.contains('\0') {
+        return Err(ArchiveError::SecurityViolation {
+            reason: "path contains null bytes - potential security issue".to_string(),
+        });
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_raw_path_str_accepts_normal() {
+        assert!(validate_raw_path_str("/tmp/test.tar.gz").is_ok());
+        assert!(validate_raw_path_str("relative/path.tar").is_ok());
+        assert!(validate_raw_path_str("").is_ok());
+    }
+
+    #[test]
+    fn test_validate_raw_path_str_rejects_null_bytes() {
+        let err = validate_raw_path_str("/tmp/test\0malicious").expect_err("null byte");
+        match err {
+            ArchiveError::SecurityViolation { reason } => {
+                assert_eq!(
+                    reason,
+                    "path contains null bytes - potential security issue"
+                );
+            }
+            other => panic!("expected SecurityViolation, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_validate_raw_path_str_rejects_too_long() {
+        let long_path = "x".repeat(MAX_PATH_LENGTH + 1);
+        let err = validate_raw_path_str(&long_path).expect_err("too long");
+        match err {
+            ArchiveError::SecurityViolation { reason } => {
+                assert_eq!(
+                    reason,
+                    format!(
+                        "path exceeds maximum length of {MAX_PATH_LENGTH} bytes (got {} bytes)",
+                        long_path.len()
+                    )
+                );
+            }
+            other => panic!("expected SecurityViolation, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_validate_raw_path_str_checks_length_before_null_byte() {
+        let long_path_with_null = format!("{}\0", "x".repeat(MAX_PATH_LENGTH));
+        let err = validate_raw_path_str(&long_path_with_null).expect_err("too long");
+        match err {
+            ArchiveError::SecurityViolation { reason } => {
+                assert!(
+                    reason.contains("maximum length"),
+                    "length check should run first: {reason}"
+                );
+            }
+            other => panic!("expected SecurityViolation, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_validate_raw_path_str_accepts_max_length() {
+        let max_path = "x".repeat(MAX_PATH_LENGTH);
+        assert!(validate_raw_path_str(&max_path).is_ok());
+    }
+}

--- a/crates/exarch-core/src/security/mod.rs
+++ b/crates/exarch-core/src/security/mod.rs
@@ -1,5 +1,6 @@
 //! Security validation modules.
 
+pub(crate) mod boundary;
 pub(crate) mod context;
 pub(crate) mod hardlink;
 pub(crate) mod path;

--- a/crates/exarch-node/index.d.ts
+++ b/crates/exarch-node/index.d.ts
@@ -165,7 +165,7 @@ export declare class ExtractionOptions {
  * | `allow_world_writable` | false |
  * | `preserve_permissions` | false |
  * | `allowed_extensions` | empty (all allowed) |
- * | `banned_path_components` | `.git`, `.ssh` |
+ * | `banned_path_components` | `.git`, `.ssh`, `.gnupg`, `.aws`, `.kube`, `.docker`, `.env` |
  */
 export declare class SecurityConfig {
   /** Creates a new `SecurityConfig` with secure defaults. */

--- a/crates/exarch-node/src/utils.rs
+++ b/crates/exarch-node/src/utils.rs
@@ -2,49 +2,28 @@
 
 use napi::bindgen_prelude::*;
 
-/// Maximum path length in bytes (Linux/macOS `PATH_MAX` is typically 4096)
-const MAX_PATH_LENGTH: usize = 4096;
+use crate::error::convert_error;
 
 /// Validates a path string for security issues.
 ///
-/// Rejects:
-/// - Paths containing null bytes (potential injection attacks)
-/// - Paths exceeding `MAX_PATH_LENGTH` bytes (`DoS` prevention)
+/// Delegates to the shared boundary check in `exarch_core`; see
+/// [`exarch_core::validate_raw_path_str`] for the exact rules (null bytes,
+/// maximum length). Errors are routed through [`convert_error`] so they
+/// carry the same `SECURITY_VIOLATION:` code prefix as every other
+/// security-policy rejection surfaced by this crate.
 ///
 /// # Errors
 ///
 /// Returns error if path contains null bytes or exceeds maximum length.
 pub fn validate_path(path: &str) -> Result<()> {
-    // Constant-time null byte check (processes every byte regardless of match)
-    #[allow(clippy::needless_bitwise_bool)]
-    let has_null = path.bytes().fold(false, |acc, b| acc | (b == 0));
-
-    if has_null {
-        return Err(Error::from_reason(
-            "path contains null bytes - potential security issue",
-        ));
-    }
-
-    if path.len() > MAX_PATH_LENGTH {
-        // Pre-allocate string to avoid multiple allocations
-        use std::fmt::Write;
-        let mut msg = String::with_capacity(80);
-        // Writing to a String never fails
-        let _ = write!(
-            &mut msg,
-            "path exceeds maximum length of {MAX_PATH_LENGTH} bytes (got {} bytes)",
-            path.len()
-        );
-        return Err(Error::from_reason(msg));
-    }
-
-    Ok(())
+    exarch_core::validate_raw_path_str(path).map_err(convert_error)
 }
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+    use exarch_core::MAX_PATH_LENGTH;
 
     #[test]
     fn test_validate_path_accepts_normal() {

--- a/crates/exarch-python/exarch.pyi
+++ b/crates/exarch-python/exarch.pyi
@@ -596,7 +596,7 @@ def extract_archive(
         ExtractionReport with extraction statistics
 
     Raises:
-        ValueError: Invalid argument type, null bytes in path, or path too long
+        ValueError: Invalid argument type
         PathTraversalError: Path traversal attempt detected
         SymlinkEscapeError: Symlink points outside extraction directory
         HardlinkEscapeError: Hardlink target outside extraction directory
@@ -636,7 +636,7 @@ def extract_archive_with_progress(
         ExtractionReport with extraction statistics
 
     Raises:
-        ValueError: Invalid argument type, null bytes in path, or path too long
+        ValueError: Invalid argument type
         PathTraversalError: Path traversal attempt detected
         SymlinkEscapeError: Symlink points outside extraction directory
         HardlinkEscapeError: Hardlink target outside extraction directory

--- a/crates/exarch-python/src/lib.rs
+++ b/crates/exarch-python/src/lib.rs
@@ -4,15 +4,11 @@
 //! built-in protection against path traversal, zip bombs, symlink attacks,
 //! and other common vulnerabilities.
 
-use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
 mod config;
 mod error;
 mod report;
-
-/// Maximum path length in bytes (Linux/macOS `PATH_MAX` is typically 4096)
-const MAX_PATH_LENGTH: usize = 4096;
 
 use config::PyCreationConfig;
 use config::PyExtractionOptions;
@@ -46,7 +42,7 @@ use report::PyVerificationReport;
 ///
 /// # Raises
 ///
-/// * `ValueError` - Invalid argument type, null bytes in path, or path too long
+/// * `ValueError` - Invalid argument type
 /// * `PathTraversalError` - Path traversal attempt detected
 /// * `SymlinkEscapeError` - Symlink points outside extraction directory
 /// * `HardlinkEscapeError` - Hardlink target outside extraction directory
@@ -144,8 +140,11 @@ fn extract_archive(
 ///
 /// # Security
 ///
-/// - Rejects paths containing null bytes (potential injection attacks)
-/// - Rejects paths exceeding `MAX_PATH_LENGTH` bytes (`DoS` prevention)
+/// Delegates to the shared boundary check in `exarch_core`; see
+/// [`exarch_core::validate_raw_path_str`] for the exact rules (null bytes,
+/// maximum length). Errors are routed through [`convert_error`] so they
+/// surface as `SecurityViolationError`, the same exception type used for
+/// every other security-policy rejection raised by this module.
 fn path_to_string(py: Python<'_>, path: &Bound<'_, PyAny>) -> PyResult<String> {
     // Try direct string extraction first
     let path_str = if let Ok(s) = path.extract::<String>() {
@@ -158,21 +157,7 @@ fn path_to_string(py: Python<'_>, path: &Bound<'_, PyAny>) -> PyResult<String> {
         result.extract()?
     };
 
-    // Validate: reject null bytes (security)
-    if path_str.contains('\0') {
-        return Err(PyValueError::new_err(
-            "path contains null bytes - potential security issue",
-        ));
-    }
-
-    // Validate: reject excessively long paths (DoS prevention)
-    if path_str.len() > MAX_PATH_LENGTH {
-        return Err(PyValueError::new_err(format!(
-            "path exceeds maximum length of {} bytes (got {} bytes)",
-            MAX_PATH_LENGTH,
-            path_str.len()
-        )));
-    }
+    exarch_core::validate_raw_path_str(&path_str).map_err(convert_error)?;
 
     Ok(path_str)
 }
@@ -593,12 +578,6 @@ impl exarch_core::ProgressCallback for PyProgressAdapter {
     }
 }
 
-// SAFETY: We only call into Python when holding GIL via Python::attach
-// This is required because ProgressCallback trait requires Send.
-// The Py<PyAny> is Send-safe when accessed via GIL (Python::attach).
-#[allow(unsafe_code)]
-unsafe impl Send for PyProgressAdapter {}
-
 /// Python module definition.
 #[pymodule]
 fn exarch(m: &Bound<'_, PyModule>) -> PyResult<()> {
@@ -644,6 +623,7 @@ fn exarch(m: &Bound<'_, PyModule>) -> PyResult<()> {
 )]
 mod tests {
     use super::*;
+    use exarch_core::MAX_PATH_LENGTH;
     use pyo3::types::PyString;
 
     #[test]


### PR DESCRIPTION
## Summary

- Extract the duplicated null-byte and `MAX_PATH_LENGTH` boundary check from `exarch-python` and `exarch-node` into `exarch_core::validate_raw_path_str()`. The two bindings had drifted (full-scan fold vs short-circuiting `contains` for the null-byte check, no shared check order). Both bindings now route the resulting error through their existing `convert_error()` — Python raises `SecurityViolationError` (was a bare `ValueError`), Node carries the `SECURITY_VIOLATION:` prefix (was unprefixed) — for null-byte/too-long path rejections.
- Remove the redundant `unsafe impl Send for PyProgressAdapter` in `exarch-python`: pyo3 0.29's `Py<T>` is unconditionally `Send`, so the struct already auto-derives `Send`.
- Regenerate `exarch-node/index.d.ts` so the `banned_path_components` doc table reflects all 7 current defaults instead of the stale 2-entry list.

Reviewed by an independent security audit (unsafe removal proven sound via `Cargo.lock`-pinned pyo3 0.29.0 and the `ProgressCallback: Send` bound; `cargo deny`/`cargo audit` clean) and an adversarial critique (caught the error-conversion bypass fixed above, plus check-order, doc-accuracy, and visibility nitpicks — all addressed).

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` (963 passed)
- [x] `cargo test --doc --workspace --all-features --exclude exarch-python --exclude exarch-node` (99 passed)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace`
- [x] `cargo test -p exarch-node --all-features --lib` (136 passed)
- [x] `cargo check -p exarch-python --all-features`
- [x] `git diff crates/exarch-node/index.d.ts` confirmed 7-entry `banned_path_components` table

Closes #406
Closes #405
Closes #404