### PR TITLE
fix(security): restore catch_unwind panic safety in Python/Node bindings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,13 @@ jobs:
             python:
               - 'crates/exarch-python/**'
               - 'crates/exarch-core/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
             node:
               - 'crates/exarch-node/**'
               - 'crates/exarch-core/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
             ci:
               - '.github/workflows/**'
               - '.github/labeler.yml'
@@ -259,7 +263,10 @@ jobs:
       - name: Build Python bindings
         run: |
           cd crates/exarch-python
-          maturin build --release
+          # panic-injection exposes a deliberate-panic test hook used by the
+          # #395 regression test (test_panic_safety.py); never enabled for
+          # published wheels (see release.yml).
+          maturin build --release --features panic-injection,abi3
 
       - name: Install Python bindings
         run: uv pip install --system target/wheels/*.whl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   transitive `lzma-rust2` bump from 0.16.5 to 0.18.0 (required by sevenz-rust2's own `^0.18`
   dependency), which rearchitects the LZMA2/XZ decoders into a sans-I/O design — no known
   advisories against either version; audited with no regressions found.
+- **Release profile aborted on panic, silently disabling FFI panic guards (#395)**: the
+  workspace `[profile.release]` set `panic = "abort"`, which made every `catch_unwind` guard in
+  `exarch-python` and `exarch-node` dead code in published wheels and npm packages — a Rust
+  panic inside `extract_archive`/`create_archive`/etc. aborted the whole Python or Node.js
+  process instead of surfacing as a catchable exception/error. Removed `panic = "abort"` from
+  `Cargo.toml` so release builds unwind (this also lets `exarch-cli`'s `Drop` impls run cleanup
+  on panic). Added a compile-time `const _: () = assert!(cfg!(panic = "unwind"), ...)` guard near
+  the top of both binding crates' `lib.rs` so any future reintroduction (workspace profile,
+  `.cargo/config.toml`, or `RUSTFLAGS`) fails the build instead of silently reintroducing the
+  vulnerability. Also closed a related gap in `exarch-python`: the progress-callback branches of
+  `create_archive_with_progress` and `extract_archive_with_progress` had no `catch_unwind` at
+  all (only the no-callback branch was guarded) — both branches are now wrapped, mirroring
+  `exarch-node`'s existing helper shape. Added runtime regression coverage of the
+  `catch_unwind` -> exception/error conversion itself: `exarch-node` gained a Rust-level test
+  that calls the real `catch_panic_as_js_err` production helper with a panicking closure and
+  asserts a catchable `Error` comes back; `exarch-python` gained an end-to-end pytest
+  (`test_panic_safety.py`) that triggers a real panic through the compiled extension module via
+  a `panic-injection`-feature-gated test hook and asserts a catchable `RuntimeError` is raised
+  instead of the process aborting (the feature is only enabled by CI's `test-python` job, never
+  in published wheels).
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,6 @@ opt-level = 3
 lto = "thin"
 codegen-units = 16
 strip = true
-panic = "abort"
 
 [profile.bench]
 inherits = "release"

--- a/crates/exarch-node/src/lib.rs
+++ b/crates/exarch-node/src/lib.rs
@@ -63,6 +63,27 @@ use report::ExtractionReport;
 use report::VerificationReport;
 use utils::validate_path;
 
+// The `catch_unwind` guards throughout this module only convert Rust panics
+// into a catchable `Error` when the crate is built with `panic = "unwind"`;
+// under `panic = "abort"` they are dead code and the whole Node.js process
+// aborts on any panic. Fail the build loudly instead of silently
+// reintroducing that vulnerability (see issue #395).
+const _: () = assert!(
+    cfg!(panic = "unwind"),
+    "exarch-node must be built with panic=unwind so catch_unwind can convert Rust panics into catchable JS errors; see issue #395"
+);
+
+/// Runs `f`, converting a Rust panic into a catchable napi `Error` instead of
+/// letting it unwind across the FFI boundary (see issue #395).
+///
+/// `context` is interpolated into the error message as "Internal panic
+/// during {context}".
+fn catch_panic_as_js_err<T>(context: &str, f: impl FnOnce() -> Result<T>) -> Result<T> {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(f))
+        .map_err(|_| Error::from_reason(format!("Internal panic during {context}")))
+        .flatten()
+}
+
 /// Extract an archive to the specified directory (async).
 ///
 /// This function provides secure archive extraction with configurable
@@ -625,7 +646,7 @@ pub async fn extract_archive_with_progress(
         options.map(|o| o.as_core().clone()).unwrap_or_default();
 
     let report = tokio::task::spawn_blocking(move || {
-        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        catch_panic_as_js_err("archive extraction with progress", || {
             run_extract_with_optional_progress(
                 &archive_path,
                 &output_dir,
@@ -634,9 +655,7 @@ pub async fn extract_archive_with_progress(
                 progress,
             )
             .map_err(convert_error)
-        }))
-        .map_err(|_| Error::from_reason("Internal panic during archive extraction with progress"))
-        .flatten()
+        })
     })
     .await
     .map_err(|e| Error::from_reason(format!("task join error: {e}")))
@@ -1174,6 +1193,24 @@ mod tests {
         assert!(
             result.unwrap_err().to_string().contains("maximum length"),
             "error message should mention length limit"
+        );
+    }
+
+    /// Regression test for #395: a panic inside the code guarded by
+    /// `catch_panic_as_js_err` (the exact helper
+    /// `extract_archive_with_progress` calls in production) must be
+    /// converted into a catchable `Error`, not left to unwind/abort.
+    #[test]
+    fn catch_panic_as_js_err_converts_panic_to_catchable_error() {
+        let result: Result<()> = catch_panic_as_js_err("test operation", || {
+            panic!("synthetic panic for #395 regression test")
+        });
+
+        let err = result.expect_err("panic must be converted into a catchable Error, not abort");
+        assert!(
+            err.to_string()
+                .contains("Internal panic during test operation"),
+            "unexpected error message: {err}"
         );
     }
 }

--- a/crates/exarch-python/Cargo.toml
+++ b/crates/exarch-python/Cargo.toml
@@ -21,6 +21,12 @@ pyo3 = { workspace = true, features = ["extension-module"] }
 [features]
 default = []
 abi3 = ["pyo3/abi3-py39"]
+# Exposes `_trigger_panic_for_testing()`, a deliberate-panic hook used by the
+# #395 regression test to verify the catch_unwind -> PyRuntimeError
+# conversion end-to-end through the real Python API. Never enabled for
+# published wheels (see release.yml); only CI's test-python job builds with
+# it (see ci.yml).
+panic-injection = []
 
 [lints]
 workspace = true

--- a/crates/exarch-python/src/lib.rs
+++ b/crates/exarch-python/src/lib.rs
@@ -22,6 +22,16 @@ use report::PyExtractionReport;
 use report::PyVerificationIssue;
 use report::PyVerificationReport;
 
+// The `catch_unwind` guards throughout this module only convert Rust panics
+// into `PyRuntimeError` when the crate is built with `panic = "unwind"`;
+// under `panic = "abort"` they are dead code and the whole Python process
+// aborts on any panic. Fail the build loudly instead of silently
+// reintroducing that vulnerability (see issue #395).
+const _: () = assert!(
+    cfg!(panic = "unwind"),
+    "exarch-python must be built with panic=unwind so catch_unwind can convert Rust panics into catchable Python exceptions; see issue #395"
+);
+
 /// Extract an archive to the specified directory.
 ///
 /// This function provides secure archive extraction with configurable
@@ -160,6 +170,38 @@ fn path_to_string(py: Python<'_>, path: &Bound<'_, PyAny>) -> PyResult<String> {
     exarch_core::validate_raw_path_str(&path_str).map_err(convert_error)?;
 
     Ok(path_str)
+}
+
+/// Runs `f`, converting a Rust panic into a `PyRuntimeError` instead of
+/// letting it unwind across the FFI boundary (see issue #395).
+///
+/// `context` is interpolated into the error message as "Internal panic
+/// during {context}".
+fn catch_panic_as_py_err<T>(
+    context: &str,
+    f: impl FnOnce() -> exarch_core::Result<T>,
+) -> PyResult<T> {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(f))
+        .map_err(|_| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
+                "Internal panic during {context}"
+            ))
+        })?
+        .map_err(convert_error)
+}
+
+/// Deliberately panics inside [`catch_panic_as_py_err`] so the panic ->
+/// `PyRuntimeError` conversion can be verified end-to-end through the real
+/// Python API surface (see issue #395's regression-test requirement).
+///
+/// Only present when the crate is built with the `panic-injection` feature,
+/// which is never enabled for published wheels.
+#[cfg(feature = "panic-injection")]
+#[pyfunction]
+fn _trigger_panic_for_testing() -> PyResult<()> {
+    catch_panic_as_py_err("test operation (panic-injection)", || {
+        panic!("deliberate panic from _trigger_panic_for_testing (issue #395 regression test)")
+    })
 }
 
 /// Create an archive from source files and directories.
@@ -384,43 +426,47 @@ fn create_archive_with_progress(
     let default_config = exarch_core::creation::CreationConfig::default();
     let config_ref = config.map_or(&default_config, |c| c.as_core());
 
-    // Create progress callback adapter
-    if let Some(py_callback) = progress {
-        let mut callback = PyProgressAdapter::new(py_callback);
+    let report = catch_panic_as_py_err("archive creation with progress", || {
+        run_create_with_optional_progress(py, &output_path, &source_paths, config_ref, progress)
+    })?;
 
-        // CRITICAL: Do NOT release GIL when using Python callback!
-        // Python callback requires GIL to call into Python.
-        let report = exarch_core::create_archive_with_progress(
-            &output_path,
-            &source_paths,
-            config_ref,
-            &mut callback,
-        )
-        .map_err(convert_error)?;
+    Ok(PyCreationReport::from(report))
+}
 
-        Ok(PyCreationReport::from(report))
-    } else {
-        // No progress callback - can release GIL
-        let mut noop = exarch_core::NoopProgress;
-        let report = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+/// Runs `create_archive_with_progress` routed to the Python callback when
+/// present, or with the GIL released and a no-op reporter when absent.
+fn run_create_with_optional_progress(
+    py: Python<'_>,
+    output_path: &str,
+    source_paths: &[String],
+    config: &exarch_core::creation::CreationConfig,
+    progress: Option<Py<PyAny>>,
+) -> exarch_core::Result<exarch_core::creation::CreationReport> {
+    progress.map_or_else(
+        || {
+            // No progress callback - can release GIL
+            let mut noop = exarch_core::NoopProgress;
             py.detach(|| {
                 exarch_core::create_archive_with_progress(
-                    &output_path,
-                    &source_paths,
-                    config_ref,
+                    output_path,
+                    source_paths,
+                    config,
                     &mut noop,
                 )
             })
-        }))
-        .map_err(|_| {
-            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
-                "Internal panic during archive creation with progress",
+        },
+        |py_callback| {
+            // CRITICAL: Do NOT release GIL when using Python callback!
+            // Python callback requires GIL to call into Python.
+            let mut callback = PyProgressAdapter::new(py_callback);
+            exarch_core::create_archive_with_progress(
+                output_path,
+                source_paths,
+                config,
+                &mut callback,
             )
-        })?
-        .map_err(convert_error)?;
-
-        Ok(PyCreationReport::from(report))
-    }
+        },
+    )
 }
 
 /// Extract an archive with progress callback.
@@ -494,44 +540,58 @@ fn extract_archive_with_progress(
     let default_options = exarch_core::ExtractionOptions::default();
     let options_ref = options.map_or(&default_options, |o| o.as_core());
 
-    if let Some(py_callback) = progress {
-        let mut callback = PyProgressAdapter::new(py_callback);
-
-        // CRITICAL: Do NOT release GIL when using Python callback!
-        // Python callback requires GIL to call into Python.
-        let report = exarch_core::extract_archive_with_options_and_progress(
+    let report = catch_panic_as_py_err("archive extraction with progress", || {
+        run_extract_with_optional_progress(
+            py,
             &archive_path,
             &output_dir,
             config_ref,
             options_ref,
-            &mut callback,
+            progress,
         )
-        .map_err(convert_error)?;
+    })?;
 
-        Ok(PyExtractionReport::from(report))
-    } else {
-        // No progress callback - can release GIL
-        let mut noop = exarch_core::NoopProgress;
-        let report = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+    Ok(PyExtractionReport::from(report))
+}
+
+/// Runs `extract_archive_with_options_and_progress` routed to the Python
+/// callback when present, or with the GIL released and a no-op reporter when
+/// absent.
+fn run_extract_with_optional_progress(
+    py: Python<'_>,
+    archive_path: &str,
+    output_dir: &str,
+    config: &exarch_core::SecurityConfig,
+    options: &exarch_core::ExtractionOptions,
+    progress: Option<Py<PyAny>>,
+) -> exarch_core::Result<exarch_core::ExtractionReport> {
+    progress.map_or_else(
+        || {
+            // No progress callback - can release GIL
+            let mut noop = exarch_core::NoopProgress;
             py.detach(|| {
                 exarch_core::extract_archive_with_options_and_progress(
-                    &archive_path,
-                    &output_dir,
-                    config_ref,
-                    options_ref,
+                    archive_path,
+                    output_dir,
+                    config,
+                    options,
                     &mut noop,
                 )
             })
-        }))
-        .map_err(|_| {
-            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
-                "Internal panic during archive extraction with progress",
+        },
+        |py_callback| {
+            // CRITICAL: Do NOT release GIL when using Python callback!
+            // Python callback requires GIL to call into Python.
+            let mut callback = PyProgressAdapter::new(py_callback);
+            exarch_core::extract_archive_with_options_and_progress(
+                archive_path,
+                output_dir,
+                config,
+                options,
+                &mut callback,
             )
-        })?
-        .map_err(convert_error)?;
-
-        Ok(PyExtractionReport::from(report))
-    }
+        },
+    )
 }
 
 /// Adapter that calls Python callback from Rust.
@@ -595,6 +655,8 @@ fn exarch(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(create_archive_with_progress, m)?)?;
     m.add_function(wrap_pyfunction!(list_archive, m)?)?;
     m.add_function(wrap_pyfunction!(verify_archive, m)?)?;
+    #[cfg(feature = "panic-injection")]
+    m.add_function(wrap_pyfunction!(_trigger_panic_for_testing, m)?)?;
 
     // Configuration classes
     m.add_class::<PySecurityConfig>()?;

--- a/crates/exarch-python/tests/test_panic_safety.py
+++ b/crates/exarch-python/tests/test_panic_safety.py
@@ -1,0 +1,21 @@
+"""End-to-end regression test for issue #395.
+
+Verifies that a Rust panic inside a `catch_unwind`-guarded call path surfaces
+as a catchable Python exception through the real compiled extension module,
+rather than aborting the interpreter process. This requires the extension to
+be built with the `panic-injection` Cargo feature (opt-in; CI's test-python
+job enables it, published wheels never do) so the test is skipped when the
+hook isn't present.
+"""
+
+import pytest
+
+import exarch
+
+
+def test_panic_is_converted_to_python_exception_not_process_abort():
+    if not hasattr(exarch, "_trigger_panic_for_testing"):
+        pytest.skip("extension built without the panic-injection feature")
+
+    with pytest.raises(RuntimeError, match="Internal panic"):
+        exarch._trigger_panic_for_testing()

--- a/crates/exarch-python/tests/test_progress_callbacks.py
+++ b/crates/exarch-python/tests/test_progress_callbacks.py
@@ -1,0 +1,51 @@
+"""Integration tests for the *_with_progress functions.
+
+Covers the dual-path `catch_unwind` wiring introduced for issue #395: both the
+Python-callback branch and the `progress=None` branch of
+`extract_archive_with_progress`, and the `progress=None` branch of
+`create_archive_with_progress`. `create_archive_with_progress`'s callback
+branch is already covered by
+`test_cve_regression.py::test_progress_bytes_written_not_stale`.
+"""
+
+import exarch
+
+
+def test_extract_archive_with_progress_invokes_callback(sample_tar_gz, temp_dir):
+    """extract_archive_with_progress calls back once per entry and extracts normally."""
+    output = temp_dir / "output"
+    output.mkdir()
+
+    calls: list[tuple[str, int, int, int]] = []
+
+    def callback(path: str, total: int, current: int, bytes_written: int) -> None:
+        calls.append((path, total, current, bytes_written))
+
+    report = exarch.extract_archive_with_progress(sample_tar_gz, output, None, callback)
+
+    assert report.files_extracted >= 1
+    assert calls, "progress callback was never invoked"
+
+
+def test_extract_archive_with_progress_without_callback(sample_tar_gz, temp_dir):
+    """extract_archive_with_progress(progress=None) still extracts normally."""
+    output = temp_dir / "output"
+    output.mkdir()
+
+    report = exarch.extract_archive_with_progress(sample_tar_gz, output, None, None)
+
+    assert report.files_extracted >= 1
+
+
+def test_create_archive_with_progress_without_callback(temp_dir):
+    """create_archive_with_progress(progress=None) still creates a valid archive."""
+    src_dir = temp_dir / "src"
+    src_dir.mkdir()
+    (src_dir / "file.txt").write_bytes(b"content")
+
+    archive = temp_dir / "output.tar.gz"
+
+    report = exarch.create_archive_with_progress(archive, [src_dir], None, None)
+
+    assert report.files_added >= 1
+    assert archive.exists()


### PR DESCRIPTION
## Summary

- Removed `panic = "abort"` from the workspace `[profile.release]`. It made every `catch_unwind` guard in `exarch-python` and `exarch-node` dead code in published wheels/npm packages: a Rust panic anywhere in the extraction call graph (including inside a dependency) aborted the whole host process instead of surfacing as a catchable exception/error — an externally-triggerable DoS against any application embedding these bindings to process untrusted archives.
- Added a compile-time `const _: () = assert!(cfg!(panic = "unwind"), ...)` guard near the top of both binding crates so any future reintroduction (workspace profile, `.cargo/config.toml`, `RUSTFLAGS`) fails the build instead of silently reopening the gap. Added `Cargo.toml`/`Cargo.lock` to the `python`/`node` CI paths-filters so a profile-only change still triggers the release-mode jobs that exercise the guard.
- Closed a related gap in `exarch-python`: the progress-callback branches of `create_archive_with_progress`/`extract_archive_with_progress` had no `catch_unwind` at all (only the no-callback branch was guarded); both branches now route through a shared helper wrapped in a single guard, mirroring `exarch-node`'s existing shape.
- Added runtime regression coverage of the actual `catch_unwind` → exception/error conversion: `exarch-node` gained a Rust-level test calling the real `catch_panic_as_js_err` helper with a panicking closure; `exarch-python` gained an end-to-end pytest (`test_panic_safety.py`) that triggers a real panic through the compiled extension via an opt-in, default-off `panic-injection` Cargo feature (enabled only by CI's `test-python` job, never in `release.yml`).

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node`
- [x] `cargo test --doc --workspace --all-features`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace`
- [x] `cargo nextest run -p exarch-node` (includes new panic-mapping test)
- [x] `maturin develop --features abi3 && pytest tests/` (with and without `panic-injection` feature)
- [x] `npm run build && npm test`
- [x] Manually re-added `panic = "abort"` to confirm the compile-time guard fails the build (E0080), then removed it again
- [x] `fy validate`/`fy lint` on the modified `ci.yml`

Closes #395