### PR TITLE
fix(ci): stop test-python matrix from uploading duplicate codecov data

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -24,7 +24,7 @@ comment:
   layout: "reach,diff,flags,files"
   behavior: default
   require_changes: false     # Always post comment
-  after_n_builds: 1          # Single combined coverage upload
+  after_n_builds: 2          # coverage job (core+cli) + test-python (3.12 leg only)
 
 # Coverage flags for different packages
 flags:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,12 +271,24 @@ jobs:
       - name: Install Python bindings
         run: uv pip install --system target/wheels/*.whl
 
+      - name: Test Python bindings
+        if: matrix.python-version != '3.12'
+        run: |
+          cd crates/exarch-python
+          pytest tests/ -v
+
+      # Coverage is only measured once (Python version doesn't change which
+      # lines of the Rust-backed bindings get exercised), so only one matrix
+      # leg uploads to Codecov — uploading all 5 would just duplicate the
+      # same flag's data and race codecov.yml's after_n_builds threshold.
       - name: Test Python bindings with coverage
+        if: matrix.python-version == '3.12'
         run: |
           cd crates/exarch-python
           pytest tests/ -v --cov --cov-report=xml:coverage.xml
 
       - name: Upload Python coverage to Codecov
+        if: matrix.python-version == '3.12'
         uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -408,6 +420,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
+          flags: exarch-core, exarch-cli
           fail_ci_if_error: false
           verbose: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Stale generated `exarch-node/index.d.ts` (#404)**: the napi-rs generated type declarations
   still listed only 2 of the 7 default `banned_path_components` entries in the `SecurityConfig`
   doc comment table, out of sync with the Rust source. Regenerated via `napi build`.
+- **`test-python` CI job uploaded duplicate coverage to Codecov 5x per run**: the job's
+  `python-version` matrix (3.10-3.14) ran `pytest --cov` and uploaded to Codecov under the same
+  `exarch-python` flag on every leg, even though all 5 legs exercise the same Rust-backed
+  bindings and test suite. Coverage generation and the Codecov upload now run only on the 3.12
+  leg; the other 4 legs still run the full test suite without coverage instrumentation. Also
+  fixed `.github/codecov.yml`'s `after_n_builds` (was `1`, which raced the real 6-upload count
+  per run and could post PR comments before all uploads landed; now `2`, matching the `coverage`
+  and `test-python` jobs' single upload each), and added the missing `flags: exarch-core,
+  exarch-cli` to the `coverage` job's upload — those two flags were declared with their own
+  thresholds in `codecov.yml` but never received any tagged data.
 
 ### Changed
 


### PR DESCRIPTION
## Summary
- `test-python`'s python-version matrix (3.10-3.14) ran `pytest --cov` and uploaded to Codecov under the same `exarch-python` flag on every leg, even though all legs exercise the same Rust-backed bindings and test suite. Coverage generation and the Codecov upload now run only on the 3.12 leg; the other 4 legs still run the full test suite without coverage instrumentation.
- Fixed `.github/codecov.yml`'s `after_n_builds` (was `1`, which raced the real 6-upload-per-run count and could post PR comments before all uploads landed; now `2`, matching the `coverage` and `test-python` jobs' single upload each).
- Added the missing `flags: exarch-core, exarch-cli` to the `coverage` job's Codecov upload — those flags were declared in `codecov.yml` with their own thresholds but never received any tagged data.

## Test plan
- [x] `fy lint` on `.github/workflows/ci.yml` and `.github/codecov.yml` — 0 errors
- [x] Manual review of the diff for matrix `if:` condition correctness (3.12 leg gets coverage, others get plain pytest)
- [ ] Confirm on the CI run for this PR that `test-python` uploads to Codecov exactly once and the PR comment reflects combined core/cli/python coverage