### PR TITLE
refactor(core): dedupe extension-filter skip logic across zip/tar/7z

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Extracted the duplicated extension-allowlist check from `formats/zip.rs`, `formats/tar.rs`,
+  and `formats/sevenz.rs` into a shared, `#[must_use]` `formats::common::check_extension_allowed`
+  helper (#413). Behavior is unchanged; each call site still returns its own type (`Ok(())`,
+  `Ok(None)`, `Ok(0)`) on rejection. Added direct unit tests pinning the exact skip-warning
+  message text so the wording cannot silently drift again.
 - **BREAKING: Bumped MSRV from 1.93.0 to 1.96.0 (#401)**: raises the minimum supported Rust
   version across the workspace. Downstream consumers pinned to an older toolchain must upgrade
   before taking this release. `rust-version` in the root `Cargo.toml`, the `msrv` job in

--- a/crates/exarch-core/src/formats/common.rs
+++ b/crates/exarch-core/src/formats/common.rs
@@ -9,6 +9,7 @@
 //! - [`extract_file_generic`]: Generic file extraction with buffered I/O
 //! - [`create_directory`]: Directory creation (idempotent)
 //! - [`create_symlink`]: Symbolic link creation (Unix only)
+//! - [`check_extension_allowed`]: Extension allowlist filtering
 
 use rustc_hash::FxHashSet;
 use std::fs::File;
@@ -23,6 +24,7 @@ use crate::ArchiveError;
 use crate::ExtractionReport;
 use crate::ProgressCallback;
 use crate::Result;
+use crate::SecurityConfig;
 use crate::copy::CopyBuffer;
 use crate::copy::copy_with_buffer;
 use crate::error::QuotaResource;
@@ -321,6 +323,46 @@ pub fn normalize_entry_name(name: &str) -> String {
     } else {
         name.to_owned()
     }
+}
+
+/// Returns `true` if `path`'s extension passes `config`'s allowlist.
+///
+/// If the extension is not allowed, records the skip in `report`
+/// (increments `files_skipped`, pushes the standard warning) and returns
+/// `false`. Shared by the TAR, ZIP, and 7z extractors, which all reject
+/// entries with disallowed extensions before further validation.
+///
+/// This is the single source of truth for the extension-allowlist skip
+/// check: do not re-inline this pattern at a new call site (this helper
+/// exists because the pattern already drifted once for the FFI boundary
+/// path check in #406 — see #413).
+///
+/// # Examples
+///
+/// ```ignore
+/// # use exarch_core::formats::common::check_extension_allowed;
+/// if !check_extension_allowed(&path, config, report) {
+///     return Ok(None);
+/// }
+/// ```
+#[must_use]
+#[inline]
+pub fn check_extension_allowed(
+    path: &Path,
+    config: &SecurityConfig,
+    report: &mut ExtractionReport,
+) -> bool {
+    let ext = path.extension().and_then(|e| e.to_str());
+    if config.is_path_extension_allowed(ext) {
+        return true;
+    }
+
+    report.files_skipped += 1;
+    report.warnings.push(format!(
+        "skipped entry with disallowed extension: {}",
+        path.display()
+    ));
+    false
 }
 
 /// Creates a file with permissions enforced after creation to bypass umask.
@@ -1161,5 +1203,40 @@ mod tests {
         assert_eq!(report.symlinks_created, 2);
         assert_eq!(report.files_skipped, 0);
         assert!(temp.path().join("link.txt").exists());
+    }
+
+    /// Pins the exact warning message text produced by
+    /// `check_extension_allowed`, so any future edit that changes the
+    /// wording (or re-inlines this pattern with different wording at a call
+    /// site) is caught immediately rather than drifting unnoticed, as
+    /// happened in #413.
+    #[test]
+    fn test_check_extension_allowed_warning_message_text() {
+        let config = SecurityConfig::default().with_allowed_extensions(vec!["txt".to_string()]);
+        let mut report = ExtractionReport::default();
+        let path = PathBuf::from("skip.exe");
+
+        let allowed = check_extension_allowed(&path, &config, &mut report);
+
+        assert!(!allowed, "disallowed extension must be rejected");
+        assert_eq!(report.files_skipped, 1);
+        assert_eq!(
+            report.warnings,
+            vec!["skipped entry with disallowed extension: skip.exe".to_string()]
+        );
+    }
+
+    /// Verifies the happy path leaves `report` untouched.
+    #[test]
+    fn test_check_extension_allowed_allowed_extension() {
+        let config = SecurityConfig::default().with_allowed_extensions(vec!["txt".to_string()]);
+        let mut report = ExtractionReport::default();
+        let path = PathBuf::from("keep.txt");
+
+        let allowed = check_extension_allowed(&path, &config, &mut report);
+
+        assert!(allowed, "allowed extension must pass");
+        assert_eq!(report.files_skipped, 0);
+        assert!(report.warnings.is_empty());
     }
 }

--- a/crates/exarch-core/src/formats/sevenz.rs
+++ b/crates/exarch-core/src/formats/sevenz.rs
@@ -313,16 +313,10 @@ impl<R: Read + Seek> SevenZArchive<R> {
 
         // Extension filter runs before validate_entry to avoid quota
         // double-counting for skipped files.
-        if matches!(entry_type, EntryType::File) {
-            let ext = entry_path.extension().and_then(|e| e.to_str());
-            if !config.is_path_extension_allowed(ext) {
-                report.files_skipped += 1;
-                report.warnings.push(format!(
-                    "skipped entry with disallowed extension: {}",
-                    entry_path.display()
-                ));
-                return Ok(0);
-            }
+        if matches!(entry_type, EntryType::File)
+            && !common::check_extension_allowed(entry_path, config, report)
+        {
+            return Ok(0);
         }
 
         // Re-validate (defense in depth)

--- a/crates/exarch-core/src/formats/tar.rs
+++ b/crates/exarch-core/src/formats/tar.rs
@@ -216,16 +216,10 @@ impl<R: Read> TarArchive<R> {
         let size = TarEntryAdapter::get_uncompressed_size(&entry);
         let mode = entry.header().mode().ok();
 
-        if matches!(entry_type, EntryType::File) {
-            let ext = path.extension().and_then(|e| e.to_str());
-            if !ctx.config.is_path_extension_allowed(ext) {
-                ctx.report.files_skipped += 1;
-                ctx.report.warnings.push(format!(
-                    "skipped entry with disallowed extension: {}",
-                    path.display()
-                ));
-                return Ok(None);
-            }
+        if matches!(entry_type, EntryType::File)
+            && !common::check_extension_allowed(&path, ctx.config, ctx.report)
+        {
+            return Ok(None);
         }
 
         let validated = ctx.validator.validate_entry(

--- a/crates/exarch-core/src/formats/zip.rs
+++ b/crates/exarch-core/src/formats/zip.rs
@@ -376,13 +376,7 @@ impl<R: Read + Seek> ZipArchive<R> {
                 )?;
             }
         } else {
-            let ext = path.extension().and_then(|e| e.to_str());
-            if !ctx.config.is_path_extension_allowed(ext) {
-                ctx.report.files_skipped += 1;
-                ctx.report.warnings.push(format!(
-                    "skipped entry with disallowed extension: {}",
-                    path.display()
-                ));
+            if !common::check_extension_allowed(&path, ctx.config, ctx.report) {
                 return Ok(());
             }
             // File: validate BEFORE writing (security invariant preserved),


### PR DESCRIPTION
## Summary

- Extracts the duplicated "reject entry if extension not allowed" check from `zip.rs`, `tar.rs`, and `sevenz.rs` into a single `#[must_use]` helper `check_extension_allowed` in `crates/exarch-core/src/formats/common.rs`
- Preserves behavior exactly at all three call sites: skip counter, warning message wording, check order, and per-site return semantics (`Ok(())` / `Ok(None)` / `Ok(0)`)
- Adds `#[must_use]` since the helper both returns a bool and mutates the report as a side effect — without it, a caller forgetting `if !` would silently extract a file it should have skipped
- Adds two direct unit tests pinning the exact warning message text and the untouched-report happy path
- `formats::common` is `pub(crate)`, so this adds no public API surface (semver-safe)

## Follow-ups (out of scope for this PR)

- A fourth, similarly-shaped allowlist check exists in `crates/exarch-cli/src/commands/extract.rs:130-136` (progress-bar denominator) — worth a follow-up issue if the drift pattern continues.
- A possible pre-existing progress-count discrepancy in the same file when the allowlist is non-empty, unrelated to this diff.

Closes #413

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` (968/968 passed)
- [x] `cargo test --doc --workspace --all-features`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace`