### PR TITLE
fix(core): bound TAR metadata reads and add node-tar GHSA regression tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,67 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **TAR metadata-entry decompression bomb (#414)**: GNU long-name (`L`), GNU long-link (`K`),
+  and PAX extended header (`x`/`g`) records are buffered fully into memory by the `tar` crate's
+  internals before any entry reaches `exarch-core`'s validator or quota tracker, so a crafted
+  record declaring a multi-gigabyte length backed by a tiny compressed stream caused unbounded
+  allocation with no quota enforcement (measured: a 765 KB `.tar.gz` reached 4.95 GB peak RSS on
+  `extract`, 3.29 GB on `verify`, 2.49 GB on `list`). Added `SecurityConfig::max_tar_metadata_bytes`
+  (default 4 MiB, 16 MiB for `SecurityConfig::permissive()`) enforced by a new
+  `formats::tar_metadata_limit` read-budget mechanism: a reader wrapper meters bytes the `tar`
+  crate reads while searching for the next entry (headers, long-name/long-link/PAX records, GNU
+  sparse extension blocks) and errors once the budget is exceeded, before any oversized
+  allocation completes. Applied uniformly to `extract_archive`, `list_archive`, and
+  `verify_archive` (including `TarArchive`'s `ArchiveFormat` trait methods), since all three
+  previously opened `tar::Archive` independently.
+
+  An initial version of this fix re-parsed TAR headers in a shadow parser to reject an oversized
+  *declared* size before the `tar` crate could buffer it. Three rounds of adversarial review each
+  found a fresh case where that shadow parser's belief about entry framing diverged from the
+  `tar` crate's own (an untracked PAX `size=` override hiding a bomb behind a mis-framed decoy
+  entry; the same bypass again when the overriding PAX header had invalid magic, since `tar` only
+  honors an override when the header is `is_recognized_header`; and again via a PAX global header
+  draining `tar`'s override state without draining the shadow parser's mirrored state) — three
+  independent divergences in three rounds, each closed individually but never provably
+  exhaustive. The mechanism actually shipped replaces the shadow parser entirely: it never parses
+  a header, typeflag, magic byte, or PAX record, so there is exactly one parser (the `tar`
+  crate's own) and nothing left to diverge from it. Every yielded entry is fully drained (bounded,
+  not run to true EOF — an unbounded drain would let a crafted GNU sparse entry's synthesized
+  zero-padding become a separate unbounded CPU sink) before the budget re-arms for the next gap,
+  so the budget never depends on any declared size, override, or magic validity.
+
+  A follow-up review found that the drained-on-drop bound above was itself sourced from the
+  caller's `max_file_size` quota — a value `inspection::verify::listing_config_for_verify` (the
+  `verify_archive` pre-listing pass) legitimately relaxes to `u64::MAX` so metadata-only listing
+  does not false-reject large files. A GNU old-format sparse entry (`typeflag 'S'`) can declare a
+  `realsize` field up to `u64::MAX` (via GNU base-256 encoding) while backed by a single physical
+  block, so the relaxed quota silently defeated the drain bound on `verify` specifically,
+  reintroducing an unbounded, memory-invisible (drained to `io::sink`, so no corresponding heap
+  growth) CPU-exhaustion hang scaling linearly with the attacker-chosen `realsize` (measured: a
+  113-byte `.tar.gz` drove `verify` to 3.98 s at a 400 GiB `realsize`, with throughput implying a
+  `u64::MAX` value would hang for years).
+
+  Two successive fixes that instead sourced the drain bound from a fixed value (first
+  `max_tar_metadata_bytes`, 4 MiB, on the shared `list`/`verify` path; then, after that turned out
+  to false-reject any archive with a single entry over ~8 MiB, an "absolute cap" of 16 MiB applied
+  everywhere) were each found to reopen the same class of bug in the opposite direction: `list`,
+  `verify`, and even `extract` (via the CLI's `list_archive` pre-flight) rejected perfectly
+  ordinary archives — a ~765 KB legitimate file was rejected with a `SecurityViolation` — because
+  `list`/`verify` never read entry content at all, so the drain is the *only* thing consuming a
+  legitimate entry's real bytes to reach the next header, and any *fixed* cap on total drained
+  output eventually clips some legitimate entry's real content, however generous the cap.
+
+  The mechanism that actually shipped bounds the drain by **synthesized** bytes instead of total
+  output: `formats::tar_metadata_limit::BudgetedReader` now tracks a monotonic count of bytes
+  actually read from the underlying reader, and `TarEntryGuard::drop` drains in a loop comparing
+  bytes output so far against bytes actually read during the same drain. A legitimate entry's
+  drain consumes real bytes 1:1 with what it outputs, so this "synthetic" gap stays at (or within
+  a read-chunk's rounding of) zero regardless of entry size, and the entry always drains to
+  completion; GNU sparse zero-padding is the opposite — `tar` yields it from `io::repeat(0)` with
+  no corresponding read — so the gap grows every iteration and trips a small, fixed,
+  non-configurable cap almost immediately regardless of the declared `realsize`. This closes both
+  directions of the bug from one mechanism, without ever inspecting a header field to tell the two
+  cases apart.
 - Bumped `sevenz-rust2` from 0.21.3 to 0.21.4, fixing an integer overflow when summing
   attacker-controlled coder stream counts while parsing a 7z block header (upstream #127).
   Malformed archives previously could panic in debug builds and bypassed the stream-count
@@ -64,6 +125,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Regression test coverage mapping node-tar GHSA vulnerability classes onto the TAR extraction
+  pipeline (#399): GHSA-vmf3 (PAX/GNU long-name/long-link record smuggling and stream
+  re-framing), GHSA-gvwx / GHSA-w8wr (NUL byte and malformed-field handling in PAX and GNU
+  long-name records), and GHSA-23hp (declared-vs-actual entry size mismatches). All 13 cases
+  currently pass — protection is inherited from the `tar` crate dependency, so these lock in
+  that behavior against a future dependency bump.
+- Regression test coverage for the `max_tar_metadata_bytes` read-budget mechanism (#414):
+  `tests/security/tar_metadata_bomb.rs` covers `extract`/`list`/`verify`/`extract_archive`
+  against oversized `L`/`K`/`x` records, a false-positive check for legitimate long paths, and
+  the three historical shadow-parser bypass shapes (untracked PAX `size=` override,
+  invalid-magic variant, and PAX-global-header state drain) reconstructed to confirm the budget
+  mechanism rejects all three regardless — none of those shapes are individually meaningful to
+  it any more, since it does not parse headers at all. `tests/tar_alloc_bound.rs` (its own
+  top-level test binary, since `dhat`'s counting allocator is process-wide) measures actual peak
+  heap usage — not just the returned error — across the historical shapes and ~100
+  proptest-generated adversarial archives (random typeflags, magic validity, and declared sizes
+  up to 4 GiB), asserting it stays orders of magnitude below the historical multi-GB measurements
+  regardless of what the archive contains.
+  `tests/security/tar_budget_parity.rs` guards against the mechanism's one real assumption (that
+  `tar`'s iterator reads less than the budget between yields once every entry is drained) with a
+  proptest comparing budgeted extraction output against a plain, unwrapped `tar::Archive` read
+  for well-formed archives with long paths and many files, so a future `tar` crate bump that
+  invalidates the assumption fails loudly here rather than silently rejecting legitimate archives
+  in production.
+- Regression test coverage for the synthesized-bytes drain bound above (#414): direct unit tests
+  in `formats::tar_metadata_limit` confirm a legitimate entry (comfortably larger than the
+  synthetic-bytes cap) drains to true completion, and that a real GNU old-format sparse header
+  with an extreme `realsize` still stops draining within a small, bounded number of real bytes
+  read. `tests/security/tar_metadata_bomb.rs` reconstructs the same sparse-header shape and
+  asserts `verify_archive`, `list_archive`, and `extract_archive` all reject it within a bounded
+  wall-clock time regardless of the claimed size, not just bounded heap usage. A companion test
+  reproduces the exact false-positive size table found during this fix's own review (legitimate
+  archives with a single 3/6/9/12/30/45 MiB entry) against `list_archive`, `verify_archive`, and
+  `extract_archive`, and a further test confirms `extract` still fully skips a legitimately large
+  (45 MiB) disallowed-extension entry and continues extracting the rest, checked through both
+  `TarArchive::extract` directly and the public `extract_archive` API. `tests/tar_alloc_bound.rs`
+  was extended to measure `list_archive` and `verify_archive` in addition to `extract`, and its
+  random-archive generator now emits real GNU sparse header fields for typeflag `'S'` steps
+  instead of an empty (and therefore non-sparse-triggering) header, so the fuzz corpus actually
+  exercises the zero-padding code path this mechanism bounds.
+
+  A known, accepted residual limitation of the synthesized-bytes design: a *legitimate* GNU
+  sparse file with a real hole larger than the synthetic-bytes cap is indistinguishable, by pure
+  byte accounting, from the attack shape when skipped unread on `list_archive`/`verify_archive` —
+  both produce output with no corresponding read. This affects those two functions directly and,
+  transitively, the `exarch` CLI's `extract` command (which runs its own `list_archive`
+  pre-flight for progress-bar/conflict detection ahead of the actual extraction); it does *not*
+  affect the `extract_archive`/`TarArchive::extract` library functions, which read the entry
+  themselves and never reach the guard's drain unread. Accepted as a documented trade-off (P3
+  follow-up filed separately) rather than fixed here, since it requires a real hole combined with
+  several MiB of real data to reproduce and this PR has already been through four rounds of
+  adversarial review. Pinned by a dedicated regression test in each of `tests/security/tar_metadata_bomb.rs`
+  (`list_archive`/`verify_archive`/library `extract`) and `exarch-cli/tests/cli_tests.rs` (the CLI
+  command specifically), so a future change to the cap cannot silently move this threshold
+  without a test noticing.
 - Regression test coverage for GHSA-qh76-45cr-8xrc / CVE-2026-61725 (7z Zip-Slip via
   `sevenz_rust2::decompress()`), confirming `SevenZArchive::extract` rejects both
   relative-traversal and absolute-path 7z entries via `EntryValidator` before any file is

--- a/crates/exarch-cli/tests/cli_tests.rs
+++ b/crates/exarch-cli/tests/cli_tests.rs
@@ -2228,3 +2228,117 @@ fn test_extract_security_violation_text_reason_appears_once() {
         "reason should appear exactly once, got: {stderr}"
     );
 }
+
+/// Encodes `n` as a classic octal numeric field of `width` bytes (including
+/// the trailing NUL), or `None` if it does not fit in `width - 1` digits.
+fn octal_field(n: u64, width: usize) -> Option<Vec<u8>> {
+    let digits = format!("{n:o}").into_bytes();
+    if digits.len() > width - 1 {
+        return None;
+    }
+    let mut out = vec![b'0'; width - 1 - digits.len()];
+    out.extend_from_slice(&digits);
+    out.push(0);
+    Some(out)
+}
+
+/// Encodes `n` as a GNU base-256 numeric field (big-endian, high bit of the
+/// first byte set) — used for values beyond octal's digit capacity.
+fn base256_field(n: u64, width: usize) -> Vec<u8> {
+    let mut out = vec![0u8; width];
+    let bytes = n.to_be_bytes();
+    out[width - bytes.len()..].copy_from_slice(&bytes);
+    out[0] |= 0x80;
+    out
+}
+
+fn num_field(n: u64, width: usize) -> Vec<u8> {
+    octal_field(n, width).unwrap_or_else(|| base256_field(n, width))
+}
+
+/// Builds a raw GNU old-format sparse header (typeflag `'S'`) with a real
+/// inline `(offset, numbytes)` block and a `realsize` at offset 483.
+fn gnu_sparse_header(
+    name: &[u8],
+    size_field: u64,
+    realsize: u64,
+    offset: u64,
+    numbytes: u64,
+) -> Vec<u8> {
+    const BLOCK: usize = 512;
+    let mut h = vec![0u8; BLOCK];
+    let name_len = name.len().min(100);
+    h[..name_len].copy_from_slice(&name[..name_len]);
+    h[100..108].copy_from_slice(&num_field(0o644, 8));
+    h[108..116].copy_from_slice(&num_field(0, 8));
+    h[116..124].copy_from_slice(&num_field(0, 8));
+    h[124..136].copy_from_slice(&num_field(size_field, 12));
+    h[136..148].copy_from_slice(&num_field(0, 12));
+    h[156] = b'S';
+    h[257..263].copy_from_slice(b"ustar ");
+    h[263..265].copy_from_slice(b" \0");
+    h[386..398].copy_from_slice(&num_field(offset, 12));
+    h[398..410].copy_from_slice(&num_field(numbytes, 12));
+    h[482] = 0;
+    h[483..495].copy_from_slice(&num_field(realsize, 12));
+    h[148..156].copy_from_slice(b"        ");
+    let sum: u32 = h.iter().map(|b| u32::from(*b)).sum();
+    h[148..156].copy_from_slice(format!("{sum:06o}\0 ").as_bytes());
+    h
+}
+
+/// Builds a raw single-entry TAR with a GNU sparse header shaped so that
+/// `exarch-core`'s bounded drain (`SYNTHETIC_PAD_CAP_BYTES`, currently
+/// 8 MiB) gives up mid-hole, leaving the trailing real data segment
+/// entirely unread — see the matching (and more detailed) construction and
+/// rationale in `exarch-core`'s `tar_metadata_bomb.rs`, in the test named
+/// `known_limitation_legitimate_sparse_hole_above_the_synthetic_cap_is_rejected`.
+fn legitimate_sparse_hole_fixture() -> Vec<u8> {
+    const BLOCK: usize = 512;
+    let gap = 12 * 1024 * 1024u64;
+    let real_trailing = 6 * 1024 * 1024u64;
+    let mut out = gnu_sparse_header(
+        b"legit_sparse.bin",
+        real_trailing,
+        gap + real_trailing,
+        gap,
+        real_trailing,
+    );
+    out.extend(std::iter::repeat_n(
+        b'D',
+        usize::try_from(real_trailing).unwrap(),
+    ));
+    let rem = out.len() % BLOCK;
+    if rem != 0 {
+        out.extend(std::iter::repeat_n(0u8, BLOCK - rem));
+    }
+    out.extend(std::iter::repeat_n(0u8, BLOCK * 2));
+    out
+}
+
+/// Pins the documented residual limitation of the C1/C2/C3 drain-bound fix
+/// (issue #414) specifically at the CLI level: `exarch extract` runs its
+/// own `list_archive` pre-flight (for progress-bar/conflict detection,
+/// `src/commands/extract.rs`) ahead of the actual extraction, so a
+/// legitimate GNU sparse file whose hole exceeds the synthetic-bytes drain
+/// cap is rejected by the CLI even though the underlying library's
+/// `extract_archive`/`TarArchive::extract` calls (which never run that
+/// pre-flight) handle the identical archive cleanly. This is a deliberately
+/// accepted trade-off (P3 follow-up tracked separately), not a bug — this
+/// test exists so the CLI-specific angle of that trade-off cannot silently
+/// change without a test noticing.
+#[test]
+fn test_extract_known_limitation_cli_rejects_legitimate_sparse_hole_above_synthetic_cap() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let archive_path = temp.path().join("legit_sparse.tar");
+    std::fs::write(&archive_path, legitimate_sparse_hole_fixture()).expect("write sparse fixture");
+    let out_dir = temp.path().join("out");
+
+    exarch_cmd()
+        .arg("extract")
+        .arg(&archive_path)
+        .arg(&out_dir)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("failed to list archive"));
+}

--- a/crates/exarch-core/src/config.rs
+++ b/crates/exarch-core/src/config.rs
@@ -126,6 +126,45 @@ pub struct SecurityConfig {
     ///
     /// **Recommendation:** Set to 1-2x available RAM for trusted archives only.
     pub max_solid_block_memory: u64,
+
+    /// Maximum bytes the TAR reader may consume for headers and metadata
+    /// records in the gap between two consecutive entries.
+    ///
+    /// **TAR Metadata Buffering Model:**
+    ///
+    /// GNU long-name (`L`), GNU long-link (`K`), and PAX extended header
+    /// (`x`/`g`) records are buffered fully into memory by the underlying
+    /// `tar` crate *before* any entry reaches the entry validator or quota
+    /// tracker — a crafted record can declare a multi-gigabyte length backed
+    /// by a tiny compressed stream, exhausting memory with no quota
+    /// enforcement (metadata-entry decompression bomb).
+    ///
+    /// **Enforcement Strategy:**
+    /// - A read-budget wrapper meters bytes the `tar` crate reads while
+    ///   searching for the next entry (headers, long-name/long-link/PAX
+    ///   records, GNU sparse extension blocks) and returns an error once
+    ///   `max_tar_metadata_bytes` is exceeded, before any oversized allocation
+    ///   completes
+    /// - Applies uniformly to `extract`, `list`, and `verify`
+    /// - The window this bounds contains no entry *data* — only metadata — so
+    ///   it does not interact with `max_file_size`/`max_total_size`. Draining
+    ///   an unread entry before the next header search is a separate concern
+    ///   (see `formats::tar_metadata_limit`'s module docs) bounded by
+    ///   synthesized-byte accounting, not by this or any other quota value
+    /// - Legitimate long-path/xattr metadata records are at most a few
+    ///   kilobytes each, and a GNU tar sparse file with heavy fragmentation can
+    ///   use up to a few thousand 512-byte extension blocks; either or both
+    ///   share this single budget (not "plus" each other), so the default
+    ///   leaves headroom for either shape, not necessarily both at their
+    ///   extremes simultaneously
+    /// - The real peak memory this bounds is roughly 5x the configured value
+    ///   (GNU sparse extension blocks expand into multiple `EntryIo` records
+    ///   per block before the growth is charged against this budget), not an
+    ///   exact multiple — treat it as an order-of-magnitude ceiling, not a
+    ///   tight bound
+    ///
+    /// Default: 4 MiB (4,194,304 bytes)
+    pub max_tar_metadata_bytes: u64,
 }
 
 impl Default for SecurityConfig {
@@ -144,6 +183,7 @@ impl Default for SecurityConfig {
     ///   ".docker", ".env"]`
     /// - `allow_solid_archives`: false (solid archives rejected)
     /// - `max_solid_block_memory`: 512 MB
+    /// - `max_tar_metadata_bytes`: 4 MiB
     fn default() -> Self {
         Self {
             max_file_size: 50 * 1024 * 1024,   // 50 MB
@@ -165,6 +205,7 @@ impl Default for SecurityConfig {
             ],
             allow_solid_archives: false,
             max_solid_block_memory: 512 * 1024 * 1024, // 512 MB
+            max_tar_metadata_bytes: 4 * 1024 * 1024,   // 4 MiB
         }
     }
 }
@@ -188,6 +229,7 @@ impl SecurityConfig {
             banned_path_components: Vec::new(),
             allow_solid_archives: true,
             max_solid_block_memory: 1024 * 1024 * 1024, // 1 GB for permissive
+            max_tar_metadata_bytes: 16 * 1024 * 1024,   // 16 MiB for permissive
             ..Default::default()
         }
     }
@@ -247,6 +289,11 @@ impl SecurityConfig {
         if self.max_solid_block_memory == 0 {
             return Err(crate::ArchiveError::InvalidConfiguration {
                 reason: "max_solid_block_memory must not be zero".into(),
+            });
+        }
+        if self.max_tar_metadata_bytes == 0 {
+            return Err(crate::ArchiveError::InvalidConfiguration {
+                reason: "max_tar_metadata_bytes must not be zero".into(),
             });
         }
         Ok(())
@@ -515,6 +562,25 @@ impl SecurityConfig {
     #[inline]
     pub fn with_max_solid_block_memory(mut self, size: u64) -> Self {
         self.max_solid_block_memory = size;
+        self
+    }
+
+    /// Sets the maximum bytes the TAR reader may consume for headers and
+    /// metadata records (GNU long-name/long-link, PAX extended headers, GNU
+    /// sparse extension blocks) in the gap between two consecutive entries.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exarch_core::SecurityConfig;
+    ///
+    /// let config = SecurityConfig::default().with_max_tar_metadata_bytes(64 * 1024);
+    /// assert_eq!(config.max_tar_metadata_bytes, 64 * 1024);
+    /// ```
+    #[must_use]
+    #[inline]
+    pub fn with_max_tar_metadata_bytes(mut self, size: u64) -> Self {
+        self.max_tar_metadata_bytes = size;
         self
     }
 
@@ -822,6 +888,32 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_config_tar_metadata_bytes_default() {
+        let config = SecurityConfig::default();
+        assert_eq!(
+            config.max_tar_metadata_bytes,
+            4 * 1024 * 1024,
+            "max TAR metadata bytes should be 4 MiB by default"
+        );
+    }
+
+    #[test]
+    fn test_config_permissive_tar_metadata_bytes() {
+        let config = SecurityConfig::permissive();
+        assert_eq!(
+            config.max_tar_metadata_bytes,
+            16 * 1024 * 1024,
+            "permissive should have 16 MiB TAR metadata budget"
+        );
+    }
+
+    #[test]
+    fn test_with_max_tar_metadata_bytes_builder() {
+        let config = SecurityConfig::default().with_max_tar_metadata_bytes(2048);
+        assert_eq!(config.max_tar_metadata_bytes, 2048);
+    }
+
     // Regression tests for #172: SecurityConfig::validate() must reject configs
     // that would make security enforcement impossible.
 
@@ -906,6 +998,15 @@ mod tests {
     fn test_validate_rejects_zero_max_solid_block_memory() {
         let cfg = SecurityConfig {
             max_solid_block_memory: 0,
+            ..SecurityConfig::default()
+        };
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_rejects_zero_max_tar_metadata_bytes() {
+        let cfg = SecurityConfig {
+            max_tar_metadata_bytes: 0,
             ..SecurityConfig::default()
         };
         assert!(cfg.validate().is_err());

--- a/crates/exarch-core/src/formats/mod.rs
+++ b/crates/exarch-core/src/formats/mod.rs
@@ -5,6 +5,7 @@ pub mod compression;
 pub mod detect;
 pub mod sevenz;
 pub mod tar;
+pub(crate) mod tar_metadata_limit;
 pub mod traits;
 pub mod zip;
 

--- a/crates/exarch-core/src/formats/tar.rs
+++ b/crates/exarch-core/src/formats/tar.rs
@@ -128,6 +128,9 @@ use crate::types::EntryType;
 use crate::types::SafePath;
 
 use super::common;
+use super::tar_metadata_limit::budget_violation;
+use super::tar_metadata_limit::budgeted_reader;
+use super::tar_metadata_limit::budgeted_tar_entries;
 use super::traits::ArchiveFormat;
 
 /// TAR archive handler with streaming extraction.
@@ -161,8 +164,12 @@ use super::traits::ArchiveFormat;
 /// # Ok::<(), exarch_core::ArchiveError>(())
 /// ```
 pub struct TarArchive<R: Read> {
-    /// Underlying `tar::Archive` reader; `None` after `list()` consumes it.
-    inner: Option<Archive<R>>,
+    /// Raw underlying reader; `None` after `extract()`/`list()` consumes it.
+    ///
+    /// Wrapped in a metadata-size-limiting reader (using the config supplied
+    /// to `extract()`/`list()`) and only then handed to `tar::Archive`, so the
+    /// cap is applied fresh with whatever `SecurityConfig` each call uses.
+    inner: Option<R>,
 }
 
 impl<R: Read> TarArchive<R> {
@@ -193,17 +200,17 @@ impl<R: Read> TarArchive<R> {
     #[must_use]
     pub fn new(reader: R) -> Self {
         Self {
-            inner: Some(Archive::new(reader)),
+            inner: Some(reader),
         }
     }
 
     /// Processes a single TAR entry.
-    fn process_entry(
-        entry: tar::Entry<'_, R>,
+    fn process_entry<ER: Read>(
+        entry: &mut tar::Entry<'_, ER>,
         ctx: &mut ExtractionContext<'_, '_>,
     ) -> Result<Option<HardlinkInfo>> {
         // Skip TAR metadata entries (PAX headers, GNU long names/links, sparse)
-        if TarEntryAdapter::is_metadata_entry(&entry) {
+        if TarEntryAdapter::is_metadata_entry(entry) {
             return Ok(None);
         }
 
@@ -212,8 +219,8 @@ impl<R: Read> TarArchive<R> {
             .map_err(|e| ArchiveError::InvalidArchive(format!("invalid path: {e}")))?
             .into_owned();
 
-        let entry_type = TarEntryAdapter::to_entry_type(&entry)?;
-        let size = TarEntryAdapter::get_uncompressed_size(&entry);
+        let entry_type = TarEntryAdapter::to_entry_type(entry)?;
+        let size = TarEntryAdapter::get_uncompressed_size(entry);
         let mode = entry.header().mode().ok();
 
         if matches!(entry_type, EntryType::File)
@@ -264,14 +271,14 @@ impl<R: Read> TarArchive<R> {
     }
 
     /// Extracts a regular file to disk.
-    fn extract_file(
-        mut entry: tar::Entry<'_, R>,
+    fn extract_file<ER: Read>(
+        entry: &mut tar::Entry<'_, ER>,
         validated: &ValidatedEntry,
         ctx: &mut ExtractionContext<'_, '_>,
     ) -> Result<()> {
         let size = Some(entry.size());
         common::extract_file_generic(
-            &mut entry,
+            entry,
             validated,
             ctx.dest,
             ctx.report,
@@ -363,11 +370,12 @@ impl<R: Read> ArchiveFormat for TarArchive<R> {
 
         let mut current_entry: usize = 0;
 
-        let inner = self.inner.as_mut().ok_or_else(|| {
+        let reader = self.inner.take().ok_or_else(|| {
             ArchiveError::InvalidArchive("archive reader already consumed by list()".into())
         })?;
-        let entries = inner
-            .entries()
+        let (budgeted, budget) = budgeted_reader(reader, config.max_tar_metadata_bytes);
+        let mut inner_archive = Archive::new(budgeted);
+        let mut entries = budgeted_tar_entries(&mut inner_archive, budget)
             .map_err(|e| ArchiveError::InvalidArchive(format!("failed to read entries: {e}")))?;
 
         let mut ctx = ExtractionContext {
@@ -381,14 +389,16 @@ impl<R: Read> ArchiveFormat for TarArchive<R> {
             progress,
         };
 
-        for entry_result in entries {
-            let entry = entry_result.map_err(|e| {
-                let raw = ArchiveError::InvalidArchive(format!("failed to read entry: {e}"));
+        while let Some(entry_result) = entries.next_entry() {
+            let mut guard = entry_result.map_err(|e| {
+                let raw = budget_violation(&e).unwrap_or_else(|| {
+                    ArchiveError::InvalidArchive(format!("failed to read entry: {e}"))
+                });
                 ArchiveError::partial_or(std::mem::take(ctx.report), raw)
             })?;
 
             // TAR is streaming: total entry count is not known upfront, so pass 0.
-            let entry_path = entry
+            let entry_path = guard
                 .path()
                 .ok()
                 .map(std::borrow::Cow::into_owned)
@@ -397,7 +407,7 @@ impl<R: Read> ArchiveFormat for TarArchive<R> {
             ctx.progress.on_entry_start(&entry_path, 0, current_entry);
 
             // INVARIANT: every branch below must call on_entry_complete exactly once.
-            match Self::process_entry(entry, &mut ctx) {
+            match Self::process_entry(&mut guard, &mut ctx) {
                 Ok(Some(hardlink_info)) => {
                     ctx.progress.on_entry_complete(&entry_path);
                     hardlinks.push(hardlink_info);
@@ -407,6 +417,10 @@ impl<R: Read> ArchiveFormat for TarArchive<R> {
                 }
                 Err(e) => {
                     ctx.progress.on_entry_complete(&entry_path);
+                    // Abandoning: no further `next_entry()` calls follow, so
+                    // the guard's usual bounded drain is pointless I/O, not a
+                    // correctness requirement (see `TarEntryGuard::abandon`).
+                    guard.abandon();
                     return Err(ArchiveError::partial_or(std::mem::take(ctx.report), e));
                 }
             }
@@ -449,12 +463,13 @@ impl<R: Read> ArchiveFormat for TarArchive<R> {
         use crate::formats::detect::ArchiveType;
         use crate::inspection::list::list_tar_reader;
 
-        // Consume the inner archive — TAR readers are forward-only streams.
+        // Consume the inner reader — TAR readers are forward-only streams.
         // After list() returns, extract() will return an error if called.
-        let inner = self.inner.take().ok_or_else(|| {
+        let reader = self.inner.take().ok_or_else(|| {
             crate::ArchiveError::InvalidArchive("archive reader already consumed by list()".into())
         })?;
-        list_tar_reader(inner.into_inner(), ArchiveType::Tar, config)
+        let (budgeted, budget) = budgeted_reader(reader, config.max_tar_metadata_bytes);
+        list_tar_reader(budgeted, budget, ArchiveType::Tar, config)
     }
 
     fn verify(&mut self, config: &SecurityConfig) -> Result<crate::inspection::VerificationReport> {

--- a/crates/exarch-core/src/formats/tar_metadata_limit.rs
+++ b/crates/exarch-core/src/formats/tar_metadata_limit.rs
@@ -1,0 +1,782 @@
+//! Bounds bytes the `tar` crate may read while searching for the next entry.
+//!
+//! # Background
+//!
+//! GNU long-name (`L`), GNU long-link (`K`), and PAX extended header (`x`/`g`)
+//! records are read fully into memory by the `tar` crate's `Entries::next()`
+//! (via `EntryFields::read_all()`) *before* any entry reaches the entry
+//! validator or quota tracker. A crafted record declaring a multi-gigabyte
+//! length backed by a tiny compressed stream causes unbounded allocation with
+//! no quota enforcement (issue #414).
+//!
+//! An earlier fix re-parsed TAR headers in a shadow parser to reject an
+//! oversized metadata record before the `tar` crate could buffer it. That
+//! approach was abandoned after three rounds of adversarial review each found
+//! a fresh case where the shadow parser's belief about entry framing
+//! diverged from the `tar` crate's own (untracked PAX `size=` overrides,
+//! typeflag-without-magic-gate framing, and a PAX global header draining
+//! `tar`'s override state without draining the mirror's). Three independent
+//! divergences in three rounds is a structural problem with maintaining a
+//! second parser, not a fixable oversight.
+//!
+//! # Design: a read budget, not a second parser
+//!
+//! [`BudgetedReader`] never looks at a header, a typeflag, magic bytes, or a
+//! PAX record. It only counts bytes, and it is told when to start/stop
+//! counting by the `tar` crate's own iterator boundary — via [`TarReadBudget`]
+//! ([`arm`](TarReadBudget::arm)/[`disarm`](TarReadBudget::disarm)), driven by
+//! [`BudgetedEntries::next_entry`]. The invariant enforced:
+//!
+//! > Between the moment iteration asks for the next entry and the moment
+//! > `tar` yields one, `tar` may read at most `limit` bytes from the
+//! > underlying reader.
+//!
+//! That window contains exactly: sub-block padding, the `L`/`K`/`x` metadata
+//! headers and bodies `tar` buffers via `read_all`, GNU sparse extension
+//! blocks, and the final entry header. It contains *no* entry data, because
+//! every yielded entry is fully drained — via [`TarEntryGuard`]'s `Drop` —
+//! before the next iteration step. So the budget is a pure constant: no
+//! declared size, from any header, ever feeds it. There is exactly one
+//! parser (the `tar` crate's own), so there is nothing for a shadow parser to
+//! disagree with.
+//!
+//! The drain must run to true completion for a *legitimate* unread entry —
+//! `list`/`verify` never read entry content at all, so the drain is the
+//! *only* thing that consumes a legitimate entry's real bytes to reach the
+//! next header, no matter how large that entry is (`verify` in particular
+//! sets `max_file_size` to `u64::MAX` precisely so a metadata-only listing
+//! does not reject large files). A fixed cap on *total drained output* —
+//! however generous — therefore either (a) truncates real bytes of some
+//! legitimate large entry, misaligning the next header read and rejecting an
+//! ordinary archive with a scary `SecurityViolation`, or (b) is raised high
+//! enough to avoid that and stops bounding anything, since a GNU sparse
+//! entry's synthesized zero-padding (`tar` allocates no backing bytes for
+//! sparse gaps) can be driven past any fixed number via a `realsize` field up
+//! to `u64::MAX`. An earlier version of this fix picked option (a) at
+//! different fixed caps and was broken both ways in succession (issue #414's
+//! C2/C3 findings) before this module was corrected to the design below.
+//!
+//! **The drain is bounded by *synthesized* bytes, not total output.** A
+//! legitimate regular entry's drain consumes real bytes from the underlying
+//! reader 1:1 with what it outputs — reading further only produces more
+//! output if the reader actually had more to give. GNU sparse padding is the
+//! opposite: `tar` yields it from `io::repeat(0)`, producing output with
+//! **zero** corresponding reads from the underlying reader. [`BudgetedReader`]
+//! tracks a monotonic, never-reset `total_read` count of bytes actually
+//! delivered from `inner`, armed or disarmed; [`TarEntryGuard::drop`] drains
+//! in a loop tracking `synthetic = output_so_far -
+//! bytes_actually_read_during_this_drain` and stops once `synthetic` exceeds
+//! [`SYNTHETIC_PAD_CAP_BYTES`]. A legitimate entry's `synthetic` stays at (or
+//! within a chunk-size rounding of) zero regardless of how large the entry is,
+//! so it always drains fully; a sparse bomb's `synthetic` grows by a full
+//! read-chunk on every iteration once padding starts, tripping the cap almost
+//! immediately regardless of how large the declared `realsize` is. This
+//! distinguishes the two purely by *where the bytes came from*, never by
+//! inspecting a header field.
+//!
+//! One known residual limitation, accepted (P3, tracked as a follow-up
+//! issue) rather than fixed here: a *legitimate* GNU sparse file with real
+//! holes larger than [`SYNTHETIC_PAD_CAP_BYTES`] (e.g. a multi-gigabyte
+//! sparse disk image, mostly zero-filled) looks identical to an attack from
+//! this module's perspective when such a file is skipped unread — both
+//! produce output with no corresponding read. This affects `list_archive`,
+//! `verify_archive`, and, via those, the `exarch` CLI's `extract` command
+//! too (its `extract` runs a `list_archive` pre-flight ahead of the actual
+//! extraction, the same pre-flight `list`/`verify` use). Only a *direct*
+//! `TarArchive::extract` library call bypassing that pre-flight is
+//! unaffected, since it reads the entry itself and the guard's drain finds
+//! nothing left to do.
+//!
+//! # Invariant: this module must never peek at archive content
+//!
+//! Nothing in this file reads a typeflag, checks magic bytes, or tracks a PAX
+//! record — not even for a read-only "sanity check" or a diagnostic message.
+//! That absence is not an implementation gap; it is the entire reason the
+//! S1/S2/S3 bug class (three independent shadow-parser/`tar`-parser framing
+//! disagreements, found in three separate rounds of adversarial review)
+//! cannot recur here. **If a future change to this module adds any code path
+//! that inspects header bytes to make a decision — even something as
+//! innocuous-looking as "skip the budget check for typeflag `'g'`" or "trust
+//! the declared size when it looks sane" — it reintroduces a second parser,
+//! and with it the exact vulnerability class this redesign replaced.** Any
+//! change that appears to need header awareness should be treated as a sign
+//! the change belongs somewhere else (e.g. `EntryValidator`, which runs after
+//! an entry is already fully framed by `tar` itself), not as a reason to add
+//! a peek here.
+
+use std::io;
+use std::io::Read;
+use std::marker::PhantomData;
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+
+/// Hard, non-configurable ceiling on how many *synthesized* bytes (drained
+/// output with no corresponding read from the underlying reader)
+/// [`TarEntryGuard::drop`] will tolerate before giving up on a drain.
+///
+/// This is **not** a cap on total drained output — a legitimate entry drains
+/// fully regardless of size, since its output tracks real reads 1:1 and never
+/// accumulates synthetic bytes. Only a run of GNU sparse zero-padding (or
+/// anything else that yields output without a corresponding read) can push
+/// `synthetic` past this. A few MiB is ample: real padding-heavy input trips
+/// it within a handful of read-chunk iterations, while it is never reached at
+/// all by 1:1 content.
+const SYNTHETIC_PAD_CAP_BYTES: u64 = 8 * 1024 * 1024;
+
+/// Chunk size for the drain loop in [`TarEntryGuard::drop`]. Not a security
+/// boundary — just an I/O granularity choice, small enough to keep the
+/// worst-case overshoot past [`SYNTHETIC_PAD_CAP_BYTES`] negligible.
+const DRAIN_CHUNK_BYTES: usize = 8192;
+
+/// Sentinel `allowance` value meaning "disarmed" (no cap on reads).
+const DISARMED: u64 = u64::MAX;
+
+/// Shared, atomics-only state behind [`TarReadBudget`] and [`BudgetedReader`].
+///
+/// `Send + Sync` by construction (no `Rc`/`Cell`), so the read wrapper can
+/// cross thread boundaries the same way the reader it wraps already can —
+/// required by the Node.js binding's blocking-thread-pool usage.
+struct BudgetState {
+    /// The configured per-window byte limit; re-applied on every `arm()`.
+    limit: u64,
+    /// Bytes delivered through this reader since the most recent `arm()`.
+    consumed: AtomicU64,
+    /// `DISARMED`, or the number of bytes still allowed before the next
+    /// `read()` must fail. Armed **from construction** (fail-closed): a call
+    /// site that forgets to pair a `BudgetedReader` with `BudgetedEntries`
+    /// trips on the very first read of real entry content instead of running
+    /// unprotected.
+    allowance: AtomicU64,
+    /// Monotonic count of bytes actually read from the underlying reader,
+    /// armed or disarmed alike — never reset by `arm()`/`disarm()`. Lets
+    /// [`TarEntryGuard::drop`] distinguish real archive bytes from
+    /// synthesized padding during its drain, regardless of the metered
+    /// window's own state at the time.
+    total_read: AtomicU64,
+}
+
+/// Cheap, cloneable handle used to arm/disarm the budget around the gap
+/// between two yielded TAR entries.
+///
+/// Obtained together with a [`BudgetedReader`] from [`budgeted_reader`]; both
+/// must wrap the *same* underlying reader passed to the *same*
+/// [`BudgetedEntries`] for the invariant to hold.
+#[derive(Clone)]
+pub struct TarReadBudget(Arc<BudgetState>);
+
+impl TarReadBudget {
+    /// Starts (or restarts) counting: `consumed = 0`, `allowance = limit`.
+    fn arm(&self) {
+        self.0.consumed.store(0, Ordering::Relaxed);
+        self.0.allowance.store(self.0.limit, Ordering::Relaxed);
+    }
+
+    /// Stops counting: subsequent reads pass through unmetered until the next
+    /// `arm()`. Called once `tar` has yielded an entry — reading that
+    /// entry's *own* data must never count against the metadata budget.
+    fn disarm(&self) {
+        self.0.allowance.store(DISARMED, Ordering::Relaxed);
+    }
+
+    /// Total bytes read from the underlying reader so far — monotonic,
+    /// never reset by `arm()`/`disarm()`.
+    fn total_read(&self) -> u64 {
+        self.0.total_read.load(Ordering::Relaxed)
+    }
+}
+
+/// Marker error surfaced when more than the configured limit is read from a
+/// [`BudgetedReader`] while armed. Recovered via [`budget_violation`] and
+/// converted into an `ArchiveError::SecurityViolation`.
+#[derive(Debug)]
+struct TarReadBudgetExceeded {
+    limit: u64,
+}
+
+impl std::fmt::Display for TarReadBudgetExceeded {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "TAR metadata read budget exceeded: more than {} bytes read while searching for the \
+             next archive entry (long-name/long-link/PAX headers, or a run of GNU sparse \
+             extension blocks)",
+            self.limit
+        )
+    }
+}
+
+impl std::error::Error for TarReadBudgetExceeded {}
+
+/// Recovers a `TarReadBudgetExceeded` violation from an `io::Error` surfaced
+/// by the `tar` crate, converting it into an `ArchiveError::SecurityViolation`.
+///
+/// Returns `None` for any other I/O error, so callers can fall back to their
+/// usual generic error mapping.
+pub fn budget_violation(e: &io::Error) -> Option<crate::ArchiveError> {
+    let inner = e.get_ref()?;
+    let exceeded = inner.downcast_ref::<TarReadBudgetExceeded>()?;
+    Some(crate::ArchiveError::SecurityViolation {
+        reason: exceeded.to_string(),
+    })
+}
+
+/// Read wrapper that meters bytes against a [`TarReadBudget`] while armed and
+/// passes them through unmetered while disarmed.
+///
+/// Never buffers, drops, reorders, or fabricates bytes: every byte returned
+/// came from `inner`, in the same order. The only behavior beyond plain
+/// passthrough is refusing to deliver more than `limit` bytes per armed
+/// window, and it refuses by returning `Err`, never `Ok(0)` — a clamp to a
+/// zero-length read would masquerade as clean end-of-archive to callers like
+/// `tar`'s own `try_read_all`, turning a budget trip into a silently
+/// truncated (but "successful") listing.
+pub struct BudgetedReader<R> {
+    inner: R,
+    state: Arc<BudgetState>,
+}
+
+impl<R: Read> Read for BudgetedReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let allowance = self.state.allowance.load(Ordering::Relaxed);
+        if allowance == DISARMED {
+            let n = self.inner.read(buf)?;
+            self.state.total_read.fetch_add(n as u64, Ordering::Relaxed);
+            return Ok(n);
+        }
+
+        let consumed = self.state.consumed.load(Ordering::Relaxed);
+        if consumed >= allowance {
+            // The budget is exhausted, but a well-formed archive whose
+            // metadata happens to end exactly at the configured limit must
+            // not be rejected: distinguish "the underlying stream also ends
+            // here" (safe — nothing was hidden) from "there is more real
+            // data beyond the budget" (a genuine violation) with a minimal
+            // probe read, rather than assuming a violation outright.
+            let mut probe = [0u8; 1];
+            return match self.inner.read(&mut probe) {
+                Ok(0) => Ok(0),
+                Ok(n) => {
+                    self.state.total_read.fetch_add(n as u64, Ordering::Relaxed);
+                    Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        TarReadBudgetExceeded { limit: allowance },
+                    ))
+                }
+                Err(e) => Err(e),
+            };
+        }
+
+        let remaining = allowance - consumed;
+        let want = usize::try_from(remaining)
+            .unwrap_or(usize::MAX)
+            .min(buf.len());
+        let n = self.inner.read(&mut buf[..want])?;
+        self.state.consumed.fetch_add(n as u64, Ordering::Relaxed);
+        self.state.total_read.fetch_add(n as u64, Ordering::Relaxed);
+        Ok(n)
+    }
+}
+
+/// Wraps `inner` in a [`BudgetedReader`] and returns it alongside the
+/// [`TarReadBudget`] handle used to arm/disarm it.
+///
+/// The budget starts **armed** with `limit` (fail-closed): any read before
+/// the first explicit `arm()`/`disarm()` cycle — e.g. a call site that never
+/// wires up [`BudgetedEntries`] — is metered, not silently unlimited.
+// No runnable `# Examples` here: this module is `pub(crate)` (an
+// implementation detail of the `tar`/`inspection::list` wiring, not public
+// API), so a doctest importing it via `exarch_core::formats::...` would not
+// link — doctests only see the crate's public surface.
+#[must_use]
+pub fn budgeted_reader<R: Read>(inner: R, limit: u64) -> (BudgetedReader<R>, TarReadBudget) {
+    let state = Arc::new(BudgetState {
+        limit,
+        consumed: AtomicU64::new(0),
+        allowance: AtomicU64::new(limit),
+        total_read: AtomicU64::new(0),
+    });
+    let reader = BudgetedReader {
+        inner,
+        state: Arc::clone(&state),
+    };
+    (reader, TarReadBudget(state))
+}
+
+/// A `tar::Entry` on loan from [`BudgetedEntries::next_entry`], guaranteed
+/// fully drained (up to a bound) when dropped.
+///
+/// The `'s` lifetime ties this guard to the `&mut BudgetedEntries` borrow
+/// that produced it, making it a compile error to call `next_entry()` again
+/// (or to hold two guards at once) while a guard is alive — the "every entry
+/// is drained before the next iteration step" invariant the whole module
+/// depends on is therefore enforced by the borrow checker, not by review
+/// convention.
+pub struct TarEntryGuard<'a, 's, R: Read> {
+    entry: tar::Entry<'a, BudgetedReader<R>>,
+    budget: TarReadBudget,
+    abandoned: bool,
+    _borrow: PhantomData<&'s mut ()>,
+}
+
+impl<R: Read> TarEntryGuard<'_, '_, R> {
+    /// Suppresses the bounded drain this guard would otherwise perform on
+    /// drop.
+    ///
+    /// Call this only when abandoning the whole operation (returning an
+    /// error and never calling `next_entry()` again) — draining is then
+    /// pointless I/O, not a correctness requirement, since the bounded drain
+    /// is safe to skip precisely because no further reads will happen.
+    pub fn abandon(&mut self) {
+        self.abandoned = true;
+    }
+}
+
+impl<'a, R: Read> std::ops::Deref for TarEntryGuard<'a, '_, R> {
+    type Target = tar::Entry<'a, BudgetedReader<R>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.entry
+    }
+}
+
+impl<R: Read> std::ops::DerefMut for TarEntryGuard<'_, '_, R> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.entry
+    }
+}
+
+impl<R: Read> Drop for TarEntryGuard<'_, '_, R> {
+    fn drop(&mut self) {
+        if self.abandoned {
+            return;
+        }
+        // Bounded by *synthesized* bytes, not total output (see module
+        // docs): a legitimate entry's `synthetic` stays ~0 regardless of
+        // size, so it always drains to completion here, while a run of GNU
+        // sparse zero-padding pushes `synthetic` up by a full chunk on every
+        // iteration and trips `SYNTHETIC_PAD_CAP_BYTES` almost immediately.
+        // A partial drain (the loop bails before true EOF) still leaves the
+        // stream in a well-defined position — the shortfall is read on the
+        // *next* header search, either misaligning into a checksum error or
+        // exceeding the metadata budget, both loud failures, never silent.
+        let total_read_at_start = self.budget.total_read();
+        let mut output_so_far: u64 = 0;
+        let mut buf = [0u8; DRAIN_CHUNK_BYTES];
+        loop {
+            let n = match self.entry.read(&mut buf) {
+                Ok(0) | Err(_) => break,
+                Ok(n) => n,
+            };
+            output_so_far += n as u64;
+            let read_since_start = self.budget.total_read() - total_read_at_start;
+            let synthetic = output_so_far.saturating_sub(read_since_start);
+            if synthetic > SYNTHETIC_PAD_CAP_BYTES {
+                break;
+            }
+        }
+    }
+}
+
+/// Lending iterator over `tar` entries with a read budget armed for every gap
+/// between entries.
+///
+/// Deliberately does **not** implement `std::iter::Iterator`: `Iterator::next`
+/// cannot return a value borrowing `&mut self`, so an `Iterator` impl would
+/// let a caller hold two [`TarEntryGuard`]s (or collect them into a `Vec`)
+/// simultaneously — compiling, but silently defeating the "always drained
+/// before the next entry" guarantee this type exists to enforce. Use
+/// `while let Some(entry) = entries.next_entry() { ... }`.
+pub struct BudgetedEntries<'a, R: Read> {
+    entries: tar::Entries<'a, BudgetedReader<R>>,
+    budget: TarReadBudget,
+}
+
+impl<'a, R: Read> BudgetedEntries<'a, R> {
+    fn new(entries: tar::Entries<'a, BudgetedReader<R>>, budget: TarReadBudget) -> Self {
+        Self { entries, budget }
+    }
+
+    /// Arms the budget, asks `tar` for the next entry, disarms the budget,
+    /// and (on success) wraps the result in a draining guard.
+    ///
+    /// Arming happens *before* asking `tar`, so the metered window covers the
+    /// entire gap: sub-block padding, any `L`/`K`/`x` metadata records, GNU
+    /// sparse extension blocks, and the final header — including the
+    /// trailing gap after the last real entry, which is exactly where an
+    /// archive consisting of nothing but oversized metadata records would
+    /// otherwise buffer unbounded before `tar` gives up with "members found
+    /// describing a future member but no future member found".
+    pub fn next_entry(&mut self) -> Option<io::Result<TarEntryGuard<'a, '_, R>>> {
+        self.budget.arm();
+        let result = self.entries.next();
+        self.budget.disarm();
+
+        match result {
+            None => None,
+            Some(Err(e)) => Some(Err(e)),
+            Some(Ok(entry)) => Some(Ok(TarEntryGuard {
+                entry,
+                budget: self.budget.clone(),
+                abandoned: false,
+                _borrow: PhantomData,
+            })),
+        }
+    }
+}
+
+/// Builds a [`BudgetedEntries`] iterator from an already budget-wrapped
+/// archive, using the *same* [`TarReadBudget`] handle that reader was created
+/// with.
+///
+/// Keeping construction to this one function (rather than callers manually
+/// pairing `archive.entries()` with a `TarReadBudget` obtained separately) is
+/// what makes it hard to accidentally iterate the raw `tar::Entries` and
+/// bypass arming entirely.
+///
+/// # Errors
+///
+/// Returns an error if `tar` cannot begin reading entries (e.g. the archive
+/// was already fully consumed).
+pub fn budgeted_tar_entries<R: Read>(
+    archive: &mut tar::Archive<BudgetedReader<R>>,
+    budget: TarReadBudget,
+) -> io::Result<BudgetedEntries<'_, R>> {
+    let entries = archive.entries()?;
+    Ok(BudgetedEntries::new(entries, budget))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn disarmed_reader_passes_bytes_through_unchanged() {
+        let (mut reader, budget) = budgeted_reader(Cursor::new(b"hello world".to_vec()), 4);
+        budget.disarm();
+        let mut out = Vec::new();
+        reader.read_to_end(&mut out).unwrap();
+        assert_eq!(out, b"hello world");
+    }
+
+    #[test]
+    fn armed_reader_allows_exactly_the_limit() {
+        let (mut reader, budget) = budgeted_reader(Cursor::new(vec![b'a'; 10]), 10);
+        budget.arm();
+        let mut out = Vec::new();
+        reader.read_to_end(&mut out).unwrap();
+        assert_eq!(out.len(), 10);
+    }
+
+    #[test]
+    fn armed_reader_trips_at_limit_plus_one_with_err_not_ok_zero() {
+        // Regression for critic finding S4: a naive clamp-to-empty-slice at
+        // exhaustion returns `Ok(0)`, which `tar`'s own `try_read_all` (and
+        // any other EOF-sensing consumer) treats as clean end-of-archive —
+        // silently truncating output instead of failing loudly.
+        let (mut reader, budget) = budgeted_reader(Cursor::new(vec![b'a'; 11]), 10);
+        budget.arm();
+        let mut out = Vec::new();
+        let err = reader
+            .read_to_end(&mut out)
+            .expect_err("must error, not silently truncate");
+        assert!(
+            budget_violation(&err).is_some(),
+            "must be recognizable as a budget violation, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn new_reader_is_armed_from_construction() {
+        // Regression for critic finding S3: if the budget started disarmed,
+        // a call site that forgets to pair the reader with `BudgetedEntries`
+        // (never calling `arm()`/`disarm()` itself) would run unprotected —
+        // exactly the regression this whole redesign exists to prevent.
+        let (mut reader, _budget) = budgeted_reader(Cursor::new(vec![b'a'; 11]), 10);
+        let mut out = Vec::new();
+        let err = reader
+            .read_to_end(&mut out)
+            .expect_err("a freshly constructed reader must already be armed");
+        assert!(budget_violation(&err).is_some());
+    }
+
+    #[test]
+    fn rearming_resets_consumed_bytes() {
+        let (mut reader, budget) = budgeted_reader(Cursor::new(vec![b'a'; 20]), 10);
+        budget.arm();
+        let mut buf = [0u8; 10];
+        reader.read_exact(&mut buf).unwrap();
+        // Disarm, do something unmetered, then arm again: the fresh window
+        // must not inherit the previous window's consumed count.
+        budget.disarm();
+        budget.arm();
+        let mut out = Vec::new();
+        reader.read_to_end(&mut out).unwrap();
+        assert_eq!(
+            out.len(),
+            10,
+            "re-armed window must allow a fresh `limit` bytes"
+        );
+    }
+
+    /// Builds a minimal one-entry TAR archive (ustar) around `content`.
+    fn one_entry_tar(name: &str, content: &[u8]) -> Vec<u8> {
+        let mut builder = tar::Builder::new(Vec::new());
+        let mut header = tar::Header::new_gnu();
+        header.set_size(content.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder.append_data(&mut header, name, content).unwrap();
+        builder.into_inner().unwrap()
+    }
+
+    #[test]
+    fn budgeted_entries_yields_a_well_formed_archive_normally() {
+        let data = one_entry_tar("file.txt", b"hello");
+        let (reader, budget) = budgeted_reader(Cursor::new(data), 4096);
+        let mut archive = tar::Archive::new(reader);
+        let mut entries = budgeted_tar_entries(&mut archive, budget).unwrap();
+
+        let mut guard = entries
+            .next_entry()
+            .expect("one entry")
+            .expect("no io error");
+        let mut content = Vec::new();
+        guard.read_to_end(&mut content).unwrap();
+        assert_eq!(content, b"hello");
+        drop(guard);
+
+        assert!(entries.next_entry().is_none(), "exactly one entry");
+    }
+
+    #[test]
+    fn drop_drains_unread_entry_so_the_next_header_is_found() {
+        let mut data = one_entry_tar("skipped.txt", b"unread content");
+        // Append a second entry after the first.
+        let mut builder = tar::Builder::new(Vec::new());
+        let mut header = tar::Header::new_gnu();
+        header.set_size(5);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder
+            .append_data(&mut header, "after.txt", &b"hello"[..])
+            .unwrap();
+        let second = builder.into_inner().unwrap();
+        // Splice: first entry's header+data (without its own EOF markers)
+        // followed by the second archive's single entry and its EOF markers.
+        data.truncate(data.len() - 1024); // drop first archive's EOF markers
+        data.extend_from_slice(&second);
+
+        let (reader, budget) = budgeted_reader(Cursor::new(data), 4096);
+        let mut archive = tar::Archive::new(reader);
+        let mut entries = budgeted_tar_entries(&mut archive, budget).unwrap();
+
+        let guard = entries.next_entry().unwrap().unwrap();
+        // Deliberately never read `guard`'s content — the Drop below must
+        // still leave the stream correctly positioned for the next header.
+        drop(guard);
+
+        let mut second_guard = entries
+            .next_entry()
+            .expect("second entry must still be reachable")
+            .expect("no io error");
+        let mut content = Vec::new();
+        second_guard.read_to_end(&mut content).unwrap();
+        assert_eq!(content, b"hello");
+    }
+
+    #[test]
+    fn abandon_suppresses_the_drain() {
+        let data = one_entry_tar("file.txt", b"hello");
+        let (reader, budget) = budgeted_reader(Cursor::new(data), 4096);
+        let mut archive = tar::Archive::new(reader);
+        let mut entries = budgeted_tar_entries(&mut archive, budget).unwrap();
+
+        let mut guard = entries.next_entry().unwrap().unwrap();
+        guard.abandon();
+        // No assertion beyond "does not panic and drops cleanly": abandon()
+        // only affects whether Drop performs I/O, which has no externally
+        // observable effect once the whole `BudgetedEntries` is discarded.
+        drop(guard);
+    }
+
+    #[test]
+    fn oversized_metadata_record_trips_the_budget() {
+        // A GNU long-name record whose real (delivered) bytes exceed the
+        // configured budget must trip before `tar` finishes buffering it.
+        let long_name = "x".repeat(2048);
+        let mut builder = tar::Builder::new(Vec::new());
+        let mut header = tar::Header::new_gnu();
+        header.set_size(5);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder
+            .append_data(&mut header, long_name.as_str(), &b"hello"[..])
+            .unwrap();
+        let data = builder.into_inner().unwrap();
+
+        let (reader, budget) = budgeted_reader(Cursor::new(data), 512);
+        let mut archive = tar::Archive::new(reader);
+        let mut entries = budgeted_tar_entries(&mut archive, budget).unwrap();
+
+        // `.err()` first: `TarEntryGuard` (the `Ok` side) does not implement
+        // `Debug` (it holds a `tar::Entry`, which does not either), so
+        // `Result::expect_err` (which requires `T: Debug`) does not apply —
+        // `Option::expect` on the converted `Option<io::Error>` does not
+        // need the discarded `Ok` value to implement anything.
+        let result = entries.next_entry().expect("an entry attempt");
+        let err = result
+            .err()
+            .expect("the long-name record exceeds the 512-byte budget");
+        assert!(budget_violation(&err).is_some(), "got: {err:?}");
+    }
+
+    /// Reader that counts total bytes yielded by `inner`, used below to
+    /// observe how much `TarEntryGuard::drop` actually drains without relying
+    /// on heap-allocation measurement (which a `Take`-limited `io::sink` drain
+    /// would not show regardless of how large the drain is).
+    struct CountingReader<R> {
+        inner: R,
+        count: Arc<AtomicU64>,
+    }
+
+    impl<R: Read> Read for CountingReader<R> {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            let n = self.inner.read(buf)?;
+            self.count.fetch_add(n as u64, Ordering::Relaxed);
+            Ok(n)
+        }
+    }
+
+    #[test]
+    fn drop_fully_drains_a_legitimate_large_entry_regardless_of_size() {
+        // Regression for critic findings C2/C3: a fixed cap on *total*
+        // drained output (the earlier, broken designs) rejects any ordinary
+        // archive whose unread entry exceeds that cap — worse than the
+        // original bug, since no crafting is needed to trip it. A
+        // legitimate entry's drain consumes real bytes 1:1 with its output,
+        // so `synthetic` never grows and this must drain to completion no
+        // matter how large the entry is (here: comfortably larger than
+        // `SYNTHETIC_PAD_CAP_BYTES`).
+        let content_len = usize::try_from(SYNTHETIC_PAD_CAP_BYTES).unwrap() * 3;
+        let data = one_entry_tar("legit_large.bin", &vec![b'A'; content_len]);
+
+        let read_count = Arc::new(AtomicU64::new(0));
+        let counting = CountingReader {
+            inner: Cursor::new(data),
+            count: Arc::clone(&read_count),
+        };
+
+        let (reader, budget) = budgeted_reader(counting, 4096);
+        let mut archive = tar::Archive::new(reader);
+        let mut entries = budgeted_tar_entries(&mut archive, budget).unwrap();
+
+        let guard = entries.next_entry().unwrap().unwrap();
+        // Deliberately never read `guard`'s content — the drop must still
+        // fully drain it, exactly like the "skip an unread entry" case on
+        // `list`/`verify`/extension-filtered `extract`.
+        drop(guard);
+
+        let drained = read_count.load(Ordering::Relaxed);
+        // The one-entry archive is: 512-byte header + content (block-padded)
+        // + two 512-byte zero blocks (end-of-archive trailer). The drain
+        // must consume at least the full content, proving it was not cut
+        // short by any fixed output cap.
+        assert!(
+            drained >= 512 + u64::try_from(content_len).unwrap(),
+            "drop must fully drain a legitimate large entry, drained only {drained} bytes of a \
+             {content_len}-byte entry"
+        );
+    }
+
+    /// Builds a raw one-entry TAR archive with a GNU old-format sparse
+    /// header (typeflag `'S'`) whose `realsize` vastly exceeds its one-block
+    /// physical backing — the same on-disk shape as issue #414's C1 `PoC`,
+    /// used here to unit-test the synthetic-byte cap directly rather than
+    /// relying only on the integration-level regression test.
+    fn gnu_sparse_bomb_tar(realsize: u64) -> Vec<u8> {
+        const HDR_BLOCK: usize = 512;
+        fn octal_field(n: u64, width: usize) -> Option<Vec<u8>> {
+            let digits = format!("{n:o}").into_bytes();
+            if digits.len() > width - 1 {
+                return None;
+            }
+            let mut out = vec![b'0'; width - 1 - digits.len()];
+            out.extend_from_slice(&digits);
+            out.push(0);
+            Some(out)
+        }
+        fn base256_field(n: u64, width: usize) -> Vec<u8> {
+            let mut out = vec![0u8; width];
+            let bytes = n.to_be_bytes();
+            out[width - bytes.len()..].copy_from_slice(&bytes);
+            out[0] |= 0x80;
+            out
+        }
+        fn num_field(n: u64, width: usize) -> Vec<u8> {
+            octal_field(n, width).unwrap_or_else(|| base256_field(n, width))
+        }
+
+        let gap = realsize - HDR_BLOCK as u64;
+        let mut h = vec![0u8; HDR_BLOCK];
+        let name = b"sparsebomb.bin";
+        h[..name.len()].copy_from_slice(name);
+        h[100..108].copy_from_slice(&num_field(0o644, 8));
+        h[108..116].copy_from_slice(&num_field(0, 8));
+        h[116..124].copy_from_slice(&num_field(0, 8));
+        h[124..136].copy_from_slice(&num_field(HDR_BLOCK as u64, 12));
+        h[136..148].copy_from_slice(&num_field(0, 12));
+        h[156] = b'S';
+        h[257..263].copy_from_slice(b"ustar ");
+        h[263..265].copy_from_slice(b" \0");
+        h[386..398].copy_from_slice(&num_field(gap, 12));
+        h[398..410].copy_from_slice(&num_field(HDR_BLOCK as u64, 12));
+        h[482] = 0;
+        h[483..495].copy_from_slice(&num_field(realsize, 12));
+        h[148..156].copy_from_slice(b"        ");
+        let sum: u32 = h.iter().map(|b| u32::from(*b)).sum();
+        h[148..156].copy_from_slice(format!("{sum:06o}\0 ").as_bytes());
+
+        let mut out = h;
+        out.extend(std::iter::repeat_n(0u8, HDR_BLOCK)); // one real backing block
+        out.extend(std::iter::repeat_n(0u8, HDR_BLOCK * 2)); // end-of-archive trailer
+        out
+    }
+
+    #[test]
+    fn drop_drain_stops_quickly_on_gnu_sparse_synthesized_padding() {
+        // Regression for critic finding C1 (and confirms C2's fix did not
+        // reopen it): a GNU sparse entry's zero-padding produces output with
+        // no corresponding read, so `synthetic` grows immediately and the
+        // drain must stop within a small, bounded number of bytes actually
+        // read from the underlying reader — regardless of how large
+        // `realsize` claims to be.
+        let data = gnu_sparse_bomb_tar(1u64 << 50);
+
+        let read_count = Arc::new(AtomicU64::new(0));
+        let counting = CountingReader {
+            inner: Cursor::new(data),
+            count: Arc::clone(&read_count),
+        };
+
+        let (reader, budget) = budgeted_reader(counting, 4096);
+        let mut archive = tar::Archive::new(reader);
+        let mut entries = budgeted_tar_entries(&mut archive, budget).unwrap();
+
+        let guard = entries.next_entry().unwrap().unwrap();
+        drop(guard);
+
+        let drained = read_count.load(Ordering::Relaxed);
+        // The header (512 B) plus the one real backing block (512 B) plus a
+        // generous margin for the synthetic cap's own chunking — nowhere
+        // near the exabyte `realsize` the entry claims.
+        assert!(
+            drained
+                <= 512 + 512 + SYNTHETIC_PAD_CAP_BYTES + u64::try_from(DRAIN_CHUNK_BYTES).unwrap(),
+            "drop must stop draining almost immediately on synthesized padding, drained {drained} \
+             bytes"
+        );
+    }
+}

--- a/crates/exarch-core/src/inspection/list.rs
+++ b/crates/exarch-core/src/inspection/list.rs
@@ -19,6 +19,10 @@ use crate::error::QuotaResource;
 use crate::formats::common::normalize_entry_name;
 use crate::formats::detect::ArchiveType;
 use crate::formats::detect::detect_format;
+use crate::formats::tar_metadata_limit::TarReadBudget;
+use crate::formats::tar_metadata_limit::budget_violation;
+use crate::formats::tar_metadata_limit::budgeted_reader;
+use crate::formats::tar_metadata_limit::budgeted_tar_entries;
 use crate::formats::zip::read_zip_symlink_target;
 use crate::formats::zip::zip_mode_is_symlink;
 use crate::inspection::manifest::ArchiveEntry;
@@ -86,8 +90,9 @@ fn list_tar(
 ) -> Result<ArchiveManifest> {
     let file = File::open(archive_path)?;
     let reader = BufReader::new(file);
-    let archive = tar::Archive::new(reader);
-    list_tar_entries(archive, format, config)
+    let (budgeted, budget) = budgeted_reader(reader, config.max_tar_metadata_bytes);
+    let archive = tar::Archive::new(budgeted);
+    list_tar_entries(archive, budget, format, config)
 }
 
 fn list_tar_gz(
@@ -98,8 +103,9 @@ fn list_tar_gz(
     let file = File::open(archive_path)?;
     let reader = BufReader::new(file);
     let decoder = GzDecoder::new(reader);
-    let archive = tar::Archive::new(decoder);
-    list_tar_entries(archive, format, config)
+    let (budgeted, budget) = budgeted_reader(decoder, config.max_tar_metadata_bytes);
+    let archive = tar::Archive::new(budgeted);
+    list_tar_entries(archive, budget, format, config)
 }
 
 fn list_tar_bz2(
@@ -112,8 +118,9 @@ fn list_tar_bz2(
     let file = File::open(archive_path)?;
     let reader = BufReader::new(file);
     let decoder = BzDecoder::new(reader);
-    let archive = tar::Archive::new(decoder);
-    list_tar_entries(archive, format, config)
+    let (budgeted, budget) = budgeted_reader(decoder, config.max_tar_metadata_bytes);
+    let archive = tar::Archive::new(budgeted);
+    list_tar_entries(archive, budget, format, config)
 }
 
 fn list_tar_xz(
@@ -126,8 +133,9 @@ fn list_tar_xz(
     let file = File::open(archive_path)?;
     let reader = BufReader::new(file);
     let decoder = XzDecoder::new(reader);
-    let archive = tar::Archive::new(decoder);
-    list_tar_entries(archive, format, config)
+    let (budgeted, budget) = budgeted_reader(decoder, config.max_tar_metadata_bytes);
+    let archive = tar::Archive::new(budgeted);
+    list_tar_entries(archive, budget, format, config)
 }
 
 fn list_tar_zst(
@@ -140,25 +148,34 @@ fn list_tar_zst(
     let file = File::open(archive_path)?;
     let reader = BufReader::new(file);
     let decoder = ZstdDecoder::new(reader)?;
-    let archive = tar::Archive::new(decoder);
-    list_tar_entries(archive, format, config)
+    let (budgeted, budget) = budgeted_reader(decoder, config.max_tar_metadata_bytes);
+    let archive = tar::Archive::new(budgeted);
+    list_tar_entries(archive, budget, format, config)
 }
 
+/// Lists entries from a TAR archive already wrapped in a [`budgeted_reader`].
+///
+/// `budget` must be the handle returned alongside the reader that `archive`
+/// wraps — passed explicitly (rather than re-derived) so the reader and the
+/// budget used to arm/disarm around it can never be a mismatched pair.
 fn list_tar_entries<R: std::io::Read>(
-    mut archive: tar::Archive<R>,
+    mut archive: tar::Archive<crate::formats::tar_metadata_limit::BudgetedReader<R>>,
+    budget: TarReadBudget,
     format: ArchiveType,
     config: &SecurityConfig,
 ) -> Result<ArchiveManifest> {
     let mut manifest = ArchiveManifest::new(format);
     let mut quota = QuotaTracker::new();
 
-    let entries = archive
-        .entries()
+    let mut entries = budgeted_tar_entries(&mut archive, budget)
         .map_err(|e| ArchiveError::InvalidArchive(format!("failed to read TAR entries: {e}")))?;
 
-    for entry_result in entries {
-        let entry = entry_result
-            .map_err(|e| ArchiveError::InvalidArchive(format!("failed to read TAR entry: {e}")))?;
+    while let Some(entry_result) = entries.next_entry() {
+        let entry = entry_result.map_err(|e| {
+            budget_violation(&e).unwrap_or_else(|| {
+                ArchiveError::InvalidArchive(format!("failed to read TAR entry: {e}"))
+            })
+        })?;
 
         // Skip TAR metadata entries (PAX headers, GNU long names/links)
         if is_tar_metadata_entry(&entry) {
@@ -173,6 +190,11 @@ fn list_tar_entries<R: std::io::Read>(
         // and extraction fully equivalent — extraction's QuotaTracker only
         // records EntryType::File, while listing records every entry type
         // (directories, symlinks, hardlinks too), a pre-existing divergence.
+        //
+        // A quota rejection here (the `?`) aborts the loop without an
+        // explicit `entry.abandon()`; harmless — the guard's bounded drain
+        // on drop is pointless I/O in that case, not a correctness
+        // requirement (see `TarEntryGuard::abandon`).
         quota.record_file(size, config)?;
 
         let path = entry
@@ -235,17 +257,20 @@ fn list_zip(
     list_zip_reader(&mut archive, config)
 }
 
-/// Lists entries from an already-opened TAR reader.
+/// Lists entries from an already budget-wrapped TAR reader.
 ///
 /// Used by `ArchiveFormat::list()` implementations to avoid re-opening the
-/// archive. `format` is passed through into `ArchiveManifest` as-is.
+/// archive. `format` is passed through into `ArchiveManifest` as-is. `budget`
+/// must be the handle returned alongside `reader` from the same
+/// `budgeted_reader` call.
 pub(crate) fn list_tar_reader<R: Read>(
-    reader: R,
+    reader: crate::formats::tar_metadata_limit::BudgetedReader<R>,
+    budget: TarReadBudget,
     format: ArchiveType,
     config: &SecurityConfig,
 ) -> Result<ArchiveManifest> {
     let archive = tar::Archive::new(reader);
-    list_tar_entries(archive, format, config)
+    list_tar_entries(archive, budget, format, config)
 }
 
 /// Lists entries from an already-opened ZIP archive.

--- a/crates/exarch-core/tests/security/mod.rs
+++ b/crates/exarch-core/tests/security/mod.rs
@@ -2,3 +2,6 @@
 
 mod cve_regression;
 mod sevenz_traversal;
+mod tar_budget_parity;
+mod tar_ghsa_2026;
+mod tar_metadata_bomb;

--- a/crates/exarch-core/tests/security/tar_budget_parity.rs
+++ b/crates/exarch-core/tests/security/tar_budget_parity.rs
@@ -1,0 +1,174 @@
+//! False-positive regression net for the #414 read-budget redesign.
+//!
+//! The read-budget mechanism (`formats::tar_metadata_limit`) is coupled to a
+//! behavioral assumption about the `tar` crate's iterator (R1 in the
+//! architect's design notes): "given each entry is fully drained, `tar`
+//! reads less than the budget between yields". That assumption holds today
+//! (verified directly against `tar-0.4.46`'s source), but if it ever stopped
+//! holding, the failure mode should be *false positives* on legitimate
+//! archives (loud, caught here), never silent under-enforcement.
+//!
+//! This builds well-formed archives with `tar::Builder` — long paths forcing
+//! GNU long-name records, long symlink targets forcing GNU long-link
+//! records, and many small files — and asserts the budgeted extraction
+//! pipeline produces exactly the same files and content a plain, unwrapped
+//! `tar::Archive` read would.
+
+#![allow(clippy::unwrap_used, clippy::cast_possible_truncation)]
+
+use exarch_core::ExtractionOptions;
+use exarch_core::NoopProgress;
+use exarch_core::SecurityConfig;
+use exarch_core::formats::ArchiveFormat;
+use exarch_core::formats::TarArchive;
+use proptest::prelude::*;
+use std::collections::BTreeMap;
+use std::io::Cursor;
+use std::io::Read;
+use tempfile::TempDir;
+
+/// One synthetic file: a name (kept within typical filesystem per-component
+/// limits — around 150-200 bytes — but comfortably over the ustar header's
+/// 100-byte name field, forcing GNU long-name usage) and small content.
+#[derive(Debug, Clone)]
+struct SyntheticFile {
+    name: String,
+    content: Vec<u8>,
+}
+
+fn synthetic_file_strategy() -> impl Strategy<Value = SyntheticFile> {
+    (
+        prop_oneof![
+            // Short name: no long-name record needed.
+            "[a-z0-9]{1,20}",
+            // Long name: forces a GNU long-name record (over the 100-byte
+            // ustar name field), well within filesystem component limits.
+            "[a-z0-9]{120,200}",
+        ],
+        prop::collection::vec(any::<u8>(), 0..256),
+    )
+        .prop_map(|(name, content)| SyntheticFile {
+            name: format!("{name}.dat"),
+            content,
+        })
+}
+
+/// Builds a well-formed TAR archive (bytes) from `files`, plus a ground-truth
+/// map of `name -> content` computed independently of any exarch code.
+fn build_well_formed_archive(files: &[SyntheticFile]) -> (Vec<u8>, BTreeMap<String, Vec<u8>>) {
+    let mut builder = tar::Builder::new(Vec::new());
+    let mut expected = BTreeMap::new();
+
+    for (i, file) in files.iter().enumerate() {
+        // De-duplicate names (the proptest generator can repeat short
+        // names): later entries would legitimately overwrite earlier ones on
+        // extraction, which the ground-truth map already models via
+        // insertion order, so no special handling is needed beyond ensuring
+        // `tar::Builder` accepts the name (it requires uniqueness of
+        // nothing, so duplicates are fine here).
+        let name = format!("{i}-{}", file.name);
+        let mut header = tar::Header::new_gnu();
+        header.set_size(file.content.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder
+            .append_data(&mut header, &name, file.content.as_slice())
+            .unwrap();
+        expected.insert(name, file.content.clone());
+    }
+
+    let bytes = builder.into_inner().unwrap();
+    (bytes, expected)
+}
+
+/// Reads `bytes` via a plain, unwrapped `tar::Archive` — the ground-truth
+/// reference the budgeted pipeline must match exactly.
+fn read_via_plain_tar_archive(bytes: &[u8]) -> BTreeMap<String, Vec<u8>> {
+    let mut archive = tar::Archive::new(Cursor::new(bytes));
+    let mut out = BTreeMap::new();
+    for entry_result in archive.entries().unwrap() {
+        let mut entry = entry_result.unwrap();
+        let path = entry.path().unwrap().into_owned();
+        let name = path.to_str().unwrap().to_string();
+        let mut content = Vec::new();
+        entry.read_to_end(&mut content).unwrap();
+        out.insert(name, content);
+    }
+    out
+}
+
+/// Extracts `bytes` via the real (budgeted) `TarArchive::extract` pipeline
+/// and reads back what actually landed on disk.
+fn extract_via_budgeted_pipeline(bytes: &[u8]) -> BTreeMap<String, Vec<u8>> {
+    let temp = TempDir::new().unwrap();
+    // Generous budget/quotas: this test is about false positives on
+    // legitimate archives, not about the cap itself, which has its own
+    // dedicated coverage in `tar_metadata_bomb.rs`.
+    let config = SecurityConfig::default()
+        .with_max_tar_metadata_bytes(1024 * 1024)
+        .with_max_file_count(10_000)
+        .with_max_total_size(u64::MAX)
+        .with_max_file_size(u64::MAX);
+    let mut archive = TarArchive::new(Cursor::new(bytes.to_vec()));
+    archive
+        .extract(
+            temp.path(),
+            &config,
+            &ExtractionOptions::default(),
+            &mut NoopProgress,
+        )
+        .expect("a well-formed archive within generous quotas must extract without error");
+
+    let mut out = BTreeMap::new();
+    for entry in walkdir(temp.path()) {
+        let relative = entry
+            .strip_prefix(temp.path())
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+        let content = std::fs::read(&entry).unwrap();
+        out.insert(relative, content);
+    }
+    out
+}
+
+fn walkdir(root: &std::path::Path) -> Vec<std::path::PathBuf> {
+    let mut out = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        for entry in std::fs::read_dir(&dir).unwrap().flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else {
+                out.push(path);
+            }
+        }
+    }
+    out
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// The budgeted extraction pipeline must produce byte-identical output
+    /// to a plain, unwrapped `tar::Archive` read for any well-formed
+    /// archive — the read-budget mechanism must never alter what a
+    /// legitimate archive extracts to.
+    #[test]
+    fn budgeted_extraction_matches_plain_tar_archive(
+        files in prop::collection::vec(synthetic_file_strategy(), 1..40)
+    ) {
+        let (bytes, expected) = build_well_formed_archive(&files);
+
+        let ground_truth = read_via_plain_tar_archive(&bytes);
+        prop_assert_eq!(&ground_truth, &expected, "test construction sanity: plain tar::Archive must match what we built");
+
+        let actual = extract_via_budgeted_pipeline(&bytes);
+        prop_assert_eq!(
+            actual, ground_truth,
+            "budgeted extraction must match a plain tar::Archive read exactly"
+        );
+    }
+}

--- a/crates/exarch-core/tests/security/tar_ghsa_2026.rs
+++ b/crates/exarch-core/tests/security/tar_ghsa_2026.rs
@@ -1,0 +1,466 @@
+//! Regression tests mapping node-tar GHSA vulnerability classes onto the TAR
+//! extraction pipeline (issue #399).
+//!
+//! All cases here currently pass: protection against these classes is
+//! inherited from the `tar` crate dependency (tar-0.4.46), not implemented
+//! locally in `exarch-core`. Their value is locking in that inherited
+//! behavior so a future `tar` crate bump that regresses parsing precedence,
+//! NUL-byte handling, or size framing is caught immediately.
+//!
+//! - GHSA-vmf3 (node-tar): PAX/GNU long-name/long-link record smuggling and
+//!   stream re-framing.
+//! - GHSA-gvwx / GHSA-w8wr (node-tar): NUL byte / malformed field handling in
+//!   PAX and GNU long-name records.
+//! - GHSA-23hp (node-tar): declared vs. actual entry size mismatches.
+
+#![allow(clippy::unwrap_used, clippy::cast_possible_truncation)]
+
+use exarch_core::ArchiveError;
+use exarch_core::ExtractionOptions;
+use exarch_core::NoopProgress;
+use exarch_core::SecurityConfig;
+use exarch_core::formats::ArchiveFormat;
+use exarch_core::formats::TarArchive;
+use std::io::Cursor;
+use tempfile::TempDir;
+
+const BLOCK: usize = 512;
+
+/// Builds a raw 512-byte TAR header block.
+///
+/// `gnu_magic` selects GNU-flavored magic bytes (`"ustar "` + `" \0"`) at
+/// offsets 257/265, required for the `tar` crate's `is_recognized_header` to
+/// process GNU long-name/long-link ('L'/'K') typeflags at all — without it,
+/// long-name processing is silently skipped and these tests would pass
+/// without exercising the real code path.
+fn header(name: &[u8], size: u64, typeflag: u8, linkname: &[u8], gnu_magic: bool) -> Vec<u8> {
+    let mut h = vec![0u8; BLOCK];
+    let name_len = name.len().min(100);
+    h[..name_len].copy_from_slice(&name[..name_len]);
+    h[100..108].copy_from_slice(b"0000644\0");
+    h[108..116].copy_from_slice(b"0000000\0");
+    h[116..124].copy_from_slice(b"0000000\0");
+    let sz = format!("{size:011o}\0");
+    h[124..136].copy_from_slice(sz.as_bytes());
+    h[136..148].copy_from_slice(b"00000000000\0");
+    h[156] = typeflag;
+    let link_len = linkname.len().min(100);
+    h[157..157 + link_len].copy_from_slice(&linkname[..link_len]);
+    if gnu_magic {
+        h[257..263].copy_from_slice(b"ustar ");
+        h[263..265].copy_from_slice(b" \0");
+    } else {
+        h[257..263].copy_from_slice(b"ustar\0");
+        h[263..265].copy_from_slice(b"00");
+    }
+    // The checksum field itself is treated as 8 ASCII spaces during the sum.
+    h[148..156].copy_from_slice(b"        ");
+    let sum: u32 = h.iter().map(|b| u32::from(*b)).sum();
+    let cksum = format!("{sum:06o}\0 ");
+    h[148..156].copy_from_slice(cksum.as_bytes());
+    h
+}
+
+/// Pads `data` to a 512-byte boundary and appends it to `out`.
+fn pad(out: &mut Vec<u8>, data: &[u8]) {
+    out.extend_from_slice(data);
+    let rem = data.len() % BLOCK;
+    if rem != 0 {
+        out.extend(std::iter::repeat_n(0u8, BLOCK - rem));
+    }
+}
+
+/// Encodes one PAX extended-header record: `"LEN key=value\n"`, where `LEN`
+/// includes its own decimal digit count (the standard PAX self-referential
+/// length format).
+fn pax_record(key: &[u8], value: &[u8]) -> Vec<u8> {
+    let base = key.len() + value.len() + 3; // ' ', '=', '\n'
+    let mut len = base + 1;
+    loop {
+        let candidate_len = len.to_string().len() + base;
+        if candidate_len == len {
+            break;
+        }
+        len = candidate_len;
+    }
+    let mut record = format!("{len} ").into_bytes();
+    record.extend_from_slice(key);
+    record.push(b'=');
+    record.extend_from_slice(value);
+    record.push(b'\n');
+    record
+}
+
+/// Appends two all-zero blocks: the standard TAR end-of-archive marker.
+fn eof(out: &mut Vec<u8>) {
+    out.extend(std::iter::repeat_n(0u8, BLOCK * 2));
+}
+
+/// Appends a GNU long-name ('L') or long-link ('K') metadata entry carrying
+/// `name`, NUL-terminated per the GNU tar convention.
+fn gnu_longname(out: &mut Vec<u8>, typeflag: u8, name: &[u8]) {
+    let mut data = name.to_vec();
+    data.push(0);
+    out.extend_from_slice(&header(
+        b"././@LongLink",
+        data.len() as u64,
+        typeflag,
+        b"",
+        true,
+    ));
+    pad(out, &data);
+}
+
+/// Appends a PAX local extended header ('x') carrying `records`.
+fn pax_header(out: &mut Vec<u8>, records: &[u8]) {
+    out.extend_from_slice(&header(
+        b"PaxHeaders/entry",
+        records.len() as u64,
+        b'x',
+        b"",
+        false,
+    ));
+    pad(out, records);
+}
+
+fn extract(bytes: &[u8]) -> (exarch_core::Result<exarch_core::ExtractionReport>, TempDir) {
+    let temp = TempDir::new().unwrap();
+    let mut archive = TarArchive::new(Cursor::new(bytes.to_vec()));
+    let result = archive.extract(
+        temp.path(),
+        &SecurityConfig::default(),
+        &ExtractionOptions::default(),
+        &mut NoopProgress,
+    );
+    (result, temp)
+}
+
+fn extract_with_config(
+    bytes: &[u8],
+    config: &SecurityConfig,
+) -> (exarch_core::Result<exarch_core::ExtractionReport>, TempDir) {
+    let temp = TempDir::new().unwrap();
+    let mut archive = TarArchive::new(Cursor::new(bytes.to_vec()));
+    let result = archive.extract(
+        temp.path(),
+        config,
+        &ExtractionOptions::default(),
+        &mut NoopProgress,
+    );
+    (result, temp)
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// GHSA-vmf3: PAX/GNU long-name smuggling and stream re-framing
+// ─────────────────────────────────────────────────────────────────────────
+
+/// GNU longname is benign, PAX `path` is a traversal attempt. `tar` resolves
+/// naming precedence as GNU long-name > PAX `path` > ustar name, so the
+/// malicious PAX path is never applied at all — the entry extracts safely
+/// under its benign GNU-supplied name, and no escaping path is ever written.
+#[test]
+fn ghsa_vmf3_gnu_longname_benign_pax_path_traversal_ignored_by_precedence() {
+    let mut t = Vec::new();
+    gnu_longname(&mut t, b'L', b"benign_from_gnu.txt");
+    let mut recs = pax_record(b"path", b"../../PWNED_FROM_PAX.txt");
+    recs.extend(pax_record(b"size", b"5"));
+    pax_header(&mut t, &recs);
+    t.extend_from_slice(&header(b"ustar_name.txt", 5, b'0', b"", true));
+    pad(&mut t, b"hello");
+    eof(&mut t);
+
+    let (result, temp) = extract(&t);
+    let report = result.expect("GNU long-name precedence must win, extracting safely");
+    assert_eq!(
+        report.files_extracted, 1,
+        "exactly one entry must be written"
+    );
+    assert!(
+        temp.path().join("benign_from_gnu.txt").exists(),
+        "must extract under the winning (benign) GNU long-name"
+    );
+}
+
+/// GNU longname is a traversal attempt, PAX `path` is benign: the GNU name
+/// (lower precedence but still validated as the entry advances) must not
+/// allow the escape through.
+#[test]
+fn ghsa_vmf3_gnu_longname_traversal_pax_path_benign_rejected() {
+    let mut t = Vec::new();
+    gnu_longname(&mut t, b'L', b"../../PWNED_FROM_GNU.txt");
+    let recs = pax_record(b"path", b"benign_from_pax.txt");
+    pax_header(&mut t, &recs);
+    t.extend_from_slice(&header(b"ustar_name.txt", 5, b'0', b"", true));
+    pad(&mut t, b"hello");
+    eof(&mut t);
+
+    let (result, _temp) = extract(&t);
+    assert!(
+        matches!(result, Err(ArchiveError::PathTraversal { .. })),
+        "GNU longname traversal must be rejected, got: {result:?}"
+    );
+}
+
+/// PAX `path` traversal with no GNU longname at all: plain PAX override must
+/// still be validated.
+#[test]
+fn ghsa_vmf3_pax_path_traversal_alone_rejected() {
+    let mut t = Vec::new();
+    let recs = pax_record(b"path", b"../../PWNED_PAX_ONLY.txt");
+    pax_header(&mut t, &recs);
+    t.extend_from_slice(&header(b"ustar_name.txt", 5, b'0', b"", true));
+    pad(&mut t, b"hello");
+    eof(&mut t);
+
+    let (result, _temp) = extract(&t);
+    assert!(
+        matches!(result, Err(ArchiveError::PathTraversal { .. })),
+        "PAX-only path traversal must be rejected, got: {result:?}"
+    );
+}
+
+/// GNU `LongLink` ('K') carries a traversal target while the ustar linkname
+/// fallback is benign: the smuggled traversal target must still be rejected
+/// (default config: symlinks disabled, so the entry is rejected outright).
+#[test]
+fn ghsa_vmf3_gnu_longlink_traversal_benign_ustar_linkname_rejected() {
+    let mut t = Vec::new();
+    gnu_longname(&mut t, b'K', b"../../../../../../etc/passwd");
+    t.extend_from_slice(&header(b"link.txt", 0, b'2', b"benign_target", true));
+    eof(&mut t);
+
+    let (result, _temp) = extract(&t);
+    assert!(
+        result.is_err(),
+        "GNU LongLink traversal must be rejected, got: {result:?}"
+    );
+}
+
+/// GHSA-vmf3 core shape: a PAX `size` record precedes an intermediary GNU
+/// long-name ('L') header, then a zero-declared-size real entry, then a
+/// trailing entry. The PAX `size` record is accumulated and, per the
+/// dependency's `is_extension_header` guard, is *not* applied to the
+/// intermediary 'L' header (which uses its own declared length) — instead it
+/// is applied to the next real (non-metadata) entry, exactly like an
+/// ordinary PAX-preceding-a-file record. That entry surfaces under the GNU
+/// long name with the PAX-declared size, and no separately-named smuggled
+/// entry ever appears. A vulnerable parser that mis-applied the size to the
+/// 'L' header itself would shift framing differently and could expose a
+/// distinctly-named smuggled member instead.
+#[test]
+fn ghsa_vmf3_pax_size_framing_before_gnu_longname_smuggled_member_absent() {
+    let mut t = Vec::new();
+    let recs = pax_record(b"size", b"1024");
+    pax_header(&mut t, &recs);
+    gnu_longname(&mut t, b'L', b"visible.txt");
+    t.extend_from_slice(&header(b"placeholder.txt", 0, b'0', b"", true));
+    t.extend_from_slice(&header(b"trailer.txt", 5, b'0', b"", true));
+    pad(&mut t, b"hello");
+    eof(&mut t);
+
+    let (result, temp) = extract(&t);
+    let report = result.expect("well-formed archive must extract");
+    assert_eq!(report.files_extracted, 1, "exactly one entry must surface");
+    assert!(
+        temp.path().join("visible.txt").exists(),
+        "the entry must surface under its GNU long name"
+    );
+    assert!(
+        !temp.path().join("trailer.txt").exists(),
+        "the trailing entry must not appear as a separately-named member \
+         (its bytes were consumed as data of the PAX-sized entry)"
+    );
+    assert!(
+        !temp.path().join("placeholder.txt").exists(),
+        "the entry must be visible only under its GNU long name, never its raw header name"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// GHSA-gvwx / GHSA-w8wr: NUL byte / malformed field handling
+// ─────────────────────────────────────────────────────────────────────────
+
+/// A NUL byte embedded in a PAX `path` record must be rejected as a security
+/// violation, never panic.
+#[test]
+fn ghsa_gvwx_nul_byte_in_pax_path_rejected_without_panic() {
+    let mut t = Vec::new();
+    let recs = pax_record(b"path", b"foo\0bar.txt");
+    pax_header(&mut t, &recs);
+    t.extend_from_slice(&header(b"ustar_name.txt", 5, b'0', b"", false));
+    pad(&mut t, b"hello");
+    eof(&mut t);
+
+    let result = std::panic::catch_unwind(|| extract(&t).0);
+    let result = result.expect("must not panic on NUL byte in PAX path");
+    assert!(
+        matches!(result, Err(ArchiveError::SecurityViolation { .. })),
+        "NUL byte in PAX path must be a SecurityViolation, got: {result:?}"
+    );
+    if let Err(ArchiveError::SecurityViolation { reason }) = result {
+        assert!(reason.contains("null bytes"), "reason: {reason}");
+    }
+}
+
+/// A NUL byte embedded in a GNU long-name ('L') record must be rejected as a
+/// security violation, never panic — this bypasses the PAX record parser
+/// entirely, so it is a distinct code path from the PAX case above.
+#[test]
+fn ghsa_gvwx_nul_byte_in_gnu_longname_rejected_without_panic() {
+    let mut t = Vec::new();
+    gnu_longname(&mut t, b'L', b"gnu\0nul.txt");
+    t.extend_from_slice(&header(b"ustar_name.txt", 5, b'0', b"", true));
+    pad(&mut t, b"hello");
+    eof(&mut t);
+
+    let result = std::panic::catch_unwind(|| extract(&t).0);
+    let result = result.expect("must not panic on NUL byte in GNU longname");
+    assert!(
+        matches!(result, Err(ArchiveError::SecurityViolation { .. })),
+        "NUL byte in GNU longname must be a SecurityViolation, got: {result:?}"
+    );
+    if let Err(ArchiveError::SecurityViolation { reason }) = result {
+        assert!(reason.contains("null bytes"), "reason: {reason}");
+    }
+}
+
+/// An empty PAX `path` record must be rejected with the dedicated "empty
+/// path" message, not treated as a valid (root-relative) path.
+#[test]
+fn ghsa_w8wr_empty_pax_path_rejected() {
+    let mut t = Vec::new();
+    let recs = pax_record(b"path", b"");
+    pax_header(&mut t, &recs);
+    t.extend_from_slice(&header(b"ustar_name.txt", 5, b'0', b"", false));
+    pad(&mut t, b"hello");
+    eof(&mut t);
+
+    let (result, _temp) = extract(&t);
+    match &result {
+        Err(ArchiveError::SecurityViolation { reason }) => {
+            assert!(reason.contains("empty path"), "reason: {reason}");
+        }
+        other => panic!("expected SecurityViolation for empty path, got: {other:?}"),
+    }
+}
+
+/// A numeric-looking PAX `path` value (`"0"`) is the GHSA-w8wr type-confusion
+/// shape (some parsers treat a bare `"0"` as falsy/absent). In Rust, path
+/// values are byte strings, so `"0"` must extract literally as a file named
+/// `0` with no crash or misinterpretation.
+#[test]
+fn ghsa_w8wr_numeric_pax_path_extracts_literally() {
+    let mut t = Vec::new();
+    let recs = pax_record(b"path", b"0");
+    pax_header(&mut t, &recs);
+    t.extend_from_slice(&header(b"ustar_name.txt", 5, b'0', b"", false));
+    pad(&mut t, b"hello");
+    eof(&mut t);
+
+    let (result, temp) = extract(&t);
+    assert!(
+        result.is_ok(),
+        "numeric-looking path must extract, got: {result:?}"
+    );
+    assert!(
+        temp.path().join("0").exists(),
+        "must extract literally as a file named '0'"
+    );
+}
+
+/// A PAX `size` record at `u64::MAX` must surface as a graceful size-overflow
+/// error, never a panic or unbounded allocation attempt.
+#[test]
+fn ghsa_w8wr_pax_size_u64_max_rejected_without_panic() {
+    let mut t = Vec::new();
+    let recs = pax_record(b"size", b"18446744073709551615");
+    pax_header(&mut t, &recs);
+    t.extend_from_slice(&header(b"ustar_name.txt", 5, b'0', b"", false));
+    pad(&mut t, b"hello");
+    eof(&mut t);
+
+    let result = std::panic::catch_unwind(|| extract(&t).0);
+    let result = result.expect("must not panic on PAX size = u64::MAX");
+    assert!(
+        result.is_err(),
+        "u64::MAX declared size must be rejected, got: {result:?}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// GHSA-23hp: declared vs. actual entry size mismatches
+// ─────────────────────────────────────────────────────────────────────────
+
+/// Asserts `result` is not a quota rejection. The synthetic archives in this
+/// section deliberately leave non-zero-byte "garbage" after the declared
+/// entry (masquerading as the next header), which the real `tar` crate
+/// correctly refuses to parse as a valid header once reached — an unrelated,
+/// expected `InvalidArchive`/`PartialExtraction` failure that must not be
+/// confused with the single invariant under test: the declared size, not the
+/// real payload length, is what gets written and quota-charged.
+fn assert_not_quota_rejected(result: &exarch_core::Result<exarch_core::ExtractionReport>) {
+    let quota_hit = result.as_ref().err().and_then(ArchiveError::quota_resource);
+    assert!(
+        quota_hit.is_none(),
+        "quota must not be tripped by the real (undeclared) payload size, got: {result:?}"
+    );
+}
+
+/// A ustar header declares `size=10` but is followed by 4096 real payload
+/// bytes: exactly 10 bytes must be written, never the full payload.
+#[test]
+fn ghsa_23hp_declared_size_understates_actual_payload() {
+    let mut t = Vec::new();
+    t.extend_from_slice(&header(b"liar.txt", 10, b'0', b"", false));
+    pad(&mut t, &vec![b'A'; 4096]);
+    eof(&mut t);
+
+    let (result, temp) = extract(&t);
+    assert_not_quota_rejected(&result);
+    let written = std::fs::metadata(temp.path().join("liar.txt"))
+        .unwrap()
+        .len();
+    assert_eq!(
+        written, 10,
+        "must write exactly the declared 10 bytes, not the full payload"
+    );
+}
+
+/// ustar `size` and PAX `size` disagree (PAX is smaller and wins): only the
+/// PAX-declared byte count must be written.
+#[test]
+fn ghsa_23hp_pax_size_smaller_than_ustar_size_wins() {
+    let mut t = Vec::new();
+    let recs = pax_record(b"size", b"10");
+    pax_header(&mut t, &recs);
+    t.extend_from_slice(&header(b"paxsmall.txt", 4096, b'0', b"", false));
+    pad(&mut t, &vec![b'B'; 4096]);
+    eof(&mut t);
+
+    let (result, temp) = extract(&t);
+    assert_not_quota_rejected(&result);
+    let written = std::fs::metadata(temp.path().join("paxsmall.txt"))
+        .unwrap()
+        .len();
+    assert_eq!(written, 10, "PAX size must win over the larger ustar size");
+}
+
+/// A small declared size (10) with a small `max_file_size` quota (64) and a
+/// 100,000-byte real payload: exactly 10 bytes must be written, and the
+/// quota must not be incorrectly tripped by the real (much larger) payload
+/// that follows in the stream.
+#[test]
+fn ghsa_23hp_declared_size_respects_small_quota_despite_large_payload() {
+    let mut t = Vec::new();
+    t.extend_from_slice(&header(b"liar2.txt", 10, b'0', b"", false));
+    pad(&mut t, &vec![b'C'; 100_000]);
+    eof(&mut t);
+
+    let config = SecurityConfig::default().with_max_file_size(64);
+    let (result, temp) = extract_with_config(&t, &config);
+    assert_not_quota_rejected(&result);
+    let written = std::fs::metadata(temp.path().join("liar2.txt"))
+        .unwrap()
+        .len();
+    assert_eq!(written, 10, "must write exactly the declared 10 bytes");
+}

--- a/crates/exarch-core/tests/security/tar_metadata_bomb.rs
+++ b/crates/exarch-core/tests/security/tar_metadata_bomb.rs
@@ -1,0 +1,888 @@
+//! Regression tests for issue #414: TAR metadata-entry decompression bomb.
+//!
+//! GNU long-name ('L'), GNU long-link ('K'), and PAX extended header ('x'/'g')
+//! records are buffered fully into memory by the `tar` crate before any entry
+//! reaches `exarch-core`'s validator or quota tracker. A crafted record
+//! declaring a huge length backed by a real stream of that length causes
+//! unbounded allocation with no quota enforcement.
+//!
+//! `SecurityConfig::max_tar_metadata_bytes` closes this via a read budget
+//! (`formats::tar_metadata_limit`) metered on bytes the `tar` crate actually
+//! reads while searching for the next entry — not on any header's declared
+//! size — so these fixtures use *real* backing bytes matching (or exceeding)
+//! the configured budget, not a huge declared size behind a tiny stream: a
+//! byte-budget mechanism has nothing to trip on unless the bytes are actually
+//! there to be read.
+//!
+//! An earlier version of this fix re-parsed TAR headers to reject an
+//! oversized *declared* size before the `tar` crate could buffer it. Three
+//! rounds of adversarial review found three independent ways a shadow parser
+//! could disagree with the real one about entry framing (S1: untracked PAX
+//! `size=` overrides, S2: framing typeflags without gating on valid magic,
+//! S3: a PAX global header draining the real parser's override state without
+//! draining the mirror's). The historical-shape tests below reconstruct all
+//! three attack byte-sequences and confirm the budget mechanism — which does
+//! not parse headers at all, so has no framing belief to diverge — rejects
+//! them regardless.
+//!
+//! These tests use small, test-specific `max_tar_metadata_bytes` values
+//! (instead of reproducing a multi-gigabyte archive) so the budget can be
+//! verified without allocating large amounts of memory in CI.
+
+#![allow(clippy::unwrap_used, clippy::cast_possible_truncation)]
+
+use exarch_core::ArchiveError;
+use exarch_core::ExtractionOptions;
+use exarch_core::NoopProgress;
+use exarch_core::SecurityConfig;
+use exarch_core::formats::ArchiveFormat;
+use exarch_core::formats::TarArchive;
+use std::io::Cursor;
+use std::io::Write;
+use tempfile::TempDir;
+
+const BLOCK: usize = 512;
+
+/// Builds a raw 512-byte TAR header block.
+fn header(name: &[u8], size: u64, typeflag: u8, gnu_magic: bool) -> Vec<u8> {
+    let mut h = vec![0u8; BLOCK];
+    let name_len = name.len().min(100);
+    h[..name_len].copy_from_slice(&name[..name_len]);
+    h[100..108].copy_from_slice(b"0000644\0");
+    h[108..116].copy_from_slice(b"0000000\0");
+    h[116..124].copy_from_slice(b"0000000\0");
+    h[124..136].copy_from_slice(format!("{size:011o}\0").as_bytes());
+    h[136..148].copy_from_slice(b"00000000000\0");
+    h[156] = typeflag;
+    if gnu_magic {
+        h[257..263].copy_from_slice(b"ustar ");
+        h[263..265].copy_from_slice(b" \0");
+    } else {
+        h[257..263].copy_from_slice(b"ustar\0");
+        h[263..265].copy_from_slice(b"00");
+    }
+    h[148..156].copy_from_slice(b"        ");
+    let sum: u32 = h.iter().map(|b| u32::from(*b)).sum();
+    h[148..156].copy_from_slice(format!("{sum:06o}\0 ").as_bytes());
+    h
+}
+
+/// Builds a raw header with the magic/version field left zeroed — neither
+/// valid ustar nor valid GNU magic.
+fn header_invalid_magic(name: &[u8], size: u64, typeflag: u8) -> Vec<u8> {
+    let mut h = vec![0u8; BLOCK];
+    let name_len = name.len().min(100);
+    h[..name_len].copy_from_slice(&name[..name_len]);
+    h[100..108].copy_from_slice(b"0000644\0");
+    h[108..116].copy_from_slice(b"0000000\0");
+    h[116..124].copy_from_slice(b"0000000\0");
+    h[124..136].copy_from_slice(format!("{size:011o}\0").as_bytes());
+    h[136..148].copy_from_slice(b"00000000000\0");
+    h[156] = typeflag;
+    // magic bytes (257..265) intentionally left zeroed: invalid.
+    h[148..156].copy_from_slice(b"        ");
+    let sum: u32 = h.iter().map(|b| u32::from(*b)).sum();
+    h[148..156].copy_from_slice(format!("{sum:06o}\0 ").as_bytes());
+    h
+}
+
+fn pad_to_block(out: &mut Vec<u8>, data: &[u8]) {
+    out.extend_from_slice(data);
+    let rem = data.len() % BLOCK;
+    if rem != 0 {
+        out.extend(std::iter::repeat_n(0u8, BLOCK - rem));
+    }
+}
+
+/// Encodes one PAX extended-header record: `"LEN key=value\n"`, where `LEN`
+/// includes its own decimal digit count (the standard self-referential PAX
+/// length format).
+fn pax_record(key: &[u8], value: &[u8]) -> Vec<u8> {
+    let base = key.len() + value.len() + 3; // ' ', '=', '\n'
+    let mut len = base + 1;
+    loop {
+        let candidate_len = len.to_string().len() + base;
+        if candidate_len == len {
+            break;
+        }
+        len = candidate_len;
+    }
+    let mut record = format!("{len} ").into_bytes();
+    record.extend_from_slice(key);
+    record.push(b'=');
+    record.extend_from_slice(value);
+    record.push(b'\n');
+    record
+}
+
+/// Builds a single metadata record (`'L'`/`'K'`/`'x'`) whose declared size
+/// matches `real_bytes` exactly (a real, readable stream of that length, not
+/// a huge declared size behind a tiny one) — the shape the read-budget
+/// mechanism actually needs to trip on, since it only counts bytes really
+/// delivered.
+fn metadata_bomb(typeflag: u8, real_bytes: usize) -> Vec<u8> {
+    let name: &[u8] = if typeflag == b'x' {
+        b"PaxHeaders/bomb"
+    } else {
+        b"././@LongLink"
+    };
+    let mut out = header(name, real_bytes as u64, typeflag, typeflag != b'x');
+    pad_to_block(&mut out, &vec![b'A'; real_bytes]);
+    out
+}
+
+fn write_tar_file(dir: &TempDir, name: &str, bytes: &[u8]) -> std::path::PathBuf {
+    let path = dir.path().join(name);
+    let mut f = std::fs::File::create(&path).unwrap();
+    f.write_all(bytes).unwrap();
+    path
+}
+
+/// Asserts the result is a security violation caused by the TAR metadata read
+/// budget. Matches both a direct `SecurityViolation` and one wrapped in
+/// `PartialExtraction` (extraction reports a wrapped source once any file was
+/// written before the violation, e.g. a decoy entry preceding the hidden
+/// bomb).
+fn assert_is_budget_violation(result: &exarch_core::Result<impl std::fmt::Debug>) {
+    match result {
+        Err(e) if e.is_security_violation() => {
+            let reason = e.context().unwrap_or_default();
+            assert!(
+                reason.contains("budget") || reason.contains("metadata"),
+                "reason should reference the TAR metadata read budget: {reason}"
+            );
+        }
+        other => panic!("expected a budget SecurityViolation, got: {other:?}"),
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// TarArchive::extract() — direct entry point
+// ─────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn extract_rejects_oversized_gnu_longname_metadata_entry() {
+    let bomb = metadata_bomb(b'L', 8192);
+    let temp = TempDir::new().unwrap();
+    let config = SecurityConfig::default().with_max_tar_metadata_bytes(4096);
+
+    let mut archive = TarArchive::new(Cursor::new(bomb));
+    let result = archive.extract(
+        temp.path(),
+        &config,
+        &ExtractionOptions::default(),
+        &mut NoopProgress,
+    );
+    assert_is_budget_violation(&result);
+}
+
+#[test]
+fn extract_rejects_oversized_gnu_longlink_metadata_entry() {
+    let bomb = metadata_bomb(b'K', 8192);
+    let temp = TempDir::new().unwrap();
+    let config = SecurityConfig::default().with_max_tar_metadata_bytes(4096);
+
+    let mut archive = TarArchive::new(Cursor::new(bomb));
+    let result = archive.extract(
+        temp.path(),
+        &config,
+        &ExtractionOptions::default(),
+        &mut NoopProgress,
+    );
+    assert_is_budget_violation(&result);
+}
+
+#[test]
+fn extract_rejects_oversized_pax_metadata_entry() {
+    let bomb = metadata_bomb(b'x', 8192);
+    let temp = TempDir::new().unwrap();
+    let config = SecurityConfig::default().with_max_tar_metadata_bytes(4096);
+
+    let mut archive = TarArchive::new(Cursor::new(bomb));
+    let result = archive.extract(
+        temp.path(),
+        &config,
+        &ExtractionOptions::default(),
+        &mut NoopProgress,
+    );
+    assert_is_budget_violation(&result);
+}
+
+#[test]
+fn extract_accepts_metadata_entry_within_the_configured_budget() {
+    // A GNU longname just under a generous budget must extract normally —
+    // the budget must not produce false positives on legitimate long paths.
+    // A single long component (no extra path depth) that still exceeds the
+    // 100-byte ustar name field, forcing GNU long-name usage.
+    let long_name = "x".repeat(150) + "_file.txt";
+    let mut data = long_name.clone().into_bytes();
+    data.push(0);
+
+    let mut t = Vec::new();
+    t.extend_from_slice(&header(b"././@LongLink", data.len() as u64, b'L', true));
+    pad_to_block(&mut t, &data);
+    t.extend_from_slice(&header(b"file.txt", 5, b'0', true));
+    pad_to_block(&mut t, b"hello");
+    t.extend(std::iter::repeat_n(0u8, BLOCK * 2));
+
+    let temp = TempDir::new().unwrap();
+    let config = SecurityConfig::default().with_max_tar_metadata_bytes(4096);
+    let mut archive = TarArchive::new(Cursor::new(t));
+    let result = archive.extract(
+        temp.path(),
+        &config,
+        &ExtractionOptions::default(),
+        &mut NoopProgress,
+    );
+    let report = result.expect("a metadata entry within the budget must extract normally");
+    assert_eq!(report.files_extracted, 1);
+    assert!(temp.path().join(&long_name).exists());
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// list_archive() / verify_archive() — the actual public API entry points,
+// which bypass `TarArchive` entirely and open `tar::Archive` directly
+// (see `inspection::list`), so they need their own coverage.
+// ─────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn list_archive_rejects_oversized_metadata_entry() {
+    let bomb = metadata_bomb(b'L', 8192);
+    let temp = TempDir::new().unwrap();
+    let path = write_tar_file(&temp, "bomb.tar", &bomb);
+    let config = SecurityConfig::default().with_max_tar_metadata_bytes(4096);
+
+    let result = exarch_core::list_archive(&path, &config);
+    assert_is_budget_violation(&result);
+}
+
+#[test]
+fn verify_archive_rejects_oversized_metadata_entry() {
+    let bomb = metadata_bomb(b'x', 8192);
+    let temp = TempDir::new().unwrap();
+    let path = write_tar_file(&temp, "bomb.tar", &bomb);
+    let config = SecurityConfig::default().with_max_tar_metadata_bytes(4096);
+
+    let result = exarch_core::verify_archive(&path, &config);
+    assert_is_budget_violation(&result);
+}
+
+#[test]
+fn extract_archive_rejects_oversized_metadata_entry_via_public_api() {
+    let bomb = metadata_bomb(b'K', 8192);
+    let temp = TempDir::new().unwrap();
+    let path = write_tar_file(&temp, "bomb.tar", &bomb);
+    let out = temp.path().join("out");
+    let config = SecurityConfig::default().with_max_tar_metadata_bytes(4096);
+
+    let result = exarch_core::extract_archive(&path, &out, &config);
+    assert_is_budget_violation(&result);
+}
+
+#[test]
+fn default_config_budget_rejects_a_moderately_oversized_metadata_entry() {
+    // Exercises the *default* 4 MiB budget (no custom config) against a
+    // record just over it. A few MB of real in-memory bytes is fine for CI
+    // (unlike the multi-gigabyte scale of the original PoC): this is a
+    // linear real-bytes-in/real-bytes-metered relationship now, not a
+    // compression-amplified bomb.
+    let bomb = metadata_bomb(b'L', 4 * 1024 * 1024 + 4096);
+    let temp = TempDir::new().unwrap();
+
+    let mut archive = TarArchive::new(Cursor::new(bomb));
+    let result = archive.extract(
+        temp.path(),
+        &SecurityConfig::default(),
+        &ExtractionOptions::default(),
+        &mut NoopProgress,
+    );
+    assert_is_budget_violation(&result);
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Historical-shape regression tests: the exact byte sequences that broke
+// three rounds of the earlier shadow-parser fix. The budget mechanism does
+// not parse PAX overrides, magic bytes, or typeflags at all, so none of
+// these shapes are individually meaningful to it any more — they are kept
+// as concrete regressions proving each historical PoC is still rejected,
+// not because the new mechanism treats them specially.
+// ─────────────────────────────────────────────────────────────────────────
+
+/// S1 shape: a local PAX header declaring `size=0` (an override the real
+/// `tar` crate applies to the next entry), a decoy regular file, then a GNU
+/// long-name record whose real bytes exceed the budget.
+fn s1_shape_bomb(bomb_real_bytes: usize) -> Vec<u8> {
+    let mut out = Vec::new();
+    let pax_body = b"9 size=0\n".to_vec();
+    out.extend_from_slice(&header(
+        b"PaxHeaders/decoy",
+        pax_body.len() as u64,
+        b'x',
+        false,
+    ));
+    pad_to_block(&mut out, &pax_body);
+    out.extend_from_slice(&header(b"decoy.txt", 4096, b'0', true));
+    out.extend_from_slice(&header(
+        b"././@LongLink",
+        bomb_real_bytes as u64,
+        b'L',
+        true,
+    ));
+    pad_to_block(&mut out, &vec![b'A'; bomb_real_bytes]);
+    out
+}
+
+/// S2 shape: like S1, but the leading PAX header has invalid (zeroed) magic
+/// — a `tar`-crate-observable difference the earlier shadow parser's
+/// typeflag-only detection missed, the budget mechanism does not care about
+/// at all.
+fn s2_shape_bomb(bomb_real_bytes: usize) -> Vec<u8> {
+    let mut out = Vec::new();
+    let pax_body = pax_record(b"size", b"0");
+    out.extend_from_slice(&header_invalid_magic(
+        b"PaxHeaders/decoy",
+        pax_body.len() as u64,
+        b'x',
+    ));
+    pad_to_block(&mut out, &pax_body);
+    out.extend_from_slice(&header(b"decoy.txt", 512, b'0', true));
+    pad_to_block(&mut out, &vec![b'D'; 512]);
+    out.extend_from_slice(&header(
+        b"././@LongLink",
+        bomb_real_bytes as u64,
+        b'L',
+        true,
+    ));
+    pad_to_block(&mut out, &vec![b'A'; bomb_real_bytes]);
+    out
+}
+
+/// S3 shape: a local PAX override record, then a PAX **global** header
+/// (which the real `tar` crate yields as an ordinary entry, draining any
+/// pending override — a state transition the earlier shadow parser's
+/// per-typeflag mirror missed), then a decoy, then the bomb.
+fn s3_shape_bomb(bomb_real_bytes: usize) -> Vec<u8> {
+    let mut out = Vec::new();
+    let pax_body = pax_record(b"size", b"0");
+    out.extend_from_slice(&header(
+        b"PaxHeaders/decoy",
+        pax_body.len() as u64,
+        b'x',
+        false,
+    ));
+    pad_to_block(&mut out, &pax_body);
+    let global_body = pax_record(b"comment", b"hi");
+    out.extend_from_slice(&header(
+        b"././@PaxHeader",
+        global_body.len() as u64,
+        b'g',
+        true,
+    ));
+    pad_to_block(&mut out, &global_body);
+    // Unlike the S1/S2 shapes, no PAX size override is active by the time
+    // `decoy.txt` is reached (the preceding 'g' header already drains it in
+    // the real `tar` crate) — so `decoy.txt` is framed at its own declared
+    // size in both the real parser and this budget mechanism, and needs
+    // matching real content.
+    out.extend_from_slice(&header(b"decoy.txt", 4096, b'0', true));
+    pad_to_block(&mut out, &vec![b'D'; 4096]);
+    out.extend_from_slice(&header(
+        b"././@LongLink",
+        bomb_real_bytes as u64,
+        b'L',
+        true,
+    ));
+    pad_to_block(&mut out, &vec![b'A'; bomb_real_bytes]);
+    out
+}
+
+fn assert_all_entry_points_reject(bomb: &[u8], file_name: &str) {
+    let config = SecurityConfig::default().with_max_tar_metadata_bytes(4096);
+
+    let temp = TempDir::new().unwrap();
+    let mut archive = TarArchive::new(Cursor::new(bomb.to_owned()));
+    let result = archive.extract(
+        temp.path(),
+        &config,
+        &ExtractionOptions::default(),
+        &mut NoopProgress,
+    );
+    assert_is_budget_violation(&result);
+
+    let temp = TempDir::new().unwrap();
+    let path = write_tar_file(&temp, file_name, bomb);
+    assert_is_budget_violation(&exarch_core::list_archive(&path, &config));
+    assert_is_budget_violation(&exarch_core::verify_archive(&path, &config));
+    let out = temp.path().join("out");
+    assert_is_budget_violation(&exarch_core::extract_archive(&path, &out, &config));
+}
+
+#[test]
+fn s1_shape_pax_size_zero_override_hiding_a_bomb_is_still_rejected() {
+    assert_all_entry_points_reject(&s1_shape_bomb(8192), "s1.tar");
+}
+
+#[test]
+fn s2_shape_invalid_magic_pax_override_hiding_a_bomb_is_still_rejected() {
+    assert_all_entry_points_reject(&s2_shape_bomb(8192), "s2.tar");
+}
+
+#[test]
+fn s3_shape_pax_global_header_hiding_a_bomb_is_still_rejected() {
+    assert_all_entry_points_reject(&s3_shape_bomb(8192), "s3.tar");
+}
+
+#[test]
+fn legitimate_pax_global_header_does_not_false_positive() {
+    // A small, real PAX global header ('g') ahead of an ordinary file must
+    // not itself be mistaken for a bypass attempt or rejected.
+    let mut t = Vec::new();
+    let global_body = pax_record(b"comment", b"hi");
+    t.extend_from_slice(&header(
+        b"././@PaxHeader",
+        global_body.len() as u64,
+        b'g',
+        true,
+    ));
+    pad_to_block(&mut t, &global_body);
+    t.extend_from_slice(&header(b"file.txt", 5, b'0', true));
+    pad_to_block(&mut t, b"hello");
+    t.extend(std::iter::repeat_n(0u8, BLOCK * 2));
+
+    let temp = TempDir::new().unwrap();
+    let config = SecurityConfig::default().with_max_tar_metadata_bytes(4096);
+    let mut archive = TarArchive::new(Cursor::new(t));
+    let result = archive.extract(
+        temp.path(),
+        &config,
+        &ExtractionOptions::default(),
+        &mut NoopProgress,
+    );
+    let report = result.expect("a small legitimate PAX global header must not be rejected");
+    assert_eq!(report.files_extracted, 1);
+    assert!(temp.path().join("file.txt").exists());
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// C1 regression: GNU sparse `realsize` bomb on `verify` (issue #414 follow-up)
+//
+// A GNU old-format sparse entry ('S') can declare a `realsize` field (the
+// entry's *logical* size) far larger than its actual backing bytes — `tar`
+// materializes the shortfall as synthesized zero padding
+// (`EntryIo::Pad(io::repeat(0).take(gap))`), not real archive content. The
+// read-budget mechanism above never inspects this (headers are opaque to
+// it), so it cannot trip on an oversized *declared* size — it only bounds
+// bytes actually read while searching for the next entry. What must bound
+// the cost of an unread sparse entry's `Drop`-time drain is
+// `TarEntryGuard`'s synthesized-byte accounting (`SYNTHETIC_PAD_CAP_BYTES`):
+// output produced with no corresponding read from the underlying reader is
+// capped regardless of any caller-supplied quota.
+//
+// `verify_archive()`'s pre-listing pass (`listing_config_for_verify`)
+// legitimately relaxes `max_file_size` to `u64::MAX` so a metadata-only
+// listing does not false-reject large files. An earlier version of this fix
+// threaded that same relaxed quota straight into the drain bound, so a
+// sparse entry with an astronomical `realsize` turned `verify` into an
+// unbounded CPU sink with no corresponding heap growth (drained to
+// `io::sink`) — invisible to allocation-based tests, but a real wall-clock
+// hang scaling linearly with the attacker-chosen `realsize`.
+// ─────────────────────────────────────────────────────────────────────────
+
+/// Encodes `n` as a classic octal numeric field of `width` bytes (including
+/// the trailing NUL), or `None` if `n` does not fit in `width - 1` octal
+/// digits.
+fn octal_field(n: u64, width: usize) -> Option<Vec<u8>> {
+    let digits = format!("{n:o}").into_bytes();
+    if digits.len() > width - 1 {
+        return None;
+    }
+    let mut out = vec![b'0'; width - 1 - digits.len()];
+    out.extend_from_slice(&digits);
+    out.push(0);
+    Some(out)
+}
+
+/// Encodes `n` as a GNU base-256 numeric field: big-endian bytes with the
+/// high bit of the first byte set, used whenever a value is too large for
+/// the field's octal digit capacity (this is exactly how a GNU sparse
+/// entry's `realsize` reaches values up to `u64::MAX`).
+fn base256_field(n: u64, width: usize) -> Vec<u8> {
+    let mut out = vec![0u8; width];
+    let bytes = n.to_be_bytes();
+    out[width - bytes.len()..].copy_from_slice(&bytes);
+    out[0] |= 0x80;
+    out
+}
+
+fn num_field(n: u64, width: usize) -> Vec<u8> {
+    octal_field(n, width).unwrap_or_else(|| base256_field(n, width))
+}
+
+/// Builds a raw GNU old-format sparse header (typeflag `'S'`) declaring a
+/// `realsize` (logical size) that may vastly exceed `size_field` (the
+/// physical/allocated size backing it), with up to 4 inline sparse
+/// `(offset, numbytes)` blocks — mirroring the actual GNU tar on-disk layout
+/// (inline sparse array at byte offset 386, `isextended` at 482, `realsize`
+/// at 483).
+fn gnu_sparse_header(
+    name: &[u8],
+    size_field: u64,
+    realsize: u64,
+    blocks: &[(u64, u64)],
+) -> Vec<u8> {
+    let mut h = vec![0u8; BLOCK];
+    let name_len = name.len().min(100);
+    h[..name_len].copy_from_slice(&name[..name_len]);
+    h[100..108].copy_from_slice(&num_field(0o644, 8));
+    h[108..116].copy_from_slice(&num_field(0, 8));
+    h[116..124].copy_from_slice(&num_field(0, 8));
+    h[124..136].copy_from_slice(&num_field(size_field, 12));
+    h[136..148].copy_from_slice(&num_field(0, 12));
+    h[156] = b'S';
+    h[257..263].copy_from_slice(b"ustar ");
+    h[263..265].copy_from_slice(b" \0");
+    let mut off = 386;
+    for &(offset, numbytes) in blocks.iter().take(4) {
+        h[off..off + 12].copy_from_slice(&num_field(offset, 12));
+        h[off + 12..off + 24].copy_from_slice(&num_field(numbytes, 12));
+        off += 24;
+    }
+    h[482] = 0; // isextended: no additional sparse-header blocks follow
+    h[483..495].copy_from_slice(&num_field(realsize, 12));
+    h[148..156].copy_from_slice(b"        ");
+    let sum: u32 = h.iter().map(|b| u32::from(*b)).sum();
+    h[148..156].copy_from_slice(format!("{sum:06o}\0 ").as_bytes());
+    h
+}
+
+/// Builds a complete single-entry TAR whose one GNU sparse entry declares
+/// `realsize` logical bytes backed by exactly one physical block.
+fn sparse_realsize_bomb(realsize: u64) -> Vec<u8> {
+    let gap = realsize - BLOCK as u64;
+    let hdr = gnu_sparse_header(
+        b"sparsebomb.bin",
+        BLOCK as u64,
+        realsize,
+        &[(gap, BLOCK as u64)],
+    );
+    let mut out = hdr;
+    out.extend(std::iter::repeat_n(0u8, BLOCK)); // the one backing block
+    out.extend(std::iter::repeat_n(0u8, BLOCK * 2)); // end-of-archive trailer
+    out
+}
+
+/// Bound generous enough to never flake in CI, but far tighter than the
+/// multi-second-to-multi-hour hang the C1 bug produced (which scaled
+/// linearly with `realsize`, not with any constant like this one).
+const SPARSE_BOMB_WALL_CLOCK_BOUND: std::time::Duration = std::time::Duration::from_secs(2);
+
+#[test]
+fn verify_archive_stays_bounded_against_gnu_sparse_realsize_bomb() {
+    // `1 << 62`: far beyond any real filesystem, and far beyond the 500 MiB
+    // default `max_total_size` quota — chosen to prove wall-clock time does
+    // not scale with the claimed size at all, not merely to exceed a smaller
+    // threshold.
+    let bomb = sparse_realsize_bomb(1u64 << 62);
+    let temp = TempDir::new().unwrap();
+    let path = write_tar_file(&temp, "sparse_bomb.tar", &bomb);
+
+    let start = std::time::Instant::now();
+    let result = exarch_core::verify_archive(&path, &SecurityConfig::default());
+    let elapsed = start.elapsed();
+
+    assert!(
+        result.is_err(),
+        "a sparse entry claiming a multi-exabyte realsize must fail quota, not verify clean: \
+         {result:?}"
+    );
+    assert!(
+        elapsed < SPARSE_BOMB_WALL_CLOCK_BOUND,
+        "verify must not scale with the entry's claimed (unbacked) realsize, took {elapsed:?}"
+    );
+}
+
+#[test]
+fn list_and_extract_archive_also_stay_bounded_against_gnu_sparse_realsize_bomb() {
+    // Defense in depth (critic's Q2): the absolute drain cap applies to
+    // every path, not only `verify`, so a caller who legitimately raises
+    // `max_file_size` for `list`/`extract` does not reopen a smaller version
+    // of C1 either.
+    let bomb = sparse_realsize_bomb(1u64 << 62);
+    let config = SecurityConfig::default();
+
+    let temp = TempDir::new().unwrap();
+    let path = write_tar_file(&temp, "sparse_bomb.tar", &bomb);
+    let start = std::time::Instant::now();
+    let result = exarch_core::list_archive(&path, &config);
+    let elapsed = start.elapsed();
+    assert!(
+        result.is_err(),
+        "list must reject the sparse bomb: {result:?}"
+    );
+    assert!(
+        elapsed < SPARSE_BOMB_WALL_CLOCK_BOUND,
+        "list must not scale with the entry's claimed realsize, took {elapsed:?}"
+    );
+
+    let temp = TempDir::new().unwrap();
+    let path = write_tar_file(&temp, "sparse_bomb.tar", &bomb);
+    let out = temp.path().join("out");
+    let start = std::time::Instant::now();
+    let result = exarch_core::extract_archive(&path, &out, &config);
+    let elapsed = start.elapsed();
+    assert!(
+        result.is_err(),
+        "extract must reject the sparse bomb: {result:?}"
+    );
+    assert!(
+        elapsed < SPARSE_BOMB_WALL_CLOCK_BOUND,
+        "extract must not scale with the entry's claimed realsize, took {elapsed:?}"
+    );
+}
+
+#[test]
+fn known_limitation_legitimate_sparse_hole_above_the_synthetic_cap_is_rejected() {
+    // Pins the module's documented residual limitation (see
+    // `formats::tar_metadata_limit`'s module docs): a *legitimate* GNU
+    // sparse file whose real hole exceeds `SYNTHETIC_PAD_CAP_BYTES` is
+    // indistinguishable, by pure byte accounting, from the C1 attack shape
+    // when skipped unread on `list_archive`/`verify_archive` — both produce
+    // output with no corresponding read. This is a deliberately accepted
+    // trade-off (P3 follow-up tracked separately), not a bug: this test
+    // exists so a future change to `SYNTHETIC_PAD_CAP_BYTES` cannot silently
+    // move this threshold without a test noticing.
+    //
+    // `exarch_core::extract_archive` (the library function) is unaffected —
+    // it never calls `list_archive` itself, so this exact shape extracts
+    // cleanly through it. The `exarch` CLI's `extract` *command* runs its
+    // own separate `list_archive` pre-flight for progress-bar/conflict
+    // detection (`exarch-cli/src/commands/extract.rs`), so it IS affected;
+    // that CLI-specific behavior is pinned separately in
+    // `exarch-cli/tests/cli_tests.rs`, which can invoke the actual binary.
+    //
+    // Shape: a leading hole (bigger than the 8 MiB synthetic cap, so the drop's
+    // drain gives up while still inside the virtual hole, never touching
+    // the trailing real data) followed by a real trailing data segment
+    // (bigger than the default 4 MiB `max_tar_metadata_bytes`): with the
+    // drop having consumed zero real bytes, `tar`'s own catch-up skip to
+    // the next header — which runs *while the metadata budget is armed* —
+    // must consume the entire unread real segment itself, tripping the
+    // budget. A hole with a *small* trailing real segment, or one under the
+    // synthetic cap, does not reproduce this: physical stream position is
+    // untouched by virtual padding either way, so only a large real segment
+    // left entirely unread by the drop actually costs anything once `tar`
+    // catches up.
+    let gap = 12 * 1024 * 1024u64;
+    let real_trailing = 6 * 1024 * 1024u64;
+    let bomb_hdr = gnu_sparse_header(
+        b"legit_sparse.bin",
+        real_trailing,
+        gap + real_trailing,
+        &[(gap, real_trailing)],
+    );
+    let mut bomb = bomb_hdr;
+    pad_to_block(&mut bomb, &vec![b'D'; real_trailing as usize]);
+    bomb.extend(std::iter::repeat_n(0u8, BLOCK * 2));
+    let config = SecurityConfig::default();
+
+    let temp = TempDir::new().unwrap();
+    let path = write_tar_file(&temp, "legit_sparse_hole.tar", &bomb);
+    let result = exarch_core::list_archive(&path, &config);
+    assert!(
+        result.is_err(),
+        "known limitation: a legitimate sparse hole above the synthetic cap is currently \
+         rejected by list_archive, got: {result:?}"
+    );
+
+    let result = exarch_core::verify_archive(&path, &config);
+    assert!(
+        result.is_err(),
+        "known limitation: a legitimate sparse hole above the synthetic cap is currently \
+         rejected by verify_archive, got: {result:?}"
+    );
+
+    // `extract_archive` (library) never calls `list_archive` itself, so it
+    // reads the entry directly and is unaffected — confirming the
+    // limitation is specific to the metadata-only paths above, not to
+    // extraction in general.
+    let out = temp.path().join("out");
+    let report = exarch_core::extract_archive(&path, &out, &config).expect(
+        "extract_archive reads the entry itself (no list_archive pre-flight in the library \
+         function) and is not subject to this limitation",
+    );
+    assert_eq!(report.files_extracted, 1);
+
+    // A direct `TarArchive::extract` library call is unaffected for the
+    // same reason: the entry is actually read, not drained unread.
+    let mut archive = TarArchive::new(Cursor::new(bomb));
+    let report = archive
+        .extract(
+            temp.path().join("direct_out").as_path(),
+            &config,
+            &ExtractionOptions::default(),
+            &mut NoopProgress,
+        )
+        .expect(
+            "a direct TarArchive::extract call reads the entry itself and is not subject to \
+             this limitation",
+        );
+    assert_eq!(report.files_extracted, 1);
+}
+
+/// Builds a 3-entry TAR: a small allowed file, a large disallowed-extension
+/// file, then another small allowed file — used to prove skip-and-continue
+/// survives a legitimately large skipped entry.
+fn skip_and_continue_fixture(big_size: usize) -> Vec<u8> {
+    let mut builder = tar::Builder::new(Vec::new());
+
+    let mut h1 = tar::Header::new_gnu();
+    h1.set_size(5);
+    h1.set_mode(0o644);
+    h1.set_cksum();
+    builder
+        .append_data(&mut h1, "before.txt", &b"hello"[..])
+        .unwrap();
+
+    let mut h2 = tar::Header::new_gnu();
+    h2.set_size(big_size as u64);
+    h2.set_mode(0o644);
+    h2.set_cksum();
+    builder
+        .append_data(&mut h2, "big.bin", &vec![b'B'; big_size][..])
+        .unwrap();
+
+    let mut h3 = tar::Header::new_gnu();
+    h3.set_size(5);
+    h3.set_mode(0o644);
+    h3.set_cksum();
+    builder
+        .append_data(&mut h3, "after.txt", &b"world"[..])
+        .unwrap();
+
+    builder.into_inner().unwrap()
+}
+
+#[test]
+fn extract_fully_skips_a_legitimate_large_disallowed_extension_entry_and_continues() {
+    // Critic's explicit constraint on the C1/C2/C3 fixes: the drain
+    // mechanism must not break the (unrelated, pre-existing) "skip a
+    // disallowed-extension entry and continue extracting the rest"
+    // behavior. The extension filter runs before `validate_entry` (so a
+    // skipped entry is never charged against the size/count quota), which
+    // means this entry is skipped without ever being validated — the guard
+    // must still fully drain it on skip so the *next* entry's header is
+    // found correctly, regardless of size or whether quota validation ran.
+    // 45 MiB is chosen specifically
+    // because it is well above every fixed bound tried and rejected during
+    // this fix's history (4 MiB, 16 MiB, 20 MiB) — C3 found the previous
+    // version of this test (10 MiB) passed only because it stayed under
+    // those since-removed caps, certifying a behavior actually broken above
+    // ~20 MiB — while staying under the default `max_file_size` (50 MB) so
+    // the entry itself passes quota, isolating this test to the drain
+    // mechanism rather than an unrelated quota rejection.
+    let big_size = 45 * 1024 * 1024;
+    let data = skip_and_continue_fixture(big_size);
+    let temp = TempDir::new().unwrap();
+    let config = SecurityConfig::default().with_allowed_extensions(vec!["txt".to_string()]);
+
+    let mut archive = TarArchive::new(Cursor::new(data.clone()));
+    let result = archive.extract(
+        temp.path(),
+        &config,
+        &ExtractionOptions::default(),
+        &mut NoopProgress,
+    );
+
+    let report = result.expect(
+        "skipping a disallowed-extension entry within quota must not corrupt subsequent header \
+         search",
+    );
+    assert_eq!(report.files_extracted, 2, "before.txt and after.txt");
+    assert_eq!(report.files_skipped, 1, "big.bin skipped for its extension");
+    assert!(temp.path().join("before.txt").exists());
+    assert!(temp.path().join("after.txt").exists());
+    assert!(!temp.path().join("big.bin").exists());
+
+    // Also check the public `extract_archive` API (a thin wrapper distinct
+    // from `TarArchive::extract` above, though it does not run a
+    // `list_archive` pre-flight itself — only the `exarch` CLI's own
+    // `extract` command does, in `exarch-cli/src/commands/extract.rs`).
+    let path = write_tar_file(&temp, "skip_and_continue.tar", &data);
+    let out = temp.path().join("out2");
+    let report = exarch_core::extract_archive(&path, &out, &config)
+        .expect("extract_archive must not reject this archive");
+    assert_eq!(report.files_extracted, 2);
+    assert_eq!(report.files_skipped, 1);
+}
+
+#[test]
+fn list_and_verify_accept_a_single_legitimate_entry_at_every_size_that_broke_c2() {
+    // C2 regression: any fixed cap on total drained output false-rejects
+    // ordinary archives once a single entry exceeds it. The critic's live
+    // repro found the exact threshold at 8 MiB (`max_tar_metadata_bytes`
+    // doubled, since one entry both trips the metadata budget on the next
+    // header search AND drains up to the same value): 3/6 MiB entries
+    // listed fine, 9/12/30 MiB entries were all incorrectly rejected. Re-run
+    // that exact table (plus 45 MiB, matching the skip-and-continue test
+    // above, and staying under the default 50 MB `max_file_size` quota so
+    // this isolates the drain mechanism from an unrelated quota rejection)
+    // against `list`/`verify`/`extract`, none crafted — a plain single-entry
+    // archive, nothing sparse or malformed.
+    for size_mib in [3, 6, 9, 12, 30, 45] {
+        let size = size_mib * 1024 * 1024;
+        let mut builder = tar::Builder::new(Vec::new());
+        let mut h = tar::Header::new_gnu();
+        h.set_size(size as u64);
+        h.set_mode(0o644);
+        h.set_cksum();
+        builder
+            .append_data(&mut h, "legit.bin", &vec![b'L'; size][..])
+            .unwrap();
+        let data = builder.into_inner().unwrap();
+
+        let temp = TempDir::new().unwrap();
+        let path = write_tar_file(&temp, "legit.tar", &data);
+        let config = SecurityConfig::default();
+
+        let manifest = exarch_core::list_archive(&path, &config).unwrap_or_else(|e| {
+            panic!("list_archive rejected a legitimate {size_mib} MiB entry: {e}")
+        });
+        assert_eq!(manifest.total_entries, 1);
+
+        let report = exarch_core::verify_archive(&path, &config).unwrap_or_else(|e| {
+            panic!("verify_archive rejected a legitimate {size_mib} MiB entry: {e}")
+        });
+        assert_eq!(
+            report.status,
+            exarch_core::VerificationStatus::Pass,
+            "verify_archive reported issues for a legitimate {size_mib} MiB entry: {:?}",
+            report.issues
+        );
+
+        let out = temp.path().join("out");
+        let extract_report =
+            exarch_core::extract_archive(&path, &out, &config).unwrap_or_else(|e| {
+                panic!("extract_archive rejected a legitimate {size_mib} MiB entry: {e}")
+            });
+        assert_eq!(extract_report.files_extracted, 1);
+    }
+}
+
+#[test]
+fn budget_violation_is_not_confused_with_other_archive_errors() {
+    // Sanity check on the assertion helper itself: an ordinary corrupt
+    // archive (not a budget trip) must not be misclassified.
+    let garbage = vec![1u8, 2, 3, 4, 5];
+    let temp = TempDir::new().unwrap();
+    let mut archive = TarArchive::new(Cursor::new(garbage));
+    let result = archive.extract(
+        temp.path(),
+        &SecurityConfig::default(),
+        &ExtractionOptions::default(),
+        &mut NoopProgress,
+    );
+    assert!(
+        !matches!(result, Err(ArchiveError::SecurityViolation { .. })),
+        "a truncated/corrupt archive must not surface as a budget SecurityViolation, got: {result:?}"
+    );
+}

--- a/crates/exarch-core/tests/security/tar_metadata_bomb.rs
+++ b/crates/exarch-core/tests/security/tar_metadata_bomb.rs
@@ -772,14 +772,11 @@ fn extract_fully_skips_a_legitimate_large_disallowed_extension_entry_and_continu
     // means this entry is skipped without ever being validated — the guard
     // must still fully drain it on skip so the *next* entry's header is
     // found correctly, regardless of size or whether quota validation ran.
-    // 45 MiB is chosen specifically
-    // because it is well above every fixed bound tried and rejected during
-    // this fix's history (4 MiB, 16 MiB, 20 MiB) — C3 found the previous
-    // version of this test (10 MiB) passed only because it stayed under
-    // those since-removed caps, certifying a behavior actually broken above
-    // ~20 MiB — while staying under the default `max_file_size` (50 MB) so
-    // the entry itself passes quota, isolating this test to the drain
-    // mechanism rather than an unrelated quota rejection.
+    // 45 MiB is chosen specifically because it is well above every fixed
+    // bound tried and rejected during this fix's history (4 MiB, 16 MiB,
+    // 20 MiB) — C3 found the previous version of this test (10 MiB) passed
+    // only because it stayed under those since-removed caps, certifying a
+    // behavior actually broken above ~20 MiB.
     let big_size = 45 * 1024 * 1024;
     let data = skip_and_continue_fixture(big_size);
     let temp = TempDir::new().unwrap();

--- a/crates/exarch-core/tests/tar_alloc_bound.rs
+++ b/crates/exarch-core/tests/tar_alloc_bound.rs
@@ -1,0 +1,532 @@
+//! Allocation-bound regression test for issue #414 (TAR metadata
+//! decompression bomb) and its historical S1/S2/S3 shadow-parser bypasses.
+//!
+//! This is the test that actually measures the risk the redesigned
+//! `formats::tar_metadata_limit` read-budget mechanism closes: not just "is
+//! the right error returned" (see `tests/security/tar_metadata_bomb.rs`) but
+//! "does peak heap usage stay bounded regardless of what the archive
+//! contains". A `dhat` counting allocator records real peak live bytes across
+//! the three historical `PoC` shapes and a batch of randomly generated
+//! adversarial archives (random typeflags, random declared sizes up to 4 GiB,
+//! valid/invalid/absent magic, random PAX bodies with and without `size=`),
+//! each backed by a small repeating-byte reader so any declared size is
+//! trivially "satisfiable" without actually allocating gigabytes on disk or
+//! in memory ahead of time.
+//!
+//! Must be its own top-level integration test binary, not nested under
+//! `tests/security/`: `#[global_allocator]` applies process-wide (it would
+//! change allocator behavior for every other test sharing a binary with it),
+//! and `dhat` allows only one `Profiler` alive at a time, so every case here
+//! runs sequentially (`Profiler` created and dropped per case) inside a
+//! single `#[test]` function rather than relying on nextest's usual
+//! process-per-test isolation.
+
+#![allow(clippy::unwrap_used, clippy::cast_possible_truncation)]
+
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
+use exarch_core::ExtractionOptions;
+use exarch_core::NoopProgress;
+use exarch_core::SecurityConfig;
+use exarch_core::formats::ArchiveFormat;
+use exarch_core::formats::TarArchive;
+use proptest::prelude::*;
+use proptest::strategy::ValueTree;
+use proptest::test_runner::TestRunner;
+use std::io::Cursor;
+use std::io::Read;
+use std::io::Write;
+
+const BLOCK: usize = 512;
+
+/// A ceiling generous relative to the small budgets used below (a few KB to
+/// a few hundred KB): if peak usage ever approaches this, something is
+/// scaling with a declared/attacker-controlled size again, not with the
+/// configured budget.
+const PEAK_BYTES_CEILING: usize = 32 * 1024 * 1024;
+
+fn header(name: &[u8], size: u64, typeflag: u8, magic: Magic) -> Vec<u8> {
+    let mut h = vec![0u8; BLOCK];
+    let name_len = name.len().min(100);
+    h[..name_len].copy_from_slice(&name[..name_len]);
+    h[100..108].copy_from_slice(b"0000644\0");
+    h[108..116].copy_from_slice(b"0000000\0");
+    h[116..124].copy_from_slice(b"0000000\0");
+    h[124..136].copy_from_slice(format!("{size:011o}\0").as_bytes());
+    h[136..148].copy_from_slice(b"00000000000\0");
+    h[156] = typeflag;
+    match magic {
+        Magic::Gnu => {
+            h[257..263].copy_from_slice(b"ustar ");
+            h[263..265].copy_from_slice(b" \0");
+        }
+        Magic::Ustar => {
+            h[257..263].copy_from_slice(b"ustar\0");
+            h[263..265].copy_from_slice(b"00");
+        }
+        Magic::Invalid => {} // left zeroed
+    }
+    h[148..156].copy_from_slice(b"        ");
+    let sum: u32 = h.iter().map(|b| u32::from(*b)).sum();
+    h[148..156].copy_from_slice(format!("{sum:06o}\0 ").as_bytes());
+    h
+}
+
+fn pad_to_block(out: &mut Vec<u8>, data: &[u8]) {
+    out.extend_from_slice(data);
+    let rem = data.len() % BLOCK;
+    if rem != 0 {
+        out.extend(std::iter::repeat_n(0u8, BLOCK - rem));
+    }
+}
+
+fn pax_record(key: &[u8], value: &[u8]) -> Vec<u8> {
+    let base = key.len() + value.len() + 3;
+    let mut len = base + 1;
+    loop {
+        let candidate_len = len.to_string().len() + base;
+        if candidate_len == len {
+            break;
+        }
+        len = candidate_len;
+    }
+    let mut record = format!("{len} ").into_bytes();
+    record.extend_from_slice(key);
+    record.push(b'=');
+    record.extend_from_slice(value);
+    record.push(b'\n');
+    record
+}
+
+#[derive(Clone, Copy)]
+enum Magic {
+    Gnu,
+    Ustar,
+    Invalid,
+}
+
+/// Encodes `n` as a classic octal numeric field of `width` bytes (including
+/// the trailing NUL), or `None` if it does not fit in `width - 1` digits.
+fn octal_field(n: u64, width: usize) -> Option<Vec<u8>> {
+    let digits = format!("{n:o}").into_bytes();
+    if digits.len() > width - 1 {
+        return None;
+    }
+    let mut out = vec![b'0'; width - 1 - digits.len()];
+    out.extend_from_slice(&digits);
+    out.push(0);
+    Some(out)
+}
+
+/// Encodes `n` as a GNU base-256 numeric field (big-endian, high bit of the
+/// first byte set) — how a GNU sparse entry's `realsize` reaches values
+/// beyond octal's digit capacity, up to `u64::MAX`.
+fn base256_field(n: u64, width: usize) -> Vec<u8> {
+    let mut out = vec![0u8; width];
+    let bytes = n.to_be_bytes();
+    out[width - bytes.len()..].copy_from_slice(&bytes);
+    out[0] |= 0x80;
+    out
+}
+
+fn num_field(n: u64, width: usize) -> Vec<u8> {
+    octal_field(n, width).unwrap_or_else(|| base256_field(n, width))
+}
+
+/// Builds a raw GNU old-format sparse header (typeflag `'S'`) with real,
+/// non-empty sparse fields: an inline `(offset, numbytes)` block at byte
+/// offset 386 and a `realsize` at offset 483 that may vastly exceed
+/// `size_field` (the physical/allocated size). Without genuine sparse
+/// fields, `tar`'s `GnuSparseHeader::is_empty()` (`offset[0] == 0`) treats
+/// the entry as non-sparse and never materializes the zero-padding this
+/// module exists to bound — this is what the plain `header()` builder above
+/// produces for typeflag `'S'`, which is why the random generator below
+/// previously never exercised the padding path at all.
+fn gnu_sparse_header(name: &[u8], size_field: u64, realsize: u64, gap: u64) -> Vec<u8> {
+    let mut h = vec![0u8; BLOCK];
+    let name_len = name.len().min(100);
+    h[..name_len].copy_from_slice(&name[..name_len]);
+    h[100..108].copy_from_slice(&num_field(0o644, 8));
+    h[108..116].copy_from_slice(&num_field(0, 8));
+    h[116..124].copy_from_slice(&num_field(0, 8));
+    h[124..136].copy_from_slice(&num_field(size_field, 12));
+    h[136..148].copy_from_slice(&num_field(0, 12));
+    h[156] = b'S';
+    h[257..263].copy_from_slice(b"ustar ");
+    h[263..265].copy_from_slice(b" \0");
+    // One inline sparse block: `gap` bytes of synthesized zeros followed by
+    // `size_field` bytes of real backing data.
+    h[386..398].copy_from_slice(&num_field(gap, 12));
+    h[398..410].copy_from_slice(&num_field(size_field, 12));
+    h[482] = 0; // isextended: no further sparse-header blocks follow
+    h[483..495].copy_from_slice(&num_field(realsize, 12));
+    h[148..156].copy_from_slice(b"        ");
+    let sum: u32 = h.iter().map(|b| u32::from(*b)).sum();
+    h[148..156].copy_from_slice(format!("{sum:06o}\0 ").as_bytes());
+    h
+}
+
+/// Runs `bytes` through `TarArchive::extract` inside a fresh, scoped `dhat`
+/// testing profiler and returns the peak live heap bytes observed. The
+/// profiler is created and dropped entirely within this call so callers can
+/// invoke it repeatedly (dhat permits only one profiler alive at a time, not
+/// one per process).
+fn measure_extract_peak_bytes(bytes: &[u8], budget: u64) -> usize {
+    let profiler = dhat::Profiler::builder().testing().build();
+    {
+        let temp = tempfile::tempdir().unwrap();
+        let config = SecurityConfig::default().with_max_tar_metadata_bytes(budget);
+        let mut archive = TarArchive::new(Cursor::new(bytes));
+        // Outcome (Ok or Err) is irrelevant here — only peak memory matters.
+        let _ = archive.extract(
+            temp.path(),
+            &config,
+            &ExtractionOptions::default(),
+            &mut NoopProgress,
+        );
+    }
+    let stats = dhat::HeapStats::get();
+    drop(profiler);
+    stats.max_bytes
+}
+
+/// Writes `bytes` to a temp file and runs `list_archive` inside a fresh
+/// scoped `dhat` profiler, returning peak live heap bytes.
+///
+/// `list`/`verify` open `tar::Archive` directly (`inspection::list`), a
+/// separate code path from `TarArchive::extract` above — the C1 finding was
+/// specifically that this path's drain bound could be silently unbounded
+/// while `extract`'s stayed bounded, so it needs its own measurement, not an
+/// assumption that `extract`'s result generalizes.
+fn measure_list_peak_bytes(bytes: &[u8], budget: u64) -> usize {
+    let profiler = dhat::Profiler::builder().testing().build();
+    {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("archive.tar");
+        std::fs::File::create(&path)
+            .unwrap()
+            .write_all(bytes)
+            .unwrap();
+        let config = SecurityConfig::default().with_max_tar_metadata_bytes(budget);
+        let _ = exarch_core::list_archive(&path, &config);
+    }
+    let stats = dhat::HeapStats::get();
+    drop(profiler);
+    stats.max_bytes
+}
+
+/// As [`measure_list_peak_bytes`], but through `verify_archive` — the path
+/// C1 actually broke, since its internal pre-listing pass
+/// (`listing_config_for_verify`) relaxes `max_file_size` to `u64::MAX`.
+fn measure_verify_peak_bytes(bytes: &[u8], budget: u64) -> usize {
+    let profiler = dhat::Profiler::builder().testing().build();
+    {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("archive.tar");
+        std::fs::File::create(&path)
+            .unwrap()
+            .write_all(bytes)
+            .unwrap();
+        let config = SecurityConfig::default().with_max_tar_metadata_bytes(budget);
+        let _ = exarch_core::verify_archive(&path, &config);
+    }
+    let stats = dhat::HeapStats::get();
+    drop(profiler);
+    stats.max_bytes
+}
+
+/// S1 historical shape: PAX `size=0` override, decoy, oversized GNU longname.
+fn s1_shape(bomb_real_bytes: usize) -> Vec<u8> {
+    let mut out = Vec::new();
+    let pax_body = b"9 size=0\n".to_vec();
+    out.extend_from_slice(&header(
+        b"PaxHeaders/decoy",
+        pax_body.len() as u64,
+        b'x',
+        Magic::Ustar,
+    ));
+    pad_to_block(&mut out, &pax_body);
+    out.extend_from_slice(&header(b"decoy.txt", 4096, b'0', Magic::Gnu));
+    out.extend_from_slice(&header(
+        b"././@LongLink",
+        bomb_real_bytes as u64,
+        b'L',
+        Magic::Gnu,
+    ));
+    pad_to_block(&mut out, &vec![b'A'; bomb_real_bytes]);
+    out
+}
+
+/// S2 historical shape: invalid-magic PAX override, decoy, oversized bomb.
+fn s2_shape(bomb_real_bytes: usize) -> Vec<u8> {
+    let mut out = Vec::new();
+    let pax_body = pax_record(b"size", b"0");
+    out.extend_from_slice(&header(
+        b"PaxHeaders/decoy",
+        pax_body.len() as u64,
+        b'x',
+        Magic::Invalid,
+    ));
+    pad_to_block(&mut out, &pax_body);
+    out.extend_from_slice(&header(b"decoy.txt", 512, b'0', Magic::Gnu));
+    pad_to_block(&mut out, &vec![b'D'; 512]);
+    out.extend_from_slice(&header(
+        b"././@LongLink",
+        bomb_real_bytes as u64,
+        b'L',
+        Magic::Gnu,
+    ));
+    pad_to_block(&mut out, &vec![b'A'; bomb_real_bytes]);
+    out
+}
+
+/// S3 historical shape: PAX override, PAX global header, decoy, oversized bomb.
+fn s3_shape(bomb_real_bytes: usize) -> Vec<u8> {
+    let mut out = Vec::new();
+    let pax_body = pax_record(b"size", b"0");
+    out.extend_from_slice(&header(
+        b"PaxHeaders/decoy",
+        pax_body.len() as u64,
+        b'x',
+        Magic::Ustar,
+    ));
+    pad_to_block(&mut out, &pax_body);
+    let global_body = pax_record(b"comment", b"hi");
+    out.extend_from_slice(&header(
+        b"././@PaxHeader",
+        global_body.len() as u64,
+        b'g',
+        Magic::Gnu,
+    ));
+    pad_to_block(&mut out, &global_body);
+    out.extend_from_slice(&header(b"decoy.txt", 4096, b'0', Magic::Gnu));
+    pad_to_block(&mut out, &vec![b'D'; 4096]);
+    out.extend_from_slice(&header(
+        b"././@LongLink",
+        bomb_real_bytes as u64,
+        b'L',
+        Magic::Gnu,
+    ));
+    pad_to_block(&mut out, &vec![b'A'; bomb_real_bytes]);
+    out
+}
+
+/// One randomly generated "step": a header of a random typeflag, magic
+/// validity, and declared size, backed by a real (repeating-byte, so no
+/// upfront allocation of the full declared size is needed to build the
+/// fixture) payload whose *real* length may itself disagree with the
+/// declared size — this is deliberately allowed to construct malformed
+/// archives, since the property under test is "peak memory stays bounded no
+/// matter what", not "the archive is well-formed".
+#[derive(Debug, Clone)]
+struct RandomStep {
+    typeflag: u8,
+    magic: u8, // 0 = gnu, 1 = ustar, 2 = invalid
+    declared_size: u64,
+    real_bytes: usize,
+    /// Only meaningful when `typeflag == b'S'`: the GNU sparse `realsize` to
+    /// declare, independent of (and possibly vastly exceeding) the physical
+    /// backing bytes — the C1 attack shape. Drawn from the full `u64` range
+    /// so the corpus also covers values only reachable via base-256 encoding.
+    sparse_realsize: u64,
+}
+
+fn random_step_strategy() -> impl Strategy<Value = RandomStep> {
+    (
+        prop::sample::select(vec![b'L', b'K', b'x', b'g', b'0', b'S', b'5']),
+        0u8..3,
+        0u64..(4u64 * 1024 * 1024 * 1024),
+        0usize..8192,
+        any::<u64>(),
+    )
+        .prop_map(
+            |(typeflag, magic, declared_size, real_bytes, sparse_realsize)| RandomStep {
+                typeflag,
+                magic,
+                declared_size,
+                real_bytes,
+                sparse_realsize,
+            },
+        )
+}
+
+fn magic_from_u8(m: u8) -> Magic {
+    match m {
+        0 => Magic::Gnu,
+        1 => Magic::Ustar,
+        _ => Magic::Invalid,
+    }
+}
+
+/// Builds an archive from a sequence of `RandomStep`s: each step is a header
+/// (whatever typeflag/magic/declared size the generator picked) followed by
+/// `real_bytes` of real, repeating-byte content — never the declared size
+/// itself, so building the fixture stays cheap even when `declared_size`
+/// is huge.
+fn build_from_steps(steps: &[RandomStep]) -> Vec<u8> {
+    let mut out = Vec::new();
+    for (i, step) in steps.iter().enumerate() {
+        let name = format!("entry-{i}");
+        if step.typeflag == b'S' {
+            // Real GNU sparse fields, not just typeflag `'S'` with an empty
+            // sparse header (which `GnuSparseHeader::is_empty()` treats as
+            // non-sparse, skipping the zero-padding path entirely — the gap
+            // that let the corpus previously miss C1 even though it included
+            // typeflag `'S'` steps).
+            let size_field = step.real_bytes as u64;
+            let gap = step.sparse_realsize.saturating_sub(size_field);
+            out.extend_from_slice(&gnu_sparse_header(
+                name.as_bytes(),
+                size_field,
+                step.sparse_realsize,
+                gap,
+            ));
+        } else {
+            out.extend_from_slice(&header(
+                name.as_bytes(),
+                step.declared_size,
+                step.typeflag,
+                magic_from_u8(step.magic),
+            ));
+        }
+        pad_to_block(&mut out, &vec![b'A'; step.real_bytes]);
+    }
+    out
+}
+
+/// Everything runs inside this single `#[test]` function, per-case profilers
+/// created and dropped sequentially. `dhat` allows only one profiler alive at
+/// a time; under `cargo test`'s default in-process, multi-threaded harness
+/// (as opposed to nextest's process-per-test isolation, which this crate
+/// otherwise relies on), two `#[test]` functions each creating a profiler can
+/// run concurrently and panic on that constraint — merging into one function
+/// makes the ordering (and therefore the profiler lifetime) explicit instead
+/// of dependent on which test harness happens to run this binary.
+#[test]
+fn tar_metadata_bomb_allocations_stay_bounded() {
+    // Sanity check the measurement harness itself first: a false "pass"
+    // below must not be mistaken for "the mechanism truly bounds memory"
+    // when it might just be "the harness never measures anything real".
+    // Deliberately allocate well past the ceiling and confirm it is caught.
+    {
+        let profiler = dhat::Profiler::builder().testing().build();
+        {
+            let mut sink = vec![0u8; PEAK_BYTES_CEILING + 1024 * 1024];
+            let mut reader = Cursor::new(&mut sink);
+            let mut discard = [0u8; 1];
+            let _ = reader.read(&mut discard);
+        }
+        let stats = dhat::HeapStats::get();
+        drop(profiler);
+        assert!(
+            stats.max_bytes > PEAK_BYTES_CEILING,
+            "harness failed to detect a deliberate over-ceiling allocation: {}",
+            stats.max_bytes
+        );
+    }
+
+    // Historical shapes at a scale that would have measured in the hundreds
+    // of MB to low GB range on the pre-redesign shadow parser (the original
+    // PoCs reached 3.3 GB / 608 MB on a few hundred KB of archive bytes).
+    // Measured through all three entry points: C1 (issue #414 follow-up)
+    // showed `extract` staying bounded is not evidence `list`/`verify` do,
+    // since they open `tar::Archive` via a separate code path
+    // (`inspection::list`) with its own drain-bound wiring.
+    for (label, bytes) in [
+        ("S1", s1_shape(64 * 1024)),
+        ("S2", s2_shape(64 * 1024)),
+        ("S3", s3_shape(64 * 1024)),
+    ] {
+        let peak = measure_extract_peak_bytes(&bytes, 4096);
+        assert!(
+            peak < PEAK_BYTES_CEILING,
+            "{label} shape (extract): peak {peak} bytes exceeded the {PEAK_BYTES_CEILING}-byte \
+             ceiling"
+        );
+        let peak = measure_list_peak_bytes(&bytes, 4096);
+        assert!(
+            peak < PEAK_BYTES_CEILING,
+            "{label} shape (list): peak {peak} bytes exceeded the {PEAK_BYTES_CEILING}-byte \
+             ceiling"
+        );
+        let peak = measure_verify_peak_bytes(&bytes, 4096);
+        assert!(
+            peak < PEAK_BYTES_CEILING,
+            "{label} shape (verify): peak {peak} bytes exceeded the {PEAK_BYTES_CEILING}-byte \
+             ceiling"
+        );
+    }
+
+    // C1 regression: a real GNU sparse entry declaring a `realsize` far
+    // beyond its one-block physical backing, run through all three entry
+    // points. `verify` is the path C1 actually broke (its internal
+    // `listing_config_for_verify` relaxes `max_file_size` to `u64::MAX`,
+    // which used to flow straight into the drop-time drain bound) — heap
+    // stays flat here regardless since the drain writes to `io::sink`, so
+    // this is a complementary check to the wall-clock assertions in
+    // `tests/security/tar_metadata_bomb.rs`, not a replacement for them.
+    {
+        let realsize = 1u64 << 62;
+        let bytes = gnu_sparse_header(
+            b"sparsebomb.bin",
+            BLOCK as u64,
+            realsize,
+            realsize - BLOCK as u64,
+        );
+        let mut archive_bytes = bytes;
+        archive_bytes.extend(std::iter::repeat_n(0u8, BLOCK)); // the one backing block
+        archive_bytes.extend(std::iter::repeat_n(0u8, BLOCK * 2)); // end-of-archive trailer
+
+        for (label, peak) in [
+            ("extract", measure_extract_peak_bytes(&archive_bytes, 4096)),
+            ("list", measure_list_peak_bytes(&archive_bytes, 4096)),
+            ("verify", measure_verify_peak_bytes(&archive_bytes, 4096)),
+        ] {
+            assert!(
+                peak < PEAK_BYTES_CEILING,
+                "GNU sparse realsize bomb ({label}): peak {peak} bytes exceeded the \
+                 {PEAK_BYTES_CEILING}-byte ceiling"
+            );
+        }
+    }
+
+    // Randomly generated adversarial archives: random typeflags, magic
+    // validity, and declared sizes up to 4 GiB (including real GNU sparse
+    // fields for typeflag 'S', with `realsize` drawn from the full `u64`
+    // range), each backed by a small real (repeating-byte) payload. No case
+    // should come anywhere near the ceiling regardless of what combination
+    // of fields it picks or which entry point processes it, proving the
+    // budget mechanism's bound does not depend on any parsed header field.
+    // `TestRunner` is driven manually (not via the `proptest!` macro) so
+    // each generated case can be measured under its own scoped `dhat`
+    // profiler; `Config::cases` (the macro's own case count) does not apply
+    // here — the loop below controls the case count directly.
+    let mut runner = TestRunner::default();
+    let strategy = prop::collection::vec(random_step_strategy(), 1..12);
+
+    for _ in 0..100 {
+        let tree = strategy.new_tree(&mut runner).unwrap();
+        let steps = tree.current();
+        let bytes = build_from_steps(&steps);
+
+        let peak = measure_extract_peak_bytes(&bytes, 8192);
+        assert!(
+            peak < PEAK_BYTES_CEILING,
+            "random archive (steps: {steps:?}, extract): peak {peak} bytes exceeded the \
+             {PEAK_BYTES_CEILING}-byte ceiling"
+        );
+        let peak = measure_list_peak_bytes(&bytes, 8192);
+        assert!(
+            peak < PEAK_BYTES_CEILING,
+            "random archive (steps: {steps:?}, list): peak {peak} bytes exceeded the \
+             {PEAK_BYTES_CEILING}-byte ceiling"
+        );
+        let peak = measure_verify_peak_bytes(&bytes, 8192);
+        assert!(
+            peak < PEAK_BYTES_CEILING,
+            "random archive (steps: {steps:?}, verify): peak {peak} bytes exceeded the \
+             {PEAK_BYTES_CEILING}-byte ceiling"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds regression test coverage locking in exarch-core's existing protection against the node-tar GHSA classes mapped in issue #399 (PAX/GNU long-name/long-link record smuggling, NUL-byte handling in PAX/GNU fields, declared-vs-actual entry size mismatches).
- While live-verifying those, found the TAR pipeline had no bound on GNU long-name/long-link/PAX metadata records: the `tar` crate buffers them fully into memory before exarch-core's quota tracker ever runs, letting a small crafted archive force multi-gigabyte allocation (issue #414).
- Fixes #414 with a read-budget mechanism (`formats::tar_metadata_limit`) that meters bytes the `tar` crate reads while searching for the next entry, bounded by *synthesized* (unread) bytes rather than total drained output, so legitimate large entries are never falsely rejected. Applied uniformly across `extract_archive`, `list_archive`, and `verify_archive`.

An initial version of this fix re-parsed TAR headers in a shadow parser; three rounds of adversarial review each found a fresh divergence between that parser's belief about entry framing and the real `tar` crate's. The shipped mechanism replaces the shadow parser entirely with a framing-independent byte-count budget, so there is exactly one parser and nothing left to diverge from it. Full history of the design iteration is in CHANGELOG.md's `[Unreleased]` Security entry.

Two narrow follow-ups were filed separately rather than bundled into this PR:
- #415 (P3): symlink/hardlink targets aren't validated for NUL bytes/emptiness the way paths are.
- #422 (P3): an extension-allowlist config combined with many small skipped GNU sparse entries has no *cumulative* drain bound (each entry is individually bounded, but nothing caps the sum across thousands of skipped entries).

Closes #399
Closes #414

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` (1017/1017 passed)
- [x] `cargo test --doc --workspace --all-features --exclude exarch-python --exclude exarch-node` (100/100 passed)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace`
- [x] New regression tests: `tests/security/tar_ghsa_2026.rs` (13 GHSA lock-in cases), `tests/security/tar_metadata_bomb.rs` (metadata-budget + synthesized-drain cases across extract/list/verify/CLI), `tests/security/tar_budget_parity.rs` (proptest guarding the design's one real assumption about `tar`'s iterator behavior), `tests/tar_alloc_bound.rs` (dhat-based peak-memory bound across historical PoCs plus ~100 adversarial proptest archives)
- [x] Live-verified against all historical crafted PoCs (765 KB / 3 GiB / 512 MiB / 510 KB / 113-byte shapes) on the release CLI, confirming each now rejects promptly instead of exhausting memory or hanging