### PR TITLE
fix(core): validate symlink/hardlink targets for NUL bytes and emptiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   non-configurable cap almost immediately regardless of the declared `realsize`. This closes both
   directions of the bug from one mechanism, without ever inspecting a header field to tell the two
   cases apart.
+- **Symlink/hardlink targets were not validated for embedded NUL bytes or emptiness (#415)**:
+  the link path was already checked for NUL bytes and emptiness via `SafePath::validate`, but
+  the target (linkname) was not — a NUL byte in the target fell through to the OS as a raw
+  `io::Error` instead of a structured `SecurityViolation`, an empty target was silently accepted
+  (creating a dangling symlink on platforms that allow it), and a NUL-containing hardlink target
+  could be embedded verbatim into a formatted error message further downstream. `SafeSymlink::validate`
+  and `HardlinkTracker::validate_hardlink` now apply the same NUL-byte and emptiness checks to
+  the target as the link path (`types::safe_path::has_null_bytes` made `pub(crate)` for reuse),
+  without ever embedding the raw target bytes into an error message. A short (<=100 byte)
+  linkname written through the `tar` crate's own header field cannot carry an embedded NUL byte
+  or reach an empty value while non-`None`, so the regression tests use a GNU `LongLink` (`K`)
+  record's raw payload to smuggle both past the header-field-level shortcuts, exercising the
+  same path a real crafted archive would take.
 - Bumped `sevenz-rust2` from 0.21.3 to 0.21.4, fixing an integer overflow when summing
   attacker-controlled coder stream counts while parsing a 7z block header (upstream #127).
   Malformed archives previously could panic in debug builds and bypassed the stream-count

--- a/crates/exarch-core/src/security/hardlink.rs
+++ b/crates/exarch-core/src/security/hardlink.rs
@@ -81,7 +81,8 @@ impl HardlinkTracker {
     ///
     /// Returns an error if:
     /// - Hardlinks are not allowed in configuration
-    /// - Target is an absolute path
+    /// - Target is empty or contains NUL bytes
+    /// - Target is an absolute path (including Windows drive/UNC prefixes)
     /// - Target would escape the destination directory
     ///
     /// # Examples
@@ -119,6 +120,25 @@ impl HardlinkTracker {
         if !config.allowed.hardlinks {
             return Err(ArchiveError::SecurityViolation {
                 reason: "hardlinks not allowed".into(),
+            });
+        }
+
+        // Reject empty targets: they do not point anywhere.
+        if target.as_os_str().is_empty() {
+            return Err(ArchiveError::SecurityViolation {
+                reason: "hardlink target is empty".into(),
+            });
+        }
+
+        // Reject null bytes in the target before any error message can be
+        // built from it. Without this check, a NUL byte either falls
+        // through to the OS as a raw `io::Error`, or gets embedded verbatim
+        // into a formatted `InvalidArchive` message further downstream (e.g.
+        // "hardlink target does not exist: {target}"). The message here
+        // intentionally omits the raw target bytes.
+        if crate::types::safe_path::has_null_bytes(target) {
+            return Err(ArchiveError::SecurityViolation {
+                reason: "hardlink target contains null bytes".into(),
             });
         }
 

--- a/crates/exarch-core/src/types/safe_path.rs
+++ b/crates/exarch-core/src/types/safe_path.rs
@@ -354,14 +354,14 @@ fn paths_start_with(path: &Path, base: &Path) -> bool {
 
 /// Checks if a path contains null bytes.
 #[cfg(unix)]
-fn has_null_bytes(path: &Path) -> bool {
+pub(crate) fn has_null_bytes(path: &Path) -> bool {
     use std::os::unix::ffi::OsStrExt;
     path.as_os_str().as_bytes().contains(&b'\0')
 }
 
 /// Checks if a path contains null bytes.
 #[cfg(not(unix))]
-fn has_null_bytes(path: &Path) -> bool {
+pub(crate) fn has_null_bytes(path: &Path) -> bool {
     path.to_str().is_none_or(|s| s.contains('\0'))
 }
 

--- a/crates/exarch-core/src/types/safe_symlink.rs
+++ b/crates/exarch-core/src/types/safe_symlink.rs
@@ -60,15 +60,24 @@ impl SafeSymlink {
     /// # Validation Steps
     ///
     /// 1. Verify symlinks are allowed in the security configuration
-    /// 2. Validate target is relative (reject absolute symlinks)
-    /// 3. Resolve target against the link's parent directory
-    /// 4. Verify resolved target stays within destination directory
+    /// 2. Reject an empty target (points nowhere) or a target containing NUL
+    ///    bytes
+    /// 3. Validate target is relative (reject absolute symlinks)
+    /// 4. Check target components against banned components and
+    ///    `max_path_depth`
+    /// 5. Verify the link's parent directory chain contains no symlinks (TOCTOU
+    ///    protection)
+    /// 6. Resolve target against the link's parent directory, following any
+    ///    on-disk symlinks encountered
+    /// 7. Verify resolved target stays within destination directory
     ///
     /// # Errors
     ///
     /// Returns an error if:
     /// - Symlinks are not allowed by configuration
+    /// - Target is empty or contains NUL bytes
     /// - Target is an absolute path
+    /// - Target contains a banned path component or exceeds `max_path_depth`
     /// - Resolved target escapes the destination directory
     ///
     /// # Examples
@@ -102,6 +111,26 @@ impl SafeSymlink {
         if !config.allowed.symlinks {
             return Err(ArchiveError::SecurityViolation {
                 reason: "symlinks not allowed".into(),
+            });
+        }
+
+        // 1.5. Reject empty targets: an empty target does not point anywhere
+        // (some platforms would silently create a dangling symlink); reject
+        // it explicitly rather than letting it through.
+        if target.as_os_str().is_empty() {
+            return Err(ArchiveError::SecurityViolation {
+                reason: "symlink target is empty".into(),
+            });
+        }
+
+        // 1.6. Reject null bytes in the target, matching the same check
+        // already applied to the link path. Without this, a NUL byte falls
+        // through to the OS and surfaces as a raw `io::Error` instead of a
+        // structured `SecurityViolation`. The message intentionally omits
+        // the raw target bytes so a NUL byte is never embedded in it.
+        if super::safe_path::has_null_bytes(target) {
+            return Err(ArchiveError::SecurityViolation {
+                reason: "symlink target contains null bytes".into(),
             });
         }
 
@@ -587,8 +616,33 @@ mod tests {
         let target = PathBuf::from("");
 
         let result = SafeSymlink::validate(&link, &target, &dest, &config);
-        // Empty target should resolve to link's parent directory
-        assert!(result.is_ok(), "empty target should be allowed");
+        assert_matches!(
+            result,
+            Err(ArchiveError::SecurityViolation { .. }),
+            "empty symlink target should be rejected, not silently accepted"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_safe_symlink_target_with_null_byte() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        let (_temp, dest) = create_test_dest();
+        let config = create_config_with_symlinks();
+
+        let link = SafePath::validate(&PathBuf::from("link"), &dest, &config)
+            .expect("link path should be valid");
+
+        let target = PathBuf::from(OsStr::from_bytes(b"benign\0target"));
+
+        let result = SafeSymlink::validate(&link, &target, &dest, &config);
+        assert_matches!(
+            result,
+            Err(ArchiveError::SecurityViolation { .. }),
+            "symlink target containing a null byte should be rejected"
+        );
     }
 
     #[test]

--- a/crates/exarch-core/tests/security/mod.rs
+++ b/crates/exarch-core/tests/security/mod.rs
@@ -2,6 +2,7 @@
 
 mod cve_regression;
 mod sevenz_traversal;
+mod symlink_target_validation;
 mod tar_budget_parity;
 mod tar_ghsa_2026;
 mod tar_metadata_bomb;

--- a/crates/exarch-core/tests/security/symlink_target_validation.rs
+++ b/crates/exarch-core/tests/security/symlink_target_validation.rs
@@ -1,0 +1,141 @@
+//! Regression tests for issue #415: symlink/hardlink targets were not
+//! validated for embedded NUL bytes or emptiness, unlike the link path
+//! itself.
+//!
+//! A short (<=100 byte) linkname written through the `tar` crate's own
+//! `Header::set_link_name`/`set_link_name_literal` cannot carry an embedded
+//! NUL byte or reach an empty value while non-`None` (the crate either
+//! rejects NUL bytes outright or treats an all-zero field as "no link name").
+//! A GNU `LongLink` (`K`) record's raw payload has no such restriction, so
+//! these tests use one to smuggle both an embedded NUL byte and a truly
+//! empty target past the header-field-level shortcuts, exercising the same
+//! path a real crafted archive would take.
+
+#![allow(clippy::unwrap_used, clippy::cast_possible_truncation)]
+
+use exarch_core::ArchiveError;
+use exarch_core::ExtractionOptions;
+use exarch_core::SecurityConfig;
+use exarch_core::formats::ArchiveFormat;
+use exarch_core::formats::TarArchive;
+use std::assert_matches;
+use std::io::Cursor;
+use tempfile::TempDir;
+
+/// Builds a TAR archive with a GNU `LongLink` (`K`) record carrying
+/// `raw_target` verbatim as its payload, followed by an entry of type
+/// `entry_type` at `path` whose own (short) linkname field is overridden by
+/// the preceding `LongLink` record.
+fn build_tar_with_raw_link_target(
+    entry_type: tar::EntryType,
+    path: &str,
+    raw_target: &[u8],
+) -> Vec<u8> {
+    let mut builder = tar::Builder::new(Vec::new());
+
+    let mut long_link_header = tar::Header::new_gnu();
+    long_link_header.set_entry_type(tar::EntryType::GNULongLink);
+    long_link_header.set_size(raw_target.len() as u64);
+    long_link_header.set_cksum();
+    builder.append(&long_link_header, raw_target).unwrap();
+
+    let mut header = tar::Header::new_gnu();
+    header.set_entry_type(entry_type);
+    header.set_size(0);
+    header.set_mode(0o644);
+    // Placeholder short name; overridden by the preceding LongLink record.
+    header.set_link_name_literal(b"placeholder").unwrap();
+    header.set_cksum();
+    builder
+        .append_data(&mut header, path, std::io::empty())
+        .unwrap();
+
+    builder.into_inner().unwrap()
+}
+
+fn extract_with_symlinks_allowed(
+    tar_data: Vec<u8>,
+) -> exarch_core::Result<exarch_core::ExtractionReport> {
+    let temp = TempDir::new().unwrap();
+    let mut archive = TarArchive::new(Cursor::new(tar_data));
+    let config = SecurityConfig::default().with_allow_symlinks(true);
+    archive.extract(
+        temp.path(),
+        &config,
+        &ExtractionOptions::default(),
+        &mut exarch_core::NoopProgress,
+    )
+}
+
+fn extract_with_hardlinks_allowed(
+    tar_data: Vec<u8>,
+) -> exarch_core::Result<exarch_core::ExtractionReport> {
+    let temp = TempDir::new().unwrap();
+    let mut archive = TarArchive::new(Cursor::new(tar_data));
+    let config = SecurityConfig::default().with_allow_hardlinks(true);
+    archive.extract(
+        temp.path(),
+        &config,
+        &ExtractionOptions::default(),
+        &mut exarch_core::NoopProgress,
+    )
+}
+
+#[test]
+fn extract_rejects_symlink_target_with_null_byte() {
+    let tar_data =
+        build_tar_with_raw_link_target(tar::EntryType::Symlink, "link", b"benign\0target");
+
+    let result = extract_with_symlinks_allowed(tar_data);
+
+    assert_matches!(
+        result,
+        Err(ArchiveError::SecurityViolation { .. }),
+        "symlink target containing a null byte must be rejected as a SecurityViolation, got: {result:?}"
+    );
+}
+
+#[test]
+fn extract_rejects_empty_symlink_target() {
+    let tar_data = build_tar_with_raw_link_target(tar::EntryType::Symlink, "link", b"");
+
+    let result = extract_with_symlinks_allowed(tar_data);
+
+    assert_matches!(
+        result,
+        Err(ArchiveError::SecurityViolation { .. }),
+        "empty symlink target must be rejected, not silently create a dangling symlink, got: {result:?}"
+    );
+}
+
+#[test]
+fn extract_hardlink_null_byte_error_does_not_embed_raw_null() {
+    let tar_data = build_tar_with_raw_link_target(tar::EntryType::Link, "link", b"benign\0target");
+
+    let result = extract_with_hardlinks_allowed(tar_data);
+
+    let err = result.expect_err("hardlink target containing a null byte must be rejected");
+    assert_matches!(
+        err,
+        ArchiveError::SecurityViolation { .. },
+        "expected SecurityViolation, got: {err:?}"
+    );
+    let message = err.to_string();
+    assert!(
+        !message.contains('\0'),
+        "error message must not embed the raw null byte: {message:?}"
+    );
+}
+
+#[test]
+fn extract_rejects_empty_hardlink_target() {
+    let tar_data = build_tar_with_raw_link_target(tar::EntryType::Link, "link", b"");
+
+    let result = extract_with_hardlinks_allowed(tar_data);
+
+    assert_matches!(
+        result,
+        Err(ArchiveError::SecurityViolation { .. }),
+        "empty hardlink target must be rejected, got: {result:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- `SafeSymlink::validate` and `HardlinkTracker::validate_hardlink` validated the symlink/hardlink target for absoluteness, banned components, and depth, but not for NUL bytes or emptiness, unlike the equivalent entry path validation in `SafePath::validate`.
- A NUL byte in the target fell through to the OS as a raw `io::Error` instead of a structured `SecurityViolation`; an empty target was silently accepted, creating a dangling symlink; a NUL-containing hardlink target could reach a formatted error message downstream (log-injection nuisance).
- Both validators now reuse `types::safe_path::has_null_bytes` (made `pub(crate)`) to reject either case before any error message is built, without ever embedding the raw target bytes in the message.

Note: this branch originally also targeted issue #414 (TAR metadata entries bypassing `QuotaTracker`), but that was independently fixed and merged via #423 before this branch was finalized, so this PR's scope narrowed to #415 only.

Closes #415

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` (1022/1022 passed)
- [x] `cargo test --doc --workspace --all-features --exclude exarch-python --exclude exarch-node` (100/100 passed)
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --all-features --workspace` (clean)
- [x] New regression tests in `tests/security/symlink_target_validation.rs`: symlink NUL target, symlink empty target, hardlink NUL target (asserts no raw NUL in the error message), hardlink empty target — all smuggled past the `tar` crate's own header-field-level shortcuts via a raw GNU `LongLink` record