### PR TITLE
fix(core): bound cumulative synthetic-byte drain across TAR entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   or reach an empty value while non-`None`, so the regression tests use a GNU `LongLink` (`K`)
   record's raw payload to smuggle both past the header-field-level shortcuts, exercising the
   same path a real crafted archive would take.
+- **TAR extension-filter skip has no cumulative bound on synthesized drain across many small
+  sparse entries (#422)**: the per-entry synthetic-byte drain cap from #414 bounds the cost of any
+  *single* unread GNU sparse entry, but when `SecurityConfig` has an extension allowlist
+  configured, entries that fail the extension check are skipped before `QuotaTracker` ever runs
+  (intentional, per #421's fix for quota double-counting) — so `max_total_size`/`max_file_count`
+  provided no cumulative bound across many such pre-quota skips (measured: a ~20 MB archive of
+  20,000 small extension-filtered GNU sparse entries took ~1.41 s to extract, versus ~150 ms for
+  the same archive without an extension filter, which hits `QuotaExceeded` immediately). Added a
+  second, cumulative counter to `formats::tar_metadata_limit::TarReadBudget`: every
+  `TarEntryGuard::drop`'s own synthesized-byte count is now summed across the whole archive-open
+  operation, and `BudgetedEntries::next_entry` fails fast with a `SecurityViolation` once the sum
+  exceeds a fixed, non-configurable 1 GiB cap (roughly 128 maximally-saturating entries), rather
+  than continuing to drain further entries. The check lives in `next_entry` itself, so it applies
+  uniformly to `extract_archive`, `list_archive`, and `verify_archive` regardless of
+  extension-filter ordering — including `list_archive`/`verify_archive`, which skip *every* entry
+  unconditionally (they never read entry content at all), not only extension-filtered ones.
+
+  An initial version of this fix used a much tighter 64 MiB cap (8x the per-entry cap). Adversarial
+  review found that gave any legitimate archive of `list`/`verify`/extension-filtered-`extract`
+  sparse entries only 8 entries of headroom before false-positiving with a `SecurityViolation`,
+  since `list`/`verify` drain every entry unconditionally. The cap was raised to 1 GiB: worst-case
+  cost stays a fixed, sub-second amount of wasted `io::sink` throughput regardless of entry count,
+  while legitimate multi-entry sparse archives now have generous (~128-entry) headroom. This widens
+  this module's existing documented residual limitation (a legitimate GNU sparse file with real
+  holes larger than the per-entry cap is indistinguishable from an attack when skipped unread) from
+  a single oversized entry to roughly a hundred such entries in aggregate — still an accepted,
+  documented trade-off (P3), not a new bug.
 - Bumped `sevenz-rust2` from 0.21.3 to 0.21.4, fixing an integer overflow when summing
   attacker-controlled coder stream counts while parsing a 7z block header (upstream #127).
   Malformed archives previously could panic in debug builds and bypassed the stream-count

--- a/crates/exarch-core/src/formats/tar_metadata_limit.rs
+++ b/crates/exarch-core/src/formats/tar_metadata_limit.rs
@@ -79,13 +79,49 @@
 //! holes larger than [`SYNTHETIC_PAD_CAP_BYTES`] (e.g. a multi-gigabyte
 //! sparse disk image, mostly zero-filled) looks identical to an attack from
 //! this module's perspective when such a file is skipped unread — both
-//! produce output with no corresponding read. This affects `list_archive`,
-//! `verify_archive`, and, via those, the `exarch` CLI's `extract` command
-//! too (its `extract` runs a `list_archive` pre-flight ahead of the actual
-//! extraction, the same pre-flight `list`/`verify` use). Only a *direct*
-//! `TarArchive::extract` library call bypassing that pre-flight is
-//! unaffected, since it reads the entry itself and the guard's drain finds
-//! nothing left to do.
+//! produce output with no corresponding read. This affects `list_archive`
+//! and `verify_archive` unconditionally (neither reads entry content at all,
+//! so *every* entry hits this), and affects `extract_archive`/
+//! `TarArchive::extract` whenever any pre-read skip causes the entry not to
+//! be read at all — currently two such paths: a `SecurityConfig` extension
+//! allowlist rejecting the entry (`common::check_extension_allowed`, see the
+//! "Cumulative synthetic-byte budget" section below) and `skip_duplicates`
+//! finding the destination path already exists
+//! (`common::extract_file_generic`, `formats/common.rs`) — both return
+//! before the entry's content is ever read. Only an extract call that
+//! actually reads the entry (no pre-read skip of any kind) is unaffected,
+//! since the guard's drain then finds nothing left to do.
+//! [`CUMULATIVE_SYNTHETIC_CAP_BYTES`] below widens this same limitation
+//! across entries: an archive containing more than roughly a hundred such
+//! large-hole sparse entries, skipped unread by any of the paths above, is
+//! now also rejected, not just a single oversized one.
+//!
+//! # Cumulative synthetic-byte budget (issue #422)
+//!
+//! [`SYNTHETIC_PAD_CAP_BYTES`] bounds the drain cost of any *single* unread
+//! entry, but a caller with an extension allowlist configured
+//! (`common::check_extension_allowed`) skips disallowed entries *before*
+//! `QuotaTracker` ever sees them (intentional — see PR #421, which moved the
+//! check there specifically to stop quota from double-counting files that
+//! end up skipped); `skip_duplicates` skips an already-extracted path after
+//! quota has run but still before the entry is read
+//! (`common::extract_file_generic`); and `list_archive`/`verify_archive`
+//! skip *every* entry unconditionally regardless of any allowlist.
+//! `max_total_size`/`max_file_count` therefore provide no cumulative bound
+//! across many such skips: an archive of many small GNU sparse entries, each
+//! individually capped, could still sum to an arbitrarily large amount of
+//! wasted drain work.
+//!
+//! [`TarReadBudget`] closes this with a second counter — `cumulative_synthetic`
+//! on [`BudgetState`], summed across every [`TarEntryGuard::drop`] for the
+//! lifetime of one `TarReadBudget` (i.e. one archive-open operation) — capped
+//! at [`CUMULATIVE_SYNTHETIC_CAP_BYTES`]. [`BudgetedEntries::next_entry`]
+//! checks it before asking `tar` for the next entry, so a caller that keeps
+//! skipping synthetic-heavy entries fails fast on the next iteration rather
+//! than continuing to drain. Because the check lives in `next_entry` (used by
+//! `extract`, `list`, and — via `list` — `verify` alike), it applies
+//! uniformly regardless of extension-filter ordering — at the cost of the
+//! widened residual limitation described above.
 //!
 //! # Invariant: this module must never peek at archive content
 //!
@@ -124,6 +160,41 @@ use std::sync::atomic::Ordering;
 /// all by 1:1 content.
 const SYNTHETIC_PAD_CAP_BYTES: u64 = 8 * 1024 * 1024;
 
+/// Hard, non-configurable ceiling on the *sum* of every entry's synthesized-
+/// byte drain (see [`SYNTHETIC_PAD_CAP_BYTES`]) across a single archive-open
+/// operation — i.e. the lifetime of one [`TarReadBudget`] handle, shared by
+/// every [`TarEntryGuard`] it produces.
+///
+/// [`SYNTHETIC_PAD_CAP_BYTES`] alone bounds the cost of any one unread entry,
+/// not the *count* of such entries — a caller with an extension allowlist
+/// skips disallowed entries before `QuotaTracker` runs (issue #422), and
+/// `list_archive`/`verify_archive` skip every entry unconditionally (they
+/// never read entry content at all), so nothing else previously capped how
+/// many synthetic-heavy entries an archive could contain.
+///
+/// Calibrated generously, not tightly: every entry that individually
+/// saturates `SYNTHETIC_PAD_CAP_BYTES` — attack or legitimate large-hole
+/// sparse file alike, since this module cannot tell the two apart by design
+/// (see the module's residual-limitation docs) — consumes a full
+/// `SYNTHETIC_PAD_CAP_BYTES` (8 MiB) of this budget. At 1 GiB, that is
+/// roughly 128 such maximally-saturating entries (`1 GiB / 8 MiB`) before
+/// this trips: generous headroom for a real archive holding dozens of large
+/// sparse files, while still bounding the worst case to a fixed, small
+/// amount of wasted `io::sink` throughput — well under a second even at the
+/// cap (see `cumulative_synthetic_budget_trips_on_many_maximally_saturating_entries`
+/// in this module's tests) — no matter how many more entries an attacker
+/// piles on beyond that. The reported attack (a ~20 MB archive of 20,000
+/// small sparse entries, issue #422) took ~1.4 s to fully drain with no
+/// cumulative bound at all; this caps the equivalent cost near what ~128
+/// entries would cost, regardless of how many entries the archive actually
+/// contains. An earlier version of this constant used `8 *
+/// SYNTHETIC_PAD_CAP_BYTES` (64 MiB); adversarial review found that gave
+/// legitimate multi-entry sparse archives only 8 entries of headroom before
+/// false-positiving, while raising the cap all the way to 1 GiB only adds
+/// single-digit milliseconds to the worst case relative to the reported
+/// attack's own baseline.
+const CUMULATIVE_SYNTHETIC_CAP_BYTES: u64 = 1024 * 1024 * 1024;
+
 /// Chunk size for the drain loop in [`TarEntryGuard::drop`]. Not a security
 /// boundary — just an I/O granularity choice, small enough to keep the
 /// worst-case overshoot past [`SYNTHETIC_PAD_CAP_BYTES`] negligible.
@@ -154,6 +225,12 @@ struct BudgetState {
     /// synthesized padding during its drain, regardless of the metered
     /// window's own state at the time.
     total_read: AtomicU64,
+    /// Running sum of every [`TarEntryGuard::drop`]'s own synthesized-byte
+    /// count, across the whole lifetime of this state (i.e. one archive-open
+    /// operation) — never reset. Checked against
+    /// [`CUMULATIVE_SYNTHETIC_CAP_BYTES`] in
+    /// [`BudgetedEntries::next_entry`].
+    cumulative_synthetic: AtomicU64,
 }
 
 /// Cheap, cloneable handle used to arm/disarm the budget around the gap
@@ -184,6 +261,32 @@ impl TarReadBudget {
     fn total_read(&self) -> u64 {
         self.0.total_read.load(Ordering::Relaxed)
     }
+
+    /// Adds `synthetic` to the running cross-entry synthetic-byte sum.
+    /// Called once per [`TarEntryGuard::drop`], with that guard's own final
+    /// `synthetic` count.
+    fn add_cumulative_synthetic(&self, synthetic: u64) {
+        if synthetic > 0 {
+            self.0
+                .cumulative_synthetic
+                .fetch_add(synthetic, Ordering::Relaxed);
+        }
+    }
+
+    /// Returns a [`TarCumulativeSyntheticBudgetExceeded`] I/O error if the
+    /// running cross-entry synthetic-byte sum has exceeded
+    /// [`CUMULATIVE_SYNTHETIC_CAP_BYTES`], else `None`.
+    fn cumulative_synthetic_violation(&self) -> Option<io::Error> {
+        let total = self.0.cumulative_synthetic.load(Ordering::Relaxed);
+        (total > CUMULATIVE_SYNTHETIC_CAP_BYTES).then(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                TarCumulativeSyntheticBudgetExceeded {
+                    limit: CUMULATIVE_SYNTHETIC_CAP_BYTES,
+                },
+            )
+        })
+    }
 }
 
 /// Marker error surfaced when more than the configured limit is read from a
@@ -208,17 +311,49 @@ impl std::fmt::Display for TarReadBudgetExceeded {
 
 impl std::error::Error for TarReadBudgetExceeded {}
 
-/// Recovers a `TarReadBudgetExceeded` violation from an `io::Error` surfaced
-/// by the `tar` crate, converting it into an `ArchiveError::SecurityViolation`.
+/// Marker error surfaced when the cross-entry
+/// [`CUMULATIVE_SYNTHETIC_CAP_BYTES`] budget is exceeded. Recovered via
+/// [`budget_violation`] and converted into
+/// an `ArchiveError::SecurityViolation`, the same as
+/// [`TarReadBudgetExceeded`].
+#[derive(Debug)]
+struct TarCumulativeSyntheticBudgetExceeded {
+    limit: u64,
+}
+
+impl std::fmt::Display for TarCumulativeSyntheticBudgetExceeded {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "TAR cumulative synthetic-byte drain budget exceeded: more than {} bytes of \
+             synthesized (unbacked) padding drained from unread entries across this archive",
+            self.limit
+        )
+    }
+}
+
+impl std::error::Error for TarCumulativeSyntheticBudgetExceeded {}
+
+/// Recovers a `TarReadBudgetExceeded` or `TarCumulativeSyntheticBudgetExceeded`
+/// violation from an `io::Error` surfaced by the `tar` crate or by
+/// [`BudgetedEntries::next_entry`], converting it into an
+/// `ArchiveError::SecurityViolation`.
 ///
 /// Returns `None` for any other I/O error, so callers can fall back to their
 /// usual generic error mapping.
 pub fn budget_violation(e: &io::Error) -> Option<crate::ArchiveError> {
     let inner = e.get_ref()?;
-    let exceeded = inner.downcast_ref::<TarReadBudgetExceeded>()?;
-    Some(crate::ArchiveError::SecurityViolation {
-        reason: exceeded.to_string(),
-    })
+    if let Some(exceeded) = inner.downcast_ref::<TarReadBudgetExceeded>() {
+        return Some(crate::ArchiveError::SecurityViolation {
+            reason: exceeded.to_string(),
+        });
+    }
+    if let Some(exceeded) = inner.downcast_ref::<TarCumulativeSyntheticBudgetExceeded>() {
+        return Some(crate::ArchiveError::SecurityViolation {
+            reason: exceeded.to_string(),
+        });
+    }
+    None
 }
 
 /// Read wrapper that meters bytes against a [`TarReadBudget`] while armed and
@@ -295,6 +430,7 @@ pub fn budgeted_reader<R: Read>(inner: R, limit: u64) -> (BudgetedReader<R>, Tar
         consumed: AtomicU64::new(0),
         allowance: AtomicU64::new(limit),
         total_read: AtomicU64::new(0),
+        cumulative_synthetic: AtomicU64::new(0),
     });
     let reader = BudgetedReader {
         inner,
@@ -362,6 +498,7 @@ impl<R: Read> Drop for TarEntryGuard<'_, '_, R> {
         // exceeding the metadata budget, both loud failures, never silent.
         let total_read_at_start = self.budget.total_read();
         let mut output_so_far: u64 = 0;
+        let mut synthetic: u64 = 0;
         let mut buf = [0u8; DRAIN_CHUNK_BYTES];
         loop {
             let n = match self.entry.read(&mut buf) {
@@ -370,11 +507,18 @@ impl<R: Read> Drop for TarEntryGuard<'_, '_, R> {
             };
             output_so_far += n as u64;
             let read_since_start = self.budget.total_read() - total_read_at_start;
-            let synthetic = output_so_far.saturating_sub(read_since_start);
+            synthetic = output_so_far.saturating_sub(read_since_start);
             if synthetic > SYNTHETIC_PAD_CAP_BYTES {
                 break;
             }
         }
+        // Feeds the cross-entry cumulative budget (issue #422): this
+        // entry's own synthesized-byte count, summed with every other
+        // entry's over the lifetime of this `TarReadBudget`, is what
+        // `BudgetedEntries::next_entry` checks before yielding the next
+        // entry — bounding total drain work across many small
+        // synthetic-heavy entries, not just any single one.
+        self.budget.add_cumulative_synthetic(synthetic);
     }
 }
 
@@ -390,11 +534,23 @@ impl<R: Read> Drop for TarEntryGuard<'_, '_, R> {
 pub struct BudgetedEntries<'a, R: Read> {
     entries: tar::Entries<'a, BudgetedReader<R>>,
     budget: TarReadBudget,
+    /// Set once `next_entry` has yielded an `Err`; latches further calls to
+    /// `None` instead of re-yielding (or re-deriving) an error. Without
+    /// this, a hypothetical caller that logs an error from `next_entry` and
+    /// keeps calling it in a loop — rather than propagating with `?` as
+    /// every current call site does — would spin forever once the
+    /// cumulative budget trips, since the violation condition never clears
+    /// itself.
+    poisoned: bool,
 }
 
 impl<'a, R: Read> BudgetedEntries<'a, R> {
     fn new(entries: tar::Entries<'a, BudgetedReader<R>>, budget: TarReadBudget) -> Self {
-        Self { entries, budget }
+        Self {
+            entries,
+            budget,
+            poisoned: false,
+        }
     }
 
     /// Arms the budget, asks `tar` for the next entry, disarms the budget,
@@ -407,14 +563,32 @@ impl<'a, R: Read> BudgetedEntries<'a, R> {
     /// archive consisting of nothing but oversized metadata records would
     /// otherwise buffer unbounded before `tar` gives up with "members found
     /// describing a future member but no future member found".
+    ///
+    /// Before any of that, checks the cross-entry cumulative synthetic-byte
+    /// budget (issue #422): if prior entries' drains have already summed
+    /// past [`CUMULATIVE_SYNTHETIC_CAP_BYTES`], fails immediately rather than
+    /// asking `tar` for (and then draining) yet another entry.
+    ///
+    /// Once this has returned `Some(Err(_))` once, every subsequent call
+    /// returns `None` rather than repeating (or re-deriving) the error.
     pub fn next_entry(&mut self) -> Option<io::Result<TarEntryGuard<'a, '_, R>>> {
+        if self.poisoned {
+            return None;
+        }
+        if let Some(err) = self.budget.cumulative_synthetic_violation() {
+            self.poisoned = true;
+            return Some(Err(err));
+        }
         self.budget.arm();
         let result = self.entries.next();
         self.budget.disarm();
 
         match result {
             None => None,
-            Some(Err(e)) => Some(Err(e)),
+            Some(Err(e)) => {
+                self.poisoned = true;
+                Some(Err(e))
+            }
             Some(Ok(entry)) => Some(Ok(TarEntryGuard {
                 entry,
                 budget: self.budget.clone(),
@@ -691,37 +865,41 @@ mod tests {
         );
     }
 
-    /// Builds a raw one-entry TAR archive with a GNU old-format sparse
-    /// header (typeflag `'S'`) whose `realsize` vastly exceeds its one-block
-    /// physical backing — the same on-disk shape as issue #414's C1 `PoC`,
-    /// used here to unit-test the synthetic-byte cap directly rather than
-    /// relying only on the integration-level regression test.
-    fn gnu_sparse_bomb_tar(realsize: u64) -> Vec<u8> {
-        const HDR_BLOCK: usize = 512;
-        fn octal_field(n: u64, width: usize) -> Option<Vec<u8>> {
-            let digits = format!("{n:o}").into_bytes();
-            if digits.len() > width - 1 {
-                return None;
-            }
-            let mut out = vec![b'0'; width - 1 - digits.len()];
-            out.extend_from_slice(&digits);
-            out.push(0);
-            Some(out)
+    fn octal_field(n: u64, width: usize) -> Option<Vec<u8>> {
+        let digits = format!("{n:o}").into_bytes();
+        if digits.len() > width - 1 {
+            return None;
         }
-        fn base256_field(n: u64, width: usize) -> Vec<u8> {
-            let mut out = vec![0u8; width];
-            let bytes = n.to_be_bytes();
-            out[width - bytes.len()..].copy_from_slice(&bytes);
-            out[0] |= 0x80;
-            out
-        }
-        fn num_field(n: u64, width: usize) -> Vec<u8> {
-            octal_field(n, width).unwrap_or_else(|| base256_field(n, width))
-        }
+        let mut out = vec![b'0'; width - 1 - digits.len()];
+        out.extend_from_slice(&digits);
+        out.push(0);
+        Some(out)
+    }
+    fn base256_field(n: u64, width: usize) -> Vec<u8> {
+        let mut out = vec![0u8; width];
+        let bytes = n.to_be_bytes();
+        out[width - bytes.len()..].copy_from_slice(&bytes);
+        out[0] |= 0x80;
+        out
+    }
+    fn num_field(n: u64, width: usize) -> Vec<u8> {
+        octal_field(n, width).unwrap_or_else(|| base256_field(n, width))
+    }
 
+    const HDR_BLOCK: usize = 512;
+
+    /// Builds a raw GNU old-format sparse header + one-block physical
+    /// backing (typeflag `'S'`) whose `realsize` vastly exceeds that one
+    /// block — the same on-disk shape as issue #414's C1 `PoC` — *without* a
+    /// trailing end-of-archive trailer, so several can be concatenated into
+    /// one multi-entry archive.
+    fn gnu_sparse_bomb_entry(name: &[u8], realsize: u64) -> Vec<u8> {
+        assert!(
+            name.len() <= 100,
+            "test helper: name field is 100 bytes, {name:?} does not fit"
+        );
         let gap = realsize - HDR_BLOCK as u64;
         let mut h = vec![0u8; HDR_BLOCK];
-        let name = b"sparsebomb.bin";
         h[..name.len()].copy_from_slice(name);
         h[100..108].copy_from_slice(&num_field(0o644, 8));
         h[108..116].copy_from_slice(&num_field(0, 8));
@@ -741,6 +919,13 @@ mod tests {
 
         let mut out = h;
         out.extend(std::iter::repeat_n(0u8, HDR_BLOCK)); // one real backing block
+        out
+    }
+
+    /// Builds a raw one-entry TAR archive around a single
+    /// [`gnu_sparse_bomb_entry`], closed with an end-of-archive trailer.
+    fn gnu_sparse_bomb_tar(realsize: u64) -> Vec<u8> {
+        let mut out = gnu_sparse_bomb_entry(b"sparsebomb.bin", realsize);
         out.extend(std::iter::repeat_n(0u8, HDR_BLOCK * 2)); // end-of-archive trailer
         out
     }
@@ -777,6 +962,138 @@ mod tests {
                 <= 512 + 512 + SYNTHETIC_PAD_CAP_BYTES + u64::try_from(DRAIN_CHUNK_BYTES).unwrap(),
             "drop must stop draining almost immediately on synthesized padding, drained {drained} \
              bytes"
+        );
+    }
+
+    /// Drives `entries` to completion or a violation, draining every
+    /// yielded guard exactly like a real skip loop would. Returns the count
+    /// of entries yielded before either running out or hitting an error.
+    fn drain_all_entries<R: Read>(
+        entries: &mut BudgetedEntries<'_, R>,
+    ) -> (usize, Option<io::Error>) {
+        let mut yielded = 0usize;
+        while let Some(result) = entries.next_entry() {
+            match result {
+                Ok(guard) => {
+                    yielded += 1;
+                    drop(guard);
+                }
+                Err(e) => return (yielded, Some(e)),
+            }
+        }
+        (yielded, None)
+    }
+
+    #[test]
+    fn cumulative_synthetic_budget_trips_on_many_maximally_saturating_entries() {
+        // Regression for issue #422: SYNTHETIC_PAD_CAP_BYTES bounds any one
+        // entry's drain, but nothing previously bounded the *count* of such
+        // entries — a caller that keeps skipping synthetic-heavy entries
+        // (e.g. all extension-filtered pre-quota, per PR #421's ordering)
+        // could drain an unbounded total. This is the worst case the
+        // cumulative cap has to bound: every entry individually saturates
+        // SYNTHETIC_PAD_CAP_BYTES, the maximum any single entry can
+        // contribute, so this is also the *fewest* entries that can trip
+        // CUMULATIVE_SYNTHETIC_CAP_BYTES — computed from the real constants
+        // (not a hardcoded entry count) so this stays correct if either cap
+        // is retuned. Also validates the wall-clock claim in
+        // CUMULATIVE_SYNTHETIC_CAP_BYTES's own doc comment: even this worst
+        // case must stay fast, not scale with an attacker's entry count.
+        const WORST_CASE_BOUND: std::time::Duration = std::time::Duration::from_secs(5);
+        let entries_needed = CUMULATIVE_SYNTHETIC_CAP_BYTES / SYNTHETIC_PAD_CAP_BYTES + 1;
+        let entry_count = usize::try_from(entries_needed).unwrap() + 5; // margin past the trip
+
+        let mut data = Vec::new();
+        for i in 0..entry_count {
+            data.extend(gnu_sparse_bomb_entry(
+                format!("spam{i}.bin").as_bytes(),
+                1u64 << 40,
+            ));
+        }
+        data.extend(std::iter::repeat_n(0u8, HDR_BLOCK * 2)); // end-of-archive trailer
+
+        let (reader, budget) = budgeted_reader(Cursor::new(data), 4096);
+        let mut archive = tar::Archive::new(reader);
+        let mut entries = budgeted_tar_entries(&mut archive, budget).unwrap();
+
+        let start = std::time::Instant::now();
+        let (yielded, violation) = drain_all_entries(&mut entries);
+        let elapsed = start.elapsed();
+
+        let err = violation.expect(
+            "the cumulative synthetic budget must trip before every entry is drained, not \
+             silently allow all of them",
+        );
+        assert!(
+            budget_violation(&err).is_some(),
+            "must be recognizable as a budget violation, got: {err:?}"
+        );
+        assert!(
+            yielded < entry_count,
+            "must fail fast well before draining all {entry_count} entries, but yielded \
+             {yielded} of them"
+        );
+        assert!(
+            elapsed < WORST_CASE_BOUND,
+            "the worst case (every entry maximally saturating) took {elapsed:?} to trip, \
+             expected well under {WORST_CASE_BOUND:?}"
+        );
+    }
+
+    #[test]
+    fn cumulative_synthetic_budget_trips_from_many_sub_cap_contributions() {
+        // Regression for critic finding S3: the test above only proves the
+        // budget trips when every entry individually saturates
+        // SYNTHETIC_PAD_CAP_BYTES. The issue's actual reported shape is
+        // different — many small entries, each producing far less
+        // synthesized output than the per-entry cap on its own — and a
+        // buggy accumulation (e.g. one that only counted entries which
+        // individually tripped SYNTHETIC_PAD_CAP_BYTES) would let this
+        // archive drain in full. Each entry here contributes a fixed,
+        // well-under-cap `GAP` to the cumulative sum; only their sum, not
+        // any single one of them, exceeds CUMULATIVE_SYNTHETIC_CAP_BYTES.
+        const GAP: u64 = 4 * 1024 * 1024;
+        const _: () = assert!(
+            GAP < SYNTHETIC_PAD_CAP_BYTES,
+            "test premise: each entry must stay well under the per-entry cap on its own"
+        );
+        let entries_needed = CUMULATIVE_SYNTHETIC_CAP_BYTES / GAP + 1;
+        let entry_count = usize::try_from(entries_needed).unwrap() + 20; // margin past the trip
+
+        let mut data = Vec::new();
+        for i in 0..entry_count {
+            data.extend(gnu_sparse_bomb_entry(
+                format!("small{i}.bin").as_bytes(),
+                HDR_BLOCK as u64 + GAP,
+            ));
+        }
+        data.extend(std::iter::repeat_n(0u8, HDR_BLOCK * 2)); // end-of-archive trailer
+
+        let (reader, budget) = budgeted_reader(Cursor::new(data), 4096);
+        let mut archive = tar::Archive::new(reader);
+        let mut entries = budgeted_tar_entries(&mut archive, budget).unwrap();
+
+        let (yielded, violation) = drain_all_entries(&mut entries);
+
+        let err = violation.expect(
+            "many sub-cap synthetic contributions must still sum past the cumulative budget, \
+             not silently drain in full",
+        );
+        assert!(
+            budget_violation(&err).is_some(),
+            "must be recognizable as a budget violation, got: {err:?}"
+        );
+        assert!(
+            yielded < entry_count,
+            "must fail before draining every one of the {entry_count} sub-cap entries, yielded \
+             {yielded}"
+        );
+        // Proves the accumulation is real (many sub-cap entries actually
+        // summed), not a fluke of some unrelated check firing on entry one.
+        assert!(
+            yielded >= 2,
+            "expected several sub-cap entries to be individually drained before the cumulative \
+             cap trips, only {yielded} were"
         );
     }
 }

--- a/crates/exarch-core/tests/security/tar_metadata_bomb.rs
+++ b/crates/exarch-core/tests/security/tar_metadata_bomb.rs
@@ -865,6 +865,189 @@ fn list_and_verify_accept_a_single_legitimate_entry_at_every_size_that_broke_c2(
     }
 }
 
+// ─────────────────────────────────────────────────────────────────────────
+// Issue #422: cumulative synthetic-byte budget across many small entries
+// ─────────────────────────────────────────────────────────────────────────
+//
+// SYNTHETIC_PAD_CAP_BYTES (formats::tar_metadata_limit) bounds the drain
+// cost of any *single* unread GNU sparse entry, but a caller with an
+// extension allowlist configured skips disallowed entries before
+// QuotaTracker ever runs (PR #421 moved the check there specifically to
+// stop quota from double-counting files that end up skipped) — so nothing
+// previously bounded the *count* of synthetic-heavy entries an archive
+// could contain. An archive of many small extension-filtered GNU sparse
+// entries could sum to an unbounded amount of wasted drain work even though
+// each entry alone stayed within its own cap. The deterministic version of
+// this regression (entry-yield counts, not wall-clock) lives in
+// `formats::tar_metadata_limit`'s own test module, which can drive the
+// crate-internal `BudgetedEntries` iterator directly; the tests below
+// exercise the same shapes through the public API these internals actually
+// serve, so wall-clock is the only externally observable "failed fast"
+// signal available here (the extension-filter skip path never populates a
+// `PartialExtraction` report to count against, since only `files_skipped`,
+// not `total_items()`, would be nonzero).
+
+/// Builds a multi-entry TAR of `n` GNU sparse entries, each named
+/// `spam{i}.bin`, each declaring a hole (`gap`) beyond its one physical
+/// backing block — many small copies of the same C1 shape used above,
+/// concatenated instead of standing alone.
+fn many_sparse_bombs_tar(n: usize, gap: u64) -> Vec<u8> {
+    let mut out = Vec::new();
+    for i in 0..n {
+        let name = format!("spam{i}.bin");
+        let realsize = BLOCK as u64 + gap;
+        let hdr = gnu_sparse_header(
+            name.as_bytes(),
+            BLOCK as u64,
+            realsize,
+            &[(gap, BLOCK as u64)],
+        );
+        out.extend(hdr);
+        out.extend(std::iter::repeat_n(0u8, BLOCK)); // one real backing block
+    }
+    out.extend(std::iter::repeat_n(0u8, BLOCK * 2)); // end-of-archive trailer
+    out
+}
+
+#[test]
+fn extract_rejects_many_extension_filtered_sparse_entries_via_cumulative_budget() {
+    // Reproduces the issue directly: an extension allowlist skips every one
+    // of 200 small sparse-bomb entries before QuotaTracker ever sees them,
+    // so max_total_size/max_file_count provide no cover. Without a
+    // cumulative bound, extraction would drain every entry (bounded per-entry
+    // but unbounded in sum) and eventually "succeed" having done far more
+    // work than a well-formed archive of this size should ever cost. With
+    // the fix, iteration must fail fast once the cross-entry synthetic sum
+    // exceeds the cumulative cap (roughly 128 maximally-saturating entries
+    // at the current 1 GiB cap) — well before entry 200.
+    let bomb = many_sparse_bombs_tar(200, 1u64 << 40);
+    let config = SecurityConfig::default().with_allowed_extensions(vec!["txt".to_string()]);
+
+    let temp = TempDir::new().unwrap();
+    let path = write_tar_file(&temp, "many_sparse.tar", &bomb);
+    let out = temp.path().join("out");
+
+    let start = std::time::Instant::now();
+    let result = exarch_core::extract_archive(&path, &out, &config);
+    let elapsed = start.elapsed();
+
+    assert_is_budget_violation(&result);
+    assert!(
+        elapsed < SPARSE_BOMB_WALL_CLOCK_BOUND,
+        "extract must not scale with the number of skipped synthetic-heavy entries, took \
+         {elapsed:?}"
+    );
+}
+
+#[test]
+fn extract_rejects_many_extension_filtered_sub_cap_sparse_entries_via_cumulative_budget() {
+    // Regression for critic finding S3: the test above only proves the
+    // budget trips when every entry individually saturates
+    // SYNTHETIC_PAD_CAP_BYTES (8 MiB). The issue's own reported shape is
+    // 20,000 *small* entries — each producing far less synthesized output
+    // than the per-entry cap on its own — whose sum, not any single entry,
+    // exceeds the cumulative cap. A regression that only accumulated when
+    // the per-entry cap tripped would pass the test above but let this one
+    // drain in full. 300 entries of a 4 MiB (sub-cap) hole each are needed
+    // to exceed the 1 GiB cumulative cap (~256 entries) with margin.
+    let bomb = many_sparse_bombs_tar(300, 4 * 1024 * 1024);
+    let config = SecurityConfig::default().with_allowed_extensions(vec!["txt".to_string()]);
+
+    let temp = TempDir::new().unwrap();
+    let path = write_tar_file(&temp, "many_sub_cap_sparse.tar", &bomb);
+    let out = temp.path().join("out");
+
+    let start = std::time::Instant::now();
+    let result = exarch_core::extract_archive(&path, &out, &config);
+    let elapsed = start.elapsed();
+
+    assert_is_budget_violation(&result);
+    assert!(
+        elapsed < SPARSE_BOMB_WALL_CLOCK_BOUND,
+        "extract must not scale with the number of skipped sub-cap synthetic-heavy entries, \
+         took {elapsed:?}"
+    );
+}
+
+#[test]
+fn list_and_verify_bound_total_drain_across_many_sparse_entries_even_with_relaxed_quota() {
+    // The cumulative budget lives in `next_entry()`, used by extract, list,
+    // and (via list) verify alike — not gated on extension filtering at
+    // all — so it also covers a caller that legitimately relaxes quota
+    // limits (e.g. to list/verify a huge archive) and would otherwise let
+    // QuotaTracker wave every sparse-bomb entry through instead of catching
+    // it early.
+    //
+    // This config relaxation is deliberately broader than what
+    // `listing_config_for_verify` (inspection/verify.rs) applies on its
+    // own — that helper only relaxes `max_file_size` to `u64::MAX`, not
+    // `max_total_size`/`max_file_count`, so `verify_archive` under its
+    // *default* config would already reject a huge declared `realsize` via
+    // ordinary total-size quota before ever reaching the cumulative
+    // synthetic path. The manual relaxation below represents a caller who
+    // has legitimately raised every quota limit (e.g. to inspect a
+    // multi-terabyte archive), which is exactly the case
+    // `listing_config_for_verify` does *not* cover and where this budget is
+    // the only remaining defense.
+    let bomb = many_sparse_bombs_tar(200, 1u64 << 40);
+    let config = SecurityConfig::default()
+        .with_max_file_size(u64::MAX)
+        .with_max_total_size(u64::MAX)
+        .with_max_file_count(usize::MAX);
+
+    let temp = TempDir::new().unwrap();
+    let path = write_tar_file(&temp, "many_sparse_relaxed.tar", &bomb);
+
+    let start = std::time::Instant::now();
+    let result = exarch_core::list_archive(&path, &config);
+    let elapsed = start.elapsed();
+    assert_is_budget_violation(&result);
+    assert!(
+        elapsed < SPARSE_BOMB_WALL_CLOCK_BOUND,
+        "list must not scale with the number of unbounded-quota sparse entries, took {elapsed:?}"
+    );
+
+    let start = std::time::Instant::now();
+    let result = exarch_core::verify_archive(&path, &config);
+    let elapsed = start.elapsed();
+    assert_is_budget_violation(&result);
+    assert!(
+        elapsed < SPARSE_BOMB_WALL_CLOCK_BOUND,
+        "verify must not scale with the number of unbounded-quota sparse entries, took {elapsed:?}"
+    );
+}
+
+#[test]
+fn list_and_verify_accept_many_sparse_entries_comfortably_under_the_cumulative_cap() {
+    // Regression for critic finding N1: every other cumulative-budget test
+    // either derives its entry count from CUMULATIVE_SYNTHETIC_CAP_BYTES or
+    // deliberately exceeds it, so none would notice if the cap were
+    // silently retuned back down (e.g. to the original, too-tight 64 MiB) —
+    // that would reintroduce the exact S1 false-positive undetected. This
+    // pins the acceptance side: 50 entries, each individually saturating
+    // SYNTHETIC_PAD_CAP_BYTES (8 MiB), sum to ~400 MiB — comfortably under
+    // the 1 GiB cap, and already far more large-hole sparse entries than a
+    // real archive would plausibly contain — and must still list and verify
+    // cleanly, not trip the cumulative budget.
+    const ENTRY_COUNT: usize = 50;
+    let bomb = many_sparse_bombs_tar(ENTRY_COUNT, 1u64 << 40);
+    let config = SecurityConfig::default()
+        .with_max_file_size(u64::MAX)
+        .with_max_total_size(u64::MAX)
+        .with_max_file_count(usize::MAX);
+
+    let temp = TempDir::new().unwrap();
+    let path = write_tar_file(&temp, "many_sparse_under_cap.tar", &bomb);
+
+    let manifest = exarch_core::list_archive(&path, &config)
+        .expect("an archive comfortably under the cumulative synthetic cap must list cleanly");
+    assert_eq!(manifest.total_entries, ENTRY_COUNT);
+
+    let report = exarch_core::verify_archive(&path, &config)
+        .expect("an archive comfortably under the cumulative synthetic cap must verify cleanly");
+    assert_eq!(report.status, exarch_core::VerificationStatus::Pass);
+}
+
 #[test]
 fn budget_violation_is_not_confused_with_other_archive_errors() {
     // Sanity check on the assertion helper itself: an ordinary corrupt


### PR DESCRIPTION
## Summary

- `TarReadBudget`'s per-entry synthetic-byte drain cap (added in #414/#423) bounds the CPU cost of draining any single unread GNU sparse entry, but nothing bounded the *sum* of per-entry drains across an archive when entries are skipped before `QuotaTracker` runs (extension allowlist skip, per #421's ordering; duplicate-name skip).
- An attacker could chain many small extension-filtered GNU sparse entries to amplify wall-clock cost with no memory growth: a ~20 MB archive of 20,000 such entries measured ~1.41 s to extract versus ~150 ms for the same archive without an extension filter (which hits `QuotaExceeded` immediately).
- Adds a second, cumulative synthetic-byte counter to `formats::tar_metadata_limit::TarReadBudget`, summed across the whole archive-open operation and checked in `BudgetedEntries::next_entry` before each read. Trips a `SecurityViolation` at a fixed, non-configurable 1 GiB cap, applying uniformly to `extract_archive`, `list_archive`, and `verify_archive` regardless of extension-filter ordering.
- The extension-check-before-`QuotaTracker` ordering from #421 is untouched — this fix does not reintroduce the quota double-counting problem #421 removed.

## Review process

Went through two rounds of adversarial critique (`rust-critic`) before code review:
- Round 1: significant findings — initial 64 MiB cap gave legitimate multi-entry sparse archives on `list`/`verify` only 8 entries of headroom before false-positiving; a stale doc claim; tests only exercised single-entry-saturating cases, not the issue's actual sub-cap accumulation shape.
- Round 2 (after fixes): minor — cap recalibrated to 1 GiB (confirmed by measurement: ~17-20ms marginal worst-case cost vs. the issue's ~150ms baseline, ~128-entry headroom), docs corrected, sub-cap accumulation tests added.
- Landed two final follow-ups: a test pinning the *acceptance* side of the cap (so a silent future downward retune can't slip through undetected) and a doc fix naming a second pre-read skip path (`skip_duplicates`).

Code review approved after independently re-running the full check suite.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` (1023/1023)
- [x] `cargo test --doc --workspace --all-features`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace`
- [x] New regression tests reproduce the issue's repro shape (many small sub-cap synthetic contributions accumulating to trip the budget) and cover `extract`/`list`/`verify`
- [x] New acceptance test confirms a legitimate sparse archive comfortably under the cumulative cap still lists/verifies successfully

Closes #422