### PR TITLE
fix(core): enforce quota tracking on hardlink extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -229,6 +229,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Regression test for the #397 coder-stream-count overflow fix (upstream sevenz-rust2 issue
   #127), using the fixture ported from upstream's own regression test, confirming the
   malformed archive is now rejected gracefully instead of risking a panic (#397).
+- **TAR hardlink extraction bypassed quota tracking entirely (#426)**: `EntryValidator::validate_entry`
+  only ran `QuotaTracker::record_file` for `EntryType::File`, so hardlink entries (opt-in via
+  `config.allowed.hardlinks`) never counted against `max_file_size`, `max_file_count`, or
+  `max_total_size`, even though `TarArchive::create_hardlink` copies the target's full on-disk
+  bytes via `std::fs::copy` for every hardlink entry. A crafted archive with one file within
+  quota followed by many hardlink entries pointing at it extracted unlimited copies with zero
+  enforcement. `EntryValidator` gained `record_hardlink`, and the TAR second pass now calls it
+  with the target's on-disk size (read via `std::fs::metadata`) before copying, routing hardlink
+  bytes and counts through the same `QuotaTracker` instance used for regular files.
 
 ### Fixed
 
@@ -295,6 +304,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `test-python` jobs' single upload each), and added the missing `flags: exarch-core,
   exarch-cli` to the `coverage` job's upload — those two flags were declared with their own
   thresholds in `codecov.yml` but never received any tagged data.
+- **TAR hardlink byte/count accounting used unchecked `+=` (#427)**: `TarArchive::create_hardlink`
+  incremented `ExtractionReport::files_extracted`/`bytes_written`/`files_skipped` with plain `+=`
+  after copying a hardlink's target bytes, inconsistent with `formats::common::extract_file_generic`'s
+  `checked_add`-guarded `bytes_written` accounting. All three counters in `create_hardlink` now use
+  the same `checked_add(..).ok_or(ArchiveError::QuotaExceeded { resource: QuotaResource::IntegerOverflow })`
+  pattern; this is not yet a crate-wide guarantee, since `formats/common.rs` and `formats/sevenz.rs`
+  still increment their own `files_extracted` counters with unchecked `+=`.
 
 ### Changed
 

--- a/crates/exarch-core/src/formats/tar.rs
+++ b/crates/exarch-core/src/formats/tar.rs
@@ -312,7 +312,13 @@ impl<R: Read> TarArchive<R> {
 
         if link_path.exists() {
             if ctx.skip_duplicates {
-                ctx.report.files_skipped += 1;
+                ctx.report.files_skipped =
+                    ctx.report
+                        .files_skipped
+                        .checked_add(1)
+                        .ok_or(ArchiveError::QuotaExceeded {
+                            resource: crate::QuotaResource::IntegerOverflow,
+                        })?;
                 ctx.report.warnings.push(format!(
                     "skipped duplicate hardlink: {}",
                     info.link_path.as_path().display()
@@ -325,12 +331,32 @@ impl<R: Read> TarArchive<R> {
             )));
         }
 
+        // Every hardlink copies the target's real bytes to a new inode, so it
+        // must be charged against the same quota tracker as regular files
+        // (issue #426): otherwise N hardlinks to one small file extract N
+        // full copies with no size or count enforcement. Charged after the
+        // duplicate-skip check above (mirroring `extract_file_generic`) so a
+        // `skip_duplicates=true` archive is not spuriously charged for an
+        // entry that is ultimately never copied.
+        let target_size = std::fs::metadata(&target_path)?.len();
+        ctx.validator.record_hardlink(target_size)?;
+
         // Copy content to a new independent inode. Any subsequent write to
         // `link_path` cannot corrupt `target_path` because they are separate files.
         let bytes_copied = std::fs::copy(&target_path, &link_path)?;
 
-        ctx.report.files_extracted += 1;
-        ctx.report.bytes_written += bytes_copied;
+        ctx.report.files_extracted =
+            ctx.report
+                .files_extracted
+                .checked_add(1)
+                .ok_or(ArchiveError::QuotaExceeded {
+                    resource: crate::QuotaResource::IntegerOverflow,
+                })?;
+        ctx.report.bytes_written = ctx.report.bytes_written.checked_add(bytes_copied).ok_or(
+            ArchiveError::QuotaExceeded {
+                resource: crate::QuotaResource::IntegerOverflow,
+            },
+        )?;
         ctx.progress.on_bytes_written(bytes_copied);
 
         Ok(())

--- a/crates/exarch-core/src/security/validator.rs
+++ b/crates/exarch-core/src/security/validator.rs
@@ -212,6 +212,23 @@ impl<'a> EntryValidator<'a> {
         })
     }
 
+    /// Records a hardlink's copied byte count against the shared quota tracker.
+    ///
+    /// Hardlinks are validated for path/target escape during the first pass
+    /// (`validate_entry`), but their size is only known once the target file
+    /// exists on disk, in the second pass. This routes that size through the
+    /// same `QuotaTracker` used for regular files, so `max_file_size`,
+    /// `max_file_count`, and `max_total_size` are enforced uniformly
+    /// regardless of entry type.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ArchiveError::QuotaExceeded`] if recording this hardlink
+    /// would exceed `max_file_size`, `max_file_count`, or `max_total_size`.
+    pub(crate) fn record_hardlink(&mut self, size: u64) -> Result<()> {
+        self.quota_tracker.record_file(size, self.config)
+    }
+
     /// Finishes validation and returns a summary report.
     ///
     /// This consumes the validator and returns statistics about the
@@ -721,5 +738,86 @@ mod tests {
             .unwrap();
 
         assert!(validator.symlink_seen);
+    }
+
+    // Issue #426: hardlink quota bypass regression tests.
+
+    #[test]
+    fn test_record_hardlink_exceeding_max_file_size_rejected() {
+        let temp = TempDir::new().unwrap();
+        let dest = DestDir::new(temp.path().to_path_buf()).unwrap();
+        let mut config = SecurityConfig::default();
+        config.max_file_size = 100;
+        let mut validator = EntryValidator::new(&config, &dest);
+
+        // A single hardlink whose on-disk target size alone exceeds
+        // max_file_size must be rejected, exactly like an oversized regular
+        // file would be.
+        let result = validator.record_hardlink(1_000);
+
+        assert_matches!(
+            result,
+            Err(crate::ArchiveError::QuotaExceeded {
+                resource: crate::QuotaResource::FileSize { .. }
+            }),
+            "hardlink exceeding max_file_size must be rejected, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_record_hardlink_shares_quota_tracker_with_files() {
+        let temp = TempDir::new().unwrap();
+        let dest = DestDir::new(temp.path().to_path_buf()).unwrap();
+        let mut config = SecurityConfig::default();
+        config.allowed.hardlinks = true;
+        config.max_total_size = 250;
+        let mut validator = EntryValidator::new(&config, &dest);
+
+        // A regular file consumes part of the shared total-size budget...
+        validator
+            .validate_entry(
+                Path::new("file1.txt"),
+                &EntryType::File,
+                100,
+                None,
+                Some(0o644),
+                None,
+            )
+            .unwrap();
+
+        // ...and a hardlink recorded afterwards must be charged against the
+        // same tracker, not a separate/untracked counter.
+        assert!(validator.record_hardlink(100).is_ok());
+
+        let result = validator.record_hardlink(100);
+        assert_matches!(
+            result,
+            Err(crate::ArchiveError::QuotaExceeded {
+                resource: crate::QuotaResource::TotalSize { .. }
+            }),
+            "hardlink bytes must accumulate on the same tracker as file bytes \
+             (200 already recorded + 100 more exceeds the 250 budget), got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_record_hardlink_exceeding_max_file_count() {
+        let temp = TempDir::new().unwrap();
+        let dest = DestDir::new(temp.path().to_path_buf()).unwrap();
+        let mut config = SecurityConfig::default();
+        config.max_file_count = 2;
+        let mut validator = EntryValidator::new(&config, &dest);
+
+        assert!(validator.record_hardlink(1).is_ok());
+        assert!(validator.record_hardlink(1).is_ok());
+
+        let result = validator.record_hardlink(1);
+        assert_matches!(
+            result,
+            Err(crate::ArchiveError::QuotaExceeded {
+                resource: crate::QuotaResource::FileCount { .. }
+            }),
+            "hardlink count alone exceeding max_file_count must be rejected, got: {result:?}"
+        );
     }
 }

--- a/crates/exarch-core/tests/security/hardlink_quota_bypass.rs
+++ b/crates/exarch-core/tests/security/hardlink_quota_bypass.rs
@@ -1,0 +1,228 @@
+//! Regression tests for issue #426: hardlink quota bypass.
+//!
+//! Before the fix, `TarArchive::create_hardlink` copied a hardlink target's
+//! bytes to a brand-new inode via `std::fs::copy` without ever routing the
+//! copied size through `QuotaTracker`. A small archive containing one
+//! legitimate file followed by many hardlink entries pointing at it could
+//! inflate to an arbitrary multiple of the declared archive size with no
+//! `max_file_size`, `max_file_count`, or `max_total_size` enforcement — a
+//! classic hardlink-bomb bypass of the same class as decompression bombs.
+//!
+//! The fix adds `EntryValidator::record_hardlink`, which charges each
+//! hardlink's on-disk target size against the *same* `QuotaTracker` instance
+//! used for regular files, called before the parent-dir/duplicate checks and
+//! before `std::fs::copy` runs.
+
+#![allow(clippy::unwrap_used, clippy::cast_possible_truncation)]
+
+use exarch_core::ArchiveError;
+use exarch_core::ExtractionOptions;
+use exarch_core::NoopProgress;
+use exarch_core::QuotaResource;
+use exarch_core::SecurityConfig;
+use exarch_core::formats::ArchiveFormat;
+use exarch_core::formats::TarArchive;
+use std::assert_matches;
+use std::io::Cursor;
+use tempfile::TempDir;
+
+struct TarTestBuilder {
+    builder: tar::Builder<Vec<u8>>,
+}
+
+impl TarTestBuilder {
+    fn new() -> Self {
+        Self {
+            builder: tar::Builder::new(Vec::new()),
+        }
+    }
+
+    fn add_file(mut self, path: &str, data: &[u8]) -> Self {
+        let mut header = tar::Header::new_gnu();
+        header.set_size(data.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        self.builder.append_data(&mut header, path, data).unwrap();
+        self
+    }
+
+    fn add_hardlink(mut self, path: &str, target: &str) -> Self {
+        let mut header = tar::Header::new_gnu();
+        header.set_size(0);
+        header.set_mode(0o644);
+        header.set_entry_type(tar::EntryType::Link);
+        header.set_link_name(target).unwrap();
+        header.set_cksum();
+        self.builder
+            .append_data(&mut header, path, std::io::empty())
+            .unwrap();
+        self
+    }
+
+    /// Adds `count` hardlink entries named `{prefix}{i}` all pointing at
+    /// `target`, simulating a hardlink-bomb archive: many small entries that
+    /// each materialize a full copy of the same target file.
+    fn add_hardlink_bomb(mut self, prefix: &str, target: &str, count: usize) -> Self {
+        for i in 0..count {
+            self = self.add_hardlink(&format!("{prefix}{i}"), target);
+        }
+        self
+    }
+
+    fn build(self) -> Vec<u8> {
+        self.builder.into_inner().unwrap()
+    }
+}
+
+/// Counts regular files directly inside `dir` (non-recursive; these fixtures
+/// are all flat).
+fn count_entries(dir: &std::path::Path) -> usize {
+    std::fs::read_dir(dir).unwrap().count()
+}
+
+/// Extraction failures surface as `ArchiveError::PartialExtraction { source,
+/// report }`, wrapping the triggering error together with a report of what
+/// was written before it fired. Unwraps to `(quota_error, files_extracted)`.
+fn quota_failure(err: &ArchiveError) -> (&ArchiveError, usize) {
+    match err {
+        ArchiveError::PartialExtraction { source, report } => {
+            (source.as_ref(), report.files_extracted)
+        }
+        other => panic!("expected PartialExtraction, got: {other:?}"),
+    }
+}
+
+// ── #426: total-size bypass ───────────────────────────────────────────────
+//
+// One legitimate file within quota, followed by many hardlinks to it, where
+// N * target_size exceeds max_total_size. Pre-fix, this extracted silently
+// with N full copies on disk and no quota error.
+
+#[test]
+fn test_hardlink_bomb_exceeds_total_size() {
+    let target_size = 5_000usize;
+    let tar_data = TarTestBuilder::new()
+        .add_file("target.txt", &vec![b'A'; target_size])
+        .add_hardlink_bomb("link", "target.txt", 20)
+        .build();
+
+    let temp = TempDir::new().unwrap();
+    let config = SecurityConfig::default()
+        .with_allow_hardlinks(true)
+        .with_max_file_size(target_size as u64 + 1)
+        .with_max_total_size(20_000) // room for target + 3 links, not 4
+        .with_max_file_count(1_000);
+
+    let mut archive = TarArchive::new(Cursor::new(tar_data));
+    let result = archive.extract(
+        temp.path(),
+        &config,
+        &ExtractionOptions::default(),
+        &mut NoopProgress,
+    );
+
+    let err = result.expect_err("hardlink bomb exceeding max_total_size must be rejected");
+    let (quota_err, files_extracted) = quota_failure(&err);
+    assert_matches!(
+        quota_err,
+        ArchiveError::QuotaExceeded {
+            resource: QuotaResource::TotalSize { .. }
+        },
+        "expected TotalSize quota error, got: {quota_err:?}"
+    );
+
+    // Must have stopped well short of all 20 hardlinks (target + at most 3 links).
+    assert!(
+        files_extracted <= 4,
+        "extraction must stop at the quota boundary, not write all hardlinks; wrote {files_extracted}"
+    );
+    let written = count_entries(temp.path());
+    assert_eq!(
+        written, files_extracted,
+        "disk contents must match the reported partial extraction count"
+    );
+}
+
+// ── #426: file-count bypass ───────────────────────────────────────────────
+//
+// Many small hardlinks whose combined bytes are trivial but whose count
+// alone exceeds max_file_count.
+
+#[test]
+fn test_hardlink_bomb_exceeds_file_count() {
+    let tar_data = TarTestBuilder::new()
+        .add_file("target.txt", b"x")
+        .add_hardlink_bomb("link", "target.txt", 10)
+        .build();
+
+    let temp = TempDir::new().unwrap();
+    let config = SecurityConfig::default()
+        .with_allow_hardlinks(true)
+        .with_max_file_size(1_000_000)
+        .with_max_total_size(1_000_000)
+        .with_max_file_count(3); // target.txt + 2 hardlinks allowed, 3rd rejected
+
+    let mut archive = TarArchive::new(Cursor::new(tar_data));
+    let result = archive.extract(
+        temp.path(),
+        &config,
+        &ExtractionOptions::default(),
+        &mut NoopProgress,
+    );
+
+    let err = result.expect_err("hardlink count alone exceeding max_file_count must be rejected");
+    let (quota_err, files_extracted) = quota_failure(&err);
+    assert_matches!(
+        quota_err,
+        ArchiveError::QuotaExceeded {
+            resource: QuotaResource::FileCount { .. }
+        },
+        "expected FileCount quota error, got: {quota_err:?}"
+    );
+
+    assert!(
+        files_extracted <= 3,
+        "extraction must stop at the file-count boundary; wrote {files_extracted}"
+    );
+    let written = count_entries(temp.path());
+    assert_eq!(
+        written, files_extracted,
+        "disk contents must match the reported partial extraction count"
+    );
+}
+
+// ── #426: positive case — legitimate hardlinks within all quotas ─────────
+//
+// A small, well-behaved number of hardlinks to a small target must still
+// extract successfully; the fix must not regress the legitimate path.
+
+#[test]
+fn test_legitimate_hardlinks_within_quota_succeed() {
+    let tar_data = TarTestBuilder::new()
+        .add_file("target.txt", b"hello world")
+        .add_hardlink_bomb("link", "target.txt", 3)
+        .build();
+
+    let temp = TempDir::new().unwrap();
+    let config = SecurityConfig::default().with_allow_hardlinks(true);
+
+    let mut archive = TarArchive::new(Cursor::new(tar_data));
+    let result = archive.extract(
+        temp.path(),
+        &config,
+        &ExtractionOptions::default(),
+        &mut NoopProgress,
+    );
+
+    assert!(
+        result.is_ok(),
+        "legitimate hardlinks well within quota must succeed, got: {result:?}"
+    );
+    let report = result.unwrap();
+    assert_eq!(report.files_extracted, 4); // target.txt + 3 hardlinks
+
+    for i in 0..3 {
+        let linked = std::fs::read(temp.path().join(format!("link{i}"))).unwrap();
+        assert_eq!(linked, b"hello world");
+    }
+}

--- a/crates/exarch-core/tests/security/mod.rs
+++ b/crates/exarch-core/tests/security/mod.rs
@@ -1,6 +1,7 @@
 //! CVE regression tests for security vulnerabilities.
 
 mod cve_regression;
+mod hardlink_quota_bypass;
 mod sevenz_traversal;
 mod symlink_target_validation;
 mod tar_budget_parity;


### PR DESCRIPTION
## Summary

- `TarArchive::create_hardlink` copied a hardlink target's full on-disk bytes without ever consulting `max_file_size`/`max_file_count`/`max_total_size`, since `EntryValidator` only recorded `EntryType::File` against `QuotaTracker`. A crafted archive with one file within quota followed by many hardlink entries pointing at it extracted unlimited copies with zero enforcement — a hardlink-bomb analog of zip-bomb resource exhaustion.
- Added `EntryValidator::record_hardlink`, which routes a hardlink's on-disk size through the same `QuotaTracker` instance used for regular files. The TAR second pass charges it before copying, but after the duplicate-skip check, so a `skip_duplicates` archive with duplicate hardlinks is not spuriously charged for an entry that is never copied.
- Replaced the unchecked `+=` accumulation of `files_extracted`, `bytes_written`, and `files_skipped` in `create_hardlink` with the same `checked_add`/`QuotaExceeded::IntegerOverflow` pattern already used elsewhere in the crate's byte-accounting sites.

## Test plan

- [x] 3 new integration tests in `crates/exarch-core/tests/security/hardlink_quota_bypass.rs`: total-size bypass, file-count bypass, and a positive case (legitimate hardlinks within quota still extract).
- [x] 3 new unit tests in `crates/exarch-core/src/security/validator.rs`: single hardlink exceeding `max_file_size`, shared-tracker accumulation with regular files, file-count-alone bypass.
- [x] Confirmed the two bypass regression tests fail on pre-fix code and pass post-fix.
- [x] Live-tested via the CLI binary with a crafted hardlink-bomb TAR (1 file + 50 hardlinks) and custom quota flags — confirmed real rejection with an accurate partial-write count on disk.
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` — 1034/1034 passed.
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo +nightly fmt --all -- --check` — clean.
- [x] Security audit (rust-security-maintenance): 0 blocking findings, `cargo deny`/`cargo audit` clean, no `unsafe` introduced.
- [x] Adversarial critique: verdict `minor` — the hardlink-bomb attack is genuinely closed across ordering, multi-target-chain, symlink, and feature-gate vectors.

Closes #426
Closes #427