### PR TITLE
fix: rename exarch-python lib target to avoid cargo doc collision

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,14 @@ jobs:
       - name: Check documentation
         env:
           RUSTDOCFLAGS: "-D warnings"
-        run: cargo doc --no-deps --all-features --workspace
+        run: |
+          cargo doc --no-deps --all-features --workspace 2>&1 | tee /tmp/cargo-doc.log
+          # cargo emits target output-path collisions as a warning, not a rustdoc lint, so
+          # RUSTDOCFLAGS="-D warnings" above cannot catch it (see #429) — assert it separately.
+          if grep -q "output filename collision" /tmp/cargo-doc.log; then
+            echo "::error::cargo doc reported an output filename collision (see #429)"
+            exit 1
+          fi
 
   # Security audit
   security:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -311,6 +311,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the same `checked_add(..).ok_or(ArchiveError::QuotaExceeded { resource: QuotaResource::IntegerOverflow })`
   pattern; this is not yet a crate-wide guarantee, since `formats/common.rs` and `formats/sevenz.rs`
   still increment their own `files_extracted` counters with unchecked `+=`.
+- **`cargo doc --workspace` silently overwrote one target's docs (#429)**: `exarch-cli`'s
+  `[[bin]]` target and `exarch-python`'s `[lib]` target both used the crate name `exarch`, so
+  rustdoc wrote both targets' output to the same path and one silently clobbered the other. The
+  build itself still exited 0 — this is a `cargo`-level warning, not a rustdoc lint, so
+  `RUSTDOCFLAGS="-D warnings"` never caught it. Renamed the `exarch-python` Cargo `[lib]` target
+  to `exarch_pylib`; the `exarch-cli` binary name is unchanged since it is the user-facing name
+  installed via `cargo install`. Considered and rejected `doc = false` on `exarch-cli`'s
+  `[[bin]]` as a smaller alternative fix: it would resolve the collision in one line without
+  touching Python packaging, but sacrifices exarch-cli's own rustdoc output, which the rename
+  preserves for both targets. Also added `module-name = "exarch"` under `[tool.maturin]` in
+  `crates/exarch-python/pyproject.toml`, since maturin otherwise derives the expected `PyInit_*`
+  symbol name from the Cargo `[lib]` name and would no longer find the `#[pymodule] fn
+  exarch(...)` entry point, breaking the Python extension import. The CI `Documentation` job
+  (`.github/workflows/ci.yml`) now fails if `cargo doc`'s output contains an "output filename
+  collision" warning, closing the gap that let this regression ship silently in the first place.
 
 ### Changed
 

--- a/crates/exarch-python/Cargo.toml
+++ b/crates/exarch-python/Cargo.toml
@@ -11,7 +11,10 @@ homepage.workspace = true
 publish = false
 
 [lib]
-name = "exarch"
+# Deliberately not "exarch": that collides with exarch-cli's `[[bin]]` name at the
+# `cargo doc` output-path level (#429). The Python-facing module name stays "exarch"
+# via `[tool.maturin] module-name` in pyproject.toml, decoupled from this Cargo name.
+name = "exarch_pylib"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]

--- a/crates/exarch-python/pyproject.toml
+++ b/crates/exarch-python/pyproject.toml
@@ -52,6 +52,11 @@ dev = [
 ]
 
 [tool.maturin]
+# Pins the Python-facing module name independently of Cargo's `[lib] name`
+# (which is "exarch_pylib", see crates/exarch-python/Cargo.toml, #429). This
+# drives PyInit_* symbol resolution, the wheel's module directory name, and
+# `exarch.pyi` stub discovery — must match `#[pymodule] fn exarch(...)`.
+module-name = "exarch"
 features = ["pyo3/extension-module", "abi3"]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Summary

- `exarch-cli`'s `[[bin]]` target and `exarch-python`'s `[lib]` target both used the crate name `exarch`, so `cargo doc --workspace` wrote both targets' output to `target/doc/exarch/` and one silently overwrote the other. This is a cargo-level warning, not a rustdoc lint, so `RUSTDOCFLAGS="-D warnings"` never caught it.
- Renamed `exarch-python`'s Cargo `[lib]` target to `exarch_pylib`; left `exarch-cli`'s bin target unchanged since it's the user-facing name installed via `cargo install`.
- Pinned the Python-facing module name independently via `[tool.maturin] module-name = "exarch"` in `pyproject.toml`, since maturin otherwise derives the expected `PyInit_*` symbol from the Cargo `[lib]` name and the rename alone would have silently broken `import exarch`.
- Added a regression guard to the CI `Documentation` job: it now fails if `cargo doc`'s output contains an "output filename collision" warning, closing the detection gap that let this ship silently in the first place.

## Test plan

- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace` — exit 0, zero "output filename collision" occurrences; `target/doc/exarch/` and `target/doc/exarch_pylib/` both generated
- [x] `cargo check --workspace --all-features` — exit 0
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` — 1034 passed, 0 failed
- [x] `cargo test --doc --workspace --all-features --exclude exarch-python` — 100 passed, 0 failed
- [x] `maturin build --features abi3` in `crates/exarch-python` — builds clean, no `PyInit` warning
- [x] Installed built wheel into a scratch venv, `python3 -c "import exarch"` — succeeds
- [x] CI guard verified in both directions: passes on the fixed workspace, fails with the collision warning surfaced when the `[lib]` rename is reverted
- [x] `fy lint .github/workflows/ci.yml` — 0 errors, no new warnings

Closes #429