### PR TITLE
fix(core): reject NUL bytes and invalid link targets in list_archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **`list` accepted NUL bytes, empty targets, and missing targets that `extract`/`verify` already
+  rejected (#430)**: `list_tar_entries` and `list_zip_reader` validated entry paths for path
+  traversal but not embedded NUL bytes, unlike `SafePath::validate` (used by `extract`). For TAR,
+  this meant `exarch list`/`list_archive` silently returned a NUL-containing path as an ordinary
+  entry instead of rejecting the archive. ZIP was affected differently: the `zip` crate's own
+  `enclosed_name()` already rejects a NUL-containing name under the default configuration, so that
+  case was already rejected pre-fix — just via the wrong mechanism (`PathTraversal`, from
+  `enclosed_name()` returning `None`, rather than a NUL-specific error). Only ZIP's
+  `allow_absolute_paths` fallback path — which reads the raw entry name directly, bypassing
+  `enclosed_name()` — was genuinely silent pre-fix, the same way TAR was unconditionally. The same
+  asymmetry existed for symlink/hardlink targets
+  relative to the checks `extract` gained in #424: an empty or NUL-containing target, or (TAR
+  only) a symlink/hardlink entry with no target at all (`link_name()` returns `None` — no ustar
+  linkname field and no PAX `linkpath` override), was silently accepted by `list`. `list_tar_entries`
+  and `list_zip_reader` now reject a NUL byte in the entry path (checked before path-traversal, in
+  both formats, for consistent ordering), and a new `validate_link_target` helper (mirroring
+  `SafeSymlink::validate`/`HardlinkTracker::validate_hardlink`'s wording, though it only checks
+  emptiness and NUL bytes — it does not give `list` full parity with `extract`'s target validation)
+  rejects an empty or NUL-containing `symlink_target`/`hardlink_target`; `list_tar_entries`
+  separately rejects a `None` link target with the same `InvalidArchive` message `extract` uses
+  (`"symlink missing target"` / `"hardlink missing target"`). 7z listing was not changed:
+  `sevenz_rust2::Archive::read` decodes each entry name as UTF-16 and stops at the first zero code
+  unit while parsing the header, so an embedded NUL cannot reach `list_sevenz_archive` in the first
+  place.
+  **`verify_archive`'s report-based behavior is preserved**: `verify_archive` lists the archive as
+  a pre-flight step before building its report, and `verify_entry` already had its own working
+  graceful handling for all of the above (a NUL-byte entry path via `validate_path`, and an empty/
+  NUL/missing link target via `validate_symlink`/`validate_path`, added in #424) — surfacing each as
+  a `VerificationIssue` rather than aborting. An earlier round of this fix let the new list-level
+  checks abort that pre-flight step before `verify_entry` ever ran, silently turning those graceful
+  reports into hard `Err` results (and, for the Python/Node bindings, a report object into a raised
+  exception) — caught and reverted before merging. `listing_config_for_verify` now also relaxes the
+  list-level NUL-byte/empty/missing-target checks (`SecurityConfig::relaxed_for_verify_preflight`,
+  a crate-internal config flag, not part of the public builder API) for `verify_archive`'s pre-flight
+  listing call specifically, so `verify` continues to report rather than abort. Bare `exarch list`/
+  `list_archive` is unaffected by this flag and still hard-aborts on all of the above — that hard
+  behavior is the actual #430 fix.
 - **TAR metadata-entry decompression bomb (#414)**: GNU long-name (`L`), GNU long-link (`K`),
   and PAX extended header (`x`/`g`) records are buffered fully into memory by the `tar` crate's
   internals before any entry reaches `exarch-core`'s validator or quota tracker, so a crafted

--- a/crates/exarch-core/src/config.rs
+++ b/crates/exarch-core/src/config.rs
@@ -165,6 +165,23 @@ pub struct SecurityConfig {
     ///
     /// Default: 4 MiB (4,194,304 bytes)
     pub max_tar_metadata_bytes: u64,
+
+    /// Internal only — not part of the public builder API, and never set by
+    /// `SecurityConfig::default()`/`permissive()` construction paths that
+    /// external callers use.
+    ///
+    /// When `true`, `list_archive`'s entry-path NUL-byte check, symlink/
+    /// hardlink target NUL-byte/emptiness check, and missing-link-target
+    /// check are all skipped, instead of aborting the listing pass. Set only
+    /// by `inspection::verify::listing_config_for_verify` for
+    /// `verify_archive`'s internal pre-flight listing step, so a NUL-byte or
+    /// empty/missing link target reaches `verify_entry`'s own equivalent
+    /// checks (`SafePath::validate`, `SafeSymlink::validate`) and surfaces as
+    /// a graceful `VerificationIssue` in the report, matching `verify`'s
+    /// behavior before these list-level checks existed. Bare `list_archive`
+    /// always leaves this `false`, so `exarch list` still hard-aborts on
+    /// these conditions.
+    pub(crate) relaxed_for_verify_preflight: bool,
 }
 
 impl Default for SecurityConfig {
@@ -206,6 +223,7 @@ impl Default for SecurityConfig {
             allow_solid_archives: false,
             max_solid_block_memory: 512 * 1024 * 1024, // 512 MB
             max_tar_metadata_bytes: 4 * 1024 * 1024,   // 4 MiB
+            relaxed_for_verify_preflight: false,
         }
     }
 }
@@ -581,6 +599,16 @@ impl SecurityConfig {
     #[inline]
     pub fn with_max_tar_metadata_bytes(mut self, size: u64) -> Self {
         self.max_tar_metadata_bytes = size;
+        self
+    }
+
+    /// Marks this config as the internal pre-flight listing pass inside
+    /// `verify_archive`. Not part of the public API — see
+    /// `relaxed_for_verify_preflight`'s field doc for what this relaxes.
+    #[must_use]
+    #[inline]
+    pub(crate) fn with_relaxed_for_verify_preflight(mut self) -> Self {
+        self.relaxed_for_verify_preflight = true;
         self
     }
 

--- a/crates/exarch-core/src/inspection/list.rs
+++ b/crates/exarch-core/src/inspection/list.rs
@@ -29,6 +29,7 @@ use crate::inspection::manifest::ArchiveEntry;
 use crate::inspection::manifest::ArchiveManifest;
 use crate::inspection::manifest::ManifestEntryType;
 use crate::security::quota::QuotaTracker;
+use crate::types::safe_path::has_null_bytes;
 
 /// Lists archive contents without extracting.
 ///
@@ -202,6 +203,12 @@ fn list_tar_entries<R: std::io::Read>(
             .map_err(|e| ArchiveError::InvalidArchive(format!("invalid path: {e}")))?
             .into_owned();
 
+        if !config.relaxed_for_verify_preflight && has_null_bytes(&path) {
+            return Err(ArchiveError::SecurityViolation {
+                reason: format!("path contains null bytes: {}", path.display()),
+            });
+        }
+
         if contains_traversal(&path, config) {
             return Err(ArchiveError::PathTraversal { path });
         }
@@ -219,8 +226,30 @@ fn list_tar_entries<R: std::io::Read>(
                     .link_name()
                     .map_err(|e| ArchiveError::InvalidArchive(format!("invalid link target: {e}")))?
                     .map(std::borrow::Cow::into_owned);
+                let is_symlink = entry.header().entry_type() == tar::EntryType::Symlink;
+                let kind = if is_symlink { "symlink" } else { "hardlink" };
 
-                if entry.header().entry_type() == tar::EntryType::Symlink {
+                match &target {
+                    Some(t) => validate_link_target(t, kind, config)?,
+                    // `link_name()` returns `None` when neither the ustar
+                    // linkname field nor a PAX `linkpath` override is
+                    // present — a structurally different case from an
+                    // empty-string target (see `validate_link_target`).
+                    // `extract` rejects this via `to_entry_type`
+                    // (formats/tar.rs) with the same message; mirrored here
+                    // for list/extract parity, still relaxed for verify's
+                    // pre-flight pass since `verify_entry` already turns a
+                    // missing target into an empty one via
+                    // `unwrap_or_default()` and reports it gracefully.
+                    None if !config.relaxed_for_verify_preflight => {
+                        return Err(ArchiveError::InvalidArchive(format!(
+                            "{kind} missing target"
+                        )));
+                    }
+                    None => {}
+                }
+
+                if is_symlink {
                     (target.clone(), None)
                 } else {
                     (None, target.clone())
@@ -321,6 +350,18 @@ pub(crate) fn list_zip_reader<R: Read + Seek>(
                     });
                 }
                 let p = PathBuf::from(stripped);
+                // NUL before traversal, matching `list_tar_entries`'s check
+                // order. `enclosed_name()` already rejects NUL bytes
+                // internally and returns `None` for them (caught by the
+                // other two match arms), so this is the only branch where a
+                // NUL byte can reach `p`: it bypasses `enclosed_name()`
+                // entirely by reading `raw_name` straight from the ZIP
+                // central directory.
+                if !config.relaxed_for_verify_preflight && has_null_bytes(&p) {
+                    return Err(ArchiveError::SecurityViolation {
+                        reason: format!("path contains null bytes: {}", p.display()),
+                    });
+                }
                 if contains_traversal(&p, config) {
                     return Err(ArchiveError::PathTraversal {
                         path: PathBuf::from(&raw_name),
@@ -355,7 +396,9 @@ pub(crate) fn list_zip_reader<R: Read + Seek>(
             let mut sym_entry = archive.by_index(i).map_err(|e| {
                 ArchiveError::InvalidArchive(format!("failed to re-read ZIP entry {i}: {e}"))
             })?;
-            Some(read_zip_symlink_target(&mut sym_entry)?)
+            let target = read_zip_symlink_target(&mut sym_entry)?;
+            validate_link_target(&target, "symlink", config)?;
+            Some(target)
         } else {
             None
         };
@@ -441,6 +484,14 @@ fn is_empty_sevenz_archive_reader<R: Read + Seek>(
 }
 
 /// Builds a manifest from a parsed 7z archive structure.
+///
+/// No NUL-byte check is applied to `entry.name`, unlike `list_tar_entries`
+/// and `list_zip_reader`: `sevenz_rust2::Archive::read` decodes each name as
+/// UTF-16 and stops at the first zero code unit while parsing the header
+/// (see `sevenz-rust2::reader`'s `NamesReader`), so an embedded NUL cannot
+/// survive into `entry.name` here. This is a format-parser guarantee, not a
+/// scope decision — it would need re-checking if `sevenz-rust2` ever changes
+/// that truncation behavior.
 fn list_sevenz_archive(
     archive: &sevenz_rust2::Archive,
     config: &SecurityConfig,
@@ -524,6 +575,37 @@ fn sevenz_manifest_entry_type(entry: &sevenz_rust2::ArchiveEntry) -> ManifestEnt
     ManifestEntryType::File
 }
 
+/// Checks a symlink/hardlink target parsed during listing for emptiness and
+/// NUL bytes — the same two conditions `SafeSymlink::validate` and
+/// `HardlinkTracker::validate_hardlink` reject during extraction (#424).
+/// `kind` is `"symlink"` or `"hardlink"`, matching the wording used by those
+/// extraction-side checks.
+///
+/// This does not give `list` full parity with `extract`: unlike the
+/// extraction-side validators, it does not check
+/// `config.allowed.symlinks`/`hardlinks`, reject absolute targets, or detect
+/// traversal within the target — only emptiness and NUL bytes. Skipped
+/// entirely when `config.relaxed_for_verify_preflight` is set (see that
+/// field's doc), so `verify_archive`'s pre-flight listing pass can defer to
+/// `verify_entry`'s own equivalent checks and report a graceful
+/// `VerificationIssue` instead of aborting.
+fn validate_link_target(target: &Path, kind: &str, config: &SecurityConfig) -> Result<()> {
+    if config.relaxed_for_verify_preflight {
+        return Ok(());
+    }
+    if target.as_os_str().is_empty() {
+        return Err(ArchiveError::SecurityViolation {
+            reason: format!("{kind} target is empty"),
+        });
+    }
+    if has_null_bytes(target) {
+        return Err(ArchiveError::SecurityViolation {
+            reason: format!("{kind} target contains null bytes"),
+        });
+    }
+    Ok(())
+}
+
 /// Checks whether a sevenz-rust2 parse failure is due to a valid empty 7z
 /// Returns `true` if the path contains traversal attempts.
 ///
@@ -590,6 +672,8 @@ mod tests {
     use std::assert_matches;
 
     use crate::test_utils::create_raw_zip_entry;
+    use crate::test_utils::tar_with_pax_linkpath;
+    use crate::test_utils::tar_with_pax_nul_path;
     use flate2::write::GzEncoder;
     use std::io::Write;
     use tempfile::NamedTempFile;
@@ -856,6 +940,10 @@ mod tests {
             manifest.entries[0].symlink_target,
             Some(PathBuf::from("target.txt")),
             "symlink_target must be the actual link target, not the entry path"
+        );
+        assert_eq!(
+            manifest.entries[0].hardlink_target, None,
+            "ZIP has no hardlink concept — hardlink_target must always be None"
         );
     }
 
@@ -1997,6 +2085,339 @@ mod tests {
             result,
             Err(ArchiveError::PathTraversal { .. }),
             "traversal inside absolute path must still be rejected, got: {result:?}"
+        );
+    }
+
+    // --- Regression tests for #430: list() must reject NUL bytes in entry
+    // paths, matching extract()/verify() ---
+
+    #[test]
+    fn test_list_tar_pax_path_nul_byte_rejected() {
+        let mut temp_file = NamedTempFile::with_suffix(".tar").unwrap();
+        temp_file
+            .write_all(&tar_with_pax_nul_path(b"foo\0bar.txt", b"hello"))
+            .unwrap();
+        temp_file.flush().unwrap();
+
+        let config = SecurityConfig::default();
+        let result = list_archive(temp_file.path(), &config);
+        match result {
+            Err(ArchiveError::SecurityViolation { reason }) => {
+                assert!(reason.contains("null bytes"), "reason: {reason}");
+            }
+            other => {
+                panic!("expected SecurityViolation for NUL byte in PAX path, got: {other:?}")
+            }
+        }
+    }
+
+    #[test]
+    fn test_list_zip_nul_byte_rejected_as_path_traversal_by_default() {
+        // Under default config, `enclosed_name()` already rejects NUL bytes
+        // internally, so this hits the pre-existing `None => PathTraversal`
+        // fallback rather than the new NUL-byte check — must not regress.
+        let zip_bytes = create_raw_zip_entry("foo\0bar.txt", b"");
+        let mut temp_file = NamedTempFile::with_suffix(".zip").unwrap();
+        temp_file.write_all(&zip_bytes).unwrap();
+        temp_file.flush().unwrap();
+
+        let config = SecurityConfig::default();
+        let result = list_archive(temp_file.path(), &config);
+        assert_matches!(
+            result,
+            Err(ArchiveError::PathTraversal { .. }),
+            "NUL byte in ZIP filename must be rejected by default, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_list_zip_nul_byte_rejected_with_allow_absolute_paths() {
+        // The actual bypass closed by #430: allow_absolute_paths routes
+        // through the raw-name fallback, bypassing enclosed_name()'s NUL
+        // check entirely, so only the new has_null_bytes() check catches it.
+        let zip_bytes = create_raw_zip_entry("foo\0bar.txt", b"");
+        let mut temp_file = NamedTempFile::with_suffix(".zip").unwrap();
+        temp_file.write_all(&zip_bytes).unwrap();
+        temp_file.flush().unwrap();
+
+        let config = SecurityConfig::default().with_allow_absolute_paths(true);
+        let result = list_archive(temp_file.path(), &config);
+        match result {
+            Err(ArchiveError::SecurityViolation { reason }) => {
+                assert!(reason.contains("null bytes"), "reason: {reason}");
+            }
+            other => panic!(
+                "expected SecurityViolation for NUL byte in ZIP filename with allow_absolute_paths, got: {other:?}"
+            ),
+        }
+    }
+
+    // --- Regression tests for #430 follow-up: list() must reject NUL bytes
+    // and emptiness in symlink/hardlink targets, matching extract()'s
+    // SafeSymlink/HardlinkTracker checks (#424) ---
+
+    #[test]
+    fn test_list_tar_symlink_target_nul_byte_rejected() {
+        let mut temp_file = NamedTempFile::with_suffix(".tar").unwrap();
+        temp_file
+            .write_all(&tar_with_pax_linkpath(b"foo\0bar", b'2'))
+            .unwrap();
+        temp_file.flush().unwrap();
+
+        let config = SecurityConfig::default();
+        let result = list_archive(temp_file.path(), &config);
+        match result {
+            Err(ArchiveError::SecurityViolation { reason }) => {
+                assert_eq!(reason, "symlink target contains null bytes");
+            }
+            other => {
+                panic!("expected SecurityViolation for NUL byte in symlink target, got: {other:?}")
+            }
+        }
+    }
+
+    #[test]
+    fn test_list_tar_symlink_target_empty_rejected() {
+        let mut temp_file = NamedTempFile::with_suffix(".tar").unwrap();
+        temp_file
+            .write_all(&tar_with_pax_linkpath(b"", b'2'))
+            .unwrap();
+        temp_file.flush().unwrap();
+
+        let config = SecurityConfig::default();
+        let result = list_archive(temp_file.path(), &config);
+        match result {
+            Err(ArchiveError::SecurityViolation { reason }) => {
+                assert_eq!(reason, "symlink target is empty");
+            }
+            other => panic!("expected SecurityViolation for empty symlink target, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_list_tar_hardlink_target_nul_byte_rejected() {
+        let mut temp_file = NamedTempFile::with_suffix(".tar").unwrap();
+        temp_file
+            .write_all(&tar_with_pax_linkpath(b"foo\0bar", b'1'))
+            .unwrap();
+        temp_file.flush().unwrap();
+
+        let config = SecurityConfig::default();
+        let result = list_archive(temp_file.path(), &config);
+        match result {
+            Err(ArchiveError::SecurityViolation { reason }) => {
+                assert_eq!(reason, "hardlink target contains null bytes");
+            }
+            other => {
+                panic!("expected SecurityViolation for NUL byte in hardlink target, got: {other:?}")
+            }
+        }
+    }
+
+    #[test]
+    fn test_list_tar_hardlink_target_empty_rejected() {
+        let mut temp_file = NamedTempFile::with_suffix(".tar").unwrap();
+        temp_file
+            .write_all(&tar_with_pax_linkpath(b"", b'1'))
+            .unwrap();
+        temp_file.flush().unwrap();
+
+        let config = SecurityConfig::default();
+        let result = list_archive(temp_file.path(), &config);
+        match result {
+            Err(ArchiveError::SecurityViolation { reason }) => {
+                assert_eq!(reason, "hardlink target is empty");
+            }
+            other => panic!("expected SecurityViolation for empty hardlink target, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_list_zip_symlink_target_nul_byte_rejected() {
+        use crate::test_utils::create_zip_with_symlink;
+        use std::io::Cursor;
+
+        let zip_bytes = create_zip_with_symlink("link", "foo\0bar");
+        let mut archive = zip::ZipArchive::new(Cursor::new(zip_bytes)).unwrap();
+        let config = SecurityConfig::default();
+        let result = list_zip_reader(&mut archive, &config);
+        match result {
+            Err(ArchiveError::SecurityViolation { reason }) => {
+                assert_eq!(reason, "symlink target contains null bytes");
+            }
+            other => panic!(
+                "expected SecurityViolation for NUL byte in ZIP symlink target, got: {other:?}"
+            ),
+        }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_list_zip_symlink_target_empty_rejected() {
+        use crate::test_utils::create_zip_with_symlink;
+        use std::io::Cursor;
+
+        let zip_bytes = create_zip_with_symlink("link", "");
+        let mut archive = zip::ZipArchive::new(Cursor::new(zip_bytes)).unwrap();
+        let config = SecurityConfig::default();
+        let result = list_zip_reader(&mut archive, &config);
+        match result {
+            Err(ArchiveError::SecurityViolation { reason }) => {
+                assert_eq!(reason, "symlink target is empty");
+            }
+            other => {
+                panic!("expected SecurityViolation for empty ZIP symlink target, got: {other:?}")
+            }
+        }
+    }
+
+    // --- Regression tests for #430 follow-up (round 3): a symlink/hardlink
+    // entry with no link target at all (no ustar linkname field, no PAX
+    // `linkpath` override — `entry.link_name()` returns `None`) must be
+    // rejected by bare `list`, matching extract's `to_entry_type` wording,
+    // while `relaxed_for_verify_preflight` must skip this check (and the
+    // entry-path NUL and link-target emptiness/NUL checks) so verify's
+    // pre-flight listing pass can defer to `verify_entry`'s own graceful
+    // checks instead of aborting ---
+
+    #[test]
+    fn test_list_tar_symlink_missing_target_rejected() {
+        let mut temp_file = NamedTempFile::with_suffix(".tar").unwrap();
+        let mut builder = tar::Builder::new(Vec::new());
+
+        let mut header = tar::Header::new_gnu();
+        header.set_path("link").unwrap();
+        header.set_size(0);
+        header.set_entry_type(tar::EntryType::Symlink);
+        // Deliberately no `set_link_name()` call: the raw linkname field
+        // stays all-zero, so `entry.link_name()` returns `None` rather than
+        // `Some(empty)`.
+        header.set_cksum();
+        builder.append(&header, &[][..]).unwrap();
+
+        let data = builder.into_inner().unwrap();
+        temp_file.write_all(&data).unwrap();
+        temp_file.flush().unwrap();
+
+        let config = SecurityConfig::default();
+        let result = list_archive(temp_file.path(), &config);
+        match result {
+            Err(ArchiveError::InvalidArchive(msg)) => {
+                assert_eq!(msg, "symlink missing target");
+            }
+            other => panic!("expected InvalidArchive for missing symlink target, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_list_tar_hardlink_missing_target_rejected() {
+        let mut temp_file = NamedTempFile::with_suffix(".tar").unwrap();
+        let mut builder = tar::Builder::new(Vec::new());
+
+        let mut header = tar::Header::new_gnu();
+        header.set_path("link").unwrap();
+        header.set_size(0);
+        header.set_entry_type(tar::EntryType::Link);
+        header.set_cksum();
+        builder.append(&header, &[][..]).unwrap();
+
+        let data = builder.into_inner().unwrap();
+        temp_file.write_all(&data).unwrap();
+        temp_file.flush().unwrap();
+
+        let config = SecurityConfig::default();
+        let result = list_archive(temp_file.path(), &config);
+        match result {
+            Err(ArchiveError::InvalidArchive(msg)) => {
+                assert_eq!(msg, "hardlink missing target");
+            }
+            other => panic!("expected InvalidArchive for missing hardlink target, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_list_tar_relaxed_preflight_allows_nul_byte_path() {
+        let mut temp_file = NamedTempFile::with_suffix(".tar").unwrap();
+        temp_file
+            .write_all(&tar_with_pax_nul_path(b"foo\0bar.txt", b"hello"))
+            .unwrap();
+        temp_file.flush().unwrap();
+
+        let config = SecurityConfig::default().with_relaxed_for_verify_preflight();
+        let manifest = list_archive(temp_file.path(), &config)
+            .expect("relaxed_for_verify_preflight must let a NUL-byte entry path through");
+
+        assert_eq!(manifest.total_entries, 1);
+        assert!(
+            has_null_bytes(&manifest.entries[0].path),
+            "the raw NUL-byte path must reach the manifest unmodified"
+        );
+    }
+
+    #[test]
+    fn test_list_tar_relaxed_preflight_allows_missing_link_target() {
+        let mut temp_file = NamedTempFile::with_suffix(".tar").unwrap();
+        let mut builder = tar::Builder::new(Vec::new());
+
+        let mut header = tar::Header::new_gnu();
+        header.set_path("link").unwrap();
+        header.set_size(0);
+        header.set_entry_type(tar::EntryType::Symlink);
+        header.set_cksum();
+        builder.append(&header, &[][..]).unwrap();
+
+        let data = builder.into_inner().unwrap();
+        temp_file.write_all(&data).unwrap();
+        temp_file.flush().unwrap();
+
+        let config = SecurityConfig::default().with_relaxed_for_verify_preflight();
+        let manifest = list_archive(temp_file.path(), &config)
+            .expect("relaxed_for_verify_preflight must let a missing symlink target through");
+
+        assert_eq!(manifest.total_entries, 1);
+        assert_eq!(manifest.entries[0].symlink_target, None);
+    }
+
+    #[test]
+    fn test_list_tar_relaxed_preflight_allows_nul_byte_link_target() {
+        let mut temp_file = NamedTempFile::with_suffix(".tar").unwrap();
+        temp_file
+            .write_all(&tar_with_pax_linkpath(b"foo\0bar", b'2'))
+            .unwrap();
+        temp_file.flush().unwrap();
+
+        let config = SecurityConfig::default().with_relaxed_for_verify_preflight();
+        let manifest = list_archive(temp_file.path(), &config)
+            .expect("relaxed_for_verify_preflight must let a NUL-byte symlink target through");
+
+        assert_eq!(manifest.total_entries, 1);
+        assert!(
+            manifest.entries[0]
+                .symlink_target
+                .as_ref()
+                .is_some_and(|t| has_null_bytes(t)),
+            "the raw NUL-byte target must reach the manifest unmodified"
+        );
+    }
+
+    #[test]
+    fn test_list_zip_relaxed_preflight_allows_nul_byte_path() {
+        let zip_bytes = create_raw_zip_entry("foo\0bar.txt", b"");
+        let mut temp_file = NamedTempFile::with_suffix(".zip").unwrap();
+        temp_file.write_all(&zip_bytes).unwrap();
+        temp_file.flush().unwrap();
+
+        let config = SecurityConfig::default()
+            .with_allow_absolute_paths(true)
+            .with_relaxed_for_verify_preflight();
+        let manifest = list_archive(temp_file.path(), &config)
+            .expect("relaxed_for_verify_preflight must let a NUL-byte ZIP entry path through");
+
+        assert_eq!(manifest.total_entries, 1);
+        assert!(
+            has_null_bytes(&manifest.entries[0].path),
+            "the raw NUL-byte path must reach the manifest unmodified"
         );
     }
 

--- a/crates/exarch-core/src/inspection/verify.rs
+++ b/crates/exarch-core/src/inspection/verify.rs
@@ -120,15 +120,24 @@ pub fn verify_archive<P: AsRef<Path>>(
 }
 
 /// Returns a config variant for the pre-flight listing step that feeds
-/// `verify_manifest`, with `max_file_size` relaxed to unlimited.
+/// `verify_manifest`, with `max_file_size` relaxed to unlimited and the
+/// list-level NUL-byte/link-target checks relaxed to defer to
+/// `verify_entry`'s own equivalent checks.
 ///
-/// `verify` is a read-only, report-based operation: an oversized entry is
-/// meant to surface as a `VerificationIssue` from `verify_entry` (which
-/// re-checks the real `config` against every manifest entry), not abort the
-/// listing step before any report exists. `max_file_count` and
-/// `max_total_size` are left untouched, matching prior behavior.
+/// `verify` is a read-only, report-based operation: an oversized entry,
+/// a NUL byte in an entry path, or an empty/NUL/missing symlink or hardlink
+/// target are all meant to surface as a `VerificationIssue` from
+/// `verify_entry` (which re-checks the real `config` against every manifest
+/// entry via `validate_path`/`validate_symlink`), not abort the listing step
+/// before any report exists. `max_file_count` and `max_total_size` are left
+/// untouched, matching prior behavior. See
+/// `SecurityConfig::relaxed_for_verify_preflight`'s field doc for exactly
+/// which `list_archive` checks this skips.
 pub(crate) fn listing_config_for_verify(config: &SecurityConfig) -> SecurityConfig {
-    config.clone().with_max_file_size(u64::MAX)
+    config
+        .clone()
+        .with_max_file_size(u64::MAX)
+        .with_relaxed_for_verify_preflight()
 }
 
 fn verify_entry(
@@ -305,6 +314,7 @@ fn determine_security_status(issues: &[VerificationIssue]) -> CheckStatus {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+    use crate::test_utils::tar_with_pax_nul_path;
     use std::assert_matches;
     use std::io::Write;
     use std::path::PathBuf;
@@ -487,7 +497,7 @@ mod tests {
     }
 
     #[test]
-    fn test_listing_config_for_verify_relaxes_only_max_file_size() {
+    fn test_listing_config_for_verify_relaxes_max_file_size_and_preflight_checks() {
         let config = SecurityConfig {
             max_file_size: 1000,
             max_total_size: 2000,
@@ -499,6 +509,102 @@ mod tests {
         assert_eq!(listing_config.max_file_size, u64::MAX);
         assert_eq!(listing_config.max_total_size, config.max_total_size);
         assert_eq!(listing_config.max_file_count, config.max_file_count);
+        assert!(
+            listing_config.relaxed_for_verify_preflight,
+            "verify's pre-flight listing pass must set relaxed_for_verify_preflight so \
+             NUL-byte paths and empty/NUL/missing link targets defer to verify_entry's own \
+             graceful checks instead of aborting list_archive"
+        );
+    }
+
+    // Regression test for #430 follow-up (round 3): a NUL-byte entry path
+    // must surface as a graceful VerificationIssue, not abort verify_archive
+    // with a hard `Err`, matching verify's behavior before the list-level
+    // NUL-byte check (this PR) existed. An earlier version of this test
+    // pinned the opposite (hard-error) behavior, which a code-review pass
+    // identified as a real regression: verify_entry's own validate_path
+    // call (line ~156) already had a working graceful NUL-byte check via
+    // SafePath::validate, and the list-level check was aborting before that
+    // mechanism ever ran. `listing_config_for_verify` now also relaxes the
+    // list-level NUL-byte check (see
+    // `SecurityConfig::relaxed_for_verify_preflight`), restoring the original
+    // graceful-report behavior — this test was rewritten (not just renamed) to
+    // assert that restored behavior instead of the hard-error behavior it
+    // previously pinned.
+    #[test]
+    fn test_verify_archive_nul_byte_path_reports_issue_not_error() {
+        let mut temp_file = NamedTempFile::with_suffix(".tar").unwrap();
+        temp_file
+            .write_all(&tar_with_pax_nul_path(b"foo\0bar.txt", b"hello"))
+            .unwrap();
+        temp_file.flush().unwrap();
+
+        let config = SecurityConfig::default();
+        let report = verify_archive(temp_file.path(), &config)
+            .expect("verify_archive must report a NUL-byte entry path, not error out");
+
+        assert_eq!(
+            report.status,
+            VerificationStatus::Fail,
+            "NUL-byte entry path must fail verification via a report, not a hard error"
+        );
+        assert_eq!(report.suspicious_entries, 1);
+        assert!(
+            report
+                .issues
+                .iter()
+                .any(|i| i.message.contains("null bytes")),
+            "expected an issue mentioning null bytes, got: {:?}",
+            report.issues
+        );
+    }
+
+    // Regression test for #430 follow-up (round 3, item 2): a hardlink entry
+    // with no link target at all must still surface as a graceful
+    // VerificationIssue from verify_archive, not the InvalidArchive hard
+    // error that bare `list_archive` now raises (see
+    // `test_list_tar_hardlink_missing_target_rejected` in
+    // `inspection::list::tests`). `relaxed_for_verify_preflight` lets the
+    // missing target through the pre-flight listing pass as `None`;
+    // `verify_entry` then treats it as an empty target via
+    // `unwrap_or_default()`, which `validate_path` rejects with its own
+    // pre-existing "empty path not allowed" check.
+    #[test]
+    fn test_verify_archive_hardlink_missing_target_reports_issue_not_error() {
+        let mut temp_file = NamedTempFile::with_suffix(".tar").unwrap();
+        let mut builder = tar::Builder::new(Vec::new());
+
+        let mut header = tar::Header::new_gnu();
+        header.set_path("link").unwrap();
+        header.set_size(0);
+        header.set_entry_type(tar::EntryType::Link);
+        header.set_cksum();
+        builder.append(&header, &[][..]).unwrap();
+
+        let archive_data = builder.into_inner().unwrap();
+        temp_file.write_all(&archive_data).unwrap();
+        temp_file.flush().unwrap();
+
+        let config = SecurityConfig::default();
+        let report = verify_archive(temp_file.path(), &config)
+            .expect("verify_archive must report a missing hardlink target, not error out");
+
+        assert_eq!(
+            report.status,
+            VerificationStatus::Fail,
+            "missing hardlink target must fail verification via a report, not a hard error"
+        );
+        assert_eq!(report.suspicious_entries, 1);
+        assert!(
+            report.issues.iter().any(|i| {
+                i.category == IssueCategory::HardlinkEscape
+                    && i.context
+                        .as_deref()
+                        .is_some_and(|c| c.contains("empty path not allowed"))
+            }),
+            "expected a HardlinkEscape issue citing the empty target, got: {:?}",
+            report.issues
+        );
     }
 
     // Note: Full CVE regression tests for path traversal require real malicious

--- a/crates/exarch-core/src/test_utils.rs
+++ b/crates/exarch-core/src/test_utils.rs
@@ -365,6 +365,93 @@ impl Default for ZipTestBuilder {
     }
 }
 
+/// Builds a 512-byte raw ustar TAR header block, bypassing `tar::Header`'s
+/// safety checks (`set_path`/`set_link_name` reject NUL bytes and other
+/// adversarial values) so fixtures for security regression tests can be
+/// constructed byte-for-byte.
+fn raw_tar_header(name: &[u8], size: usize, typeflag: u8) -> [u8; 512] {
+    let mut h = [0u8; 512];
+    let name_len = name.len().min(100);
+    h[..name_len].copy_from_slice(&name[..name_len]);
+    h[100..108].copy_from_slice(b"0000644\0");
+    h[108..116].copy_from_slice(b"0000000\0");
+    h[116..124].copy_from_slice(b"0000000\0");
+    h[124..136].copy_from_slice(format!("{size:011o}\0").as_bytes());
+    h[136..148].copy_from_slice(b"00000000000\0");
+    h[156] = typeflag;
+    h[257..263].copy_from_slice(b"ustar\0");
+    h[263..265].copy_from_slice(b"00");
+    h[148..156].copy_from_slice(b"        ");
+    let checksum: u32 = h.iter().map(|&b| u32::from(b)).sum();
+    h[148..156].copy_from_slice(format!("{checksum:06o}\0 ").as_bytes());
+    h
+}
+
+/// Pads `data` to a 512-byte TAR block boundary and appends it to `out`.
+fn pad_tar_block(out: &mut Vec<u8>, data: &[u8]) {
+    out.extend_from_slice(data);
+    let rem = data.len() % 512;
+    if rem != 0 {
+        out.extend(std::iter::repeat_n(0u8, 512 - rem));
+    }
+}
+
+/// Builds a raw ustar-format TAR archive with a PAX extended header record
+/// (`{pax_key}={pax_value}`) followed by one entry of type `typeflag` named
+/// `entry_name` with body `data`.
+///
+/// Writes headers directly rather than through `tar::Header`'s safe setters,
+/// so adversarial PAX overrides — e.g. an embedded NUL byte or an empty
+/// value in a `path`/`linkpath` record — can be constructed for security
+/// regression tests.
+#[must_use]
+pub fn tar_with_pax_record(
+    pax_key: &str,
+    pax_value: &[u8],
+    entry_name: &[u8],
+    typeflag: u8,
+    data: &[u8],
+) -> Vec<u8> {
+    // Self-referential PAX record length: "<len> <key>=<value>\n".
+    let base = pax_key.len() + pax_value.len() + 3;
+    let mut len = base + 1;
+    loop {
+        let candidate = len.to_string().len() + base;
+        if candidate == len {
+            break;
+        }
+        len = candidate;
+    }
+    let mut record = format!("{len} {pax_key}=").into_bytes();
+    record.extend_from_slice(pax_value);
+    record.push(b'\n');
+
+    let mut tar = Vec::new();
+    tar.extend_from_slice(&raw_tar_header(b"PaxHeaders/entry", record.len(), b'x'));
+    pad_tar_block(&mut tar, &record);
+    tar.extend_from_slice(&raw_tar_header(entry_name, data.len(), typeflag));
+    pad_tar_block(&mut tar, data);
+    tar.extend(std::iter::repeat_n(0u8, 1024));
+    tar
+}
+
+/// Builds a raw ustar-format TAR archive with a PAX `path` record embedding
+/// `pax_path` (which may contain a NUL byte) as the effective path of a
+/// regular-file entry with body `data`.
+#[must_use]
+pub fn tar_with_pax_nul_path(pax_path: &[u8], data: &[u8]) -> Vec<u8> {
+    tar_with_pax_record("path", pax_path, b"ustar_name.txt", b'0', data)
+}
+
+/// Builds a raw ustar-format TAR archive with a PAX `linkpath` record
+/// embedding `pax_linkpath` (which may be empty or contain a NUL byte) as
+/// the effective link target of a symlink/hardlink entry. `typeflag` is
+/// `b'2'` for a symlink entry, `b'1'` for a hardlink entry.
+#[must_use]
+pub fn tar_with_pax_linkpath(pax_linkpath: &[u8], typeflag: u8) -> Vec<u8> {
+    tar_with_pax_record("linkpath", pax_linkpath, b"link_entry", typeflag, b"")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

- `list_tar_entries` and `list_zip_reader` validated entry paths for path traversal but not embedded NUL bytes, unlike `SafePath::validate` (used by `extract`), so `list_archive` silently returned a NUL-containing path as an ordinary entry instead of rejecting the archive.
- The same asymmetry existed for symlink/hardlink targets relative to the checks `extract` gained in #424: an empty or NUL-containing target, or (TAR only) a missing target entirely, was silently accepted by `list`.
- Both `list_tar_entries` and `list_zip_reader` now reject a NUL byte in the entry path, and a new `validate_link_target` helper rejects an empty or NUL-containing symlink/hardlink target; `list_tar_entries` separately rejects a missing link target with the same `InvalidArchive` message `extract` uses.
- `verify_archive` lists the archive as a pre-flight step before building its report, and `verify_entry` already had its own graceful handling for all of the above, surfacing each as a `VerificationIssue` rather than aborting. To preserve that report-based behavior, `listing_config_for_verify` now also relaxes the new list-level checks via a crate-internal `SecurityConfig` flag for verify's pre-flight listing call specifically. Bare `list_archive` is unaffected and still hard-aborts.

Closes #430

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` (1051/1051 passing)
- [x] `cargo test --doc --workspace --all-features` (100 passing)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace`
- [x] Manual verification: `exarch list`/`exarch extract`/`exarch verify` against TAR/ZIP fixtures with NUL bytes, empty, and missing link targets in entry paths and symlink/hardlink targets