### PR TITLE
fix(core)!: enforce SecurityConfig validation and entry sealing at compile time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING: `SecurityConfig` is now a two-state typestate over `Unvalidated`/`Validated`
+  (#433, #434, #435)**: `SecurityConfig<State = Unvalidated>` carries a phantom marker; the
+  fluent `with_*` builder methods remain available only on `SecurityConfig<Unvalidated>`, and
+  `SecurityConfig::validate()` now consumes `self` and returns
+  `Result<SecurityConfig<Validated>>` instead of `Result<()>`. The `ArchiveFormat` trait
+  (`extract`, `list`, `verify`) and every function downstream of validation in `exarch-core`
+  (`EntryValidator`, `SafePath::validate`, `SafeSymlink::validate`, `QuotaTracker::record_file`,
+  `validate_symlink`, `validate_compression_ratio`, `HardlinkTracker::validate_hardlink`,
+  `sanitize_permissions`, and the per-format `list`/`extract` helpers) now require
+  `&SecurityConfig<Validated>`, so a config that skipped or failed validation can no longer
+  reach extraction, listing, or verification — enforced by the compiler instead of by
+  convention. Fields are sealed behind a private inner struct, reachable read-only via `Deref`
+  for both typestates but mutable (`DerefMut`) only for `SecurityConfig<Unvalidated>`, so a
+  `SecurityConfig<Validated>` cannot be mutated back into an invalid state after the fact while
+  `cfg.max_file_size`-style field access keeps working unchanged for every existing caller. The
+  top-level `extract_archive*`, `list_archive`, `verify_archive`, and `create_archive*`
+  functions are unaffected: they still accept `&SecurityConfig` (defaulting to `Unvalidated`)
+  and validate internally. `SecurityConfig::default()` continues to infer `Unvalidated` with no
+  turbofish required. `Validated` and `Unvalidated` are re-exported from the crate root.
+  `exarch-cli`, `exarch-python`, and `exarch-node` need no changes: they only ever hold
+  `SecurityConfig<Unvalidated>` and pass it to the top-level API. `ValidatedEntry`
+  (`security::validator`) becomes sealed: its fields are private, its constructor is
+  `pub(crate)`, and `safe_path()`/`entry_type()`/`mode()` accessors replace direct field access,
+  so it is assemblable only from inside this crate, and in practice only via
+  `EntryValidator::validate_entry()`. `ValidatedEntryType` is now `#[non_exhaustive]`; its
+  `Symlink`/`Hardlink` variants wrap the already-sealed `SafeSymlink`/`SafePath`, so their
+  payloads cannot be forged even from within the crate. No validation logic changed — this is
+  purely a compile-time hardening of the existing
+  runtime checks.
 - Extracted the duplicated extension-allowlist check from `formats/zip.rs`, `formats/tar.rs`,
   and `formats/sevenz.rs` into a shared, `#[must_use]` `formats::common::check_extension_allowed`
   helper (#413). Behavior is unchanged; each call site still returns its own type (`Ok(())`,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,9 +281,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -291,9 +291,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",
@@ -463,9 +463,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9bb72bb94fdc1bd619f4c18cc91ecf6302aeb333d31b3c6ec0bb841cd920209"
+checksum = "2d83cb7e7a873830708d6b02a78cd36a592c6fa14bf267b68725103b85c0d77f"
 
 [[package]]
 name = "deflate64"
@@ -576,6 +576,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "time",
+ "trybuild",
  "walkdir",
  "xz2",
  "zip",
@@ -767,6 +768,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -791,9 +798,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
@@ -964,9 +971,9 @@ checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
 
 [[package]]
 name = "napi"
-version = "3.11.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de33522036981030a75c231829566bc63414e08101a6f5ff4ac6cef19c8e0941"
+checksum = "6f71d6bc097c4a6eb853c3f24991ab8c9f50f57d1f719e305175541482217e36"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -981,15 +988,15 @@ dependencies = [
 
 [[package]]
 name = "napi-build"
-version = "2.3.2"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9c366d2c8c60b86fa632df75f745509b52f9128f91a6bad4c796e44abb505e1"
+checksum = "5282704fbe8d49b0cf8b08e3f33233416a528658f205c7e5ace63b582de0b11c"
 
 [[package]]
 name = "napi-derive"
-version = "3.6.0"
+version = "3.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a49c513341a61a16a10af6efcce46b30d0822ba2d4fb197d24d33dfc199c78d5"
+checksum = "6d9002b2940f0184444754546e0fcd15182f56948e6f381968b019d549387c42"
 dependencies = [
  "convert_case",
  "ctor",
@@ -1001,9 +1008,9 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "6.0.0"
+version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4747005fa3e2c9989ac45a723a514c5db2411238b72981a3cda4c701a9dfea17"
+checksum = "d60b5d773ad46c698c8cc2cd9fde0b283d39cbb7f71c04bee633c7bdba4423bd"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -1235,9 +1242,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
+checksum = "fc153f5fd745cc038b5eed86622125969f8a39834a57bc96beaaf2512b1da729"
 dependencies = [
  "libc",
  "once_cell",
@@ -1249,18 +1256,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
+checksum = "bb77d9aa6d647507b55c69ee714d266d84c526c78ff0bc6dd8757f58591e64d1"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
+checksum = "3160087aa5733bce7d9a729f8c55f85a2a53b74742a09613178eeebff0722253"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1268,9 +1275,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
+checksum = "91f9d455db760a9a0b0ddeaac25f1390b8a36ba73dfbda9f127cac6fc340d4d5"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1280,9 +1287,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
+checksum = "e343bcec300ff262f5806a33a4e51b6d097a8a46435f512fcb83e95592581625"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1527,6 +1534,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "sevenz-rust2"
 version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1625,6 +1641,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
+name = "target-triple"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3a6bfce3d99adfa72d24750a61f782f3036a81e7f86d8841ee1326deaebd171"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1635,6 +1657,15 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1681,9 +1712,9 @@ checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "time"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "js-sys",
@@ -1721,13 +1752,67 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.4+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
+
+[[package]]
+name = "trybuild"
+version = "1.0.119"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c5c9f7b7b1a048dd2bebdb7260b0cc71ec5587b19352fa5c3cd9e1c067103f0"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml",
 ]
 
 [[package]]
@@ -1916,6 +2001,12 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ tempfile = "3.27"
 thiserror = "2.0"
 time = "0.3"
 tokio = "1.52"
+trybuild = "1.0"
 walkdir = "2.5"
 xz2 = { version = "0.1", features = ["static"] }
 zip = { version = "9.0.0-pre2", default-features = false }

--- a/crates/exarch-core/Cargo.toml
+++ b/crates/exarch-core/Cargo.toml
@@ -33,6 +33,7 @@ libc.workspace = true
 criterion.workspace = true
 dhat.workspace = true
 proptest.workspace = true
+trybuild.workspace = true
 
 [features]
 # Exposes security primitives as `pub` for external benchmarks and integration

--- a/crates/exarch-core/benches/extraction.rs
+++ b/crates/exarch-core/benches/extraction.rs
@@ -71,6 +71,13 @@ fn benchmark_config() -> SecurityConfig {
         .with_max_path_depth(100)
 }
 
+/// Validated variant of [`benchmark_config`] for direct
+/// `ArchiveFormat::extract` trait calls, which require
+/// `SecurityConfig<Validated>`.
+fn benchmark_config_validated() -> SecurityConfig<exarch_core::Validated> {
+    benchmark_config().validate().unwrap()
+}
+
 /// Returns fixture path if it exists, otherwise None.
 fn get_fixture(name: &str) -> Option<PathBuf> {
     let path = fixtures_dir().join(name);
@@ -237,7 +244,7 @@ fn benchmark_many_small_files(c: &mut Criterion) {
                     archive
                         .extract(
                             temp.path(),
-                            &SecurityConfig::default(),
+                            &SecurityConfig::default().validate().unwrap(),
                             &ExtractionOptions::default(),
                             &mut exarch_core::NoopProgress,
                         )
@@ -270,7 +277,9 @@ fn benchmark_large_files(c: &mut Criterion) {
                     // Use config with increased limits for benchmarks
                     let config = SecurityConfig::default()
                         .with_max_file_size(200 * 1024 * 1024)
-                        .with_max_total_size(500 * 1024 * 1024);
+                        .with_max_total_size(500 * 1024 * 1024)
+                        .validate()
+                        .unwrap();
 
                     archive
                         .extract(
@@ -303,7 +312,7 @@ fn benchmark_nested_directories(c: &mut Criterion) {
                 archive
                     .extract(
                         temp.path(),
-                        &SecurityConfig::default(),
+                        &SecurityConfig::default().validate().unwrap(),
                         &ExtractionOptions::default(),
                         &mut exarch_core::NoopProgress,
                     )
@@ -317,7 +326,7 @@ fn benchmark_nested_directories(c: &mut Criterion) {
 
 fn benchmark_compression_methods(c: &mut Criterion) {
     let mut group = c.benchmark_group("compression_methods");
-    let config = benchmark_config();
+    let config = benchmark_config_validated();
 
     let size_bytes = 10 * 1024 * 1024; // 10 MB
     group.throughput(Throughput::Bytes(size_bytes as u64));
@@ -394,7 +403,7 @@ fn benchmark_sevenz_simple(c: &mut Criterion) {
             archive
                 .extract(
                     temp.path(),
-                    &SecurityConfig::default(),
+                    &SecurityConfig::default().validate().unwrap(),
                     &ExtractionOptions::default(),
                     &mut exarch_core::NoopProgress,
                 )
@@ -419,7 +428,7 @@ fn benchmark_sevenz_nested_dirs(c: &mut Criterion) {
             archive
                 .extract(
                     temp.path(),
-                    &SecurityConfig::default(),
+                    &SecurityConfig::default().validate().unwrap(),
                     &ExtractionOptions::default(),
                     &mut exarch_core::NoopProgress,
                 )
@@ -445,7 +454,7 @@ fn benchmark_sevenz_large_file(c: &mut Criterion) {
             archive
                 .extract(
                     temp.path(),
-                    &SecurityConfig::default(),
+                    &SecurityConfig::default().validate().unwrap(),
                     &ExtractionOptions::default(),
                     &mut exarch_core::NoopProgress,
                 )
@@ -480,7 +489,7 @@ fn benchmark_file_count_scaling(c: &mut Criterion) {
         let count_u64 = count as u64;
         group.throughput(Throughput::Elements(count_u64));
         group.bench_with_input(BenchmarkId::new("files", count), &zip_data, |b, data| {
-            let config = SecurityConfig::default();
+            let config = SecurityConfig::default().validate().unwrap();
             b.iter(|| {
                 let temp = TempDir::new().unwrap();
                 let cursor = Cursor::new(data.clone());
@@ -503,7 +512,7 @@ fn benchmark_file_count_scaling(c: &mut Criterion) {
 /// Directory depth scaling benchmark.
 fn benchmark_depth_scaling(c: &mut Criterion) {
     let mut group = c.benchmark_group("depth_scaling");
-    let config = benchmark_config();
+    let config = benchmark_config_validated();
 
     for depth in [5, 10, 20, 50] {
         let zip_data = {

--- a/crates/exarch-core/benches/validation.rs
+++ b/crates/exarch-core/benches/validation.rs
@@ -40,7 +40,7 @@ fn benchmark_path_validation(c: &mut Criterion) {
 
     let temp = TempDir::new().unwrap();
     let dest = DestDir::new(temp.path().to_path_buf()).unwrap();
-    let config = SecurityConfig::default();
+    let config = SecurityConfig::default().validate().unwrap();
 
     // Simple path (most common case)
     group.bench_function("simple_nonexistent", |b| {
@@ -70,6 +70,7 @@ fn benchmark_path_validation(c: &mut Criterion) {
     group.bench_function("no_banned_components", |b| {
         let mut config_no_banned = SecurityConfig::default();
         config_no_banned.banned_path_components.clear();
+        let config_no_banned = config_no_banned.validate().unwrap();
         let path = PathBuf::from("foo/bar/baz.txt");
         b.iter(|| {
             SafePath::validate(
@@ -89,7 +90,7 @@ fn benchmark_normalization(c: &mut Criterion) {
 
     let temp = TempDir::new().unwrap();
     let dest = DestDir::new(temp.path().to_path_buf()).unwrap();
-    let config = SecurityConfig::default();
+    let config = SecurityConfig::default().validate().unwrap();
 
     // Path without . components (should use Cow::Borrowed)
     group.bench_function("no_normalization_needed", |b| {
@@ -114,6 +115,7 @@ fn benchmark_symlink_validation(c: &mut Criterion) {
     let dest = DestDir::new(temp.path().to_path_buf()).unwrap();
     let mut config = SecurityConfig::default();
     config.allowed.symlinks = true;
+    let config = config.validate().unwrap();
 
     // Valid relative symlink
     group.bench_function("valid_relative", |b| {
@@ -159,7 +161,7 @@ fn benchmark_symlink_validation(c: &mut Criterion) {
 
     // Disabled symlinks (should fail very fast)
     group.bench_function("disabled_reject", |b| {
-        let disabled_config = SecurityConfig::default(); // symlinks disabled
+        let disabled_config = SecurityConfig::default().validate().unwrap(); // symlinks disabled
         let link = SafePath::validate(&PathBuf::from("link"), &dest, &disabled_config).unwrap();
         let target = PathBuf::from("target.txt");
         b.iter(|| {
@@ -183,6 +185,7 @@ fn benchmark_hardlink_validation(c: &mut Criterion) {
     let dest = DestDir::new(temp.path().to_path_buf()).unwrap();
     let mut config = SecurityConfig::default();
     config.allowed.hardlinks = true;
+    let config = config.validate().unwrap();
 
     // Valid hardlink
     group.bench_function("valid_target", |b| {
@@ -249,7 +252,7 @@ fn benchmark_hardlink_validation(c: &mut Criterion) {
 fn benchmark_compression_ratio(c: &mut Criterion) {
     let mut group = c.benchmark_group("compression_ratio");
 
-    let config = SecurityConfig::default();
+    let config = SecurityConfig::default().validate().unwrap();
 
     // Normal ratio (should pass quickly)
     group.bench_function("normal_ratio", |b| {
@@ -299,7 +302,7 @@ fn benchmark_entry_validator(c: &mut Criterion) {
 
     let temp = TempDir::new().unwrap();
     let dest = DestDir::new(temp.path().to_path_buf()).unwrap();
-    let config = SecurityConfig::default();
+    let config = SecurityConfig::default().validate().unwrap();
 
     // Single file entry
     group.bench_function("single_file", |b| {
@@ -367,9 +370,11 @@ fn benchmark_entry_validator(c: &mut Criterion) {
 
     // Mixed entries
     group.bench_function("mixed_entries", |b| {
-        let mut config_with_links = config.clone();
-        config_with_links.allowed.symlinks = true;
-        config_with_links.allowed.hardlinks = true;
+        let config_with_links = SecurityConfig::default()
+            .with_allow_symlinks(true)
+            .with_allow_hardlinks(true)
+            .validate()
+            .unwrap();
 
         b.iter(|| {
             let mut validator = EntryValidator::new(&config_with_links, &dest);
@@ -436,7 +441,7 @@ fn benchmark_validation_throughput(c: &mut Criterion) {
 
     let temp = TempDir::new().unwrap();
     let dest = DestDir::new(temp.path().to_path_buf()).unwrap();
-    let config = SecurityConfig::default();
+    let config = SecurityConfig::default().validate().unwrap();
 
     // Pre-generate paths for consistent timing
     let paths: Vec<PathBuf> = (0..1000)

--- a/crates/exarch-core/examples/dhat_extraction.rs
+++ b/crates/exarch-core/examples/dhat_extraction.rs
@@ -62,7 +62,7 @@ fn create_tar_in_memory(file_count: usize, file_size: usize) -> Vec<u8> {
 
 fn profile_zip_extraction(file_count: usize, file_size: usize) {
     let zip_data = create_zip_in_memory(file_count, file_size);
-    let config = SecurityConfig::default();
+    let config = SecurityConfig::default().validate().unwrap();
     let temp = tempfile::tempdir().unwrap();
 
     let _profiler = dhat::Profiler::new_heap();
@@ -81,7 +81,7 @@ fn profile_zip_extraction(file_count: usize, file_size: usize) {
 
 fn profile_tar_extraction(file_count: usize, file_size: usize) {
     let tar_data = create_tar_in_memory(file_count, file_size);
-    let config = SecurityConfig::default();
+    let config = SecurityConfig::default().validate().unwrap();
     let temp = tempfile::tempdir().unwrap();
 
     let _profiler = dhat::Profiler::new_heap();

--- a/crates/exarch-core/src/api.rs
+++ b/crates/exarch-core/src/api.rs
@@ -9,6 +9,7 @@ use crate::ProgressCallback;
 use crate::Result;
 use crate::SecurityConfig;
 use crate::config::ExtractionOptions;
+use crate::config::Validated;
 use crate::creation::CreationConfig;
 use crate::creation::CreationReport;
 use crate::formats::detect::ArchiveType;
@@ -112,7 +113,8 @@ fn extract_impl<P: AsRef<Path>, Q: AsRef<Path>>(
     options: &ExtractionOptions,
     progress: &mut dyn ProgressCallback,
 ) -> Result<ExtractionReport> {
-    config.validate()?;
+    let config = config.clone().validate()?;
+    let config = &config;
 
     let archive_path = archive_path.as_ref();
     let output_dir = output_dir.as_ref();
@@ -328,7 +330,7 @@ fn extract_atomic<P: AsRef<Path>, Q: AsRef<Path>>(
 fn extract_tar_with_decoder<R, F>(
     archive_path: &Path,
     output_dir: &Path,
-    config: &SecurityConfig,
+    config: &SecurityConfig<Validated>,
     options: &ExtractionOptions,
     progress: &mut dyn ProgressCallback,
     make_decoder: F,
@@ -350,7 +352,7 @@ where
 fn extract_zip(
     archive_path: &Path,
     output_dir: &Path,
-    config: &SecurityConfig,
+    config: &SecurityConfig<Validated>,
     options: &ExtractionOptions,
     progress: &mut dyn ProgressCallback,
 ) -> Result<ExtractionReport> {
@@ -366,7 +368,7 @@ fn extract_zip(
 fn extract_7z(
     archive_path: &Path,
     output_dir: &Path,
-    config: &SecurityConfig,
+    config: &SecurityConfig<Validated>,
     options: &ExtractionOptions,
     progress: &mut dyn ProgressCallback,
 ) -> Result<ExtractionReport> {
@@ -1327,6 +1329,7 @@ mod tests {
         let temp = tempfile::TempDir::new().unwrap();
         let mut config = SecurityConfig::default();
         config.allowed.hardlinks = true;
+        let config = config.validate().unwrap();
 
         let mut archive = TarArchive::new(Cursor::new(tar_data));
         let mut progress = ByteTracker { total: 0 };
@@ -1390,7 +1393,7 @@ mod tests {
         };
         let result = archive.extract(
             temp.path(),
-            &SecurityConfig::default(),
+            &SecurityConfig::default().validate().unwrap(),
             &ExtractionOptions::default(),
             &mut progress,
         );
@@ -1444,7 +1447,7 @@ mod tests {
         };
         let result = archive.extract(
             temp.path(),
-            &SecurityConfig::default(),
+            &SecurityConfig::default().validate().unwrap(),
             &ExtractionOptions::default(),
             &mut progress,
         );

--- a/crates/exarch-core/src/config.rs
+++ b/crates/exarch-core/src/config.rs
@@ -1,5 +1,38 @@
 //! Security configuration for archive extraction.
 
+use std::marker::PhantomData;
+use std::ops::Deref;
+use std::ops::DerefMut;
+
+/// Marker type for a [`SecurityConfig`] whose invariants have not yet been
+/// checked.
+///
+/// This is the default type parameter for [`SecurityConfig`]. The fluent
+/// `with_*` builder methods and [`SecurityConfig::validate`] are only
+/// available in this state.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Unvalidated;
+
+/// Marker type for a [`SecurityConfig`] whose invariants have been checked.
+///
+/// Reachable only through [`SecurityConfig::validate`]. Every entry point
+/// that performs security-sensitive work — the
+/// [`ArchiveFormat`](crate::formats::traits::ArchiveFormat) trait and
+/// everything it calls — requires a `SecurityConfig<Validated>`, so an
+/// unvalidated configuration (e.g. one with `max_file_size == 0`) can never
+/// reach extraction, listing, or verification. The compiler enforces this;
+/// it is not a convention callers must remember to follow.
+///
+/// Once validated, a config's fields can still be *read* (via [`Deref`]) but
+/// no longer *written*: [`DerefMut`] is implemented only for
+/// `SecurityConfig<Unvalidated>`, so `cfg.max_compression_ratio = f64::NAN`
+/// on a `SecurityConfig<Validated>` is a compile error, not a runtime
+/// invariant violation. This is what makes the typestate airtight — without
+/// it, a caller could validate a config and then mutate it back into an
+/// invalid state before passing it to `ArchiveFormat::extract`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Validated;
+
 /// Feature flags controlling what archive features are allowed during
 /// extraction.
 ///
@@ -22,35 +55,22 @@ pub struct AllowedFeatures {
     pub world_writable: bool,
 }
 
-/// Security configuration with default-deny settings.
+/// The field data of a [`SecurityConfig`], reachable via [`Deref`]/[`DerefMut`]
+/// regardless of (or gated by) validation state.
 ///
-/// This configuration controls various security checks performed during
-/// archive extraction to prevent common vulnerabilities.
-///
-/// # Performance Note
-///
-/// This struct contains heap-allocated collections (`Vec<String>`). For
-/// performance, pass by reference (`&SecurityConfig`) rather than cloning. If
-/// shared ownership is needed across threads, consider wrapping in
-/// `Arc<SecurityConfig>`.
-///
-/// # Examples
-///
-/// ```
-/// use exarch_core::SecurityConfig;
-///
-/// // Use secure defaults
-/// let config = SecurityConfig::default();
-///
-/// // Customize via fluent builder
-/// let custom = SecurityConfig::default()
-///     .with_max_file_size(100 * 1024 * 1024)
-///     .with_max_total_size(1024 * 1024 * 1024)
-///     .with_allow_symlinks(true);
-/// ```
+/// This type is not itself part of the sealing boundary — it is a plain data
+/// bag with `pub` fields, and nothing stops external code from naming it or
+/// cloning one out of a `&SecurityConfig`. The boundary is
+/// [`SecurityConfig`]'s own private `fields` member: there is no public API
+/// that takes a bare `SecurityConfigFields` and wraps it back into a
+/// `SecurityConfig<Validated>`, so an externally-forged or externally-mutated
+/// `SecurityConfigFields` value can never be smuggled into a `Validated`
+/// config. It exists purely so [`SecurityConfig`] can implement `Deref`/
+/// `DerefMut` and keep `cfg.max_file_size`-style field access working for
+/// every existing caller instead of forcing a getter-method migration.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
-pub struct SecurityConfig {
+pub struct SecurityConfigFields {
     /// Maximum size for a single file in bytes.
     pub max_file_size: u64,
 
@@ -184,23 +204,7 @@ pub struct SecurityConfig {
     pub(crate) relaxed_for_verify_preflight: bool,
 }
 
-impl Default for SecurityConfig {
-    /// Creates a `SecurityConfig` with secure default settings.
-    ///
-    /// Default values:
-    /// - `max_file_size`: 50 MB
-    /// - `max_total_size`: 500 MB
-    /// - `max_compression_ratio`: 100.0
-    /// - `max_file_count`: 10,000
-    /// - `max_path_depth`: 32
-    /// - `allowed`: All features disabled (deny-by-default)
-    /// - `preserve_permissions`: false
-    /// - `allowed_extensions`: empty (allow all)
-    /// - `banned_path_components`: `[".git", ".ssh", ".gnupg", ".aws", ".kube",
-    ///   ".docker", ".env"]`
-    /// - `allow_solid_archives`: false (solid archives rejected)
-    /// - `max_solid_block_memory`: 512 MB
-    /// - `max_tar_metadata_bytes`: 4 MiB
+impl Default for SecurityConfigFields {
     fn default() -> Self {
         Self {
             max_file_size: 50 * 1024 * 1024,   // 50 MB
@@ -228,7 +232,104 @@ impl Default for SecurityConfig {
     }
 }
 
-impl SecurityConfig {
+/// Security configuration with default-deny settings.
+///
+/// This configuration controls various security checks performed during
+/// archive extraction to prevent common vulnerabilities.
+///
+/// # Performance Note
+///
+/// This struct contains heap-allocated collections (`Vec<String>`). For
+/// performance, pass by reference (`&SecurityConfig`) rather than cloning. If
+/// shared ownership is needed across threads, consider wrapping in
+/// `Arc<SecurityConfig>`.
+///
+/// # Examples
+///
+/// ```
+/// use exarch_core::SecurityConfig;
+///
+/// // Use secure defaults
+/// let config = SecurityConfig::default();
+///
+/// // Customize via fluent builder
+/// let custom = SecurityConfig::default()
+///     .with_max_file_size(100 * 1024 * 1024)
+///     .with_max_total_size(1024 * 1024 * 1024)
+///     .with_allow_symlinks(true);
+/// ```
+///
+/// # Typestate
+///
+/// `SecurityConfig` carries a phantom `State` type parameter — [`Unvalidated`]
+/// (the default) or [`Validated`] — that tracks whether
+/// [`validate`](SecurityConfig::validate) has been called. Builder methods
+/// are only available in the `Unvalidated` state; security-sensitive APIs
+/// (the [`ArchiveFormat`](crate::formats::traits::ArchiveFormat) trait and
+/// everything downstream of it) require `SecurityConfig<Validated>`. This
+/// makes skipping validation a compile error instead of a runtime gap.
+///
+/// # Sealing
+///
+/// Fields are private and reachable only through
+/// <code>[Deref]<Target = [SecurityConfigFields]></code>, so
+/// `cfg.max_file_size` continues to work as plain field access for both states.
+/// [`DerefMut`] is implemented only for
+/// `SecurityConfig<Unvalidated>`, so a `SecurityConfig<Validated>`'s fields
+/// cannot be reassigned after the fact — the only way to produce one is
+/// [`validate`](SecurityConfig::validate) itself, and it stays that way for
+/// its entire lifetime.
+#[derive(Debug, Clone)]
+pub struct SecurityConfig<State = Unvalidated> {
+    fields: SecurityConfigFields,
+
+    /// Typestate marker — see the "Typestate" section on the type-level docs.
+    _marker: PhantomData<State>,
+}
+
+impl<State> Deref for SecurityConfig<State> {
+    type Target = SecurityConfigFields;
+
+    fn deref(&self) -> &SecurityConfigFields {
+        &self.fields
+    }
+}
+
+/// Only `Unvalidated` configs are mutable — see the "Sealing" section on
+/// [`SecurityConfig`]'s type-level docs for why this is the crux of the
+/// typestate guarantee.
+impl DerefMut for SecurityConfig<Unvalidated> {
+    fn deref_mut(&mut self) -> &mut SecurityConfigFields {
+        &mut self.fields
+    }
+}
+
+impl Default for SecurityConfig<Unvalidated> {
+    /// Creates a `SecurityConfig` with secure default settings.
+    ///
+    /// Default values:
+    /// - `max_file_size`: 50 MB
+    /// - `max_total_size`: 500 MB
+    /// - `max_compression_ratio`: 100.0
+    /// - `max_file_count`: 10,000
+    /// - `max_path_depth`: 32
+    /// - `allowed`: All features disabled (deny-by-default)
+    /// - `preserve_permissions`: false
+    /// - `allowed_extensions`: empty (allow all)
+    /// - `banned_path_components`: `[".git", ".ssh", ".gnupg", ".aws", ".kube",
+    ///   ".docker", ".env"]`
+    /// - `allow_solid_archives`: false (solid archives rejected)
+    /// - `max_solid_block_memory`: 512 MB
+    /// - `max_tar_metadata_bytes`: 4 MiB
+    fn default() -> Self {
+        Self {
+            fields: SecurityConfigFields::default(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl SecurityConfig<Unvalidated> {
     /// Creates a permissive configuration for trusted archives.
     ///
     /// This configuration allows symlinks, hardlinks, absolute paths, and
@@ -236,26 +337,35 @@ impl SecurityConfig {
     #[must_use]
     pub fn permissive() -> Self {
         Self {
-            allowed: AllowedFeatures {
-                symlinks: true,
-                hardlinks: true,
-                absolute_paths: true,
-                world_writable: true,
+            fields: SecurityConfigFields {
+                allowed: AllowedFeatures {
+                    symlinks: true,
+                    hardlinks: true,
+                    absolute_paths: true,
+                    world_writable: true,
+                },
+                preserve_permissions: true,
+                max_compression_ratio: 1000.0,
+                banned_path_components: Vec::new(),
+                allow_solid_archives: true,
+                max_solid_block_memory: 1024 * 1024 * 1024, // 1 GB for permissive
+                max_tar_metadata_bytes: 16 * 1024 * 1024,   // 16 MiB for permissive
+                ..SecurityConfigFields::default()
             },
-            preserve_permissions: true,
-            max_compression_ratio: 1000.0,
-            banned_path_components: Vec::new(),
-            allow_solid_archives: true,
-            max_solid_block_memory: 1024 * 1024 * 1024, // 1 GB for permissive
-            max_tar_metadata_bytes: 16 * 1024 * 1024,   // 16 MiB for permissive
-            ..Default::default()
+            _marker: PhantomData,
         }
     }
 
-    /// Validates that the configuration values are logically consistent.
+    /// Validates that the configuration values are logically consistent,
+    /// transitioning to the [`Validated`] typestate on success.
     ///
     /// Returns an error if any field has a value that would make security
-    /// enforcement impossible (zero limits or non-positive ratio).
+    /// enforcement impossible (zero limits or non-positive ratio). Consumes
+    /// `self`: the only way to obtain a `SecurityConfig<Validated>`, which is
+    /// what every security-sensitive API in this crate requires. Once
+    /// returned, the `Validated` config's fields can no longer be reassigned
+    /// (see the "Sealing" section on the type-level docs), so this check can
+    /// never be silently invalidated afterward.
     ///
     /// # Errors
     ///
@@ -266,6 +376,7 @@ impl SecurityConfig {
     /// - `max_path_depth` is zero
     /// - `max_file_count` is zero
     /// - `max_solid_block_memory` is zero
+    /// - `max_tar_metadata_bytes` is zero
     ///
     /// # Examples
     ///
@@ -278,7 +389,7 @@ impl SecurityConfig {
     /// let bad = SecurityConfig::default().with_max_file_size(0);
     /// assert!(bad.validate().is_err());
     /// ```
-    pub fn validate(&self) -> crate::Result<()> {
+    pub fn validate(self) -> crate::Result<SecurityConfig<Validated>> {
         if !self.max_compression_ratio.is_finite() || self.max_compression_ratio <= 0.0 {
             return Err(crate::ArchiveError::InvalidConfiguration {
                 reason: "max_compression_ratio must be positive".into(),
@@ -314,7 +425,10 @@ impl SecurityConfig {
                 reason: "max_tar_metadata_bytes must not be zero".into(),
             });
         }
-        Ok(())
+        Ok(SecurityConfig {
+            fields: self.fields,
+            _marker: PhantomData,
+        })
     }
 
     /// Sets the maximum size for a single extracted file in bytes.
@@ -330,7 +444,7 @@ impl SecurityConfig {
     #[must_use]
     #[inline]
     pub fn with_max_file_size(mut self, size: u64) -> Self {
-        self.max_file_size = size;
+        self.fields.max_file_size = size;
         self
     }
 
@@ -347,7 +461,7 @@ impl SecurityConfig {
     #[must_use]
     #[inline]
     pub fn with_max_total_size(mut self, size: u64) -> Self {
-        self.max_total_size = size;
+        self.fields.max_total_size = size;
         self
     }
 
@@ -364,7 +478,7 @@ impl SecurityConfig {
     #[must_use]
     #[inline]
     pub fn with_max_compression_ratio(mut self, ratio: f64) -> Self {
-        self.max_compression_ratio = ratio;
+        self.fields.max_compression_ratio = ratio;
         self
     }
 
@@ -381,7 +495,7 @@ impl SecurityConfig {
     #[must_use]
     #[inline]
     pub fn with_max_file_count(mut self, count: usize) -> Self {
-        self.max_file_count = count;
+        self.fields.max_file_count = count;
         self
     }
 
@@ -398,7 +512,7 @@ impl SecurityConfig {
     #[must_use]
     #[inline]
     pub fn with_max_path_depth(mut self, depth: usize) -> Self {
-        self.max_path_depth = depth;
+        self.fields.max_path_depth = depth;
         self
     }
 
@@ -417,7 +531,7 @@ impl SecurityConfig {
     #[must_use]
     #[inline]
     pub fn with_allowed(mut self, allowed: AllowedFeatures) -> Self {
-        self.allowed = allowed;
+        self.fields.allowed = allowed;
         self
     }
 
@@ -434,7 +548,7 @@ impl SecurityConfig {
     #[must_use]
     #[inline]
     pub fn with_allow_symlinks(mut self, allow: bool) -> Self {
-        self.allowed.symlinks = allow;
+        self.fields.allowed.symlinks = allow;
         self
     }
 
@@ -451,7 +565,7 @@ impl SecurityConfig {
     #[must_use]
     #[inline]
     pub fn with_allow_hardlinks(mut self, allow: bool) -> Self {
-        self.allowed.hardlinks = allow;
+        self.fields.allowed.hardlinks = allow;
         self
     }
 
@@ -468,7 +582,7 @@ impl SecurityConfig {
     #[must_use]
     #[inline]
     pub fn with_allow_absolute_paths(mut self, allow: bool) -> Self {
-        self.allowed.absolute_paths = allow;
+        self.fields.allowed.absolute_paths = allow;
         self
     }
 
@@ -485,7 +599,7 @@ impl SecurityConfig {
     #[must_use]
     #[inline]
     pub fn with_allow_world_writable(mut self, allow: bool) -> Self {
-        self.allowed.world_writable = allow;
+        self.fields.allowed.world_writable = allow;
         self
     }
 
@@ -502,7 +616,7 @@ impl SecurityConfig {
     #[must_use]
     #[inline]
     pub fn with_preserve_permissions(mut self, preserve: bool) -> Self {
-        self.preserve_permissions = preserve;
+        self.fields.preserve_permissions = preserve;
         self
     }
 
@@ -523,7 +637,7 @@ impl SecurityConfig {
     #[must_use]
     #[inline]
     pub fn with_allowed_extensions(mut self, extensions: Vec<String>) -> Self {
-        self.allowed_extensions = extensions;
+        self.fields.allowed_extensions = extensions;
         self
     }
 
@@ -541,7 +655,7 @@ impl SecurityConfig {
     #[must_use]
     #[inline]
     pub fn with_banned_path_components(mut self, components: Vec<String>) -> Self {
-        self.banned_path_components = components;
+        self.fields.banned_path_components = components;
         self
     }
 
@@ -558,7 +672,7 @@ impl SecurityConfig {
     #[must_use]
     #[inline]
     pub fn with_allow_solid_archives(mut self, allow: bool) -> Self {
-        self.allow_solid_archives = allow;
+        self.fields.allow_solid_archives = allow;
         self
     }
 
@@ -579,7 +693,7 @@ impl SecurityConfig {
     #[must_use]
     #[inline]
     pub fn with_max_solid_block_memory(mut self, size: u64) -> Self {
-        self.max_solid_block_memory = size;
+        self.fields.max_solid_block_memory = size;
         self
     }
 
@@ -598,20 +712,30 @@ impl SecurityConfig {
     #[must_use]
     #[inline]
     pub fn with_max_tar_metadata_bytes(mut self, size: u64) -> Self {
-        self.max_tar_metadata_bytes = size;
+        self.fields.max_tar_metadata_bytes = size;
         self
     }
 
     /// Marks this config as the internal pre-flight listing pass inside
     /// `verify_archive`. Not part of the public API — see
     /// `relaxed_for_verify_preflight`'s field doc for what this relaxes.
+    ///
+    /// Production code builds this state via
+    /// `SecurityConfig::as_relaxed_for_verify_preflight` instead (it must
+    /// work on both typestates); this builder-style variant exists only so
+    /// `Unvalidated`-only test call sites don't need direct field writes.
+    #[cfg(test)]
     #[must_use]
     #[inline]
     pub(crate) fn with_relaxed_for_verify_preflight(mut self) -> Self {
-        self.relaxed_for_verify_preflight = true;
+        self.fields.relaxed_for_verify_preflight = true;
         self
     }
+}
 
+/// Read-only queries and crate-internal helpers available regardless of
+/// validation state.
+impl<State> SecurityConfig<State> {
     /// Validates whether a path component is allowed.
     ///
     /// Comparison is case-insensitive to prevent bypass on case-insensitive
@@ -666,6 +790,29 @@ impl SecurityConfig {
             return true;
         }
         extension.is_some_and(|ext| self.is_extension_allowed(ext))
+    }
+
+    /// Returns a clone with `max_file_size` relaxed to unlimited and
+    /// `relaxed_for_verify_preflight` set, preserving `State`.
+    ///
+    /// Crate-internal escape hatch backing
+    /// `inspection::verify::listing_config_for_verify`. Sound for both
+    /// typestates: it only ever *relaxes* two fields whose overridden values
+    /// (`u64::MAX`, `true`) can never fail
+    /// [`validate`](SecurityConfig::validate)'s checks, so a `Validated`
+    /// input yields a still-genuinely-valid `Validated` output without
+    /// re-running `validate()`. This must not be generalized into an
+    /// arbitrary-field mutator — that would reopen the exact hole
+    /// `DerefMut`'s state-gating exists to close.
+    #[must_use]
+    pub(crate) fn as_relaxed_for_verify_preflight(&self) -> Self {
+        let mut fields = self.fields.clone();
+        fields.max_file_size = u64::MAX;
+        fields.relaxed_for_verify_preflight = true;
+        Self {
+            fields,
+            _marker: PhantomData,
+        }
     }
 }
 
@@ -743,7 +890,11 @@ impl ExtractionOptions {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::field_reassign_with_default)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::field_reassign_with_default
+)]
 mod tests {
     use super::*;
 
@@ -952,91 +1103,86 @@ mod tests {
 
     #[test]
     fn test_validate_rejects_negative_compression_ratio() {
-        let cfg = SecurityConfig {
-            max_compression_ratio: -1.0,
-            ..SecurityConfig::default()
-        };
+        let mut cfg = SecurityConfig::default();
+        cfg.max_compression_ratio = -1.0;
         assert!(cfg.validate().is_err());
     }
 
     #[test]
     fn test_validate_rejects_zero_compression_ratio() {
-        let cfg = SecurityConfig {
-            max_compression_ratio: 0.0,
-            ..SecurityConfig::default()
-        };
+        let mut cfg = SecurityConfig::default();
+        cfg.max_compression_ratio = 0.0;
         assert!(cfg.validate().is_err());
     }
 
     #[test]
     fn test_validate_rejects_zero_max_file_size() {
-        let cfg = SecurityConfig {
-            max_file_size: 0,
-            ..SecurityConfig::default()
-        };
+        let mut cfg = SecurityConfig::default();
+        cfg.max_file_size = 0;
         assert!(cfg.validate().is_err());
     }
 
     #[test]
     fn test_validate_rejects_zero_max_total_size() {
-        let cfg = SecurityConfig {
-            max_total_size: 0,
-            ..SecurityConfig::default()
-        };
+        let mut cfg = SecurityConfig::default();
+        cfg.max_total_size = 0;
         assert!(cfg.validate().is_err());
     }
 
     #[test]
     fn test_validate_rejects_zero_max_path_depth() {
-        let cfg = SecurityConfig {
-            max_path_depth: 0,
-            ..SecurityConfig::default()
-        };
+        let mut cfg = SecurityConfig::default();
+        cfg.max_path_depth = 0;
         assert!(cfg.validate().is_err());
     }
 
     #[test]
     fn test_validate_rejects_nan_compression_ratio() {
-        let cfg = SecurityConfig {
-            max_compression_ratio: f64::NAN,
-            ..SecurityConfig::default()
-        };
+        let mut cfg = SecurityConfig::default();
+        cfg.max_compression_ratio = f64::NAN;
         assert!(cfg.validate().is_err());
     }
 
     #[test]
     fn test_validate_rejects_infinite_compression_ratio() {
-        let cfg = SecurityConfig {
-            max_compression_ratio: f64::INFINITY,
-            ..SecurityConfig::default()
-        };
+        let mut cfg = SecurityConfig::default();
+        cfg.max_compression_ratio = f64::INFINITY;
         assert!(cfg.validate().is_err());
     }
 
     #[test]
     fn test_validate_rejects_zero_max_file_count() {
-        let cfg = SecurityConfig {
-            max_file_count: 0,
-            ..SecurityConfig::default()
-        };
+        let mut cfg = SecurityConfig::default();
+        cfg.max_file_count = 0;
         assert!(cfg.validate().is_err());
     }
 
     #[test]
     fn test_validate_rejects_zero_max_solid_block_memory() {
-        let cfg = SecurityConfig {
-            max_solid_block_memory: 0,
-            ..SecurityConfig::default()
-        };
+        let mut cfg = SecurityConfig::default();
+        cfg.max_solid_block_memory = 0;
         assert!(cfg.validate().is_err());
     }
 
     #[test]
     fn test_validate_rejects_zero_max_tar_metadata_bytes() {
-        let cfg = SecurityConfig {
-            max_tar_metadata_bytes: 0,
-            ..SecurityConfig::default()
-        };
+        let mut cfg = SecurityConfig::default();
+        cfg.max_tar_metadata_bytes = 0;
         assert!(cfg.validate().is_err());
+    }
+
+    // Regression test for the C1 finding on #433/#434/#435: a
+    // `SecurityConfig<Validated>` must not be mutable. `DerefMut` is only
+    // implemented for `SecurityConfig<Unvalidated>`, so this is enforced at
+    // compile time — see `tests/ui/validated_config_field_mutation.rs` for
+    // the corresponding compile-fail fixture. This test only pins the
+    // read-side behavior: fields remain readable after validation.
+    #[test]
+    fn test_validated_config_fields_remain_readable() {
+        let validated = SecurityConfig::default()
+            .with_max_file_size(123)
+            .validate()
+            .expect("valid config");
+        assert_eq!(validated.max_file_size, 123);
     }
 }

--- a/crates/exarch-core/src/formats/common.rs
+++ b/crates/exarch-core/src/formats/common.rs
@@ -25,6 +25,7 @@ use crate::ExtractionReport;
 use crate::ProgressCallback;
 use crate::Result;
 use crate::SecurityConfig;
+use crate::config::Validated;
 use crate::copy::CopyBuffer;
 use crate::copy::copy_with_buffer;
 use crate::error::QuotaResource;
@@ -349,7 +350,7 @@ pub fn normalize_entry_name(name: &str) -> String {
 #[inline]
 pub fn check_extension_allowed(
     path: &Path,
-    config: &SecurityConfig,
+    config: &SecurityConfig<Validated>,
     report: &mut ExtractionReport,
 ) -> bool {
     let ext = path.extension().and_then(|e| e.to_str());
@@ -505,7 +506,7 @@ pub fn extract_file_generic<R: Read>(
     skip_duplicates: bool,
     progress: &mut dyn ProgressCallback,
 ) -> Result<()> {
-    let output_path = dest.join(&validated.safe_path);
+    let output_path = dest.join(validated.safe_path());
 
     // Create parent directories if needed using cache
     dir_cache.ensure_parent_dir(&output_path)?;
@@ -514,7 +515,7 @@ pub fn extract_file_generic<R: Read>(
         report.files_skipped += 1;
         report.warnings.push(format!(
             "skipped duplicate entry: {}",
-            validated.safe_path.as_path().display()
+            validated.safe_path().as_path().display()
         ));
         return Ok(());
     }
@@ -531,7 +532,7 @@ pub fn extract_file_generic<R: Read>(
 
     // Create file and enforce exact sanitized permissions (Unix only).
     // set_permissions() is called inside create_file_with_mode to bypass umask.
-    let output_file = create_file_with_mode(&output_path, validated.mode)?;
+    let output_file = create_file_with_mode(&output_path, validated.mode())?;
     let mut buffered_writer = BufWriter::with_capacity(64 * 1024, output_file);
     let bytes_written = copy_with_buffer(reader, &mut buffered_writer, copy_buffer)?;
     buffered_writer.flush()?;
@@ -583,7 +584,7 @@ pub fn create_directory(
     report: &mut ExtractionReport,
     dir_cache: &mut DirCache,
 ) -> Result<()> {
-    let dir_path = dest.join(&validated.safe_path);
+    let dir_path = dest.join(validated.safe_path());
 
     // Use cache to avoid redundant mkdir syscalls
     dir_cache.ensure_dir(&dir_path)?;
@@ -701,13 +702,13 @@ mod tests {
         // Try to extract a file with size that would overflow
         let expected_size = Some(200u64); // This would overflow when added
 
-        let config = SecurityConfig::default();
-        let validated = ValidatedEntry {
-            safe_path: SafePath::validate(&PathBuf::from("test.txt"), &dest, &config)
+        let config = SecurityConfig::default().validate().expect("valid config");
+        let validated = ValidatedEntry::new(
+            SafePath::validate(&PathBuf::from("test.txt"), &dest, &config)
                 .expect("path should be valid"),
-            mode: Some(0o644),
-            entry_type: ValidatedEntryType::File,
-        };
+            ValidatedEntryType::File,
+            Some(0o644),
+        );
 
         let mut reader = Cursor::new(b"test data");
 
@@ -1084,16 +1085,16 @@ mod tests {
         let mut copy_buffer = CopyBuffer::new();
         let mut dir_cache = DirCache::new();
 
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         // Mode 0o777 in archive, sanitized to 0o775 (world-writable stripped)
         let sanitized_mode = 0o775u32;
-        let validated = ValidatedEntry {
-            safe_path: SafePath::validate(&PathBuf::from("perm_test.txt"), &dest, &config)
+        let validated = ValidatedEntry::new(
+            SafePath::validate(&PathBuf::from("perm_test.txt"), &dest, &config)
                 .expect("path should be valid"),
-            mode: Some(sanitized_mode),
-            entry_type: ValidatedEntryType::File,
-        };
+            ValidatedEntryType::File,
+            Some(sanitized_mode),
+        );
 
         let mut reader = Cursor::new(b"content");
 
@@ -1166,18 +1167,14 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn test_duplicate_symlink_overwrites_when_skip_disabled() {
-        use crate::config::AllowedFeatures;
         use crate::types::SafeSymlink;
 
         let temp = TempDir::new().expect("failed to create temp dir");
         let dest = DestDir::new(temp.path().to_path_buf()).expect("failed to create dest");
-        let config = SecurityConfig {
-            allowed: AllowedFeatures {
-                symlinks: true,
-                ..Default::default()
-            },
-            ..Default::default()
-        };
+        let config = SecurityConfig::default()
+            .with_allow_symlinks(true)
+            .validate()
+            .expect("valid config");
 
         // Create the target file so the symlink has somewhere to point
         std::fs::write(temp.path().join("target.txt"), b"data").expect("write target");
@@ -1212,7 +1209,10 @@ mod tests {
     /// happened in #413.
     #[test]
     fn test_check_extension_allowed_warning_message_text() {
-        let config = SecurityConfig::default().with_allowed_extensions(vec!["txt".to_string()]);
+        let config = SecurityConfig::default()
+            .with_allowed_extensions(vec!["txt".to_string()])
+            .validate()
+            .expect("valid config");
         let mut report = ExtractionReport::default();
         let path = PathBuf::from("skip.exe");
 
@@ -1229,7 +1229,10 @@ mod tests {
     /// Verifies the happy path leaves `report` untouched.
     #[test]
     fn test_check_extension_allowed_allowed_extension() {
-        let config = SecurityConfig::default().with_allowed_extensions(vec!["txt".to_string()]);
+        let config = SecurityConfig::default()
+            .with_allowed_extensions(vec!["txt".to_string()])
+            .validate()
+            .expect("valid config");
         let mut report = ExtractionReport::default();
         let path = PathBuf::from("keep.txt");
 

--- a/crates/exarch-core/src/formats/sevenz.rs
+++ b/crates/exarch-core/src/formats/sevenz.rs
@@ -66,9 +66,10 @@
 //! # fn main() -> Result<(), exarch_core::ArchiveError> {
 //! let file = File::open("archive.7z")?;
 //! let mut archive = SevenZArchive::new(file)?;
+//! let config = SecurityConfig::default().validate()?;
 //! let report = archive.extract(
 //!     Path::new("/output"),
-//!     &SecurityConfig::default(),
+//!     &config,
 //!     &ExtractionOptions::default(),
 //!     &mut exarch_core::NoopProgress,
 //! )?;
@@ -111,6 +112,7 @@ use crate::ExtractionReport;
 use crate::ProgressCallback;
 use crate::Result;
 use crate::SecurityConfig;
+use crate::config::Validated;
 use crate::error::QuotaResource;
 use crate::security::EntryValidator;
 use crate::security::validator::ValidatedEntryType;
@@ -190,9 +192,10 @@ struct CachedEntry {
 ///
 /// let file = File::open("archive.7z")?;
 /// let mut archive = SevenZArchive::new(file)?;
+/// let config = SecurityConfig::default().validate()?;
 /// let report = archive.extract(
 ///     Path::new("/output"),
-///     &SecurityConfig::default(),
+///     &config,
 ///     &ExtractionOptions::default(),
 ///     &mut exarch_core::NoopProgress,
 /// )?;
@@ -305,7 +308,7 @@ impl<R: Read + Seek> SevenZArchive<R> {
         report: &mut ExtractionReport,
         dir_cache: &mut common::DirCache,
         skip_duplicates: bool,
-        config: &SecurityConfig,
+        config: &SecurityConfig<Validated>,
     ) -> std::result::Result<u64, sevenz_rust2::Error> {
         let entry_type = SevenZEntryAdapter::to_entry_type(entry).map_err(|e| {
             sevenz_rust2::Error::Other(format!("entry type detection failed: {e}").into())
@@ -325,15 +328,15 @@ impl<R: Read + Seek> SevenZArchive<R> {
             .map_err(|e| sevenz_rust2::Error::Other(format!("validation failed: {e}").into()))?;
 
         // Extract based on type
-        match validated.entry_type {
+        match validated.entry_type() {
             ValidatedEntryType::Directory => {
-                let dest_path = dest.join_path(validated.safe_path.as_path());
+                let dest_path = dest.join_path(validated.safe_path().as_path());
                 dir_cache.ensure_dir(&dest_path)?;
                 report.directories_created += 1;
                 Ok(0)
             }
             ValidatedEntryType::File => {
-                let dest_path = dest.join_path(validated.safe_path.as_path());
+                let dest_path = dest.join_path(validated.safe_path().as_path());
 
                 dir_cache.ensure_parent_dir(&dest_path)?;
 
@@ -342,7 +345,7 @@ impl<R: Read + Seek> SevenZArchive<R> {
                         report.files_skipped += 1;
                         report.warnings.push(format!(
                             "skipped duplicate entry: {}",
-                            validated.safe_path.as_path().display()
+                            validated.safe_path().as_path().display()
                         ));
                         return Ok(0);
                     }
@@ -413,7 +416,7 @@ impl<R: Read + Seek> SevenZArchive<R> {
         skip_duplicates: bool,
         progress: &mut dyn ProgressCallback,
         total: usize,
-        config: &SecurityConfig,
+        config: &SecurityConfig<Validated>,
     ) -> Result<ExtractionReport> {
         struct SzContext<'a> {
             report: ExtractionReport,
@@ -492,7 +495,7 @@ impl<R: Read + Seek> ArchiveFormat for SevenZArchive<R> {
     fn extract(
         &mut self,
         output_dir: &Path,
-        config: &SecurityConfig,
+        config: &SecurityConfig<Validated>,
         options: &ExtractionOptions,
         progress: &mut dyn ProgressCallback,
     ) -> Result<ExtractionReport> {
@@ -557,7 +560,7 @@ impl<R: Read + Seek> ArchiveFormat for SevenZArchive<R> {
             let validated =
                 prevalidator.validate_entry(&path, &entry_type, entry.size, None, None, None)?;
 
-            match validated.entry_type {
+            match validated.entry_type() {
                 ValidatedEntryType::File | ValidatedEntryType::Directory => {
                     // Will be extracted in Step 3
                 }
@@ -598,14 +601,19 @@ impl<R: Read + Seek> ArchiveFormat for SevenZArchive<R> {
         Ok(report)
     }
 
-    fn list(&mut self, config: &SecurityConfig) -> Result<crate::inspection::ArchiveManifest> {
+    fn list(
+        &mut self,
+        config: &SecurityConfig<Validated>,
+    ) -> Result<crate::inspection::ArchiveManifest> {
         use crate::inspection::list::list_sevenz_reader;
         self.source.rewind().map_err(ArchiveError::Io)?;
         list_sevenz_reader(&mut self.source, config)
     }
 
-    fn verify(&mut self, config: &SecurityConfig) -> Result<crate::inspection::VerificationReport> {
-        config.validate()?;
+    fn verify(
+        &mut self,
+        config: &SecurityConfig<Validated>,
+    ) -> Result<crate::inspection::VerificationReport> {
         let manifest = self.list(&crate::inspection::verify::listing_config_for_verify(
             config,
         ))?;
@@ -844,7 +852,7 @@ mod tests {
         let mut archive = SevenZArchive::new(cursor).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -871,7 +879,7 @@ mod tests {
         let mut archive = SevenZArchive::new(cursor).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -899,7 +907,7 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let result = archive.extract(
             temp.path(),
-            &SecurityConfig::default(),
+            &SecurityConfig::default().validate().unwrap(),
             &ExtractionOptions::default(),
             &mut crate::NoopProgress,
         );
@@ -926,7 +934,7 @@ mod tests {
         let mut archive = SevenZArchive::new(cursor).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -948,7 +956,7 @@ mod tests {
         let mut archive = SevenZArchive::new(file).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -969,10 +977,11 @@ mod tests {
         let mut archive = SevenZArchive::new(cursor).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig {
-            max_file_size: 1024, // 1 KB limit, fixture has 50 KB file
-            ..SecurityConfig::default()
-        };
+        // 1 KB limit, fixture has 50 KB file
+        let config = SecurityConfig::default()
+            .with_max_file_size(1024)
+            .validate()
+            .unwrap();
 
         let result = archive.extract(
             temp.path(),
@@ -994,10 +1003,11 @@ mod tests {
         let mut archive = SevenZArchive::new(cursor).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig {
-            max_file_count: 3, // Should allow 2 files
-            ..SecurityConfig::default()
-        };
+        // Should allow 2 files
+        let config = SecurityConfig::default()
+            .with_max_file_count(3)
+            .validate()
+            .unwrap();
 
         let result = archive.extract(
             temp.path(),
@@ -1039,11 +1049,11 @@ mod tests {
         let mut archive = SevenZArchive::new(cursor).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig {
-            allow_solid_archives: true,
-            max_solid_block_memory: 100 * 1024 * 1024, // 100 MB
-            ..SecurityConfig::default()
-        };
+        let config = SecurityConfig::default()
+            .with_allow_solid_archives(true)
+            .with_max_solid_block_memory(100 * 1024 * 1024)
+            .validate()
+            .unwrap(); // 100 MB
 
         let result = archive.extract(
             temp.path(),
@@ -1063,7 +1073,7 @@ mod tests {
         let mut archive = SevenZArchive::new(cursor).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let result = archive.extract(
             temp.path(),
@@ -1083,11 +1093,11 @@ mod tests {
         let mut archive = SevenZArchive::new(cursor).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig {
-            allow_solid_archives: true,
-            max_solid_block_memory: 1, // 1 byte (too small)
-            ..SecurityConfig::default()
-        };
+        let config = SecurityConfig::default()
+            .with_allow_solid_archives(true)
+            .with_max_solid_block_memory(1)
+            .validate()
+            .unwrap(); // 1 byte (too small)
 
         let result = archive.extract(
             temp.path(),
@@ -1107,7 +1117,7 @@ mod tests {
         let mut archive = SevenZArchive::new(cursor).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default(); // allow_solid_archives = false
+        let config = SecurityConfig::default().validate().expect("valid config"); // allow_solid_archives = false
 
         let result = archive.extract(
             temp.path(),
@@ -1153,11 +1163,11 @@ mod tests {
         // Now test with exact limit
         let mut archive = SevenZArchive::new(Cursor::new(data)).unwrap();
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig {
-            allow_solid_archives: true,
-            max_solid_block_memory: total_size, // Exact match
-            ..SecurityConfig::default()
-        };
+        let config = SecurityConfig::default()
+            .with_allow_solid_archives(true)
+            .with_max_solid_block_memory(total_size)
+            .validate()
+            .unwrap(); // Exact match
 
         let result = archive.extract(
             temp.path(),
@@ -1188,11 +1198,11 @@ mod tests {
         // Now test with one byte under
         let mut archive = SevenZArchive::new(Cursor::new(data)).unwrap();
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig {
-            allow_solid_archives: true,
-            max_solid_block_memory: total_size - 1, // One byte under
-            ..SecurityConfig::default()
-        };
+        let config = SecurityConfig::default()
+            .with_allow_solid_archives(true)
+            .with_max_solid_block_memory(total_size - 1)
+            .validate()
+            .unwrap(); // One byte under
 
         let result = archive.extract(
             temp.path(),
@@ -1214,7 +1224,7 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let result = archive.extract(
             temp.path(),
-            &SecurityConfig::default(),
+            &SecurityConfig::default().validate().unwrap(),
             &ExtractionOptions::default(),
             &mut crate::NoopProgress,
         );
@@ -1350,7 +1360,7 @@ mod tests {
     fn test_list_returns_manifest_with_entries() {
         let data = load_fixture("simple.7z");
         let mut archive = SevenZArchive::new(Cursor::new(data)).unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let manifest = archive.list(&config).unwrap();
 
@@ -1364,7 +1374,7 @@ mod tests {
     fn test_verify_clean_sevenz_is_safe() {
         let data = load_fixture("simple.7z");
         let mut archive = SevenZArchive::new(Cursor::new(data)).unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive.verify(&config).unwrap();
 
@@ -1377,7 +1387,10 @@ mod tests {
         let data = load_fixture("mixed-extensions.7z");
         let dest = TempDir::new().unwrap();
 
-        let config = SecurityConfig::default().with_allowed_extensions(vec!["txt".to_string()]);
+        let config = SecurityConfig::default()
+            .with_allowed_extensions(vec!["txt".to_string()])
+            .validate()
+            .unwrap();
 
         let report = SevenZArchive::new(Cursor::new(data))
             .unwrap()
@@ -1416,7 +1429,7 @@ mod tests {
     fn test_empty_allowed_extensions_allows_all() {
         let data = load_fixture("simple.7z");
         let dest = TempDir::new().unwrap();
-        let config = SecurityConfig::default(); // empty = allow all
+        let config = SecurityConfig::default().validate().expect("valid config"); // empty = allow all
 
         let report = SevenZArchive::new(Cursor::new(data))
             .unwrap()
@@ -1437,7 +1450,10 @@ mod tests {
         // no-extension.7z contains document.txt and Makefile (no extension)
         let data = load_fixture("no-extension.7z");
         let dest = TempDir::new().unwrap();
-        let config = SecurityConfig::default().with_allowed_extensions(vec!["txt".to_string()]);
+        let config = SecurityConfig::default()
+            .with_allowed_extensions(vec!["txt".to_string()])
+            .validate()
+            .unwrap();
 
         let report = SevenZArchive::new(Cursor::new(data))
             .unwrap()
@@ -1497,7 +1513,7 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let result = archive.extract(
             temp.path(),
-            &SecurityConfig::default(),
+            &SecurityConfig::default().validate().unwrap(),
             &ExtractionOptions::default(),
             &mut crate::NoopProgress,
         );
@@ -1518,7 +1534,7 @@ mod tests {
         let mut archive = SevenZArchive::new(Cursor::new(data)).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let result = archive.extract(
             temp.path(),
@@ -1538,7 +1554,10 @@ mod tests {
         let mut archive = SevenZArchive::new(Cursor::new(data)).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default().with_allow_absolute_paths(true);
+        let config = SecurityConfig::default()
+            .with_allow_absolute_paths(true)
+            .validate()
+            .unwrap();
 
         let report = archive
             .extract(
@@ -1562,7 +1581,10 @@ mod tests {
         let mut archive = SevenZArchive::new(Cursor::new(data)).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default().with_allow_absolute_paths(true);
+        let config = SecurityConfig::default()
+            .with_allow_absolute_paths(true)
+            .validate()
+            .unwrap();
 
         let result = archive.extract(
             temp.path(),
@@ -1593,7 +1615,7 @@ mod tests {
     fn test_process_entry_inner_rejects_traversal_independently() {
         let temp = TempDir::new().unwrap();
         let dest = DestDir::new_or_create(temp.path().to_path_buf()).unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
         let mut validator = EntryValidator::new(&config, &dest);
         let mut dir_cache = common::DirCache::new();
         let mut report = ExtractionReport::new();

--- a/crates/exarch-core/src/formats/tar.rs
+++ b/crates/exarch-core/src/formats/tar.rs
@@ -71,9 +71,10 @@
 //!
 //! let file = File::open("archive.tar")?;
 //! let mut archive = TarArchive::new(file);
+//! let config = SecurityConfig::default().validate()?;
 //! let report = archive.extract(
 //!     Path::new("/output"),
-//!     &SecurityConfig::default(),
+//!     &config,
 //!     &ExtractionOptions::default(),
 //!     &mut exarch_core::NoopProgress,
 //! )?;
@@ -95,9 +96,10 @@
 //! let file = File::open("archive.tar.gz")?;
 //! let decoder = GzDecoder::new(file);
 //! let mut archive = TarArchive::new(decoder);
+//! let config = SecurityConfig::default().validate()?;
 //! let report = archive.extract(
 //!     Path::new("/output"),
-//!     &SecurityConfig::default(),
+//!     &config,
 //!     &ExtractionOptions::default(),
 //!     &mut exarch_core::NoopProgress,
 //! )?;
@@ -119,6 +121,7 @@ use crate::ExtractionReport;
 use crate::ProgressCallback;
 use crate::Result;
 use crate::SecurityConfig;
+use crate::config::Validated;
 use crate::copy::CopyBuffer;
 use crate::security::validator::EntryValidator;
 use crate::security::validator::ValidatedEntry;
@@ -154,7 +157,7 @@ use super::traits::ArchiveFormat;
 ///
 /// let file = File::open("archive.tar")?;
 /// let mut archive = TarArchive::new(file);
-/// let config = SecurityConfig::default();
+/// let config = SecurityConfig::default().validate()?;
 /// let report = archive.extract(
 ///     Path::new("/output"),
 ///     &config,
@@ -238,7 +241,7 @@ impl<R: Read> TarArchive<R> {
             Some(ctx.dir_cache),
         )?;
 
-        match validated.entry_type {
+        match validated.entry_type() {
             ValidatedEntryType::File => {
                 Self::extract_file(entry, &validated, ctx)?;
                 Ok(None)
@@ -251,7 +254,7 @@ impl<R: Read> TarArchive<R> {
 
             ValidatedEntryType::Symlink(safe_symlink) => {
                 common::create_symlink(
-                    &safe_symlink,
+                    safe_symlink,
                     ctx.dest,
                     ctx.report,
                     ctx.dir_cache,
@@ -263,8 +266,8 @@ impl<R: Read> TarArchive<R> {
             ValidatedEntryType::Hardlink { target } => {
                 // Two-pass: defer hardlink creation until target files exist
                 Ok(Some(HardlinkInfo {
-                    link_path: validated.safe_path,
-                    target_path: target,
+                    link_path: validated.safe_path().clone(),
+                    target_path: target.clone(),
                 }))
             }
         }
@@ -375,7 +378,7 @@ impl<R: Read> ArchiveFormat for TarArchive<R> {
     fn extract(
         &mut self,
         output_dir: &Path,
-        config: &SecurityConfig,
+        config: &SecurityConfig<Validated>,
         options: &ExtractionOptions,
         progress: &mut dyn ProgressCallback,
     ) -> Result<ExtractionReport> {
@@ -485,7 +488,10 @@ impl<R: Read> ArchiveFormat for TarArchive<R> {
     /// let mut archive2 = TarArchive::open(&path)?;
     /// let report = archive2.extract(&dest, &config, &options, &mut NoopProgress)?;
     /// ```
-    fn list(&mut self, config: &SecurityConfig) -> Result<crate::inspection::ArchiveManifest> {
+    fn list(
+        &mut self,
+        config: &SecurityConfig<Validated>,
+    ) -> Result<crate::inspection::ArchiveManifest> {
         use crate::formats::detect::ArchiveType;
         use crate::inspection::list::list_tar_reader;
 
@@ -498,7 +504,10 @@ impl<R: Read> ArchiveFormat for TarArchive<R> {
         list_tar_reader(budgeted, budget, ArchiveType::Tar, config)
     }
 
-    fn verify(&mut self, config: &SecurityConfig) -> Result<crate::inspection::VerificationReport> {
+    fn verify(
+        &mut self,
+        config: &SecurityConfig<Validated>,
+    ) -> Result<crate::inspection::VerificationReport> {
         let manifest = self.list(&crate::inspection::verify::listing_config_for_verify(
             config,
         ))?;
@@ -517,7 +526,7 @@ struct ExtractionContext<'a, 'v> {
     copy_buffer: &'a mut CopyBuffer,
     dir_cache: &'a mut common::DirCache,
     skip_duplicates: bool,
-    config: &'v SecurityConfig,
+    config: &'v SecurityConfig<Validated>,
     progress: &'a mut dyn ProgressCallback,
 }
 
@@ -623,7 +632,7 @@ impl TarEntryAdapter {
 /// use std::path::Path;
 ///
 /// let mut archive = open_tar_gz("archive.tar.gz")?;
-/// let config = SecurityConfig::default();
+/// let config = SecurityConfig::default().validate()?;
 /// let report = archive.extract(
 ///     Path::new("/output"),
 ///     &config,
@@ -659,7 +668,7 @@ pub fn open_tar_gz<P: AsRef<Path>>(
 /// use std::path::Path;
 ///
 /// let mut archive = open_tar_bz2("archive.tar.bz2")?;
-/// let config = SecurityConfig::default();
+/// let config = SecurityConfig::default().validate()?;
 /// let report = archive.extract(
 ///     Path::new("/output"),
 ///     &config,
@@ -695,7 +704,7 @@ pub fn open_tar_bz2<P: AsRef<Path>>(
 /// use std::path::Path;
 ///
 /// let mut archive = open_tar_xz("archive.tar.xz")?;
-/// let config = SecurityConfig::default();
+/// let config = SecurityConfig::default().validate()?;
 /// let report = archive.extract(
 ///     Path::new("/output"),
 ///     &config,
@@ -732,7 +741,7 @@ pub fn open_tar_xz<P: AsRef<Path>>(
 /// use std::path::Path;
 ///
 /// let mut archive = open_tar_zst("archive.tar.zst")?;
-/// let config = SecurityConfig::default();
+/// let config = SecurityConfig::default().validate()?;
 /// let report = archive.extract(
 ///     Path::new("/output"),
 ///     &config,
@@ -774,7 +783,7 @@ mod tests {
         let mut archive = TarArchive::new(Cursor::new(tar_data));
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -826,7 +835,7 @@ mod tests {
         let mut archive = TarArchive::new(Cursor::new(tar_data));
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -873,6 +882,7 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let mut config = SecurityConfig::default();
         config.allowed.symlinks = true;
+        let config = config.validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -919,6 +929,7 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let mut config = SecurityConfig::default();
         config.allowed.hardlinks = true;
+        let config = config.validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -940,10 +951,10 @@ mod tests {
         let mut archive = TarArchive::new(Cursor::new(tar_data));
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig {
-            max_file_size: 100,
-            ..Default::default()
-        };
+        let config = SecurityConfig::default()
+            .with_max_file_size(100)
+            .validate()
+            .unwrap();
 
         let result = archive.extract(
             temp.path(),
@@ -970,7 +981,7 @@ mod tests {
         let mut archive = TarArchive::new(Cursor::new(tar_data));
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let result = archive.extract(
             temp.path(),
@@ -997,7 +1008,7 @@ mod tests {
         let mut archive = TarArchive::new(Cursor::new(tar_data));
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let result = archive.extract(
             temp.path(),
@@ -1024,7 +1035,7 @@ mod tests {
         let mut archive = TarArchive::new(Cursor::new(tar_data));
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let result = archive.extract(
             temp.path(),
@@ -1072,7 +1083,7 @@ mod tests {
         let mut archive = TarArchive::new(Cursor::new(tar_data));
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -1114,7 +1125,7 @@ mod tests {
         let mut archive = TarArchive::new(Cursor::new(tar_data));
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -1156,7 +1167,7 @@ mod tests {
         let mut archive = TarArchive::new(Cursor::new(tar_data));
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -1193,7 +1204,7 @@ mod tests {
         let mut archive = TarArchive::new(Cursor::new(tar_data));
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         // Either succeeds (extracted as regular file) or fails with
         // InvalidArchive due to missing GNU sparse extension headers.
@@ -1231,7 +1242,7 @@ mod tests {
         let mut archive = TarArchive::new(Cursor::new(tar_data));
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let result = archive.extract(
             temp.path(),
@@ -1264,7 +1275,7 @@ mod tests {
         let mut archive = TarArchive::new(Cursor::new(tar_data));
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -1297,7 +1308,7 @@ mod tests {
         let mut archive = TarArchive::new(decoder);
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -1330,7 +1341,7 @@ mod tests {
         let mut archive = TarArchive::new(decoder);
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -1362,7 +1373,7 @@ mod tests {
         let mut archive = TarArchive::new(decoder);
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -1390,7 +1401,7 @@ mod tests {
         let mut archive = TarArchive::new(decoder);
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -1411,7 +1422,7 @@ mod tests {
         let mut archive = TarArchive::new(Cursor::new(tar_data));
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -1432,7 +1443,7 @@ mod tests {
         let mut archive = TarArchive::new(Cursor::new(tar_data));
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -1463,7 +1474,7 @@ mod tests {
         let mut archive = TarArchive::new(Cursor::new(tar_data));
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -1490,10 +1501,10 @@ mod tests {
         let mut archive = TarArchive::new(Cursor::new(tar_data));
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig {
-            max_file_count: 2,
-            ..Default::default()
-        };
+        let config = SecurityConfig::default()
+            .with_max_file_count(2)
+            .validate()
+            .unwrap();
 
         let result = archive.extract(
             temp.path(),
@@ -1514,10 +1525,10 @@ mod tests {
         let mut archive = TarArchive::new(Cursor::new(tar_data));
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig {
-            max_total_size: 1000,
-            ..Default::default()
-        };
+        let config = SecurityConfig::default()
+            .with_max_total_size(1000)
+            .validate()
+            .unwrap();
 
         let result = archive.extract(
             temp.path(),
@@ -1547,7 +1558,7 @@ mod tests {
         let mut archive = TarArchive::new(Cursor::new(tar_data));
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -1583,7 +1594,7 @@ mod tests {
         let mut archive = TarArchive::new(Cursor::new(tar_data));
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -1608,7 +1619,7 @@ mod tests {
         let mut archive = TarArchive::new(Cursor::new(tar_data));
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -1638,7 +1649,7 @@ mod tests {
         let mut archive = TarArchive::new(Cursor::new(tar_data));
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -1672,7 +1683,7 @@ mod tests {
         let mut archive = TarArchive::new(Cursor::new(tar_data));
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default(); // symlinks disabled by default
+        let config = SecurityConfig::default().validate().expect("valid config"); // symlinks disabled by default
 
         let result = archive.extract(
             temp.path(),
@@ -1702,7 +1713,7 @@ mod tests {
         let mut archive = TarArchive::new(Cursor::new(tar_data));
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default(); // hardlinks disabled by default
+        let config = SecurityConfig::default().validate().expect("valid config"); // hardlinks disabled by default
 
         let result = archive.extract(
             temp.path(),
@@ -1720,7 +1731,7 @@ mod tests {
         let mut archive = TarArchive::new(Cursor::new(tar_data));
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -1754,7 +1765,7 @@ mod tests {
         let mut archive = TarArchive::new(Cursor::new(tar_data));
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let result = archive.extract(
             temp.path(),
@@ -1790,7 +1801,7 @@ mod tests {
         let mut archive = TarArchive::new(Cursor::new(tar_data));
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let result = archive.extract(
             temp.path(),
@@ -1837,6 +1848,7 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let mut config = SecurityConfig::default();
         config.allowed.symlinks = true;
+        let config = config.validate().expect("valid config");
 
         let result = archive.extract(
             temp.path(),
@@ -1878,6 +1890,7 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let mut config = SecurityConfig::default();
         config.allowed.hardlinks = true;
+        let config = config.validate().expect("valid config");
 
         let result = archive.extract(
             temp.path(),
@@ -1930,6 +1943,7 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let mut config = SecurityConfig::default();
         config.allowed.hardlinks = true;
+        let config = config.validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -1982,6 +1996,7 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let mut config = SecurityConfig::default();
         config.allowed.hardlinks = true;
+        let config = config.validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -2063,10 +2078,10 @@ mod tests {
 
         let mut archive = TarArchive::new(Cursor::new(tar_data));
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig {
-            max_file_size: 1024 * 1024,
-            ..Default::default()
-        };
+        let config = SecurityConfig::default()
+            .with_max_file_size(1024 * 1024)
+            .validate()
+            .unwrap();
 
         let result = archive.extract(
             temp.path(),
@@ -2091,10 +2106,10 @@ mod tests {
 
         let mut archive = TarArchive::new(Cursor::new(tar_data));
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig {
-            max_total_size: 500 * 1024,
-            ..Default::default()
-        };
+        let config = SecurityConfig::default()
+            .with_max_total_size(500 * 1024)
+            .validate()
+            .unwrap();
 
         let result = archive.extract(
             temp.path(),
@@ -2143,6 +2158,7 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let mut config = SecurityConfig::default();
         config.allowed.hardlinks = true;
+        let config = config.validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -2185,7 +2201,7 @@ mod tests {
         let mut archive = TarArchive::new(Cursor::new(tar_data));
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
         let options = ExtractionOptions::default(); // skip_duplicates = true
 
         let report = archive
@@ -2209,7 +2225,7 @@ mod tests {
         let mut archive = TarArchive::new(Cursor::new(tar_data));
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
         let options = ExtractionOptions {
             atomic: false,
             skip_duplicates: false,
@@ -2232,7 +2248,7 @@ mod tests {
     fn test_list_returns_manifest_with_entries() {
         let tar_data = create_test_tar(vec![("a.txt", b"hello"), ("b.txt", b"world")]);
         let mut archive = TarArchive::new(Cursor::new(tar_data));
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let manifest = archive.list(&config).unwrap();
 
@@ -2244,7 +2260,7 @@ mod tests {
     fn test_list_empty_archive_returns_empty_manifest() {
         let tar_data = create_test_tar(vec![]);
         let mut archive = TarArchive::new(Cursor::new(tar_data));
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let manifest = archive.list(&config).unwrap();
 
@@ -2256,7 +2272,7 @@ mod tests {
     fn test_verify_clean_archive_is_safe() {
         let tar_data = create_test_tar(vec![("safe.txt", b"data")]);
         let mut archive = TarArchive::new(Cursor::new(tar_data));
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive.verify(&config).unwrap();
 
@@ -2284,7 +2300,7 @@ mod tests {
         let mut archive = TarArchive::new(Cursor::new(tar_data));
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let result = archive.extract(
             temp.path(),
@@ -2306,7 +2322,10 @@ mod tests {
         let mut archive = TarArchive::new(Cursor::new(tar_data));
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default().with_allow_absolute_paths(true);
+        let config = SecurityConfig::default()
+            .with_allow_absolute_paths(true)
+            .validate()
+            .unwrap();
 
         let report = archive
             .extract(
@@ -2332,7 +2351,10 @@ mod tests {
         let mut archive = TarArchive::new(Cursor::new(tar_data));
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default().with_allow_absolute_paths(true);
+        let config = SecurityConfig::default()
+            .with_allow_absolute_paths(true)
+            .validate()
+            .unwrap();
 
         let result = archive.extract(
             temp.path(),
@@ -2350,7 +2372,10 @@ mod tests {
     fn test_allowed_extensions_filters_out_disallowed() {
         let tar_data = create_test_tar(vec![("keep.txt", b"keep"), ("skip.exe", b"skip")]);
         let dest = tempfile::tempdir().unwrap();
-        let config = SecurityConfig::default().with_allowed_extensions(vec!["txt".to_string()]);
+        let config = SecurityConfig::default()
+            .with_allowed_extensions(vec!["txt".to_string()])
+            .validate()
+            .unwrap();
 
         let report = TarArchive::new(Cursor::new(tar_data))
             .extract(
@@ -2372,7 +2397,7 @@ mod tests {
     fn test_empty_allowed_extensions_allows_all() {
         let tar_data = create_test_tar(vec![("a.txt", b"a"), ("b.exe", b"b")]);
         let dest = tempfile::tempdir().unwrap();
-        let config = SecurityConfig::default(); // empty = allow all
+        let config = SecurityConfig::default().validate().expect("valid config"); // empty = allow all
 
         let report = TarArchive::new(Cursor::new(tar_data))
             .extract(
@@ -2392,7 +2417,10 @@ mod tests {
         // A file without any extension must be blocked when an allowlist is set.
         let tar_data = create_test_tar(vec![("Makefile", b"all:"), ("keep.txt", b"ok")]);
         let dest = tempfile::tempdir().unwrap();
-        let config = SecurityConfig::default().with_allowed_extensions(vec!["txt".to_string()]);
+        let config = SecurityConfig::default()
+            .with_allowed_extensions(vec!["txt".to_string()])
+            .validate()
+            .unwrap();
 
         let report = TarArchive::new(Cursor::new(tar_data))
             .extract(

--- a/crates/exarch-core/src/formats/traits.rs
+++ b/crates/exarch-core/src/formats/traits.rs
@@ -7,6 +7,7 @@ use crate::ExtractionReport;
 use crate::ProgressCallback;
 use crate::Result;
 use crate::SecurityConfig;
+use crate::config::Validated;
 use crate::creation::CreationConfig;
 use crate::creation::CreationReport;
 use crate::inspection::ArchiveManifest;
@@ -17,6 +18,11 @@ use crate::inspection::VerificationReport;
 /// Implementors provide extraction, listing, and verification for a single
 /// archive format. Every new format must implement all three operations so that
 /// adding a format requires touching one trait implementation only.
+///
+/// Every method requires a [`SecurityConfig<Validated>`](SecurityConfig) —
+/// obtained only via [`SecurityConfig::validate`] — so a config that failed
+/// (or skipped) validation cannot reach extraction, listing, or verification.
+/// This is enforced by the compiler, not by convention.
 pub trait ArchiveFormat {
     /// Extracts the archive to the specified directory.
     ///
@@ -28,7 +34,7 @@ pub trait ArchiveFormat {
     fn extract(
         &mut self,
         output_dir: &Path,
-        config: &SecurityConfig,
+        config: &SecurityConfig<Validated>,
         options: &ExtractionOptions,
         progress: &mut dyn ProgressCallback,
     ) -> Result<ExtractionReport>;
@@ -42,7 +48,7 @@ pub trait ArchiveFormat {
     ///
     /// Returns an error if the archive is corrupted, encrypted, or a quota
     /// limit is exceeded.
-    fn list(&mut self, config: &SecurityConfig) -> Result<ArchiveManifest>;
+    fn list(&mut self, config: &SecurityConfig<Validated>) -> Result<ArchiveManifest>;
 
     /// Verifies the archive's integrity and security without extracting.
     ///
@@ -54,7 +60,7 @@ pub trait ArchiveFormat {
     ///
     /// Returns an error only if the archive cannot be read at all (I/O
     /// failure, encryption). Individual security issues appear in the report.
-    fn verify(&mut self, config: &SecurityConfig) -> Result<VerificationReport>;
+    fn verify(&mut self, config: &SecurityConfig<Validated>) -> Result<VerificationReport>;
 
     /// Returns the archive format name.
     fn format_name(&self) -> &'static str;
@@ -138,19 +144,19 @@ mod tests {
         fn extract(
             &mut self,
             _output_dir: &Path,
-            _config: &SecurityConfig,
+            _config: &SecurityConfig<Validated>,
             _options: &ExtractionOptions,
             _progress: &mut dyn ProgressCallback,
         ) -> Result<ExtractionReport> {
             Ok(ExtractionReport::new())
         }
 
-        fn list(&mut self, _config: &SecurityConfig) -> Result<ArchiveManifest> {
+        fn list(&mut self, _config: &SecurityConfig<Validated>) -> Result<ArchiveManifest> {
             use crate::formats::detect::ArchiveType;
             Ok(ArchiveManifest::new(ArchiveType::Tar))
         }
 
-        fn verify(&mut self, config: &SecurityConfig) -> Result<VerificationReport> {
+        fn verify(&mut self, config: &SecurityConfig<Validated>) -> Result<VerificationReport> {
             let manifest = self.list(config)?;
             crate::inspection::verify::verify_manifest(&manifest, config)
         }
@@ -171,7 +177,7 @@ mod tests {
     fn test_trait_extract_returns_report() {
         let mut format = TestFormat;
         let temp = tempfile::TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().unwrap();
         let options = ExtractionOptions::default();
         let mut noop = crate::NoopProgress;
         let report = format
@@ -184,7 +190,7 @@ mod tests {
     #[allow(clippy::unwrap_used)]
     fn test_trait_list_returns_empty_manifest() {
         let mut format = TestFormat;
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().unwrap();
         let manifest = format.list(&config).unwrap();
         assert_eq!(manifest.total_entries, 0);
         assert_eq!(manifest.total_size, 0);
@@ -194,7 +200,7 @@ mod tests {
     #[allow(clippy::unwrap_used)]
     fn test_trait_verify_returns_clean_report_for_empty_archive() {
         let mut format = TestFormat;
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().unwrap();
         let report = format.verify(&config).unwrap();
         assert_eq!(report.total_entries, 0);
         assert!(report.is_safe());
@@ -204,7 +210,7 @@ mod tests {
     #[allow(clippy::unwrap_used)]
     fn test_trait_list_via_dyn_dispatch() {
         let mut format: Box<dyn ArchiveFormat> = Box::new(TestFormat);
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().unwrap();
         let manifest = format.list(&config).unwrap();
         assert_eq!(manifest.total_entries, 0);
     }
@@ -213,7 +219,7 @@ mod tests {
     #[allow(clippy::unwrap_used)]
     fn test_trait_verify_via_dyn_dispatch() {
         let mut format: Box<dyn ArchiveFormat> = Box::new(TestFormat);
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().unwrap();
         let report = format.verify(&config).unwrap();
         assert!(report.is_safe());
     }

--- a/crates/exarch-core/src/formats/zip.rs
+++ b/crates/exarch-core/src/formats/zip.rs
@@ -94,9 +94,10 @@
 //!
 //! let file = File::open("archive.zip")?;
 //! let mut archive = ZipArchive::new(file)?;
+//! let config = SecurityConfig::default().validate()?;
 //! let report = archive.extract(
 //!     Path::new("/output"),
-//!     &SecurityConfig::default(),
+//!     &config,
 //!     &ExtractionOptions::default(),
 //!     &mut exarch_core::NoopProgress,
 //! )?;
@@ -131,6 +132,7 @@ use crate::ExtractionReport;
 use crate::ProgressCallback;
 use crate::Result;
 use crate::SecurityConfig;
+use crate::config::Validated;
 use crate::copy::CopyBuffer;
 use crate::security::EntryValidator;
 use crate::security::validator::ValidatedEntryType;
@@ -148,7 +150,7 @@ use super::traits::ArchiveFormat;
 /// function call individually.
 struct ZipExtractionContext<'a> {
     dest: &'a DestDir,
-    config: &'a SecurityConfig,
+    config: &'a SecurityConfig<Validated>,
     report: &'a mut ExtractionReport,
     copy_buffer: &'a mut CopyBuffer,
     dir_cache: &'a mut common::DirCache,
@@ -188,9 +190,10 @@ struct ZipExtractionContext<'a> {
 ///
 /// let file = File::open("archive.zip")?;
 /// let mut archive = ZipArchive::new(file)?;
+/// let config = SecurityConfig::default().validate()?;
 /// let report = archive.extract(
 ///     Path::new("/output"),
-///     &SecurityConfig::default(),
+///     &config,
 ///     &ExtractionOptions::default(),
 ///     &mut exarch_core::NoopProgress,
 /// )?;
@@ -366,9 +369,9 @@ impl<R: Read + Seek> ZipArchive<R> {
                 mode,
                 Some(ctx.dir_cache),
             )?;
-            if let ValidatedEntryType::Symlink(safe_symlink) = validated.entry_type {
+            if let ValidatedEntryType::Symlink(safe_symlink) = validated.entry_type() {
                 common::create_symlink(
-                    &safe_symlink,
+                    safe_symlink,
                     ctx.dest,
                     ctx.report,
                     ctx.dir_cache,
@@ -420,7 +423,7 @@ impl<R: Read + Seek> ArchiveFormat for ZipArchive<R> {
     fn extract(
         &mut self,
         output_dir: &Path,
-        config: &SecurityConfig,
+        config: &SecurityConfig<Validated>,
         options: &ExtractionOptions,
         progress: &mut dyn ProgressCallback,
     ) -> Result<ExtractionReport> {
@@ -486,12 +489,18 @@ impl<R: Read + Seek> ArchiveFormat for ZipArchive<R> {
         Ok(report)
     }
 
-    fn list(&mut self, config: &SecurityConfig) -> Result<crate::inspection::ArchiveManifest> {
+    fn list(
+        &mut self,
+        config: &SecurityConfig<Validated>,
+    ) -> Result<crate::inspection::ArchiveManifest> {
         use crate::inspection::list::list_zip_reader;
         list_zip_reader(&mut self.inner, config)
     }
 
-    fn verify(&mut self, config: &SecurityConfig) -> Result<crate::inspection::VerificationReport> {
+    fn verify(
+        &mut self,
+        config: &SecurityConfig<Validated>,
+    ) -> Result<crate::inspection::VerificationReport> {
         let manifest = self.list(&crate::inspection::verify::listing_config_for_verify(
             config,
         ))?;
@@ -630,7 +639,7 @@ mod tests {
         let mut archive = ZipArchive::new(cursor).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -652,7 +661,7 @@ mod tests {
         let mut archive = ZipArchive::new(cursor).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -681,7 +690,7 @@ mod tests {
         let mut archive = ZipArchive::new(cursor).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -702,7 +711,7 @@ mod tests {
         let mut archive = ZipArchive::new(cursor).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -734,7 +743,7 @@ mod tests {
         let mut archive = ZipArchive::new(cursor).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -768,7 +777,7 @@ mod tests {
         let mut archive = ZipArchive::new(cursor).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -798,7 +807,7 @@ mod tests {
         let mut archive = ZipArchive::new(cursor).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -826,7 +835,7 @@ mod tests {
         let mut archive = ZipArchive::new(cursor).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -848,7 +857,7 @@ mod tests {
         let mut archive = ZipArchive::new(cursor).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -875,6 +884,7 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let mut config = SecurityConfig::default();
         config.max_file_size = 100; // Only allow 100 bytes
+        let config = config.validate().expect("valid config");
 
         let result = archive.extract(
             temp.path(),
@@ -899,6 +909,7 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let mut config = SecurityConfig::default();
         config.max_file_count = 2; // Only allow 2 files
+        let config = config.validate().expect("valid config");
 
         let result = archive.extract(
             temp.path(),
@@ -917,7 +928,7 @@ mod tests {
         let mut archive = ZipArchive::new(cursor).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let result = archive.extract(
             temp.path(),
@@ -940,7 +951,7 @@ mod tests {
         let mut archive = ZipArchive::new(cursor).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -978,6 +989,7 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let mut config = SecurityConfig::default();
         config.max_compression_ratio = 10.0; // Low threshold for testing
+        let config = config.validate().expect("valid config");
 
         let result = archive.extract(
             temp.path(),
@@ -1007,7 +1019,7 @@ mod tests {
         let mut archive = ZipArchive::new(cursor).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -1042,7 +1054,7 @@ mod tests {
         let mut archive = ZipArchive::new(cursor).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let _report = archive
             .extract(
@@ -1077,7 +1089,7 @@ mod tests {
         let mut archive = ZipArchive::new(cursor).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let _report = archive
             .extract(
@@ -1112,7 +1124,7 @@ mod tests {
         let mut archive = ZipArchive::new(cursor).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let _report = archive
             .extract(
@@ -1142,6 +1154,7 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let mut config = SecurityConfig::default();
         config.allowed.symlinks = true;
+        let config = config.validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -1167,7 +1180,7 @@ mod tests {
         let mut archive = ZipArchive::new(cursor).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default(); // symlinks disabled by default
+        let config = SecurityConfig::default().validate().expect("valid config"); // symlinks disabled by default
 
         let result = archive.extract(
             temp.path(),
@@ -1198,7 +1211,7 @@ mod tests {
         let mut archive = ZipArchive::new(cursor).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -1234,7 +1247,7 @@ mod tests {
         let mut archive = ZipArchive::new(cursor).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -1258,7 +1271,7 @@ mod tests {
         let mut archive = ZipArchive::new(cursor).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -1279,7 +1292,7 @@ mod tests {
         let mut archive = ZipArchive::new(cursor).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -1310,7 +1323,7 @@ mod tests {
         let mut archive = ZipArchive::new(cursor).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -1339,7 +1352,7 @@ mod tests {
         let mut archive = ZipArchive::new(cursor).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -1363,7 +1376,7 @@ mod tests {
         let mut archive = ZipArchive::new(cursor).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let _report = archive
             .extract(
@@ -1389,7 +1402,7 @@ mod tests {
         let mut archive = ZipArchive::new(cursor).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -1427,7 +1440,7 @@ mod tests {
         let mut archive = ZipArchive::new(cursor).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -1453,6 +1466,7 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let mut config = SecurityConfig::default();
         config.max_total_size = 1000; // Total limit 1000 bytes
+        let config = config.validate().expect("valid config");
 
         let result = archive.extract(
             temp.path(),
@@ -1475,7 +1489,7 @@ mod tests {
         let mut archive = ZipArchive::new(cursor).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive
             .extract(
@@ -1593,7 +1607,7 @@ mod tests {
         let result = ZipArchive::new(cursor);
         if let Ok(mut archive) = result {
             let temp = TempDir::new().unwrap();
-            let config = SecurityConfig::default();
+            let config = SecurityConfig::default().validate().expect("valid config");
             let err = archive
                 .extract(
                     temp.path(),
@@ -1627,6 +1641,7 @@ mod tests {
             let temp = TempDir::new().unwrap();
             let mut config = SecurityConfig::default();
             config.allowed.symlinks = true;
+            let config = config.validate().expect("valid config");
             let err = archive
                 .extract(
                     temp.path(),
@@ -1655,6 +1670,7 @@ mod tests {
             let temp = TempDir::new().unwrap();
             let mut config = SecurityConfig::default();
             config.allowed.symlinks = true;
+            let config = config.validate().expect("valid config");
             let err = archive
                 .extract(
                     temp.path(),
@@ -1847,7 +1863,7 @@ mod tests {
         let mut archive = ZipArchive::new(cursor).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
         let options = ExtractionOptions::default(); // skip_duplicates = true
 
         let report = archive
@@ -1940,7 +1956,7 @@ mod tests {
     fn test_list_returns_manifest_with_entries() {
         let zip_data = create_test_zip(vec![("a.txt", b"hello"), ("b.txt", b"world")]);
         let mut archive = ZipArchive::new(Cursor::new(zip_data)).unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let manifest = archive.list(&config).unwrap();
 
@@ -1952,7 +1968,7 @@ mod tests {
     fn test_list_empty_zip_returns_empty_manifest() {
         let zip_data = create_test_zip(vec![]);
         let mut archive = ZipArchive::new(Cursor::new(zip_data)).unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let manifest = archive.list(&config).unwrap();
 
@@ -1964,7 +1980,7 @@ mod tests {
     fn test_verify_clean_zip_is_safe() {
         let zip_data = create_test_zip(vec![("safe.txt", b"data")]);
         let mut archive = ZipArchive::new(Cursor::new(zip_data)).unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = archive.verify(&config).unwrap();
 
@@ -1977,7 +1993,10 @@ mod tests {
         use crate::NoopProgress;
         let zip_data = create_test_zip(vec![("keep.txt", b"keep"), ("skip.exe", b"skip")]);
         let dest = tempfile::tempdir().unwrap();
-        let config = SecurityConfig::default().with_allowed_extensions(vec!["txt".to_string()]);
+        let config = SecurityConfig::default()
+            .with_allowed_extensions(vec!["txt".to_string()])
+            .validate()
+            .unwrap();
 
         let report = ZipArchive::new(Cursor::new(zip_data))
             .unwrap()
@@ -2001,7 +2020,7 @@ mod tests {
         use crate::NoopProgress;
         let zip_data = create_test_zip(vec![("a.txt", b"a"), ("b.exe", b"b")]);
         let dest = tempfile::tempdir().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let report = ZipArchive::new(Cursor::new(zip_data))
             .unwrap()
@@ -2022,7 +2041,10 @@ mod tests {
         use crate::NoopProgress;
         let zip_data = create_test_zip(vec![("Makefile", b"all:"), ("keep.txt", b"ok")]);
         let dest = tempfile::tempdir().unwrap();
-        let config = SecurityConfig::default().with_allowed_extensions(vec!["txt".to_string()]);
+        let config = SecurityConfig::default()
+            .with_allowed_extensions(vec!["txt".to_string()])
+            .validate()
+            .unwrap();
 
         let report = ZipArchive::new(Cursor::new(zip_data))
             .unwrap()
@@ -2053,7 +2075,7 @@ mod tests {
         let mut archive = ZipArchive::new(cursor).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let result = archive.extract(
             temp.path(),
@@ -2076,7 +2098,10 @@ mod tests {
         let mut archive = ZipArchive::new(cursor).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default().with_allow_absolute_paths(true);
+        let config = SecurityConfig::default()
+            .with_allow_absolute_paths(true)
+            .validate()
+            .unwrap();
 
         let result = archive.extract(
             temp.path(),
@@ -2100,7 +2125,10 @@ mod tests {
         let mut archive = ZipArchive::new(cursor).unwrap();
 
         let temp = TempDir::new().unwrap();
-        let config = SecurityConfig::default().with_allow_absolute_paths(true);
+        let config = SecurityConfig::default()
+            .with_allow_absolute_paths(true)
+            .validate()
+            .unwrap();
 
         let report = archive
             .extract(

--- a/crates/exarch-core/src/inspection/list.rs
+++ b/crates/exarch-core/src/inspection/list.rs
@@ -14,6 +14,7 @@ use flate2::read::GzDecoder;
 use crate::ArchiveError;
 use crate::Result;
 use crate::SecurityConfig;
+use crate::config::Validated;
 #[cfg(test)]
 use crate::error::QuotaResource;
 use crate::formats::common::normalize_entry_name;
@@ -69,7 +70,8 @@ pub fn list_archive<P: AsRef<Path>>(
     archive_path: P,
     config: &SecurityConfig,
 ) -> Result<ArchiveManifest> {
-    config.validate()?;
+    let config = config.clone().validate()?;
+    let config = &config;
     let archive_path = archive_path.as_ref();
     let format = detect_format(archive_path)?;
 
@@ -87,7 +89,7 @@ pub fn list_archive<P: AsRef<Path>>(
 fn list_tar(
     archive_path: &Path,
     format: ArchiveType,
-    config: &SecurityConfig,
+    config: &SecurityConfig<Validated>,
 ) -> Result<ArchiveManifest> {
     let file = File::open(archive_path)?;
     let reader = BufReader::new(file);
@@ -99,7 +101,7 @@ fn list_tar(
 fn list_tar_gz(
     archive_path: &Path,
     format: ArchiveType,
-    config: &SecurityConfig,
+    config: &SecurityConfig<Validated>,
 ) -> Result<ArchiveManifest> {
     let file = File::open(archive_path)?;
     let reader = BufReader::new(file);
@@ -112,7 +114,7 @@ fn list_tar_gz(
 fn list_tar_bz2(
     archive_path: &Path,
     format: ArchiveType,
-    config: &SecurityConfig,
+    config: &SecurityConfig<Validated>,
 ) -> Result<ArchiveManifest> {
     use bzip2::read::BzDecoder;
 
@@ -127,7 +129,7 @@ fn list_tar_bz2(
 fn list_tar_xz(
     archive_path: &Path,
     format: ArchiveType,
-    config: &SecurityConfig,
+    config: &SecurityConfig<Validated>,
 ) -> Result<ArchiveManifest> {
     use xz2::read::XzDecoder;
 
@@ -142,7 +144,7 @@ fn list_tar_xz(
 fn list_tar_zst(
     archive_path: &Path,
     format: ArchiveType,
-    config: &SecurityConfig,
+    config: &SecurityConfig<Validated>,
 ) -> Result<ArchiveManifest> {
     use zstd::stream::read::Decoder as ZstdDecoder;
 
@@ -163,7 +165,7 @@ fn list_tar_entries<R: std::io::Read>(
     mut archive: tar::Archive<crate::formats::tar_metadata_limit::BudgetedReader<R>>,
     budget: TarReadBudget,
     format: ArchiveType,
-    config: &SecurityConfig,
+    config: &SecurityConfig<Validated>,
 ) -> Result<ArchiveManifest> {
     let mut manifest = ArchiveManifest::new(format);
     let mut quota = QuotaTracker::new();
@@ -278,7 +280,7 @@ fn list_tar_entries<R: std::io::Read>(
 fn list_zip(
     archive_path: &Path,
     _format: ArchiveType,
-    config: &SecurityConfig,
+    config: &SecurityConfig<Validated>,
 ) -> Result<ArchiveManifest> {
     let file = File::open(archive_path)?;
     let mut archive = zip::ZipArchive::new(file)
@@ -296,7 +298,7 @@ pub(crate) fn list_tar_reader<R: Read>(
     reader: crate::formats::tar_metadata_limit::BudgetedReader<R>,
     budget: TarReadBudget,
     format: ArchiveType,
-    config: &SecurityConfig,
+    config: &SecurityConfig<Validated>,
 ) -> Result<ArchiveManifest> {
     let archive = tar::Archive::new(reader);
     list_tar_entries(archive, budget, format, config)
@@ -307,7 +309,7 @@ pub(crate) fn list_tar_reader<R: Read>(
 /// Used by `ArchiveFormat::list()` to avoid re-opening the archive.
 pub(crate) fn list_zip_reader<R: Read + Seek>(
     archive: &mut zip::ZipArchive<R>,
-    config: &SecurityConfig,
+    config: &SecurityConfig<Validated>,
 ) -> Result<ArchiveManifest> {
     let mut manifest = ArchiveManifest::new(ArchiveType::Zip);
     let mut quota = QuotaTracker::new();
@@ -426,7 +428,7 @@ pub(crate) fn list_zip_reader<R: Read + Seek>(
 /// must be positioned at the beginning of the 7z stream.
 pub(crate) fn list_sevenz_reader<R: Read + Seek>(
     mut source: R,
-    config: &SecurityConfig,
+    config: &SecurityConfig<Validated>,
 ) -> Result<ArchiveManifest> {
     use sevenz_rust2::Archive;
     use sevenz_rust2::Password;
@@ -494,7 +496,7 @@ fn is_empty_sevenz_archive_reader<R: Read + Seek>(
 /// that truncation behavior.
 fn list_sevenz_archive(
     archive: &sevenz_rust2::Archive,
-    config: &SecurityConfig,
+    config: &SecurityConfig<Validated>,
 ) -> Result<ArchiveManifest> {
     let mut manifest = ArchiveManifest::new(ArchiveType::SevenZ);
     let mut quota = QuotaTracker::new();
@@ -552,7 +554,7 @@ fn list_sevenz_archive(
 fn list_sevenz(
     archive_path: &Path,
     _format: ArchiveType,
-    config: &SecurityConfig,
+    config: &SecurityConfig<Validated>,
 ) -> Result<ArchiveManifest> {
     let mut file = File::open(archive_path)?;
     list_sevenz_reader(&mut file, config)
@@ -589,7 +591,11 @@ fn sevenz_manifest_entry_type(entry: &sevenz_rust2::ArchiveEntry) -> ManifestEnt
 /// field's doc), so `verify_archive`'s pre-flight listing pass can defer to
 /// `verify_entry`'s own equivalent checks and report a graceful
 /// `VerificationIssue` instead of aborting.
-fn validate_link_target(target: &Path, kind: &str, config: &SecurityConfig) -> Result<()> {
+fn validate_link_target(
+    target: &Path,
+    kind: &str,
+    config: &SecurityConfig<Validated>,
+) -> Result<()> {
     if config.relaxed_for_verify_preflight {
         return Ok(());
     }
@@ -612,7 +618,7 @@ fn validate_link_target(target: &Path, kind: &str, config: &SecurityConfig) -> R
 /// `ParentDir` (`..`) is always rejected. `RootDir` and `Prefix` (Windows drive
 /// paths such as `C:\`) are rejected only when `config.allowed.absolute_paths`
 /// is false, matching the behaviour of `SafePath::validate`.
-fn contains_traversal(path: &Path, config: &SecurityConfig) -> bool {
+fn contains_traversal(path: &Path, config: &SecurityConfig<Validated>) -> bool {
     use std::path::Component;
     path.components().any(|c| match c {
         Component::ParentDir => true,
@@ -931,7 +937,7 @@ mod tests {
 
         let zip_bytes = create_zip_with_symlink("link", "target.txt");
         let mut archive = zip::ZipArchive::new(Cursor::new(zip_bytes)).unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
         let manifest = list_zip_reader(&mut archive, &config).unwrap();
 
         assert_eq!(manifest.total_entries, 1);
@@ -999,10 +1005,7 @@ mod tests {
         temp_file.flush().unwrap();
 
         // Set quota to 1 file
-        let config = SecurityConfig {
-            max_file_count: 1,
-            ..Default::default()
-        };
+        let config = SecurityConfig::default().with_max_file_count(1);
 
         let result = list_archive(temp_file.path(), &config);
         match result {
@@ -1027,10 +1030,7 @@ mod tests {
         zip.start_file("b.txt", options).unwrap();
         zip.finish().unwrap();
 
-        let config = SecurityConfig {
-            max_file_count: 1,
-            ..Default::default()
-        };
+        let config = SecurityConfig::default().with_max_file_count(1);
 
         let result = list_archive(temp_file.path(), &config);
         match result {
@@ -1266,10 +1266,7 @@ mod tests {
         zip.write_all(&vec![0u8; 600]).unwrap();
         zip.finish().unwrap();
 
-        let config = SecurityConfig {
-            max_total_size: 100,
-            ..Default::default()
-        };
+        let config = SecurityConfig::default().with_max_total_size(100);
         let result = list_archive(temp_file.path(), &config);
         assert_matches!(
             result,
@@ -1296,10 +1293,7 @@ mod tests {
         temp_file.write_all(&archive_data).unwrap();
         temp_file.flush().unwrap();
 
-        let config = SecurityConfig {
-            max_total_size: 100,
-            ..Default::default()
-        };
+        let config = SecurityConfig::default().with_max_total_size(100);
         let result = list_archive(temp_file.path(), &config);
         assert_matches!(
             result,
@@ -1434,13 +1428,16 @@ mod tests {
         // verified by the match arm `Component::Prefix(_) | Component::RootDir`.
         let absolute = PathBuf::from("/absolute/path.txt");
 
-        let config_deny = SecurityConfig::default(); // absolute_paths = false
+        let config_deny = SecurityConfig::default().validate().expect("valid config"); // absolute_paths = false
         assert!(
             contains_traversal(&absolute, &config_deny),
             "absolute path must be rejected when allow_absolute_paths=false"
         );
 
-        let config_allow = SecurityConfig::default().with_allow_absolute_paths(true);
+        let config_allow = SecurityConfig::default()
+            .with_allow_absolute_paths(true)
+            .validate()
+            .expect("valid config");
         assert!(
             !contains_traversal(&absolute, &config_allow),
             "absolute path must be accepted when allow_absolute_paths=true"
@@ -1754,10 +1751,7 @@ mod tests {
         temp_file.write_all(&archive_bytes).unwrap();
         temp_file.flush().unwrap();
 
-        let config = SecurityConfig {
-            max_file_count: 2,
-            ..Default::default()
-        };
+        let config = SecurityConfig::default().with_max_file_count(2);
         let result = list_archive(temp_file.path(), &config);
         assert_matches!(
             result,
@@ -1777,10 +1771,7 @@ mod tests {
         temp_file.write_all(&archive_bytes).unwrap();
         temp_file.flush().unwrap();
 
-        let config = SecurityConfig {
-            max_total_size: 50,
-            ..Default::default()
-        };
+        let config = SecurityConfig::default().with_max_total_size(50);
         let result = list_archive(temp_file.path(), &config);
         assert_matches!(
             result,
@@ -1848,10 +1839,7 @@ mod tests {
         temp_file.flush().unwrap();
 
         // Small limit — must reject.
-        let small = SecurityConfig {
-            max_total_size: 100,
-            ..Default::default()
-        };
+        let small = SecurityConfig::default().with_max_total_size(100);
         assert_matches!(
             list_archive(temp_file.path(), &small),
             Err(ArchiveError::QuotaExceeded {
@@ -1861,10 +1849,7 @@ mod tests {
         );
 
         // Large limit (simulates --max-total-size 1G) — must succeed.
-        let large = SecurityConfig {
-            max_total_size: 1024 * 1024 * 1024,
-            ..Default::default()
-        };
+        let large = SecurityConfig::default().with_max_total_size(1024 * 1024 * 1024);
         assert!(
             list_archive(temp_file.path(), &large).is_ok(),
             "list_archive must succeed when caller supplies a large max_total_size (regression #166)"
@@ -1884,10 +1869,7 @@ mod tests {
             zip.finish().unwrap();
         }
 
-        let small = SecurityConfig {
-            max_total_size: 100,
-            ..Default::default()
-        };
+        let small = SecurityConfig::default().with_max_total_size(100);
         assert_matches!(
             list_archive(temp_file.path(), &small),
             Err(ArchiveError::QuotaExceeded {
@@ -1896,10 +1878,7 @@ mod tests {
             "expected TotalSize quota error with limit=100"
         );
 
-        let large = SecurityConfig {
-            max_total_size: 1024 * 1024 * 1024,
-            ..Default::default()
-        };
+        let large = SecurityConfig::default().with_max_total_size(1024 * 1024 * 1024);
         assert!(
             list_archive(temp_file.path(), &large).is_ok(),
             "list_archive must succeed when caller supplies a large max_total_size (regression #166)"
@@ -1914,10 +1893,7 @@ mod tests {
         temp_file.write_all(&archive_bytes).unwrap();
         temp_file.flush().unwrap();
 
-        let small = SecurityConfig {
-            max_total_size: 100,
-            ..Default::default()
-        };
+        let small = SecurityConfig::default().with_max_total_size(100);
         assert_matches!(
             list_archive(temp_file.path(), &small),
             Err(ArchiveError::QuotaExceeded {
@@ -1926,10 +1902,7 @@ mod tests {
             "expected TotalSize quota error with limit=100"
         );
 
-        let large = SecurityConfig {
-            max_total_size: 1024 * 1024 * 1024,
-            ..Default::default()
-        };
+        let large = SecurityConfig::default().with_max_total_size(1024 * 1024 * 1024);
         assert!(
             list_archive(temp_file.path(), &large).is_ok(),
             "list_archive must succeed when caller supplies a large max_total_size (regression #166)"
@@ -1963,10 +1936,7 @@ mod tests {
         use crate::inspection::report::IssueSeverity;
 
         let path = std::path::Path::new("../../tests/fixtures/solid.7z");
-        let config = SecurityConfig {
-            allow_solid_archives: true,
-            ..SecurityConfig::default()
-        };
+        let config = SecurityConfig::default().with_allow_solid_archives(true);
         let report = crate::verify_archive(path, &config).unwrap();
         assert_ne!(
             report.status,
@@ -1985,10 +1955,7 @@ mod tests {
 
     #[test]
     fn list_archive_rejects_invalid_security_config() {
-        let config = SecurityConfig {
-            max_file_size: 0,
-            ..SecurityConfig::default()
-        };
+        let config = SecurityConfig::default().with_max_file_size(0);
         let result = crate::list_archive("any.tar.gz", &config);
         assert_matches!(
             result,
@@ -2240,7 +2207,7 @@ mod tests {
 
         let zip_bytes = create_zip_with_symlink("link", "foo\0bar");
         let mut archive = zip::ZipArchive::new(Cursor::new(zip_bytes)).unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
         let result = list_zip_reader(&mut archive, &config);
         match result {
             Err(ArchiveError::SecurityViolation { reason }) => {
@@ -2260,7 +2227,7 @@ mod tests {
 
         let zip_bytes = create_zip_with_symlink("link", "");
         let mut archive = zip::ZipArchive::new(Cursor::new(zip_bytes)).unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
         let result = list_zip_reader(&mut archive, &config);
         match result {
             Err(ArchiveError::SecurityViolation { reason }) => {
@@ -2443,10 +2410,7 @@ mod tests {
         temp_file.write_all(&archive_data).unwrap();
         temp_file.flush().unwrap();
 
-        let config = SecurityConfig {
-            max_file_size: 500,
-            ..Default::default()
-        };
+        let config = SecurityConfig::default().with_max_file_size(500);
         let result = list_archive(temp_file.path(), &config);
         assert_matches!(
             result,
@@ -2471,10 +2435,7 @@ mod tests {
         zip.write_all(&vec![0u8; 1000]).unwrap();
         zip.finish().unwrap();
 
-        let config = SecurityConfig {
-            max_file_size: 500,
-            ..Default::default()
-        };
+        let config = SecurityConfig::default().with_max_file_size(500);
         let result = list_archive(temp_file.path(), &config);
         assert_matches!(
             result,
@@ -2496,10 +2457,7 @@ mod tests {
         temp_file.write_all(&archive_bytes).unwrap();
         temp_file.flush().unwrap();
 
-        let config = SecurityConfig {
-            max_file_size: 500,
-            ..Default::default()
-        };
+        let config = SecurityConfig::default().with_max_file_size(500);
         let result = list_archive(temp_file.path(), &config);
         assert_matches!(
             result,
@@ -2600,12 +2558,12 @@ mod tests {
         let zip_bytes = zip_with_zip64_declared_sizes(&[("a.bin", u64::MAX - 100), ("b.bin", 200)]);
         let mut archive = zip::ZipArchive::new(Cursor::new(zip_bytes)).unwrap();
 
-        let config = SecurityConfig {
-            max_file_size: u64::MAX,
-            max_file_count: usize::MAX,
-            max_total_size: u64::MAX,
-            ..Default::default()
-        };
+        let config = SecurityConfig::default()
+            .with_max_file_size(u64::MAX)
+            .with_max_file_count(usize::MAX)
+            .with_max_total_size(u64::MAX)
+            .validate()
+            .expect("valid config");
         let result = list_zip_reader(&mut archive, &config);
         assert_matches!(
             result,

--- a/crates/exarch-core/src/inspection/verify.rs
+++ b/crates/exarch-core/src/inspection/verify.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use crate::ArchiveError;
 use crate::Result;
 use crate::SecurityConfig;
+use crate::config::Validated;
 use crate::inspection::list::list_archive;
 use crate::inspection::manifest::ArchiveEntry;
 use crate::inspection::manifest::ArchiveManifest;
@@ -30,7 +31,7 @@ use crate::types::EntryType;
 /// produced by `ArchiveFormat::list()`.
 pub(crate) fn verify_manifest(
     manifest: &ArchiveManifest,
-    config: &SecurityConfig,
+    config: &SecurityConfig<Validated>,
 ) -> Result<VerificationReport> {
     let mut issues = Vec::new();
     let mut suspicious_entries = 0;
@@ -114,9 +115,9 @@ pub fn verify_archive<P: AsRef<Path>>(
     archive_path: P,
     config: &SecurityConfig,
 ) -> Result<VerificationReport> {
-    config.validate()?;
+    let validated_config = config.clone().validate()?;
     let manifest = list_archive(archive_path, &listing_config_for_verify(config))?;
-    verify_manifest(&manifest, config)
+    verify_manifest(&manifest, &validated_config)
 }
 
 /// Returns a config variant for the pre-flight listing step that feeds
@@ -133,16 +134,24 @@ pub fn verify_archive<P: AsRef<Path>>(
 /// untouched, matching prior behavior. See
 /// `SecurityConfig::relaxed_for_verify_preflight`'s field doc for exactly
 /// which `list_archive` checks this skips.
-pub(crate) fn listing_config_for_verify(config: &SecurityConfig) -> SecurityConfig {
-    config
-        .clone()
-        .with_max_file_size(u64::MAX)
-        .with_relaxed_for_verify_preflight()
+///
+/// Generic over the validation typestate so it serves both callers: the
+/// top-level [`verify_archive`] (still `Unvalidated`, feeds into
+/// [`list_archive`] which validates internally) and the
+/// [`ArchiveFormat`](crate::formats::traits::ArchiveFormat) trait's `verify()`
+/// implementations (already `Validated`, feeds into `list()` which requires
+/// it). Delegates to `SecurityConfig::as_relaxed_for_verify_preflight`, whose
+/// docs justify why re-deriving a `Validated` result without calling
+/// `validate()` again is sound.
+pub(crate) fn listing_config_for_verify<State>(
+    config: &SecurityConfig<State>,
+) -> SecurityConfig<State> {
+    config.as_relaxed_for_verify_preflight()
 }
 
 fn verify_entry(
     entry: &ArchiveEntry,
-    config: &SecurityConfig,
+    config: &SecurityConfig<Validated>,
     dest: &DestDir,
     quota_tracker: &mut QuotaTracker,
 ) -> Vec<VerificationIssue> {
@@ -215,7 +224,7 @@ fn verify_entry(
     issues
 }
 
-fn check_permissions(path: &Path, mode: u32, config: &SecurityConfig) -> Result<()> {
+fn check_permissions(path: &Path, mode: u32, config: &SecurityConfig<Validated>) -> Result<()> {
     let sanitized = sanitize_permissions(mode, config);
     if sanitized == mode {
         Ok(())
@@ -472,10 +481,7 @@ mod tests {
         temp_file.write_all(&archive_data).unwrap();
         temp_file.flush().unwrap();
 
-        let config = SecurityConfig {
-            max_file_size: 500,
-            ..Default::default()
-        };
+        let config = SecurityConfig::default().with_max_file_size(500);
         let report = verify_archive(temp_file.path(), &config)
             .expect("verify_archive must report oversized entries, not error out");
 
@@ -498,12 +504,10 @@ mod tests {
 
     #[test]
     fn test_listing_config_for_verify_relaxes_max_file_size_and_preflight_checks() {
-        let config = SecurityConfig {
-            max_file_size: 1000,
-            max_total_size: 2000,
-            max_file_count: 3,
-            ..Default::default()
-        };
+        let config = SecurityConfig::default()
+            .with_max_file_size(1000)
+            .with_max_total_size(2000)
+            .with_max_file_count(3);
         let listing_config = listing_config_for_verify(&config);
 
         assert_eq!(listing_config.max_file_size, u64::MAX);
@@ -729,10 +733,7 @@ mod tests {
 
     #[test]
     fn verify_archive_rejects_invalid_security_config() {
-        let config = SecurityConfig {
-            max_path_depth: 0,
-            ..SecurityConfig::default()
-        };
+        let config = SecurityConfig::default().with_max_path_depth(0);
         let result = crate::verify_archive("any.tar.gz", &config);
         assert_matches!(
             result,

--- a/crates/exarch-core/src/lib.rs
+++ b/crates/exarch-core/src/lib.rs
@@ -47,6 +47,8 @@ pub use archive::Archive;
 pub use archive::ArchiveBuilder;
 pub use config::ExtractionOptions;
 pub use config::SecurityConfig;
+pub use config::Unvalidated;
+pub use config::Validated;
 pub use error::ArchiveError;
 pub use error::FfiErrorMessage;
 pub use error::QuotaResource;

--- a/crates/exarch-core/src/security/hardlink.rs
+++ b/crates/exarch-core/src/security/hardlink.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 use crate::ArchiveError;
 use crate::Result;
 use crate::SecurityConfig;
+use crate::config::Validated;
 use crate::types::DestDir;
 use crate::types::SafePath;
 use crate::types::safe_symlink::resolve_through_symlinks;
@@ -114,7 +115,7 @@ impl HardlinkTracker {
         link_path: &SafePath,
         target: &Path,
         dest: &DestDir,
-        config: &SecurityConfig,
+        config: &SecurityConfig<Validated>,
     ) -> Result<()> {
         // Check if hardlinks are allowed
         if !config.allowed.hardlinks {
@@ -226,6 +227,7 @@ mod tests {
         let (_temp, dest) = create_test_dest();
         let mut config = SecurityConfig::default();
         config.allowed.hardlinks = true;
+        let config = config.validate().expect("valid config");
 
         let mut tracker = HardlinkTracker::new();
         let link = SafePath::validate(&PathBuf::from("link"), &dest, &config).unwrap();
@@ -242,7 +244,7 @@ mod tests {
     #[test]
     fn test_validate_hardlink_disabled() {
         let (_temp, dest) = create_test_dest();
-        let config = SecurityConfig::default(); // hardlinks disabled by default
+        let config = SecurityConfig::default().validate().expect("valid config"); // hardlinks disabled by default
 
         let mut tracker = HardlinkTracker::new();
         let link = SafePath::validate(&PathBuf::from("link"), &dest, &config).unwrap();
@@ -260,6 +262,7 @@ mod tests {
         let (_temp, dest) = create_test_dest();
         let mut config = SecurityConfig::default();
         config.allowed.hardlinks = true;
+        let config = config.validate().expect("valid config");
 
         let mut tracker = HardlinkTracker::new();
         let link = SafePath::validate(&PathBuf::from("link"), &dest, &config).unwrap();
@@ -274,6 +277,7 @@ mod tests {
         let (_temp, dest) = create_test_dest();
         let mut config = SecurityConfig::default();
         config.allowed.hardlinks = true;
+        let config = config.validate().expect("valid config");
 
         let mut tracker = HardlinkTracker::new();
         let link = SafePath::validate(&PathBuf::from("link"), &dest, &config).unwrap();
@@ -288,6 +292,7 @@ mod tests {
         let (_temp, dest) = create_test_dest();
         let mut config = SecurityConfig::default();
         config.allowed.hardlinks = true;
+        let config = config.validate().expect("valid config");
 
         let mut tracker = HardlinkTracker::new();
 
@@ -309,6 +314,7 @@ mod tests {
         let (_temp, dest) = create_test_dest();
         let mut config = SecurityConfig::default();
         config.allowed.hardlinks = true;
+        let config = config.validate().expect("valid config");
 
         let mut tracker = HardlinkTracker::new();
         let link = SafePath::validate(&PathBuf::from("link"), &dest, &config).unwrap();
@@ -327,6 +333,7 @@ mod tests {
         let (_temp, dest) = create_test_dest();
         let mut config = SecurityConfig::default();
         config.allowed.hardlinks = true;
+        let config = config.validate().expect("valid config");
 
         let mut tracker = HardlinkTracker::new();
         let link = SafePath::validate(&PathBuf::from("foo/link"), &dest, &config).unwrap();
@@ -343,6 +350,7 @@ mod tests {
         let (_temp, dest) = create_test_dest();
         let mut config = SecurityConfig::default();
         config.allowed.hardlinks = true;
+        let config = config.validate().expect("valid config");
 
         let mut tracker = HardlinkTracker::new();
         let target = PathBuf::from("target.txt");
@@ -372,6 +380,7 @@ mod tests {
         let (_temp, dest) = create_test_dest();
         let mut config = SecurityConfig::default();
         config.allowed.hardlinks = true;
+        let config = config.validate().expect("valid config");
 
         let mut tracker = HardlinkTracker::new();
 
@@ -407,6 +416,7 @@ mod tests {
         let (temp, dest) = create_test_dest();
         let mut config = SecurityConfig::default();
         config.allowed.hardlinks = true;
+        let config = config.validate().expect("valid config");
 
         // Simulate on-disk state after extracting the two symlink entries.
         let a = temp.path().join("a");

--- a/crates/exarch-core/src/security/path.rs
+++ b/crates/exarch-core/src/security/path.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 
 use crate::Result;
 use crate::SecurityConfig;
+use crate::config::Validated;
 use crate::types::DestDir;
 use crate::types::SafePath;
 
@@ -41,7 +42,7 @@ use crate::types::SafePath;
 ///
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let dest = DestDir::new(PathBuf::from("/tmp"))?;
-/// let config = SecurityConfig::default();
+/// let config = SecurityConfig::default().validate()?;
 ///
 /// // Valid path
 /// let path = Path::new("foo/bar.txt");
@@ -53,7 +54,11 @@ use crate::types::SafePath;
 /// # Ok(())
 /// # }
 /// ```
-pub fn validate_path(path: &Path, dest: &DestDir, config: &SecurityConfig) -> Result<SafePath> {
+pub fn validate_path(
+    path: &Path,
+    dest: &DestDir,
+    config: &SecurityConfig<Validated>,
+) -> Result<SafePath> {
     SafePath::validate(path, dest, config)
 }
 
@@ -73,7 +78,7 @@ mod tests {
     #[test]
     fn test_validate_path_valid() {
         let (_temp, dest) = create_test_dest();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
         let path = PathBuf::from("foo/bar.txt");
         assert!(validate_path(&path, &dest, &config).is_ok());
     }
@@ -81,7 +86,7 @@ mod tests {
     #[test]
     fn test_validate_path_traversal() {
         let (_temp, dest) = create_test_dest();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
         let path = PathBuf::from("../etc/passwd");
         assert!(validate_path(&path, &dest, &config).is_err());
     }
@@ -89,7 +94,7 @@ mod tests {
     #[test]
     fn test_validate_path_absolute() {
         let (_temp, dest) = create_test_dest();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
         let path = PathBuf::from("/etc/passwd");
         assert!(validate_path(&path, &dest, &config).is_err());
     }
@@ -97,7 +102,7 @@ mod tests {
     #[test]
     fn test_validate_path_nested() {
         let (_temp, dest) = create_test_dest();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
         let path = PathBuf::from("foo/bar/baz/file.txt");
         assert!(validate_path(&path, &dest, &config).is_ok());
     }
@@ -105,7 +110,7 @@ mod tests {
     #[test]
     fn test_validate_path_current_dir() {
         let (_temp, dest) = create_test_dest();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
         let path = PathBuf::from("./foo/bar.txt");
         let result = validate_path(&path, &dest, &config);
         assert!(result.is_ok());

--- a/crates/exarch-core/src/security/permissions.rs
+++ b/crates/exarch-core/src/security/permissions.rs
@@ -1,6 +1,7 @@
 //! File permission validation and sanitization.
 
 use crate::SecurityConfig;
+use crate::config::Validated;
 
 /// Sanitizes file permissions by stripping dangerous bits.
 ///
@@ -40,7 +41,7 @@ use crate::SecurityConfig;
 /// assert_eq!(sanitized, 0o775);
 /// ```
 #[must_use]
-pub fn sanitize_permissions(mode: u32, config: &SecurityConfig) -> u32 {
+pub fn sanitize_permissions(mode: u32, config: &SecurityConfig<Validated>) -> u32 {
     let mut sanitized = mode;
 
     // Strip setuid bit (04000)
@@ -58,72 +59,73 @@ pub fn sanitize_permissions(mode: u32, config: &SecurityConfig) -> u32 {
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used)]
 mod tests {
     use super::*;
 
     #[test]
     fn test_sanitize_permissions_normal() {
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
         assert_eq!(sanitize_permissions(0o644, &config), 0o644);
     }
 
     #[test]
     fn test_sanitize_permissions_executable() {
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
         assert_eq!(sanitize_permissions(0o755, &config), 0o755);
     }
 
     #[test]
     fn test_sanitize_permissions_strip_setuid() {
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
         assert_eq!(sanitize_permissions(0o4755, &config), 0o755);
     }
 
     #[test]
     fn test_sanitize_permissions_strip_setgid() {
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
         assert_eq!(sanitize_permissions(0o2755, &config), 0o755);
     }
 
     #[test]
     fn test_sanitize_permissions_strip_both() {
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
         assert_eq!(sanitize_permissions(0o6755, &config), 0o755);
     }
 
     #[test]
     fn test_sanitize_permissions_strip_world_writable() {
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
         assert_eq!(sanitize_permissions(0o777, &config), 0o775);
     }
 
     #[test]
     fn test_sanitize_permissions_world_readable_ok() {
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
         assert_eq!(sanitize_permissions(0o644, &config), 0o644);
     }
 
     #[test]
     fn test_sanitize_permissions_owner_writable_ok() {
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
         assert_eq!(sanitize_permissions(0o600, &config), 0o600);
     }
 
     #[test]
     fn test_sanitize_permissions_group_writable_ok() {
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
         assert_eq!(sanitize_permissions(0o664, &config), 0o664);
     }
 
     #[test]
     fn test_sanitize_permissions_edge_case_zero() {
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
         assert_eq!(sanitize_permissions(0o000, &config), 0o000);
     }
 
     #[test]
     fn test_sticky_bit_preservation() {
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
         let sanitized = sanitize_permissions(0o1755, &config);
         assert_eq!(sanitized & 0o1000, 0o1000, "sticky bit should be preserved");
         assert_eq!(sanitized, 0o1755, "full mode should be preserved");
@@ -131,7 +133,7 @@ mod tests {
 
     #[test]
     fn test_sticky_bit_with_setuid_stripped() {
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
         let sanitized = sanitize_permissions(0o7755, &config);
         assert_eq!(sanitized & 0o1000, 0o1000, "sticky bit should remain");
         assert_eq!(sanitized & 0o4000, 0, "setuid should be stripped");
@@ -144,6 +146,7 @@ mod tests {
     fn test_world_writable_allowed_with_config() {
         let mut config = SecurityConfig::default();
         config.allowed.world_writable = true;
+        let config = config.validate().expect("valid config");
         let sanitized = sanitize_permissions(0o777, &config);
         assert_eq!(
             sanitized & 0o002,
@@ -157,7 +160,7 @@ mod tests {
 
     #[test]
     fn test_world_writable_stripped_by_default() {
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
         assert_eq!(
             sanitize_permissions(0o777, &config),
             0o775,
@@ -167,7 +170,7 @@ mod tests {
 
     #[test]
     fn test_world_writable_bit_only_stripped() {
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
         // 0o666 = rw-rw-rw-, only other-write (0o002) should be stripped -> 0o664
         assert_eq!(
             sanitize_permissions(0o666, &config),

--- a/crates/exarch-core/src/security/quota.rs
+++ b/crates/exarch-core/src/security/quota.rs
@@ -3,6 +3,7 @@
 use crate::ArchiveError;
 use crate::Result;
 use crate::SecurityConfig;
+use crate::config::Validated;
 
 /// Tracks resource usage during extraction.
 #[derive(Debug, Default)]
@@ -30,7 +31,7 @@ impl QuotaTracker {
     /// When all quotas are set to maximum values (unlimited), the function
     /// skips quota checks and only tracks counters with overflow detection.
     #[inline]
-    pub fn record_file(&mut self, size: u64, config: &SecurityConfig) -> Result<()> {
+    pub fn record_file(&mut self, size: u64, config: &SecurityConfig<Validated>) -> Result<()> {
         // OPT-C003: Fast path when all quotas unlimited - skip checks, only detect
         // overflow
         if config.max_file_size == u64::MAX
@@ -62,7 +63,7 @@ impl QuotaTracker {
     /// This is the slow path called when quotas are actually enforced.
     /// Separated from the fast path to keep the hot path small and inlinable.
     #[inline(never)]
-    fn record_file_checked(&mut self, size: u64, config: &SecurityConfig) -> Result<()> {
+    fn record_file_checked(&mut self, size: u64, config: &SecurityConfig<Validated>) -> Result<()> {
         if size > config.max_file_size {
             core::hint::cold_path();
             return Err(ArchiveError::QuotaExceeded {
@@ -124,7 +125,7 @@ impl QuotaTracker {
 }
 
 #[cfg(test)]
-#[allow(clippy::field_reassign_with_default)]
+#[allow(clippy::field_reassign_with_default, clippy::expect_used)]
 mod tests {
     use super::*;
     use std::assert_matches;
@@ -139,7 +140,7 @@ mod tests {
     #[test]
     fn test_quota_tracker_record_file() {
         let mut tracker = QuotaTracker::new();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         assert!(tracker.record_file(1000, &config).is_ok());
         assert_eq!(tracker.files_extracted(), 1);
@@ -151,6 +152,7 @@ mod tests {
         let mut tracker = QuotaTracker::new();
         let mut config = SecurityConfig::default();
         config.max_file_count = 2;
+        let config = config.validate().expect("valid config");
 
         assert!(tracker.record_file(100, &config).is_ok());
         assert!(tracker.record_file(100, &config).is_ok());
@@ -163,6 +165,7 @@ mod tests {
         let mut tracker = QuotaTracker::new();
         let mut config = SecurityConfig::default();
         config.max_total_size = 1000;
+        let config = config.validate().expect("valid config");
 
         assert!(tracker.record_file(600, &config).is_ok());
         let result = tracker.record_file(500, &config);
@@ -174,6 +177,7 @@ mod tests {
         let mut tracker = QuotaTracker::new();
         let mut config = SecurityConfig::default();
         config.max_file_size = 1000;
+        let config = config.validate().expect("valid config");
 
         let result = tracker.record_file(2000, &config);
         assert_matches!(result, Err(ArchiveError::QuotaExceeded { .. }));
@@ -187,6 +191,7 @@ mod tests {
         config.max_file_count = 3;
         config.max_total_size = u64::MAX;
         config.max_file_size = u64::MAX;
+        let config = config.validate().expect("valid config");
 
         // Exactly at file count limit should succeed
         assert!(
@@ -221,6 +226,7 @@ mod tests {
         config.max_file_count = 100;
         config.max_total_size = 1000;
         config.max_file_size = u64::MAX;
+        let config = config.validate().expect("valid config");
 
         // Add files up to exactly the limit
         assert!(tracker.record_file(600, &config).is_ok());
@@ -250,6 +256,7 @@ mod tests {
         config.max_file_count = 100;
         config.max_total_size = u64::MAX;
         config.max_file_size = 5000;
+        let config = config.validate().expect("valid config");
 
         // File exactly at limit should succeed
         assert!(
@@ -278,6 +285,7 @@ mod tests {
         config.max_file_count = 1;
         config.max_total_size = u64::MAX;
         config.max_file_size = u64::MAX;
+        let config = config.validate().expect("valid config");
 
         // First file should succeed
         assert!(tracker.record_file(100, &config).is_ok());
@@ -296,6 +304,7 @@ mod tests {
         config.max_file_size = u64::MAX;
         config.max_file_count = usize::MAX;
         config.max_total_size = u64::MAX;
+        let config = config.validate().expect("valid config");
 
         for i in 1..=1000 {
             assert!(
@@ -316,6 +325,7 @@ mod tests {
         config.max_file_size = u64::MAX;
         config.max_file_count = usize::MAX;
         config.max_total_size = u64::MAX;
+        let config = config.validate().expect("valid config");
 
         // Manually set bytes_written to near overflow
         tracker.bytes_written = u64::MAX - 100;

--- a/crates/exarch-core/src/security/symlink.rs
+++ b/crates/exarch-core/src/security/symlink.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 
 use crate::Result;
 use crate::SecurityConfig;
+use crate::config::Validated;
 use crate::types::DestDir;
 use crate::types::SafePath;
 use crate::types::SafeSymlink;
@@ -54,7 +55,7 @@ pub fn validate_symlink(
     link_path: &SafePath,
     target: &Path,
     dest: &DestDir,
-    config: &SecurityConfig,
+    config: &SecurityConfig<Validated>,
 ) -> Result<SafeSymlink> {
     SafeSymlink::validate(link_path, target, dest, config)
 }
@@ -81,6 +82,7 @@ mod tests {
         let (_temp, dest) = create_test_dest();
         let mut config = SecurityConfig::default();
         config.allowed.symlinks = true;
+        let config = config.validate().expect("valid config");
 
         let link = SafePath::validate(&PathBuf::from("link"), &dest, &config).unwrap();
         let target = PathBuf::from("target.txt");
@@ -90,7 +92,7 @@ mod tests {
     #[test]
     fn test_validate_symlink_disabled() {
         let (_temp, dest) = create_test_dest();
-        let config = SecurityConfig::default(); // symlinks disabled by default
+        let config = SecurityConfig::default().validate().expect("valid config"); // symlinks disabled by default
 
         let link = SafePath::validate(&PathBuf::from("link"), &dest, &config).unwrap();
         let target = PathBuf::from("target.txt");
@@ -102,6 +104,7 @@ mod tests {
         let (_temp, dest) = create_test_dest();
         let mut config = SecurityConfig::default();
         config.allowed.symlinks = true;
+        let config = config.validate().expect("valid config");
 
         let link = SafePath::validate(&PathBuf::from("link"), &dest, &config).unwrap();
         let target = PathBuf::from("../../etc/passwd");
@@ -113,6 +116,7 @@ mod tests {
         let (_temp, dest) = create_test_dest();
         let mut config = SecurityConfig::default();
         config.allowed.symlinks = true;
+        let config = config.validate().expect("valid config");
 
         let link = SafePath::validate(&PathBuf::from("foo/link"), &dest, &config).unwrap();
         let target = PathBuf::from("../bar/target.txt");

--- a/crates/exarch-core/src/security/validator.rs
+++ b/crates/exarch-core/src/security/validator.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 
 use crate::Result;
 use crate::SecurityConfig;
+use crate::config::Validated;
 use crate::formats::common::DirCache;
 use crate::security::context::ValidationContext;
 use crate::security::hardlink::HardlinkTracker;
@@ -22,20 +23,79 @@ use crate::types::SafeSymlink;
 /// Result of entry validation.
 ///
 /// Contains validated and sanitized entry information ready for extraction.
+///
+/// # Security Properties
+///
+/// - Can ONLY be constructed through [`EntryValidator::validate_entry`]
+/// - Fields are private; accessed through getters, so a `ValidatedEntry` cannot
+///   be hand-assembled from unvalidated parts anywhere else in the crate
 #[derive(Debug)]
 pub struct ValidatedEntry {
-    /// Validated path within destination directory
-    pub safe_path: SafePath,
+    safe_path: SafePath,
+    entry_type: ValidatedEntryType,
+    mode: Option<u32>,
+}
 
-    /// Validated entry type
-    pub entry_type: ValidatedEntryType,
+impl ValidatedEntry {
+    /// Constructs a `ValidatedEntry` from its already-validated parts.
+    ///
+    /// `pub(crate)` rather than fully private so that unit tests elsewhere in
+    /// this crate (`formats::common`) can build fixtures without weakening
+    /// the sealing against external construction.
+    pub(crate) fn new(
+        safe_path: SafePath,
+        entry_type: ValidatedEntryType,
+        mode: Option<u32>,
+    ) -> Self {
+        Self {
+            safe_path,
+            entry_type,
+            mode,
+        }
+    }
 
-    /// Sanitized file permissions (if applicable)
-    pub mode: Option<u32>,
+    /// Returns the validated path within the destination directory.
+    #[inline]
+    #[must_use]
+    pub fn safe_path(&self) -> &SafePath {
+        &self.safe_path
+    }
+
+    /// Returns the validated entry type.
+    #[inline]
+    #[must_use]
+    pub fn entry_type(&self) -> &ValidatedEntryType {
+        &self.entry_type
+    }
+
+    /// Returns the sanitized file permissions, if applicable.
+    #[inline]
+    #[must_use]
+    pub fn mode(&self) -> Option<u32> {
+        self.mode
+    }
 }
 
 /// Validated entry type variants.
+///
+/// This enum alone does not carry the sealing guarantee — `File` and
+/// `Directory` are plain markers with no data, so they are directly
+/// constructible from any module (in or out of this crate) that can name the
+/// type. The guarantee instead comes from [`ValidatedEntry`]: its
+/// constructor is `pub(crate)`, so nothing outside this crate can assemble a
+/// `ValidatedEntry` at all, regardless of how its `ValidatedEntryType` field
+/// was produced. Within that guarantee, the `Symlink` and `Hardlink`
+/// variants add a second layer for their own payloads: they wrap
+/// [`SafeSymlink`] and [`SafePath`], which are independently sealed and can
+/// only be produced by their own validation routines, so even crate-internal
+/// code cannot forge a "validated" symlink/hardlink target.
+///
+/// `#[non_exhaustive]` so a future variant is not a breaking change for
+/// downstream matches — [`ValidatedEntry::entry_type`] is the only way
+/// external code observes this type, and even that always sees output from
+/// [`EntryValidator::validate_entry`].
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ValidatedEntryType {
     /// Regular file
     File,
@@ -79,7 +139,7 @@ pub enum ValidatedEntryType {
 ///
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let dest = DestDir::new(PathBuf::from("/tmp"))?;
-/// let config = SecurityConfig::default();
+/// let config = SecurityConfig::default().validate()?;
 ///
 /// let mut validator = EntryValidator::new(&config, &dest);
 ///
@@ -101,7 +161,7 @@ pub enum ValidatedEntryType {
 /// OPT-H004: Validator uses references to avoid cloning config and dest.
 /// This eliminates 1 clone per extraction (`SecurityConfig` + `DestDir`).
 pub struct EntryValidator<'a> {
-    config: &'a SecurityConfig,
+    config: &'a SecurityConfig<Validated>,
     dest: &'a DestDir,
     quota_tracker: QuotaTracker,
     hardlink_tracker: HardlinkTracker,
@@ -111,7 +171,7 @@ pub struct EntryValidator<'a> {
 impl<'a> EntryValidator<'a> {
     /// Creates a new entry validator with the given security configuration.
     #[must_use]
-    pub fn new(config: &'a SecurityConfig, dest: &'a DestDir) -> Self {
+    pub fn new(config: &'a SecurityConfig<Validated>, dest: &'a DestDir) -> Self {
         Self {
             config,
             dest,
@@ -205,11 +265,11 @@ impl<'a> EntryValidator<'a> {
             }
         };
 
-        Ok(ValidatedEntry {
+        Ok(ValidatedEntry::new(
             safe_path,
-            entry_type: validated_type,
-            mode: sanitized_mode,
-        })
+            validated_type,
+            sanitized_mode,
+        ))
     }
 
     /// Records a hardlink's copied byte count against the shared quota tracker.
@@ -272,7 +332,7 @@ mod tests {
     fn test_entry_validator_new() {
         let temp = TempDir::new().expect("failed to create temp dir");
         let dest = DestDir::new(temp.path().to_path_buf()).expect("failed to create dest");
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
         let validator = EntryValidator::new(&config, &dest);
         let report = validator.finish();
         assert_eq!(report.files_validated, 0);
@@ -284,7 +344,7 @@ mod tests {
     fn test_validate_file_entry() {
         let temp = TempDir::new().expect("failed to create temp dir");
         let dest = DestDir::new(temp.path().to_path_buf()).expect("failed to create dest");
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
         let mut validator = EntryValidator::new(&config, &dest);
 
         let result = validator.validate_entry(
@@ -307,7 +367,7 @@ mod tests {
     fn test_validate_directory_entry() {
         let temp = TempDir::new().expect("failed to create temp dir");
         let dest = DestDir::new(temp.path().to_path_buf()).expect("failed to create dest");
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
         let mut validator = EntryValidator::new(&config, &dest);
 
         let result =
@@ -323,7 +383,7 @@ mod tests {
     fn test_validate_path_traversal_rejected() {
         let temp = TempDir::new().expect("failed to create temp dir");
         let dest = DestDir::new(temp.path().to_path_buf()).expect("failed to create dest");
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
         let mut validator = EntryValidator::new(&config, &dest);
 
         let result = validator.validate_entry(
@@ -344,6 +404,7 @@ mod tests {
         let dest = DestDir::new(temp.path().to_path_buf()).unwrap();
         let mut config = SecurityConfig::default();
         config.max_file_size = 100;
+        let config = config.validate().expect("valid config");
         let mut validator = EntryValidator::new(&config, &dest);
 
         let result = validator.validate_entry(
@@ -364,6 +425,7 @@ mod tests {
         let dest = DestDir::new(temp.path().to_path_buf()).unwrap();
         let mut config = SecurityConfig::default();
         config.max_file_count = 2;
+        let config = config.validate().expect("valid config");
         let mut validator = EntryValidator::new(&config, &dest);
 
         assert!(
@@ -406,7 +468,7 @@ mod tests {
     fn test_zip_bomb_detected() {
         let temp = TempDir::new().expect("failed to create temp dir");
         let dest = DestDir::new(temp.path().to_path_buf()).expect("failed to create dest");
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
         let mut validator = EntryValidator::new(&config, &dest);
 
         let result = validator.validate_entry(
@@ -425,7 +487,7 @@ mod tests {
     fn test_validation_report() {
         let temp = TempDir::new().expect("failed to create temp dir");
         let dest = DestDir::new(temp.path().to_path_buf()).expect("failed to create dest");
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
         let mut validator = EntryValidator::new(&config, &dest);
 
         validator
@@ -459,7 +521,7 @@ mod tests {
     fn test_sanitize_permissions_setuid() {
         let temp = TempDir::new().expect("failed to create temp dir");
         let dest = DestDir::new(temp.path().to_path_buf()).expect("failed to create dest");
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
         let mut validator = EntryValidator::new(&config, &dest);
 
         let result = validator.validate_entry(
@@ -482,6 +544,7 @@ mod tests {
         let dest = DestDir::new(temp.path().to_path_buf()).unwrap();
         let mut config = SecurityConfig::default();
         config.allowed.symlinks = true;
+        let config = config.validate().expect("valid config");
         let mut validator = EntryValidator::new(&config, &dest);
 
         let result = validator.validate_entry(
@@ -507,6 +570,7 @@ mod tests {
         let dest = DestDir::new(temp.path().to_path_buf()).unwrap();
         let mut config = SecurityConfig::default();
         config.allowed.hardlinks = true;
+        let config = config.validate().expect("valid config");
         let mut validator = EntryValidator::new(&config, &dest);
 
         let result = validator.validate_entry(
@@ -531,6 +595,7 @@ mod tests {
         let dest = DestDir::new(temp.path().to_path_buf()).unwrap();
         let mut config = SecurityConfig::default();
         config.allowed.hardlinks = true;
+        let config = config.validate().expect("valid config");
         let mut validator = EntryValidator::new(&config, &dest);
 
         // Validate multiple entry types
@@ -573,7 +638,7 @@ mod tests {
     fn test_empty_directory_validation() {
         let temp = TempDir::new().expect("failed to create temp dir");
         let dest = DestDir::new(temp.path().to_path_buf()).expect("failed to create dest");
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
         let mut validator = EntryValidator::new(&config, &dest);
 
         // Empty directory should be valid
@@ -600,7 +665,7 @@ mod tests {
     fn test_nested_empty_directories() {
         let temp = TempDir::new().expect("failed to create temp dir");
         let dest = DestDir::new(temp.path().to_path_buf()).expect("failed to create dest");
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
         let mut validator = EntryValidator::new(&config, &dest);
 
         // Multiple nested empty directories
@@ -629,7 +694,7 @@ mod tests {
     fn test_validator_uses_references() {
         let temp = TempDir::new().unwrap();
         let dest = DestDir::new(temp.path().to_path_buf()).unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         // Create validator with references
         let validator = EntryValidator::new(&config, &dest);
@@ -654,7 +719,7 @@ mod tests {
         let temp2 = TempDir::new().unwrap();
         let dest1 = DestDir::new(temp1.path().to_path_buf()).unwrap();
         let dest2 = DestDir::new(temp2.path().to_path_buf()).unwrap();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         // Create two validators sharing the same config reference
         let mut validator1 = EntryValidator::new(&config, &dest1);
@@ -692,7 +757,7 @@ mod tests {
     fn test_validate_entry_with_dir_cache() {
         let temp = TempDir::new().expect("failed to create temp dir");
         let dest = DestDir::new(temp.path().to_path_buf()).expect("failed to create dest");
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
         let mut validator = EntryValidator::new(&config, &dest);
 
         let sub = dest.as_path().join("subdir");
@@ -719,6 +784,7 @@ mod tests {
         let dest = DestDir::new(temp.path().to_path_buf()).unwrap();
         let mut config = SecurityConfig::default();
         config.allowed.symlinks = true;
+        let config = config.validate().expect("valid config");
         let mut validator = EntryValidator::new(&config, &dest);
 
         assert!(!validator.symlink_seen);
@@ -748,6 +814,7 @@ mod tests {
         let dest = DestDir::new(temp.path().to_path_buf()).unwrap();
         let mut config = SecurityConfig::default();
         config.max_file_size = 100;
+        let config = config.validate().expect("valid config");
         let mut validator = EntryValidator::new(&config, &dest);
 
         // A single hardlink whose on-disk target size alone exceeds
@@ -771,6 +838,7 @@ mod tests {
         let mut config = SecurityConfig::default();
         config.allowed.hardlinks = true;
         config.max_total_size = 250;
+        let config = config.validate().expect("valid config");
         let mut validator = EntryValidator::new(&config, &dest);
 
         // A regular file consumes part of the shared total-size budget...
@@ -806,6 +874,7 @@ mod tests {
         let dest = DestDir::new(temp.path().to_path_buf()).unwrap();
         let mut config = SecurityConfig::default();
         config.max_file_count = 2;
+        let config = config.validate().expect("valid config");
         let mut validator = EntryValidator::new(&config, &dest);
 
         assert!(validator.record_hardlink(1).is_ok());

--- a/crates/exarch-core/src/security/zipbomb.rs
+++ b/crates/exarch-core/src/security/zipbomb.rs
@@ -3,6 +3,7 @@
 use crate::ArchiveError;
 use crate::Result;
 use crate::SecurityConfig;
+use crate::config::Validated;
 
 /// Validates compression ratio to detect potential zip bombs.
 ///
@@ -12,7 +13,7 @@ use crate::SecurityConfig;
 pub fn validate_compression_ratio(
     compressed_size: u64,
     uncompressed_size: u64,
-    config: &SecurityConfig,
+    config: &SecurityConfig<Validated>,
 ) -> Result<()> {
     // HIGH-001: Fix bypass for stored compression with compressed_size == 0
     // Reject invalid entries where compressed_size is 0 but uncompressed_size > 0
@@ -41,27 +42,28 @@ pub fn validate_compression_ratio(
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used)]
 mod tests {
     use super::*;
     use std::assert_matches;
 
     #[test]
     fn test_validate_compression_ratio_safe() {
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
         let result = validate_compression_ratio(1000, 10_000, &config);
         assert!(result.is_ok());
     }
 
     #[test]
     fn test_validate_compression_ratio_bomb() {
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
         let result = validate_compression_ratio(1000, 1_000_000, &config);
         assert_matches!(result, Err(ArchiveError::ZipBomb { .. }));
     }
 
     #[test]
     fn test_validate_compression_ratio_zero_compressed() {
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         // HIGH-001: Zero compressed with non-zero uncompressed is invalid
         let result = validate_compression_ratio(0, 1000, &config);
@@ -75,7 +77,7 @@ mod tests {
     // H-TEST-3: Division by zero edge cases test
     #[test]
     fn test_compressed_size_zero_with_uncompressed_zero() {
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         // Both zero - should be OK (empty file)
         let result = validate_compression_ratio(0, 0, &config);
@@ -84,7 +86,7 @@ mod tests {
 
     #[test]
     fn test_compressed_size_zero_with_large_uncompressed() {
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         // HIGH-001: Compressed size zero with uncompressed > 0 is INVALID
         // This prevents zip bomb bypass for stored compression
@@ -98,7 +100,7 @@ mod tests {
 
     #[test]
     fn test_very_small_compressed_large_uncompressed() {
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         // Very small compressed size (1 byte) with large uncompressed
         // This should trigger zip bomb detection
@@ -112,7 +114,7 @@ mod tests {
 
     #[test]
     fn test_equal_sizes() {
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         // No compression (ratio = 1.0)
         let result = validate_compression_ratio(1000, 1000, &config);
@@ -121,7 +123,7 @@ mod tests {
 
     #[test]
     fn test_negative_compression() {
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         // Compressed larger than uncompressed (poor compression)
         let result = validate_compression_ratio(2000, 1000, &config);

--- a/crates/exarch-core/src/types/dest_dir.rs
+++ b/crates/exarch-core/src/types/dest_dir.rs
@@ -182,7 +182,7 @@ impl DestDir {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let dest = DestDir::new(PathBuf::from("/tmp"))?;
-    /// let config = SecurityConfig::default();
+    /// let config = SecurityConfig::default().validate()?;
     /// let safe = SafePath::validate(&PathBuf::from("foo/bar.txt"), &dest, &config)?;
     ///
     /// let final_path = dest.join(&safe);

--- a/crates/exarch-core/src/types/safe_path.rs
+++ b/crates/exarch-core/src/types/safe_path.rs
@@ -3,6 +3,7 @@
 use crate::ArchiveError;
 use crate::Result;
 use crate::SecurityConfig;
+use crate::config::Validated;
 use crate::security::context::ValidationContext;
 use std::borrow::Cow;
 use std::path::Component;
@@ -38,7 +39,7 @@ use super::DestDir;
 ///
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let dest = DestDir::new(PathBuf::from("/tmp"))?;
-/// let config = SecurityConfig::default();
+/// let config = SecurityConfig::default().validate()?;
 ///
 /// // Valid path
 /// let safe = SafePath::validate(&PathBuf::from("foo/bar.txt"), &dest, &config)?;
@@ -111,14 +112,18 @@ impl SafePath {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let dest = DestDir::new(PathBuf::from("/tmp"))?;
-    /// let config = SecurityConfig::default();
+    /// let config = SecurityConfig::default().validate()?;
     ///
     /// let safe = SafePath::validate(&PathBuf::from("valid/path.txt"), &dest, &config)?;
     /// # Ok(())
     /// # }
     /// ```
     #[allow(clippy::too_many_lines)]
-    pub fn validate(path: &Path, dest: &DestDir, config: &SecurityConfig) -> Result<Self> {
+    pub fn validate(
+        path: &Path,
+        dest: &DestDir,
+        config: &SecurityConfig<Validated>,
+    ) -> Result<Self> {
         let ctx = ValidationContext::new(config.allowed.symlinks);
         Self::validate_with_context(path, dest, config, &ctx)
     }
@@ -137,7 +142,7 @@ impl SafePath {
     pub(crate) fn validate_with_context(
         path: &Path,
         dest: &DestDir,
-        config: &SecurityConfig,
+        config: &SecurityConfig<Validated>,
         ctx: &ValidationContext,
     ) -> Result<Self> {
         // Reject empty paths explicitly
@@ -391,7 +396,7 @@ mod tests {
     #[test]
     fn test_empty_path() {
         let (_temp, dest) = create_test_dest();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let result = SafePath::validate(&PathBuf::from(""), &dest, &config);
         assert_matches!(
@@ -404,7 +409,7 @@ mod tests {
     #[test]
     fn test_safe_path_valid_relative() {
         let (_temp, dest) = create_test_dest();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let path = PathBuf::from("foo/bar/baz.txt");
         let result = SafePath::validate(&path, &dest, &config);
@@ -417,7 +422,7 @@ mod tests {
     #[test]
     fn test_safe_path_reject_parent_traversal() {
         let (_temp, dest) = create_test_dest();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let paths = vec![
             PathBuf::from("../etc/passwd"),
@@ -440,7 +445,7 @@ mod tests {
     #[cfg(unix)]
     fn test_safe_path_reject_absolute_unix() {
         let (_temp, dest) = create_test_dest();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let path = PathBuf::from("/etc/passwd");
         let result = SafePath::validate(&path, &dest, &config);
@@ -451,7 +456,7 @@ mod tests {
     #[cfg(windows)]
     fn test_safe_path_reject_absolute_windows() {
         let (_temp, dest) = create_test_dest();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let paths = vec![
             PathBuf::from("C:\\Windows\\System32"),
@@ -469,6 +474,7 @@ mod tests {
         let (_temp, dest) = create_test_dest();
         let mut config = SecurityConfig::default();
         config.allowed.absolute_paths = true;
+        let config = config.validate().expect("valid config");
 
         // Verify that an external absolute path is stripped to a relative path
         // so dest.join() resolves inside dest, not at the original absolute location.
@@ -487,6 +493,7 @@ mod tests {
         let (_temp, dest) = create_test_dest();
         let mut config = SecurityConfig::default();
         config.allowed.absolute_paths = true;
+        let config = config.validate().expect("valid config");
 
         let result = SafePath::validate(Path::new("/"), &dest, &config);
         assert_matches!(
@@ -501,6 +508,7 @@ mod tests {
         let (_temp, dest) = create_test_dest();
         let mut config = SecurityConfig::default();
         config.max_path_depth = 3;
+        let config = config.validate().expect("valid config");
 
         // 4 components - should be rejected
         let path = PathBuf::from("a/b/c/d");
@@ -516,7 +524,7 @@ mod tests {
     #[test]
     fn test_safe_path_reject_banned_components() {
         let (_temp, dest) = create_test_dest();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let paths = vec![
             PathBuf::from("project/.git/config"),
@@ -538,7 +546,7 @@ mod tests {
     #[test]
     fn test_safe_path_normalize_dot_components() {
         let (_temp, dest) = create_test_dest();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let path = PathBuf::from("foo/./bar/./baz.txt");
         let result = SafePath::validate(&path, &dest, &config);
@@ -551,7 +559,7 @@ mod tests {
     #[test]
     fn test_safe_path_null_bytes() {
         let (_temp, dest) = create_test_dest();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         #[cfg(unix)]
         {
@@ -601,7 +609,7 @@ mod tests {
     #[test]
     fn test_normalize_path() {
         let (_temp, dest) = create_test_dest();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         // Normalization now happens in single-pass validation
         // Path with . components should be normalized
@@ -622,7 +630,7 @@ mod tests {
     #[test]
     fn test_safe_path_equality() {
         let (_temp, dest) = create_test_dest();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let safe1 = SafePath::validate(&PathBuf::from("foo/bar.txt"), &dest, &config)
             .expect("should be valid");
@@ -635,7 +643,7 @@ mod tests {
     #[test]
     fn test_safe_path_clone() {
         let (_temp, dest) = create_test_dest();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let safe = SafePath::validate(&PathBuf::from("foo/bar.txt"), &dest, &config)
             .expect("should be valid");
@@ -648,7 +656,7 @@ mod tests {
     #[test]
     fn test_safe_path_empty() {
         let (_temp, dest) = create_test_dest();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let path = PathBuf::from("");
         let result = SafePath::validate(&path, &dest, &config);
@@ -667,6 +675,7 @@ mod tests {
         let (_temp, dest) = create_test_dest();
         let mut config = SecurityConfig::default();
         config.max_path_depth = 5;
+        let config = config.validate().expect("valid config");
 
         // Exactly at limit
         let path = PathBuf::from("a/b/c/d/e");
@@ -684,7 +693,7 @@ mod tests {
     #[allow(clippy::unwrap_used)]
     fn test_safe_path_single_component() {
         let (_temp, dest) = create_test_dest();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let path = PathBuf::from("file.txt");
         let result = SafePath::validate(&path, &dest, &config);
@@ -698,7 +707,7 @@ mod tests {
     #[test]
     fn test_safe_path_unicode() {
         let (_temp, dest) = create_test_dest();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         // Emoji in path
         let path = PathBuf::from("folder/\u{1f4c1}test.txt");
@@ -716,7 +725,7 @@ mod tests {
     #[cfg(windows)]
     fn test_safe_path_windows_reserved_names() {
         let (_temp, dest) = create_test_dest();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let reserved = vec!["CON", "PRN", "AUX", "NUL", "COM1", "LPT1"];
 
@@ -735,7 +744,7 @@ mod tests {
 
         let temp = TempDir::new().expect("failed to create temp dir");
         let dest = DestDir::new(temp.path().to_path_buf()).expect("failed to create dest");
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         // Create: dest/parent_dir -> /tmp (symlink to outside)
         let parent_symlink = temp.path().join("parent_dir");
@@ -759,7 +768,7 @@ mod tests {
 
         let temp = TempDir::new().expect("failed to create temp dir");
         let dest = DestDir::new(temp.path().to_path_buf()).expect("failed to create dest");
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         // Create legitimate directory
         let legit_dir = temp.path().join("legit");
@@ -785,7 +794,7 @@ mod tests {
     fn test_legitimate_file_in_real_directory() {
         let temp = TempDir::new().expect("failed to create temp dir");
         let dest = DestDir::new(temp.path().to_path_buf()).expect("failed to create dest");
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         // Create real directory (not symlink)
         let real_dir = temp.path().join("real_dir");
@@ -804,7 +813,7 @@ mod tests {
     fn test_validate_with_context_trusted_parent_skips_canonicalize() {
         let temp = TempDir::new().expect("failed to create temp dir");
         let dest = DestDir::new(temp.path().to_path_buf()).expect("failed to create dest");
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         // Create a real directory and register it in DirCache
         let sub_dir = dest.as_path().join("trusted_dir");
@@ -823,7 +832,7 @@ mod tests {
     fn test_validate_with_context_untrusted_parent_still_validates() {
         let temp = TempDir::new().expect("failed to create temp dir");
         let dest = DestDir::new(temp.path().to_path_buf()).expect("failed to create dest");
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let dir_cache = DirCache::new(); // empty cache
         let ctx = ValidationContext::new(false).with_dir_cache(&dir_cache);
@@ -841,7 +850,7 @@ mod tests {
     #[test]
     fn test_validate_with_context_symlink_free_fast_path() {
         let (_temp, dest) = create_test_dest();
-        let config = SecurityConfig::default(); // symlinks = false
+        let config = SecurityConfig::default().validate().expect("valid config"); // symlinks = false
 
         // No dir_cache, no symlinks -> fast path (no canonicalize)
         let ctx = ValidationContext::new(false);
@@ -853,7 +862,7 @@ mod tests {
     #[test]
     fn test_validate_with_context_symlink_seen_disables_fast_path() {
         let (_temp, dest) = create_test_dest();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let mut ctx = ValidationContext::new(false);
         ctx.mark_symlink_seen();
@@ -873,7 +882,7 @@ mod tests {
 
         let temp = TempDir::new().expect("failed to create temp dir");
         let dest = DestDir::new(temp.path().to_path_buf()).expect("failed to create dest");
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         // Create a symlink pointing outside dest
         let malicious_link = temp.path().join("evil_dir");
@@ -902,7 +911,7 @@ mod tests {
 
         let temp = TempDir::new().expect("failed to create temp dir");
         let dest = DestDir::new(temp.path().to_path_buf()).expect("failed to create dest");
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         // Create a real subdirectory and register in DirCache
         let sub_dir = dest.as_path().join("subdir");
@@ -945,7 +954,7 @@ mod tests {
 
         let temp = TempDir::new().expect("failed to create temp dir");
         let dest = DestDir::new(temp.path().to_path_buf()).expect("failed to create dest");
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         // Create subdir and register in DirCache
         let sub_dir = dest.as_path().join("trusted");
@@ -976,7 +985,7 @@ mod tests {
     fn test_validate_backward_compat_same_result() {
         let temp = TempDir::new().expect("failed to create temp dir");
         let dest = DestDir::new(temp.path().to_path_buf()).expect("failed to create dest");
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let test_paths = vec![
             PathBuf::from("file.txt"),
@@ -1011,7 +1020,7 @@ mod tests {
     fn test_validate_backward_compat_error_paths() {
         let temp = TempDir::new().expect("failed to create temp dir");
         let dest = DestDir::new(temp.path().to_path_buf()).expect("failed to create dest");
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let error_paths = vec![
             PathBuf::from("../escape"),
@@ -1039,7 +1048,7 @@ mod tests {
 
         let temp = TempDir::new().expect("failed to create temp dir");
         let dest = DestDir::new(temp.path().to_path_buf()).expect("failed to create dest");
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         // Create dir and register in cache
         let sub = dest.as_path().join("safe_dir");
@@ -1074,7 +1083,7 @@ mod tests {
     #[cfg(unix)]
     fn test_symlink_free_fast_path_still_rejects_traversal() {
         let (_temp, dest) = create_test_dest();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         // Symlink-free fast path (no symlinks allowed, none seen)
         let ctx = ValidationContext::new(false);
@@ -1093,7 +1102,7 @@ mod tests {
     fn test_validate_with_context_dir_cache_created_vs_preexisting() {
         let temp = TempDir::new().expect("failed to create temp dir");
         let dest = DestDir::new(temp.path().to_path_buf()).expect("failed to create dest");
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         // Create directory manually (pre-existing, NOT in DirCache)
         let preexisting = dest.as_path().join("preexisting");
@@ -1123,7 +1132,7 @@ mod tests {
     #[test]
     fn test_validate_with_context_no_parent() {
         let (_temp, dest) = create_test_dest();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         // Single-component path has dest itself as parent
         let cache = DirCache::new();
@@ -1139,7 +1148,7 @@ mod tests {
     #[test]
     fn test_archive_root_dot_is_accepted() {
         let (_temp, dest) = create_test_dest();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         // "." is the archive root directory — produced by `tar -C /dir .`
         let result = SafePath::validate(Path::new("."), &dest, &config);
@@ -1153,7 +1162,7 @@ mod tests {
     #[test]
     fn test_archive_root_dot_slash_is_accepted() {
         let (_temp, dest) = create_test_dest();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         // "./" is an alternate form of the archive root directory entry
         let result = SafePath::validate(Path::new("./"), &dest, &config);
@@ -1167,7 +1176,7 @@ mod tests {
     #[test]
     fn test_archive_root_dot_dot_still_rejected() {
         let (_temp, dest) = create_test_dest();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         // ".." must still be rejected — it is a traversal attempt, not an archive root
         let result = SafePath::validate(Path::new(".."), &dest, &config);
@@ -1181,7 +1190,7 @@ mod tests {
     #[test]
     fn test_archive_root_dot_dot_slash_still_rejected() {
         let (_temp, dest) = create_test_dest();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().expect("valid config");
 
         let paths = ["./..", "./../../etc", "../foo", "./../etc/passwd"];
         for p in paths {

--- a/crates/exarch-core/src/types/safe_symlink.rs
+++ b/crates/exarch-core/src/types/safe_symlink.rs
@@ -3,6 +3,7 @@
 use crate::ArchiveError;
 use crate::Result;
 use crate::SecurityConfig;
+use crate::config::Validated;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -37,6 +38,7 @@ use super::SafePath;
 /// let dest = DestDir::new(PathBuf::from("/tmp"))?;
 /// let mut config = SecurityConfig::default();
 /// config.allowed.symlinks = true;
+/// let config = config.validate()?;
 ///
 /// let link = SafePath::validate(&PathBuf::from("mylink"), &dest, &config)?;
 /// let target = PathBuf::from("../target.txt");
@@ -93,6 +95,7 @@ impl SafeSymlink {
     /// let dest = DestDir::new(PathBuf::from("/tmp"))?;
     /// let mut config = SecurityConfig::default();
     /// config.allowed.symlinks = true;
+    /// let config = config.validate()?;
     ///
     /// let link = SafePath::validate(&PathBuf::from("dir/link"), &dest, &config)?;
     /// let target = PathBuf::from("../file.txt");
@@ -105,7 +108,7 @@ impl SafeSymlink {
         link: &SafePath,
         target: &Path,
         dest: &DestDir,
-        config: &SecurityConfig,
+        config: &SecurityConfig<Validated>,
     ) -> Result<Self> {
         // 1. Verify symlinks are allowed
         if !config.allowed.symlinks {
@@ -340,10 +343,10 @@ mod tests {
     }
 
     /// Creates a `SecurityConfig` with symlinks enabled for testing.
-    fn create_config_with_symlinks() -> SecurityConfig {
+    fn create_config_with_symlinks() -> SecurityConfig<Validated> {
         let mut config = SecurityConfig::default();
         config.allowed.symlinks = true;
-        config
+        config.validate().expect("valid config")
     }
 
     #[test]
@@ -368,6 +371,7 @@ mod tests {
         let (_temp, dest) = create_test_dest();
         let mut config = SecurityConfig::default();
         config.allowed.symlinks = false;
+        let config = config.validate().expect("valid config");
 
         let link = SafePath::validate(&PathBuf::from("link"), &dest, &config)
             .expect("link path should be valid");

--- a/crates/exarch-core/tests/integration_tests.rs
+++ b/crates/exarch-core/tests/integration_tests.rs
@@ -32,7 +32,7 @@ use tempfile::TempDir;
 fn test_full_safe_path_workflow() {
     let temp = TempDir::new().unwrap();
     let dest = DestDir::new(temp.path().to_path_buf()).unwrap();
-    let config = SecurityConfig::default();
+    let config = SecurityConfig::default().validate().unwrap();
 
     // Create actual file
     let file_path = temp.path().join("test_file.txt");
@@ -49,7 +49,7 @@ fn test_full_safe_path_workflow() {
 fn test_dest_dir_join_safe_path() {
     let temp = TempDir::new().unwrap();
     let dest = DestDir::new(temp.path().to_path_buf()).unwrap();
-    let config = SecurityConfig::default();
+    let config = SecurityConfig::default().validate().unwrap();
 
     let safe = SafePath::validate(&PathBuf::from("foo/bar.txt"), &dest, &config).unwrap();
     let joined = dest.join(&safe);
@@ -62,7 +62,7 @@ fn test_dest_dir_join_safe_path() {
 fn test_nested_directory_creation() {
     let temp = TempDir::new().unwrap();
     let dest = DestDir::new(temp.path().to_path_buf()).unwrap();
-    let config = SecurityConfig::default();
+    let config = SecurityConfig::default().validate().unwrap();
 
     // Validate nested path
     let safe = SafePath::validate(&PathBuf::from("a/b/c/d/file.txt"), &dest, &config).unwrap();
@@ -84,6 +84,7 @@ fn test_symlink_workflow() {
     let dest = DestDir::new(temp.path().to_path_buf()).unwrap();
     let mut config = SecurityConfig::default();
     config.allowed.symlinks = true;
+    let config = config.validate().unwrap();
 
     // Create target file
     let target_path = temp.path().join("target.txt");
@@ -110,7 +111,7 @@ fn test_symlink_workflow() {
 fn test_path_traversal_blocked() {
     let temp = TempDir::new().unwrap();
     let dest = DestDir::new(temp.path().to_path_buf()).unwrap();
-    let config = SecurityConfig::default();
+    let config = SecurityConfig::default().validate().unwrap();
 
     let paths = vec![
         "../etc/passwd",
@@ -132,7 +133,7 @@ fn test_path_traversal_blocked() {
 fn test_banned_components_blocked() {
     let temp = TempDir::new().unwrap();
     let dest = DestDir::new(temp.path().to_path_buf()).unwrap();
-    let config = SecurityConfig::default();
+    let config = SecurityConfig::default().validate().unwrap();
 
     let paths = vec![".git/config", "user/.ssh/id_rsa", "home/.gnupg/key"];
 
@@ -150,7 +151,7 @@ fn test_banned_components_blocked() {
 fn test_multiple_files_same_directory() {
     let temp = TempDir::new().unwrap();
     let dest = DestDir::new(temp.path().to_path_buf()).unwrap();
-    let config = SecurityConfig::default();
+    let config = SecurityConfig::default().validate().unwrap();
 
     // Create directory
     let dir_path = temp.path().join("subdir");
@@ -176,6 +177,7 @@ fn test_relative_symlink_resolution() {
     let dest = DestDir::new(temp.path().to_path_buf()).unwrap();
     let mut config = SecurityConfig::default();
     config.allowed.symlinks = true;
+    let config = config.validate().unwrap();
 
     // Create directory structure: a/b/target.txt and a/link.txt -> b/target.txt
     let a_dir = temp.path().join("a");
@@ -200,6 +202,7 @@ fn test_depth_limit_enforced() {
     let dest = DestDir::new(temp.path().to_path_buf()).unwrap();
     let mut config = SecurityConfig::default();
     config.max_path_depth = 5;
+    let config = config.validate().unwrap();
 
     // Path with 5 components should be allowed
     let ok_path = "a/b/c/d/e";

--- a/crates/exarch-core/tests/property_tests.rs
+++ b/crates/exarch-core/tests/property_tests.rs
@@ -36,7 +36,7 @@ proptest! {
         suffix in "([a-z]+/?){0,5}"
     ) {
         let (_temp, dest) = create_test_dest();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().unwrap();
         // Ensure there's a proper path separator before ..
         let path_str = if prefix.is_empty() {
             format!("../{suffix}")
@@ -54,7 +54,7 @@ proptest! {
         components in prop::collection::vec("[a-zA-Z0-9_-]{1,20}", 1..5)
     ) {
         let (_temp, dest) = create_test_dest();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().unwrap();
         let path = PathBuf::from(components.join("/"));
         let result = SafePath::validate(&path, &dest, &config);
         prop_assert!(result.is_ok(), "valid path should be accepted");
@@ -66,7 +66,7 @@ proptest! {
         depth in 33usize..100
     ) {
         let (_temp, dest) = create_test_dest();
-        let config = SecurityConfig::default(); // max_path_depth = 32
+        let config = SecurityConfig::default().validate().unwrap(); // max_path_depth = 32
         let components: Vec<String> = (0..depth).map(|i| format!("d{i}")).collect();
         let path = PathBuf::from(components.join("/"));
         let result = SafePath::validate(&path, &dest, &config);
@@ -81,6 +81,7 @@ proptest! {
         let (_temp, dest) = create_test_dest();
         let mut config = SecurityConfig::default();
         config.allowed.symlinks = true;
+        let config = config.validate().unwrap();
 
         let link = SafePath::validate(&PathBuf::from("a/b/link"), &dest, &config)
             .expect("link path should be valid");
@@ -102,7 +103,7 @@ proptest! {
         ])
     ) {
         let (_temp, dest) = create_test_dest();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().unwrap();
         let path = PathBuf::from(format!("dir/{case_variant}/file"));
         let result = SafePath::validate(&path, &dest, &config);
         prop_assert!(result.is_err(), "banned component should be rejected");
@@ -114,7 +115,7 @@ proptest! {
         depth in 1usize..32
     ) {
         let (_temp, dest) = create_test_dest();
-        let config = SecurityConfig::default(); // max_path_depth = 32
+        let config = SecurityConfig::default().validate().unwrap(); // max_path_depth = 32
         let components: Vec<String> = (0..depth).map(|i| format!("d{i}")).collect();
         let path = PathBuf::from(components.join("/"));
         let result = SafePath::validate(&path, &dest, &config);
@@ -131,7 +132,7 @@ proptest! {
         file_sizes in prop::collection::vec(0u64..1_000_000, 1..100)
     ) {
         let mut tracker = QuotaTracker::new();
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().unwrap();
         let mut expected_total: u64 = 0;
         let mut expected_count = 0;
 
@@ -164,6 +165,7 @@ proptest! {
         config.max_file_count = max_files;
         config.max_total_size = u64::MAX;
         config.max_file_size = u64::MAX;
+        let config = config.validate().unwrap();
 
         let mut success_count = 0;
         for _ in 0..num_files {
@@ -205,6 +207,7 @@ proptest! {
         config.max_total_size = max_size;
         config.max_file_count = usize::MAX;
         config.max_file_size = u64::MAX;
+        let config = config.validate().unwrap();
 
         for size in file_sizes {
             let result = tracker.record_file(size, &config);
@@ -238,6 +241,7 @@ proptest! {
         config.max_file_size = max_file_size;
         config.max_total_size = u64::MAX;
         config.max_file_count = usize::MAX;
+        let config = config.validate().unwrap();
 
         let result = tracker.record_file(file_size, &config);
 
@@ -268,6 +272,7 @@ proptest! {
         config.max_file_size = u64::MAX;
         config.max_file_count = usize::MAX;
         config.max_total_size = u64::MAX;
+        let config = config.validate().unwrap();
 
         let mut expected_total = 0u64;
         for size in &file_sizes {
@@ -302,7 +307,7 @@ proptest! {
     ) {
         use exarch_core::security::validate_compression_ratio;
 
-        let config = SecurityConfig::default(); // max_compression_ratio = 1000.0
+        let config = SecurityConfig::default().validate().unwrap(); // max_compression_ratio = 1000.0
         #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
         let uncompressed = (compressed as f64 * ratio) as u64;
 
@@ -322,7 +327,7 @@ proptest! {
     ) {
         use exarch_core::security::validate_compression_ratio;
 
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().unwrap();
         let result = validate_compression_ratio(0, uncompressed, &config);
 
         prop_assert!(
@@ -336,7 +341,7 @@ proptest! {
     fn prop_compression_both_zero(_dummy in 0..100) {
         use exarch_core::security::validate_compression_ratio;
 
-        let config = SecurityConfig::default();
+        let config = SecurityConfig::default().validate().unwrap();
         let result = validate_compression_ratio(0, 0, &config);
 
         prop_assert!(result.is_ok(), "empty file (0/0) should be valid");
@@ -350,7 +355,7 @@ proptest! {
     ) {
         use exarch_core::security::validate_compression_ratio;
 
-        let config = SecurityConfig::default(); // max = 1000.0
+        let config = SecurityConfig::default().validate().unwrap(); // max = 1000.0
         let uncompressed = compressed.saturating_mul(multiplier);
 
         let result = validate_compression_ratio(compressed, uncompressed, &config);
@@ -373,6 +378,7 @@ proptest! {
         let (_temp, dest) = create_test_dest();
         let mut config = SecurityConfig::default();
         config.allowed.hardlinks = true;
+        let config = config.validate().unwrap();
 
         let mut tracker = HardlinkTracker::new();
         let link = SafePath::validate(&PathBuf::from("link"), &dest, &config)
@@ -392,6 +398,7 @@ proptest! {
         let (_temp, dest) = create_test_dest();
         let mut config = SecurityConfig::default();
         config.allowed.hardlinks = true;
+        let config = config.validate().unwrap();
 
         let mut tracker = HardlinkTracker::new();
         let link = SafePath::validate(&PathBuf::from("link"), &dest, &config)
@@ -414,6 +421,7 @@ proptest! {
         let (_temp, dest) = create_test_dest();
         let mut config = SecurityConfig::default();
         config.allowed.hardlinks = true;
+        let config = config.validate().unwrap();
 
         let mut tracker = HardlinkTracker::new();
         let target = PathBuf::from("shared_target.txt");
@@ -437,6 +445,7 @@ proptest! {
         let (_temp, dest) = create_test_dest();
         let mut config = SecurityConfig::default();
         config.allowed.hardlinks = true;
+        let config = config.validate().unwrap();
 
         let mut tracker = HardlinkTracker::new();
 
@@ -464,6 +473,7 @@ proptest! {
         let (_temp, dest) = create_test_dest();
         let mut config = SecurityConfig::default();
         config.allowed.symlinks = true;
+        let config = config.validate().unwrap();
 
         let link = SafePath::validate(&PathBuf::from("link"), &dest, &config)
             .expect("link path should be valid");
@@ -483,6 +493,7 @@ proptest! {
         let (_temp, dest) = create_test_dest();
         let mut config = SecurityConfig::default();
         config.allowed.symlinks = true;
+        let config = config.validate().unwrap();
 
         let link_path = if link_depth == 0 {
             PathBuf::from("link")
@@ -511,7 +522,7 @@ proptest! {
         target in "[a-z/]{1,30}"
     ) {
         let (_temp, dest) = create_test_dest();
-        let config = SecurityConfig::default(); // symlinks disabled
+        let config = SecurityConfig::default().validate().unwrap(); // symlinks disabled
 
         let link = SafePath::validate(&PathBuf::from("link"), &dest, &config)
             .expect("link path should be valid");

--- a/crates/exarch-core/tests/security/cve_regression.rs
+++ b/crates/exarch-core/tests/security/cve_regression.rs
@@ -154,7 +154,7 @@ fn test_cve_2024_12718_dotslash_prefix_traversal() {
     let mut archive = TarArchive::new(Cursor::new(tar_data));
     let result = archive.extract(
         temp.path(),
-        &SecurityConfig::default(),
+        &SecurityConfig::default().validate().unwrap(),
         &ExtractionOptions::default(),
         &mut exarch_core::NoopProgress,
     );
@@ -175,7 +175,7 @@ fn test_cve_2024_12718_dotslash_complex_traversal() {
     let mut archive = TarArchive::new(Cursor::new(tar_data));
     let result = archive.extract(
         temp.path(),
-        &SecurityConfig::default(),
+        &SecurityConfig::default().validate().unwrap(),
         &ExtractionOptions::default(),
         &mut exarch_core::NoopProgress,
     );
@@ -203,7 +203,7 @@ fn test_cve_2024_12718_multiple_traversal_variants() {
         let mut archive = TarArchive::new(Cursor::new(tar_data));
         let result = archive.extract(
             temp.path(),
-            &SecurityConfig::default(),
+            &SecurityConfig::default().validate().unwrap(),
             &ExtractionOptions::default(),
             &mut exarch_core::NoopProgress,
         );
@@ -236,7 +236,7 @@ fn test_cve_2024_12905_symlink_outside_dest_rejected_by_default() {
     let mut archive = TarArchive::new(Cursor::new(tar_data));
     let result = archive.extract(
         temp.path(),
-        &SecurityConfig::default(),
+        &SecurityConfig::default().validate().unwrap(),
         &ExtractionOptions::default(),
         &mut exarch_core::NoopProgress,
     );
@@ -260,6 +260,7 @@ fn test_cve_2024_12905_symlink_outside_dest_rejected_when_allowed() {
     let temp = TempDir::new().unwrap();
     let mut config = SecurityConfig::default();
     config.allowed.symlinks = true;
+    let config = config.validate().unwrap();
 
     let mut archive = TarArchive::new(Cursor::new(tar_data));
     let result = archive.extract(
@@ -287,6 +288,7 @@ fn test_cve_2024_12905_deep_symlink_chain() {
     let temp = TempDir::new().unwrap();
     let mut config = SecurityConfig::default();
     config.allowed.symlinks = true;
+    let config = config.validate().unwrap();
 
     let mut archive = TarArchive::new(Cursor::new(tar_data));
     let result = archive.extract(
@@ -320,7 +322,7 @@ fn test_cve_2025_48387_hardlink_outside_dest_rejected_by_default() {
     let mut archive = TarArchive::new(Cursor::new(tar_data));
     let result = archive.extract(
         temp.path(),
-        &SecurityConfig::default(),
+        &SecurityConfig::default().validate().unwrap(),
         &ExtractionOptions::default(),
         &mut exarch_core::NoopProgress,
     );
@@ -343,6 +345,7 @@ fn test_cve_2025_48387_hardlink_outside_dest_rejected_when_allowed() {
     let temp = TempDir::new().unwrap();
     let mut config = SecurityConfig::default();
     config.allowed.hardlinks = true;
+    let config = config.validate().unwrap();
 
     let mut archive = TarArchive::new(Cursor::new(tar_data));
     let result = archive.extract(
@@ -369,6 +372,7 @@ fn test_cve_2025_48387_absolute_hardlink_rejected() {
     let temp = TempDir::new().unwrap();
     let mut config = SecurityConfig::default();
     config.allowed.hardlinks = true;
+    let config = config.validate().unwrap();
 
     let mut archive = TarArchive::new(Cursor::new(tar_data));
     let result = archive.extract(
@@ -409,7 +413,7 @@ fn test_rustsec_2026_0067_symlink_dir_chmod_default_config() {
     let mut archive = TarArchive::new(Cursor::new(tar_data));
     let result = archive.extract(
         temp.path(),
-        &SecurityConfig::default(),
+        &SecurityConfig::default().validate().unwrap(),
         &ExtractionOptions::default(),
         &mut exarch_core::NoopProgress,
     );
@@ -442,6 +446,7 @@ fn test_rustsec_2026_0067_symlink_dir_chmod_symlinks_allowed() {
     let temp = TempDir::new().unwrap();
     let mut config = SecurityConfig::default();
     config.allowed.symlinks = true;
+    let config = config.validate().unwrap();
 
     let mut archive = TarArchive::new(Cursor::new(tar_data));
     let result = archive.extract(
@@ -490,6 +495,7 @@ fn test_ghsa_2367_hardlink_does_not_corrupt_target() {
     let temp = TempDir::new().unwrap();
     let mut config = SecurityConfig::default();
     config.allowed.hardlinks = true;
+    let config = config.validate().unwrap();
 
     let mut archive = TarArchive::new(Cursor::new(tar_data));
     // Extraction may succeed or fail depending on platform duplicate-file handling,
@@ -522,6 +528,7 @@ fn test_ghsa_2367_hardlink_produces_independent_inode() {
     let temp = TempDir::new().unwrap();
     let mut config = SecurityConfig::default();
     config.allowed.hardlinks = true;
+    let config = config.validate().unwrap();
 
     let mut archive = TarArchive::new(Cursor::new(tar_data));
     archive
@@ -569,7 +576,7 @@ fn test_cve_2026_24842_deep_nested_hardlink_escape_rejected_by_default() {
     let mut archive = TarArchive::new(Cursor::new(tar_data));
     let result = archive.extract(
         temp.path(),
-        &SecurityConfig::default(),
+        &SecurityConfig::default().validate().unwrap(),
         &ExtractionOptions::default(),
         &mut exarch_core::NoopProgress,
     );
@@ -593,6 +600,7 @@ fn test_cve_2026_24842_deep_nested_hardlink_escape_rejected_when_allowed() {
     let temp = TempDir::new().unwrap();
     let mut config = SecurityConfig::default();
     config.allowed.hardlinks = true;
+    let config = config.validate().unwrap();
 
     let mut archive = TarArchive::new(Cursor::new(tar_data));
     let result = archive.extract(
@@ -626,6 +634,7 @@ fn test_cve_2026_24842_safe_deep_nested_hardlink_allowed() {
     let temp = TempDir::new().unwrap();
     let mut config = SecurityConfig::default();
     config.allowed.hardlinks = true;
+    let config = config.validate().unwrap();
 
     let mut archive = TarArchive::new(Cursor::new(tar_data));
     let result = archive.extract(
@@ -795,6 +804,7 @@ fn test_cve_2025_29787_zip_slip_blocked_with_symlinks_enabled() {
     let dest = TempDir::new().unwrap();
     let mut config = SecurityConfig::default();
     config.allowed.symlinks = true;
+    let config = config.validate().unwrap();
 
     let data = build_cve_2025_29787_zip();
     let mut archive = ZipArchive::new(Cursor::new(data)).unwrap();
@@ -843,7 +853,7 @@ fn test_cve_2025_29787_zip_slip_blocked_with_symlinks_enabled() {
 #[test]
 fn test_cve_2025_29787_zip_slip_blocked_with_symlinks_disabled() {
     let dest = TempDir::new().unwrap();
-    let config = SecurityConfig::default(); // symlinks = false
+    let config = SecurityConfig::default().validate().unwrap(); // symlinks = false
 
     let data = build_cve_2025_29787_zip();
     let mut archive = ZipArchive::new(Cursor::new(data)).unwrap();
@@ -883,7 +893,7 @@ fn test_windows_backslash_parent_traversal() {
     let mut archive = TarArchive::new(Cursor::new(tar_data));
     let result = archive.extract(
         temp.path(),
-        &SecurityConfig::default(),
+        &SecurityConfig::default().validate().unwrap(),
         &ExtractionOptions::default(),
         &mut exarch_core::NoopProgress,
     );
@@ -903,7 +913,7 @@ fn test_windows_backslash_deep_traversal() {
     let mut archive = TarArchive::new(Cursor::new(tar_data));
     let result = archive.extract(
         temp.path(),
-        &SecurityConfig::default(),
+        &SecurityConfig::default().validate().unwrap(),
         &ExtractionOptions::default(),
         &mut exarch_core::NoopProgress,
     );
@@ -927,7 +937,7 @@ fn test_windows_backslash_treated_as_filename_on_unix() {
     let mut archive = TarArchive::new(Cursor::new(tar_data));
     let result = archive.extract(
         temp.path(),
-        &SecurityConfig::default(),
+        &SecurityConfig::default().validate().unwrap(),
         &ExtractionOptions::default(),
         &mut exarch_core::NoopProgress,
     );
@@ -956,7 +966,7 @@ fn test_windows_absolute_path_treated_as_filename_on_unix() {
     let mut archive = TarArchive::new(Cursor::new(tar_data));
     let result = archive.extract(
         temp.path(),
-        &SecurityConfig::default(),
+        &SecurityConfig::default().validate().unwrap(),
         &ExtractionOptions::default(),
         &mut exarch_core::NoopProgress,
     );

--- a/crates/exarch-core/tests/security/hardlink_quota_bypass.rs
+++ b/crates/exarch-core/tests/security/hardlink_quota_bypass.rs
@@ -111,7 +111,9 @@ fn test_hardlink_bomb_exceeds_total_size() {
         .with_allow_hardlinks(true)
         .with_max_file_size(target_size as u64 + 1)
         .with_max_total_size(20_000) // room for target + 3 links, not 4
-        .with_max_file_count(1_000);
+        .with_max_file_count(1_000)
+        .validate()
+        .unwrap();
 
     let mut archive = TarArchive::new(Cursor::new(tar_data));
     let result = archive.extract(
@@ -160,7 +162,9 @@ fn test_hardlink_bomb_exceeds_file_count() {
         .with_allow_hardlinks(true)
         .with_max_file_size(1_000_000)
         .with_max_total_size(1_000_000)
-        .with_max_file_count(3); // target.txt + 2 hardlinks allowed, 3rd rejected
+        .with_max_file_count(3)
+        .validate()
+        .unwrap(); // target.txt + 2 hardlinks allowed, 3rd rejected
 
     let mut archive = TarArchive::new(Cursor::new(tar_data));
     let result = archive.extract(
@@ -204,7 +208,10 @@ fn test_legitimate_hardlinks_within_quota_succeed() {
         .build();
 
     let temp = TempDir::new().unwrap();
-    let config = SecurityConfig::default().with_allow_hardlinks(true);
+    let config = SecurityConfig::default()
+        .with_allow_hardlinks(true)
+        .validate()
+        .unwrap();
 
     let mut archive = TarArchive::new(Cursor::new(tar_data));
     let result = archive.extract(

--- a/crates/exarch-core/tests/security/sevenz_traversal.rs
+++ b/crates/exarch-core/tests/security/sevenz_traversal.rs
@@ -56,7 +56,7 @@ fn test_ghsa_qh76_sevenz_relative_traversal_rejected() {
 
     let result = archive.extract(
         &dest,
-        &SecurityConfig::default(),
+        &SecurityConfig::default().validate().unwrap(),
         &ExtractionOptions::default(),
         &mut exarch_core::NoopProgress,
     );
@@ -88,7 +88,7 @@ fn test_ghsa_qh76_sevenz_absolute_path_rejected() {
 
     let result = archive.extract(
         &dest,
-        &SecurityConfig::default(),
+        &SecurityConfig::default().validate().unwrap(),
         &ExtractionOptions::default(),
         &mut exarch_core::NoopProgress,
     );

--- a/crates/exarch-core/tests/security/symlink_target_validation.rs
+++ b/crates/exarch-core/tests/security/symlink_target_validation.rs
@@ -58,7 +58,10 @@ fn extract_with_symlinks_allowed(
 ) -> exarch_core::Result<exarch_core::ExtractionReport> {
     let temp = TempDir::new().unwrap();
     let mut archive = TarArchive::new(Cursor::new(tar_data));
-    let config = SecurityConfig::default().with_allow_symlinks(true);
+    let config = SecurityConfig::default()
+        .with_allow_symlinks(true)
+        .validate()
+        .unwrap();
     archive.extract(
         temp.path(),
         &config,
@@ -72,7 +75,10 @@ fn extract_with_hardlinks_allowed(
 ) -> exarch_core::Result<exarch_core::ExtractionReport> {
     let temp = TempDir::new().unwrap();
     let mut archive = TarArchive::new(Cursor::new(tar_data));
-    let config = SecurityConfig::default().with_allow_hardlinks(true);
+    let config = SecurityConfig::default()
+        .with_allow_hardlinks(true)
+        .validate()
+        .unwrap();
     archive.extract(
         temp.path(),
         &config,

--- a/crates/exarch-core/tests/security/tar_budget_parity.rs
+++ b/crates/exarch-core/tests/security/tar_budget_parity.rs
@@ -108,7 +108,9 @@ fn extract_via_budgeted_pipeline(bytes: &[u8]) -> BTreeMap<String, Vec<u8>> {
         .with_max_tar_metadata_bytes(1024 * 1024)
         .with_max_file_count(10_000)
         .with_max_total_size(u64::MAX)
-        .with_max_file_size(u64::MAX);
+        .with_max_file_size(u64::MAX)
+        .validate()
+        .unwrap();
     let mut archive = TarArchive::new(Cursor::new(bytes.to_vec()));
     archive
         .extract(

--- a/crates/exarch-core/tests/security/tar_ghsa_2026.rs
+++ b/crates/exarch-core/tests/security/tar_ghsa_2026.rs
@@ -128,7 +128,7 @@ fn extract(bytes: &[u8]) -> (exarch_core::Result<exarch_core::ExtractionReport>,
     let mut archive = TarArchive::new(Cursor::new(bytes.to_vec()));
     let result = archive.extract(
         temp.path(),
-        &SecurityConfig::default(),
+        &SecurityConfig::default().validate().unwrap(),
         &ExtractionOptions::default(),
         &mut NoopProgress,
     );
@@ -137,7 +137,7 @@ fn extract(bytes: &[u8]) -> (exarch_core::Result<exarch_core::ExtractionReport>,
 
 fn extract_with_config(
     bytes: &[u8],
-    config: &SecurityConfig,
+    config: &SecurityConfig<exarch_core::Validated>,
 ) -> (exarch_core::Result<exarch_core::ExtractionReport>, TempDir) {
     let temp = TempDir::new().unwrap();
     let mut archive = TarArchive::new(Cursor::new(bytes.to_vec()));
@@ -456,7 +456,10 @@ fn ghsa_23hp_declared_size_respects_small_quota_despite_large_payload() {
     pad(&mut t, &vec![b'C'; 100_000]);
     eof(&mut t);
 
-    let config = SecurityConfig::default().with_max_file_size(64);
+    let config = SecurityConfig::default()
+        .with_max_file_size(64)
+        .validate()
+        .unwrap();
     let (result, temp) = extract_with_config(&t, &config);
     assert_not_quota_rejected(&result);
     let written = std::fs::metadata(temp.path().join("liar2.txt"))

--- a/crates/exarch-core/tests/security/tar_metadata_bomb.rs
+++ b/crates/exarch-core/tests/security/tar_metadata_bomb.rs
@@ -164,7 +164,10 @@ fn assert_is_budget_violation(result: &exarch_core::Result<impl std::fmt::Debug>
 fn extract_rejects_oversized_gnu_longname_metadata_entry() {
     let bomb = metadata_bomb(b'L', 8192);
     let temp = TempDir::new().unwrap();
-    let config = SecurityConfig::default().with_max_tar_metadata_bytes(4096);
+    let config = SecurityConfig::default()
+        .with_max_tar_metadata_bytes(4096)
+        .validate()
+        .unwrap();
 
     let mut archive = TarArchive::new(Cursor::new(bomb));
     let result = archive.extract(
@@ -180,7 +183,10 @@ fn extract_rejects_oversized_gnu_longname_metadata_entry() {
 fn extract_rejects_oversized_gnu_longlink_metadata_entry() {
     let bomb = metadata_bomb(b'K', 8192);
     let temp = TempDir::new().unwrap();
-    let config = SecurityConfig::default().with_max_tar_metadata_bytes(4096);
+    let config = SecurityConfig::default()
+        .with_max_tar_metadata_bytes(4096)
+        .validate()
+        .unwrap();
 
     let mut archive = TarArchive::new(Cursor::new(bomb));
     let result = archive.extract(
@@ -196,7 +202,10 @@ fn extract_rejects_oversized_gnu_longlink_metadata_entry() {
 fn extract_rejects_oversized_pax_metadata_entry() {
     let bomb = metadata_bomb(b'x', 8192);
     let temp = TempDir::new().unwrap();
-    let config = SecurityConfig::default().with_max_tar_metadata_bytes(4096);
+    let config = SecurityConfig::default()
+        .with_max_tar_metadata_bytes(4096)
+        .validate()
+        .unwrap();
 
     let mut archive = TarArchive::new(Cursor::new(bomb));
     let result = archive.extract(
@@ -226,7 +235,10 @@ fn extract_accepts_metadata_entry_within_the_configured_budget() {
     t.extend(std::iter::repeat_n(0u8, BLOCK * 2));
 
     let temp = TempDir::new().unwrap();
-    let config = SecurityConfig::default().with_max_tar_metadata_bytes(4096);
+    let config = SecurityConfig::default()
+        .with_max_tar_metadata_bytes(4096)
+        .validate()
+        .unwrap();
     let mut archive = TarArchive::new(Cursor::new(t));
     let result = archive.extract(
         temp.path(),
@@ -292,7 +304,7 @@ fn default_config_budget_rejects_a_moderately_oversized_metadata_entry() {
     let mut archive = TarArchive::new(Cursor::new(bomb));
     let result = archive.extract(
         temp.path(),
-        &SecurityConfig::default(),
+        &SecurityConfig::default().validate().unwrap(),
         &ExtractionOptions::default(),
         &mut NoopProgress,
     );
@@ -398,12 +410,13 @@ fn s3_shape_bomb(bomb_real_bytes: usize) -> Vec<u8> {
 
 fn assert_all_entry_points_reject(bomb: &[u8], file_name: &str) {
     let config = SecurityConfig::default().with_max_tar_metadata_bytes(4096);
+    let validated_config = config.clone().validate().unwrap();
 
     let temp = TempDir::new().unwrap();
     let mut archive = TarArchive::new(Cursor::new(bomb.to_owned()));
     let result = archive.extract(
         temp.path(),
-        &config,
+        &validated_config,
         &ExtractionOptions::default(),
         &mut NoopProgress,
     );
@@ -450,7 +463,10 @@ fn legitimate_pax_global_header_does_not_false_positive() {
     t.extend(std::iter::repeat_n(0u8, BLOCK * 2));
 
     let temp = TempDir::new().unwrap();
-    let config = SecurityConfig::default().with_max_tar_metadata_bytes(4096);
+    let config = SecurityConfig::default()
+        .with_max_tar_metadata_bytes(4096)
+        .validate()
+        .unwrap();
     let mut archive = TarArchive::new(Cursor::new(t));
     let result = archive.extract(
         temp.path(),
@@ -715,10 +731,11 @@ fn known_limitation_legitimate_sparse_hole_above_the_synthetic_cap_is_rejected()
     // A direct `TarArchive::extract` library call is unaffected for the
     // same reason: the entry is actually read, not drained unread.
     let mut archive = TarArchive::new(Cursor::new(bomb));
+    let validated_config = config.validate().unwrap();
     let report = archive
         .extract(
             temp.path().join("direct_out").as_path(),
-            &config,
+            &validated_config,
             &ExtractionOptions::default(),
             &mut NoopProgress,
         )
@@ -781,11 +798,12 @@ fn extract_fully_skips_a_legitimate_large_disallowed_extension_entry_and_continu
     let data = skip_and_continue_fixture(big_size);
     let temp = TempDir::new().unwrap();
     let config = SecurityConfig::default().with_allowed_extensions(vec!["txt".to_string()]);
+    let validated_config = config.clone().validate().unwrap();
 
     let mut archive = TarArchive::new(Cursor::new(data.clone()));
     let result = archive.extract(
         temp.path(),
-        &config,
+        &validated_config,
         &ExtractionOptions::default(),
         &mut NoopProgress,
     );
@@ -1057,7 +1075,7 @@ fn budget_violation_is_not_confused_with_other_archive_errors() {
     let mut archive = TarArchive::new(Cursor::new(garbage));
     let result = archive.extract(
         temp.path(),
-        &SecurityConfig::default(),
+        &SecurityConfig::default().validate().unwrap(),
         &ExtractionOptions::default(),
         &mut NoopProgress,
     );

--- a/crates/exarch-core/tests/sevenz_integration.rs
+++ b/crates/exarch-core/tests/sevenz_integration.rs
@@ -38,7 +38,7 @@ fn test_7z_extraction_via_trait() {
     let report = archive
         .extract(
             temp.path(),
-            &SecurityConfig::default(),
+            &SecurityConfig::default().validate().unwrap(),
             &ExtractionOptions::default(),
             &mut exarch_core::NoopProgress,
         )
@@ -60,7 +60,10 @@ fn test_7z_security_config_integration() {
     let mut archive = SevenZArchive::new(cursor).unwrap();
 
     let temp = TempDir::new().unwrap();
-    let config = SecurityConfig::default().with_max_file_size(1024);
+    let config = SecurityConfig::default()
+        .with_max_file_size(1024)
+        .validate()
+        .unwrap();
 
     let result = archive.extract(
         temp.path(),
@@ -90,7 +93,7 @@ fn test_7z_nested_directories() {
     let report = archive
         .extract(
             temp.path(),
-            &SecurityConfig::default(),
+            &SecurityConfig::default().validate().unwrap(),
             &ExtractionOptions::default(),
             &mut exarch_core::NoopProgress,
         )
@@ -113,7 +116,7 @@ fn test_7z_solid_archive_rejected_at_new() {
     let temp = TempDir::new().unwrap();
     let result = archive.extract(
         temp.path(),
-        &SecurityConfig::default(),
+        &SecurityConfig::default().validate().unwrap(),
         &ExtractionOptions::default(),
         &mut exarch_core::NoopProgress,
     );
@@ -175,7 +178,10 @@ fn test_7z_quota_file_count() {
     let mut archive = SevenZArchive::new(cursor).unwrap();
 
     let temp = TempDir::new().unwrap();
-    let config = SecurityConfig::default().with_max_file_count(1);
+    let config = SecurityConfig::default()
+        .with_max_file_count(1)
+        .validate()
+        .unwrap();
 
     let result = archive.extract(
         temp.path(),
@@ -193,7 +199,10 @@ fn test_7z_quota_total_size() {
     let mut archive = SevenZArchive::new(cursor).unwrap();
 
     let temp = TempDir::new().unwrap();
-    let config = SecurityConfig::default().with_max_total_size(10);
+    let config = SecurityConfig::default()
+        .with_max_total_size(10)
+        .validate()
+        .unwrap();
 
     let result = archive.extract(
         temp.path(),
@@ -218,7 +227,9 @@ fn test_7z_solid_archive_extraction_success() {
     let temp = TempDir::new().unwrap();
     let config = SecurityConfig::default()
         .with_allow_solid_archives(true)
-        .with_max_solid_block_memory(100 * 1024 * 1024);
+        .with_max_solid_block_memory(100 * 1024 * 1024)
+        .validate()
+        .unwrap();
 
     let report = archive
         .extract(
@@ -247,7 +258,9 @@ fn test_7z_solid_archive_with_file_count_quota() {
     let config = SecurityConfig::default()
         .with_allow_solid_archives(true)
         .with_max_solid_block_memory(100 * 1024 * 1024)
-        .with_max_file_count(1);
+        .with_max_file_count(1)
+        .validate()
+        .unwrap();
 
     let result = archive.extract(
         temp.path(),
@@ -271,7 +284,7 @@ fn test_7z_unix_symlink_extracted_as_file() {
     let mut archive = SevenZArchive::new(cursor).unwrap();
 
     let temp = TempDir::new().unwrap();
-    let config = SecurityConfig::default();
+    let config = SecurityConfig::default().validate().unwrap();
 
     // Current behavior: succeeds, extracts symlink as file
     let result = archive.extract(
@@ -321,7 +334,7 @@ fn test_7z_hardlink_extracted_as_duplicate_files() {
     let mut archive = SevenZArchive::new(cursor).unwrap();
 
     let temp = TempDir::new().unwrap();
-    let config = SecurityConfig::default();
+    let config = SecurityConfig::default().validate().unwrap();
 
     let result = archive.extract(
         temp.path(),
@@ -420,7 +433,7 @@ fn test_7z_progress_interleaves_per_entry() {
     archive
         .extract(
             temp.path(),
-            &SecurityConfig::default(),
+            &SecurityConfig::default().validate().unwrap(),
             &ExtractionOptions::default(),
             &mut progress,
         )
@@ -461,7 +474,7 @@ fn test_7z_bytes_written_accumulates_correctly() {
     let report = archive
         .extract(
             temp.path(),
-            &SecurityConfig::default(),
+            &SecurityConfig::default().validate().unwrap(),
             &ExtractionOptions::default(),
             &mut exarch_core::NoopProgress,
         )
@@ -494,7 +507,10 @@ fn test_7z_partial_extraction_accurate_report() {
     let mut archive = SevenZArchive::new(cursor).unwrap();
     let out_temp = TempDir::new().unwrap();
 
-    let config = SecurityConfig::default().with_max_total_size(20);
+    let config = SecurityConfig::default()
+        .with_max_total_size(20)
+        .validate()
+        .unwrap();
     let result = archive.extract(
         out_temp.path(),
         &config,
@@ -547,7 +563,7 @@ fn test_7z_force_overwrite_duplicate_entry() {
     let report = archive
         .extract(
             out_temp.path(),
-            &SecurityConfig::default(),
+            &SecurityConfig::default().validate().unwrap(),
             &options,
             &mut exarch_core::NoopProgress,
         )
@@ -591,7 +607,7 @@ fn test_7z_no_partial_extraction_when_zero_items() {
 
     let result = archive.extract(
         out_temp.path(),
-        &SecurityConfig::default(),
+        &SecurityConfig::default().validate().unwrap(),
         &ExtractionOptions::default(),
         &mut exarch_core::NoopProgress,
     );

--- a/crates/exarch-core/tests/tar_alloc_bound.rs
+++ b/crates/exarch-core/tests/tar_alloc_bound.rs
@@ -176,7 +176,10 @@ fn measure_extract_peak_bytes(bytes: &[u8], budget: u64) -> usize {
     let profiler = dhat::Profiler::builder().testing().build();
     {
         let temp = tempfile::tempdir().unwrap();
-        let config = SecurityConfig::default().with_max_tar_metadata_bytes(budget);
+        let config = SecurityConfig::default()
+            .with_max_tar_metadata_bytes(budget)
+            .validate()
+            .unwrap();
         let mut archive = TarArchive::new(Cursor::new(bytes));
         // Outcome (Ok or Err) is irrelevant here — only peak memory matters.
         let _ = archive.extract(

--- a/crates/exarch-core/tests/ui.rs
+++ b/crates/exarch-core/tests/ui.rs
@@ -1,0 +1,17 @@
+//! Compile-fail regression suite for the sealing guarantees introduced by
+//! #433/#434/#435: `SecurityConfig<Validated>` and `ValidatedEntry` must stay
+//! non-constructible and non-mutable from outside their invariant-checked
+//! construction paths. See `tests/ui/*.rs` for the individual cases.
+//!
+//! Each fixture ships a committed `.stderr` snapshot that trybuild compares
+//! exactly (line/column plus rustc's help text), so this suite also pins
+//! *which* sealing mechanism rejects each attempt (private field vs. missing
+//! `DerefMut`), not just that compilation failed. A future rustc wording
+//! change may require re-blessing the snapshots (delete the stale
+//! `.stderr` and re-run to regenerate under `wip/`, then move it back).
+
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/*.rs");
+}

--- a/crates/exarch-core/tests/ui/validated_config_field_mutation.rs
+++ b/crates/exarch-core/tests/ui/validated_config_field_mutation.rs
@@ -1,0 +1,16 @@
+//! Regression for the C1 finding on #433/#434/#435: a legitimately obtained
+//! `SecurityConfig<Validated>` must not be mutable afterward. If it were,
+//! `cfg.max_compression_ratio = f64::NAN` here would reintroduce the exact
+//! runtime-invalid-config bug the typestate exists to prevent, since nothing
+//! downstream of `ArchiveFormat::extract` re-checks `validate()`'s
+//! invariants. `DerefMut` is implemented only for
+//! `SecurityConfig<Unvalidated>`, so this must be a compile error.
+
+#[allow(unused_mut)]
+fn main() {
+    let mut cfg = exarch_core::SecurityConfig::default()
+        .validate()
+        .unwrap();
+
+    cfg.max_compression_ratio = f64::NAN;
+}

--- a/crates/exarch-core/tests/ui/validated_config_field_mutation.stderr
+++ b/crates/exarch-core/tests/ui/validated_config_field_mutation.stderr
@@ -1,0 +1,7 @@
+error[E0594]: cannot assign to data in dereference of `SecurityConfig<Validated>`
+  --> tests/ui/validated_config_field_mutation.rs:15:5
+   |
+15 |     cfg.max_compression_ratio = f64::NAN;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot assign
+   |
+   = help: trait `DerefMut` is required to modify through a dereference, but it is not implemented for `SecurityConfig<Validated>`

--- a/crates/exarch-core/tests/ui/validated_config_forge_via_update_syntax.rs
+++ b/crates/exarch-core/tests/ui/validated_config_forge_via_update_syntax.rs
@@ -1,0 +1,16 @@
+//! A `SecurityConfig<Validated>` must not be forgeable from outside the
+//! crate via struct-update syntax, even when starting from a legitimately
+//! validated instance. `SecurityConfig`'s fields live behind a private
+//! `SecurityConfigFields` member, so struct-literal syntax (with or without
+//! `..base`) is rejected outright — there is no public field to name.
+
+fn main() {
+    let validated = exarch_core::SecurityConfig::default()
+        .validate()
+        .unwrap();
+
+    let _forged = exarch_core::SecurityConfig {
+        max_compression_ratio: f64::NAN,
+        ..validated
+    };
+}

--- a/crates/exarch-core/tests/ui/validated_config_forge_via_update_syntax.stderr
+++ b/crates/exarch-core/tests/ui/validated_config_forge_via_update_syntax.stderr
@@ -1,0 +1,7 @@
+error[E0560]: struct `SecurityConfig<_>` has no field named `max_compression_ratio`
+  --> tests/ui/validated_config_forge_via_update_syntax.rs:13:9
+   |
+13 |         max_compression_ratio: f64::NAN,
+   |         ^^^^^^^^^^^^^^^^^^^^^ `SecurityConfig<_>` does not have this field
+   |
+   = note: all struct fields are already assigned

--- a/crates/exarch-core/tests/ui/validated_entry_forge_via_struct_literal.rs
+++ b/crates/exarch-core/tests/ui/validated_entry_forge_via_struct_literal.rs
@@ -1,0 +1,17 @@
+//! A `ValidatedEntry` must not be assemblable from outside the crate via
+//! struct-literal syntax. Its fields are private and its only constructor,
+//! `ValidatedEntry::new`, is `pub(crate)` — so external code has no path to
+//! a `ValidatedEntry` other than observing one already produced by
+//! `EntryValidator::validate_entry`.
+
+use exarch_core::security::ValidatedEntry;
+use exarch_core::security::ValidatedEntryType;
+
+#[allow(unreachable_code)]
+fn main() {
+    let _entry = ValidatedEntry {
+        safe_path: todo!(),
+        entry_type: ValidatedEntryType::File,
+        mode: None,
+    };
+}

--- a/crates/exarch-core/tests/ui/validated_entry_forge_via_struct_literal.stderr
+++ b/crates/exarch-core/tests/ui/validated_entry_forge_via_struct_literal.stderr
@@ -1,0 +1,11 @@
+error[E0451]: fields `safe_path`, `entry_type` and `mode` of struct `ValidatedEntry` are private
+  --> tests/ui/validated_entry_forge_via_struct_literal.rs:13:9
+   |
+12 |     let _entry = ValidatedEntry {
+   |                  -------------- in this type
+13 |         safe_path: todo!(),
+   |         ^^^^^^^^^ private field
+14 |         entry_type: ValidatedEntryType::File,
+   |         ^^^^^^^^^^ private field
+15 |         mode: None,
+   |         ^^^^ private field

--- a/specs/002-format-handlers/spec.md
+++ b/specs/002-format-handlers/spec.md
@@ -224,6 +224,18 @@ FormatCreator:
   format_name() -> &'static str
 ```
 
+> [!note] Unreleased: `ArchiveFormat` requires `SecurityConfig<Validated>` (#433, #434, #435)
+> `SecurityConfig` is now a two-state typestate over `Unvalidated`/`Validated` markers
+> (`SecurityConfig<State = Unvalidated>`). `ArchiveFormat::extract`, `list`, and `verify`
+> now take `config: &SecurityConfig<Validated>` instead of `config: &SecurityConfig` — a
+> breaking change for anyone implementing `ArchiveFormat` outside the crate or calling
+> `TarArchive`/`ZipArchive`/`SevenZArchive` methods directly. The top-level
+> `extract_archive*`, `list_archive`, `verify_archive`, and `create_archive*` functions are
+> unaffected: they still accept a plain `&SecurityConfig` (defaulting to `Unvalidated`) and
+> call `validate()` internally before dispatching to `ArchiveFormat`. No validation logic
+> changed — this is purely a compile-time hardening of the existing "call `validate()` before
+> use" convention.
+
 > [!note] zip dependency
 > Upgraded from 8.6.0 to 9.0.0-pre2 in v0.4.0. `ZipFile::name()` now returns
 > `Result<Cow<str>, ZipError>` instead of `&str`; all call sites propagate the


### PR DESCRIPTION
## Summary

- `SecurityConfig::validate()` was only enforced at the top-level `extract_archive`/`create_archive` choke point, not when using the `ArchiveFormat` trait or `TarArchive`/`ZipArchive`/`SevenZArchive` directly — an invalid config (e.g. `max_compression_ratio: f64::NAN`) could silently disable zip-bomb detection via that path.
- `ValidatedEntry`/`ValidatedEntryType` had all-public fields/variants, forgeable outside the crate despite representing "passed the full security validation pipeline."
- Both are closed structurally: `SecurityConfig<Unvalidated|Validated>` is a two-state phantom-marker typestate; `ArchiveFormat::extract/list/verify` now require `&SecurityConfig<Validated>`. Config fields are sealed behind a private inner struct (`Deref` for read access in both states, `DerefMut` only pre-validation), so a validated config cannot be mutated back into an invalid state — this closes a gap in the original design that adversarial review caught mid-PR (see review history). `ValidatedEntry`/`ValidatedEntryType` are sealed with private fields, accessor methods, and a `pub(crate)` constructor reachable only from `EntryValidator::validate_entry()`.
- No runtime validation logic changed anywhere — this is purely compile-time hardening of existing checks.
- Top-level public API (`extract_archive*`, `create_archive*`, `list_archive`, `verify_archive`) is unchanged in signature; `exarch-cli`, `exarch-python`, `exarch-node` need zero changes.
- Adds a committed `trybuild` compile-fail regression suite (`crates/exarch-core/tests/ui.rs` + 3 fixtures) enforcing the sealing guarantees permanently in CI.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` (1053 passed)
- [x] `cargo test --doc -p exarch-core -p exarch-cli -p exarch-node --all-features` (100 passed; workspace-wide doc-test run hits a pre-existing, unrelated pyo3/macOS doctest-linking issue in `exarch-python`)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --all-features --workspace`
- [x] `cargo check --workspace --all-features` (confirms `exarch-cli`/`exarch-python`/`exarch-node` compile unchanged)
- [x] New `trybuild` suite (`cargo nextest run -p exarch-core --all-features --test ui`) verifies the sealing guarantees at compile time

Closes #433
Closes #434
Closes #435