### PR TITLE
ci: add benchmark build check job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,6 +355,31 @@ jobs:
           cd crates/exarch-node
           npm test
 
+  # Quick compile-only check for criterion benchmarks (does not run them)
+  bench-build:
+    name: Bench Build Check
+    needs: [changes, format]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: |
+      needs.changes.outputs.rust == 'true' ||
+      github.ref == 'refs/heads/main' ||
+      github.ref == 'refs/heads/develop'
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "bench-build"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Build benchmarks (compile only, does not run them)
+        run: cargo build --workspace --benches --all-features --exclude exarch-python --exclude exarch-node
+
   # MSRV check (exarch-core only)
   msrv:
     name: MSRV Check (exarch-core)
@@ -434,7 +459,7 @@ jobs:
   # All checks passed
   ci-success:
     name: CI Success
-    needs: [format, clippy, documentation, security, test, test-python, test-node, msrv]
+    needs: [format, clippy, documentation, security, test, test-python, test-node, msrv, bench-build]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -450,6 +475,7 @@ jobs:
             "${{ needs.test-python.result }}"
             "${{ needs.test-node.result }}"
             "${{ needs.msrv.result }}"
+            "${{ needs.bench-build.result }}"
           )
 
           for result in "${REQUIRED_JOBS[@]}"; do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- CI: add `bench-build` job to `.github/workflows/ci.yml` that compiles the
+  `exarch-core` criterion benchmarks (`--all-features`, covering the
+  `testing`-gated `validation` bench) without running them, catching
+  benchmark compilation breakage in a fast parallel job.
+
 ### Changed
 
 - **BREAKING: `SecurityConfig` is now a two-state typestate over `Unvalidated`/`Validated`


### PR DESCRIPTION
## Summary
- Add a `bench-build` job to `.github/workflows/ci.yml` that compiles the `exarch-core` criterion benchmarks (`cargo build --workspace --benches --all-features`) without running them, catching benchmark compilation breakage early.
- `--all-features` is required to cover the `testing`-gated `validation` bench.
- Runs in parallel with the other Rust jobs (`test`, `clippy`, `msrv`, etc.) and gates `ci-success`.

## Test plan
- [x] `cargo build --workspace --benches --all-features` verified locally in the worktree (succeeds)
- [x] YAML validated with `fy parse -q` / `fy lint` (0 errors)
- [ ] CI run on this PR passes the new `bench-build` job