### PR TITLE
fix(core)!: enforce quota-check-before-write via capability token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING: `ValidatedEntryType::File` now carries a `QuotaPermit` capability token (#436)**:
+  `QuotaTracker::record_file` is renamed to `reserve` and returns `Result<QuotaPermit>` instead
+  of `Result<()>`; `EntryValidator::record_hardlink` is renamed to `reserve_hardlink` for the
+  same reason. `QuotaPermit` is a zero-sized, non-`Clone`/non-`Copy` token whose only producer
+  is `QuotaTracker::reserve`, and constructing `ValidatedEntryType::File` now requires one, so a
+  `File`-typed validated entry with no quota charge is unrepresentable. `extract_file_generic`
+  (shared by TAR and ZIP) additionally rejects any non-`File` entry before touching the
+  filesystem, and TAR's hardlink-copy path now consumes its permit by value via a new
+  `copy_file_with_permit` helper, so a single reservation cannot be spent twice. This closes the
+  same class of gap as #428 (an unguarded quota-charge path) at the type level instead of by
+  convention; behavior is unchanged for every caller that already went through
+  `EntryValidator::validate_entry`.
 - **BREAKING: `SecurityConfig` is now a two-state typestate over `Unvalidated`/`Validated`
   (#433, #434, #435)**: `SecurityConfig<State = Unvalidated>` carries a phantom marker; the
   fluent `with_*` builder methods remain available only on `SecurityConfig<Unvalidated>`, and

--- a/crates/exarch-core/src/formats/common.rs
+++ b/crates/exarch-core/src/formats/common.rs
@@ -29,7 +29,9 @@ use crate::config::Validated;
 use crate::copy::CopyBuffer;
 use crate::copy::copy_with_buffer;
 use crate::error::QuotaResource;
+use crate::security::quota::QuotaPermit;
 use crate::security::validator::ValidatedEntry;
+use crate::security::validator::ValidatedEntryType;
 use crate::types::DestDir;
 use crate::types::SafeSymlink;
 
@@ -469,8 +471,11 @@ fn create_file_with_mode(path: &Path, _mode: Option<u32>) -> std::io::Result<Fil
 ///
 /// # Correctness
 ///
-/// Quota is checked BEFORE writing to prevent partial files on overflow.
-/// This fixes the inconsistency where TAR was checking AFTER write.
+/// The quota charge for this entry already happened during
+/// `EntryValidator::validate_entry`, proven by the [`QuotaPermit`] held in
+/// `validated`'s `ValidatedEntryType::File`; this function only rejects
+/// non-`File` entries and guards `report.bytes_written` against overflow
+/// before writing.
 ///
 /// # Type Parameters
 ///
@@ -508,6 +513,12 @@ pub fn extract_file_generic<R: Read>(
 ) -> Result<()> {
     let output_path = dest.join(validated.safe_path());
 
+    let ValidatedEntryType::File(_) = validated.entry_type() else {
+        return Err(ArchiveError::SecurityViolation {
+            reason: "extract_file_generic called with a non-File validated entry".into(),
+        });
+    };
+
     // Create parent directories if needed using cache
     dir_cache.ensure_parent_dir(&output_path)?;
 
@@ -520,7 +531,10 @@ pub fn extract_file_generic<R: Read>(
         return Ok(());
     }
 
-    // CRITICAL: Check quota BEFORE writing (prevents partial files on overflow)
+    // The size was already reserved against QuotaTracker during
+    // validate_entry (proven by the QuotaPermit held in `validated`'s
+    // ValidatedEntryType::File); this only guards report.bytes_written,
+    // a different quantity, against overflow before writing.
     if let Some(size) = expected_size {
         report
             .bytes_written
@@ -671,6 +685,20 @@ pub fn create_symlink(
     }
 }
 
+/// Copies a hardlink target's bytes to a new inode, consuming the
+/// [`QuotaPermit`] that authorized the copy.
+///
+/// Taking `permit` by value ensures a reservation can be spent at most once:
+/// `QuotaPermit` is neither `Clone` nor `Copy`, so the caller cannot retain
+/// it to pass to a second copy.
+///
+/// # Errors
+///
+/// Returns an I/O error if the copy fails.
+pub fn copy_file_with_permit(from: &Path, to: &Path, _permit: QuotaPermit) -> std::io::Result<u64> {
+    std::fs::copy(from, to)
+}
+
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
@@ -680,6 +708,7 @@ mod tests {
     use crate::NoopProgress;
     use crate::SecurityConfig;
     use crate::copy::CopyBuffer;
+    use crate::security::quota::QuotaTracker;
     use crate::security::validator::ValidatedEntry;
     use crate::security::validator::ValidatedEntryType;
     use crate::types::SafePath;
@@ -703,10 +732,13 @@ mod tests {
         let expected_size = Some(200u64); // This would overflow when added
 
         let config = SecurityConfig::default().validate().expect("valid config");
+        let permit = QuotaTracker::new()
+            .reserve(0, &config)
+            .expect("reservation should succeed");
         let validated = ValidatedEntry::new(
             SafePath::validate(&PathBuf::from("test.txt"), &dest, &config)
                 .expect("path should be valid"),
-            ValidatedEntryType::File,
+            ValidatedEntryType::File(permit),
             Some(0o644),
         );
 
@@ -731,6 +763,46 @@ mod tests {
             ArchiveError::QuotaExceeded {
                 resource: QuotaResource::IntegerOverflow
             }
+        );
+    }
+
+    /// A `Directory`-typed validated entry must be rejected by
+    /// `extract_file_generic` before any filesystem side effect, proving the
+    /// non-`File` guard is live and not just structurally implied.
+    #[test]
+    fn test_extract_file_generic_rejects_non_file_entry() {
+        let temp = TempDir::new().expect("failed to create temp dir");
+        let dest = DestDir::new(temp.path().to_path_buf()).expect("failed to create dest");
+        let mut report = ExtractionReport::default();
+        let mut copy_buffer = CopyBuffer::new();
+        let mut dir_cache = DirCache::new();
+
+        let config = SecurityConfig::default().validate().expect("valid config");
+        let validated = ValidatedEntry::new(
+            SafePath::validate(&PathBuf::from("dir_entry"), &dest, &config)
+                .expect("path should be valid"),
+            ValidatedEntryType::Directory,
+            None,
+        );
+
+        let mut reader = Cursor::new(b"");
+
+        let result = extract_file_generic(
+            &mut reader,
+            &validated,
+            &dest,
+            &mut report,
+            None,
+            &mut copy_buffer,
+            &mut dir_cache,
+            true,
+            &mut NoopProgress,
+        );
+
+        assert_matches!(result, Err(ArchiveError::SecurityViolation { .. }));
+        assert!(
+            !temp.path().join("dir_entry").exists(),
+            "non-File entry must not touch the filesystem"
         );
     }
 
@@ -1089,10 +1161,13 @@ mod tests {
 
         // Mode 0o777 in archive, sanitized to 0o775 (world-writable stripped)
         let sanitized_mode = 0o775u32;
+        let permit = QuotaTracker::new()
+            .reserve(0, &config)
+            .expect("reservation should succeed");
         let validated = ValidatedEntry::new(
             SafePath::validate(&PathBuf::from("perm_test.txt"), &dest, &config)
                 .expect("path should be valid"),
-            ValidatedEntryType::File,
+            ValidatedEntryType::File(permit),
             Some(sanitized_mode),
         );
 

--- a/crates/exarch-core/src/formats/sevenz.rs
+++ b/crates/exarch-core/src/formats/sevenz.rs
@@ -335,7 +335,13 @@ impl<R: Read + Seek> SevenZArchive<R> {
                 report.directories_created += 1;
                 Ok(0)
             }
-            ValidatedEntryType::File => {
+            // TODO(critic): 7z write is guarded only by this match arm; no
+            // QuotaPermit is consumed here (unlike TAR/ZIP's runtime guard in
+            // extract_file_generic and the hardlink path's by-value permit).
+            // A future refactor that lifts the temp+rename block below out of
+            // this arm would silently drop the guarantee. Extracting it into
+            // a helper taking `&QuotaPermit` would bring 7z to parity.
+            ValidatedEntryType::File(_) => {
                 let dest_path = dest.join_path(validated.safe_path().as_path());
 
                 dir_cache.ensure_parent_dir(&dest_path)?;
@@ -561,7 +567,7 @@ impl<R: Read + Seek> ArchiveFormat for SevenZArchive<R> {
                 prevalidator.validate_entry(&path, &entry_type, entry.size, None, None, None)?;
 
             match validated.entry_type() {
-                ValidatedEntryType::File | ValidatedEntryType::Directory => {
+                ValidatedEntryType::File(_) | ValidatedEntryType::Directory => {
                     // Will be extracted in Step 3
                 }
                 _ => {

--- a/crates/exarch-core/src/formats/tar.rs
+++ b/crates/exarch-core/src/formats/tar.rs
@@ -242,7 +242,7 @@ impl<R: Read> TarArchive<R> {
         )?;
 
         match validated.entry_type() {
-            ValidatedEntryType::File => {
+            ValidatedEntryType::File(_) => {
                 Self::extract_file(entry, &validated, ctx)?;
                 Ok(None)
             }
@@ -337,16 +337,17 @@ impl<R: Read> TarArchive<R> {
         // Every hardlink copies the target's real bytes to a new inode, so it
         // must be charged against the same quota tracker as regular files
         // (issue #426): otherwise N hardlinks to one small file extract N
-        // full copies with no size or count enforcement. Charged after the
+        // full copies with no size or count enforcement. Reserved after the
         // duplicate-skip check above (mirroring `extract_file_generic`) so a
         // `skip_duplicates=true` archive is not spuriously charged for an
-        // entry that is ultimately never copied.
+        // entry that is ultimately never copied. The permit is consumed by
+        // value below, so this reservation cannot be spent twice.
         let target_size = std::fs::metadata(&target_path)?.len();
-        ctx.validator.record_hardlink(target_size)?;
+        let permit = ctx.validator.reserve_hardlink(target_size)?;
 
         // Copy content to a new independent inode. Any subsequent write to
         // `link_path` cannot corrupt `target_path` because they are separate files.
-        let bytes_copied = std::fs::copy(&target_path, &link_path)?;
+        let bytes_copied = common::copy_file_with_permit(&target_path, &link_path, permit)?;
 
         ctx.report.files_extracted =
             ctx.report

--- a/crates/exarch-core/src/inspection/list.rs
+++ b/crates/exarch-core/src/inspection/list.rs
@@ -198,7 +198,7 @@ fn list_tar_entries<R: std::io::Read>(
         // explicit `entry.abandon()`; harmless — the guard's bounded drain
         // on drop is pointless I/O in that case, not a correctness
         // requirement (see `TarEntryGuard::abandon`).
-        quota.record_file(size, config)?;
+        let _permit = quota.reserve(size, config)?;
 
         let path = entry
             .path()
@@ -336,7 +336,7 @@ pub(crate) fn list_zip_reader<R: Read + Seek>(
         // and extraction fully equivalent — extraction's QuotaTracker only
         // records EntryType::File, while listing records every entry type
         // (directories, symlinks, hardlinks too), a pre-existing divergence.
-        quota.record_file(entry.size(), config)?;
+        let _permit = quota.reserve(entry.size(), config)?;
 
         let raw_name = entry
             .name()
@@ -512,7 +512,7 @@ fn list_sevenz_archive(
         // and extraction fully equivalent — extraction's QuotaTracker only
         // records EntryType::File, while listing records every entry type
         // (directories, symlinks, hardlinks too), a pre-existing divergence.
-        quota.record_file(entry.size, config)?;
+        let _permit = quota.reserve(entry.size, config)?;
 
         let path = PathBuf::from(normalize_entry_name(&entry.name));
 

--- a/crates/exarch-core/src/inspection/verify.rs
+++ b/crates/exarch-core/src/inspection/verify.rs
@@ -176,8 +176,8 @@ fn verify_entry(
         issues.push(VerificationIssue::from_error(e, Some(entry.path.clone())));
     }
 
-    // Quota validation using record_file (combines all checks)
-    if let Err(e) = quota_tracker.record_file(entry.size, config) {
+    // Quota validation using reserve (combines all checks)
+    if let Err(e) = quota_tracker.reserve(entry.size, config) {
         issues.push(VerificationIssue::from_error(&e, Some(entry.path.clone())));
     }
 

--- a/crates/exarch-core/src/security/mod.rs
+++ b/crates/exarch-core/src/security/mod.rs
@@ -16,6 +16,12 @@ pub use validator::ValidatedEntry;
 pub use validator::ValidatedEntryType;
 pub use validator::ValidationReport;
 
+// QuotaPermit rides inside the unconditionally-public
+// ValidatedEntryType::File, so it must be exported ungated: a
+// `#[cfg(feature = "testing")]` re-export (as `QuotaTracker` gets below)
+// would be a private-type-in-public-interface compile error.
+pub use quota::QuotaPermit;
+
 // Security primitives exposed under the `testing` feature for external
 // benchmarks and integration tests that cannot access pub(crate) items.
 #[cfg(feature = "testing")]

--- a/crates/exarch-core/src/security/quota.rs
+++ b/crates/exarch-core/src/security/quota.rs
@@ -1,9 +1,65 @@
 //! Extraction quota tracking and validation.
 
+use std::marker::PhantomData;
+
 use crate::ArchiveError;
 use crate::Result;
 use crate::SecurityConfig;
 use crate::config::Validated;
+
+/// Proof that a file's size was successfully reserved against a
+/// [`QuotaTracker`].
+///
+/// This is a capability token, not a data type: it carries no payload and
+/// exists only so that [`ValidatedEntryType::File`] cannot be constructed
+/// without a tracker having actually authorized the charge. Its only
+/// producer is [`QuotaTracker::reserve`] — the private field means no other
+/// code, in or out of this crate, can assemble one directly.
+///
+/// Deliberately not `Clone`/`Copy`/`Default`: a permit represents a single
+/// reservation and must not be duplicated or spent more than once. Zero-sized
+/// (`PhantomData`-based), so wrapping it in `Result` costs nothing over
+/// `Result<()>`.
+///
+/// [`ValidatedEntryType::File`]: crate::security::validator::ValidatedEntryType::File
+///
+/// # Examples
+///
+/// A `QuotaPermit` is never constructed directly — it arrives already
+/// embedded in a validated file entry:
+///
+/// ```no_run
+/// use exarch_core::SecurityConfig;
+/// use exarch_core::security::EntryValidator;
+/// use exarch_core::security::ValidatedEntryType;
+/// use exarch_core::types::DestDir;
+/// use exarch_core::types::EntryType;
+/// use std::path::Path;
+/// use std::path::PathBuf;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let dest = DestDir::new(PathBuf::from("/tmp"))?;
+/// let config = SecurityConfig::default().validate()?;
+/// let mut validator = EntryValidator::new(&config, &dest);
+///
+/// let entry = validator.validate_entry(
+///     Path::new("file.txt"),
+///     &EntryType::File,
+///     1024, // uncompressed size
+///     None, // compressed size
+///     None, // mode
+///     None, // dir_cache
+/// )?;
+///
+/// if let ValidatedEntryType::File(permit) = entry.entry_type() {
+///     println!("{permit:?}");
+/// }
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug)]
+#[must_use]
+pub struct QuotaPermit(PhantomData<()>);
 
 /// Tracks resource usage during extraction.
 #[derive(Debug, Default)]
@@ -19,7 +75,8 @@ impl QuotaTracker {
         Self::default()
     }
 
-    /// Records a file extraction.
+    /// Reserves quota capacity for a file extraction, returning a capability
+    /// token that proves the reservation succeeded.
     ///
     /// # Errors
     ///
@@ -31,7 +88,11 @@ impl QuotaTracker {
     /// When all quotas are set to maximum values (unlimited), the function
     /// skips quota checks and only tracks counters with overflow detection.
     #[inline]
-    pub fn record_file(&mut self, size: u64, config: &SecurityConfig<Validated>) -> Result<()> {
+    pub fn reserve(
+        &mut self,
+        size: u64,
+        config: &SecurityConfig<Validated>,
+    ) -> Result<QuotaPermit> {
         // OPT-C003: Fast path when all quotas unlimited - skip checks, only detect
         // overflow
         if config.max_file_size == u64::MAX
@@ -52,10 +113,11 @@ impl QuotaTracker {
                 }
             })?;
 
-            return Ok(());
+            return Ok(QuotaPermit(PhantomData));
         }
 
-        self.record_file_checked(size, config)
+        self.record_file_checked(size, config)?;
+        Ok(QuotaPermit(PhantomData))
     }
 
     /// Internal implementation with full quota validation.
@@ -138,11 +200,11 @@ mod tests {
     }
 
     #[test]
-    fn test_quota_tracker_record_file() {
+    fn test_quota_tracker_reserve() {
         let mut tracker = QuotaTracker::new();
         let config = SecurityConfig::default().validate().expect("valid config");
 
-        assert!(tracker.record_file(1000, &config).is_ok());
+        assert!(tracker.reserve(1000, &config).is_ok());
         assert_eq!(tracker.files_extracted(), 1);
         assert_eq!(tracker.bytes_written(), 1000);
     }
@@ -154,9 +216,9 @@ mod tests {
         config.max_file_count = 2;
         let config = config.validate().expect("valid config");
 
-        assert!(tracker.record_file(100, &config).is_ok());
-        assert!(tracker.record_file(100, &config).is_ok());
-        let result = tracker.record_file(100, &config);
+        assert!(tracker.reserve(100, &config).is_ok());
+        assert!(tracker.reserve(100, &config).is_ok());
+        let result = tracker.reserve(100, &config);
         assert_matches!(result, Err(ArchiveError::QuotaExceeded { .. }));
     }
 
@@ -167,8 +229,8 @@ mod tests {
         config.max_total_size = 1000;
         let config = config.validate().expect("valid config");
 
-        assert!(tracker.record_file(600, &config).is_ok());
-        let result = tracker.record_file(500, &config);
+        assert!(tracker.reserve(600, &config).is_ok());
+        let result = tracker.reserve(500, &config);
         assert_matches!(result, Err(ArchiveError::QuotaExceeded { .. }));
     }
 
@@ -179,7 +241,7 @@ mod tests {
         config.max_file_size = 1000;
         let config = config.validate().expect("valid config");
 
-        let result = tracker.record_file(2000, &config);
+        let result = tracker.reserve(2000, &config);
         assert_matches!(result, Err(ArchiveError::QuotaExceeded { .. }));
     }
 
@@ -195,21 +257,21 @@ mod tests {
 
         // Exactly at file count limit should succeed
         assert!(
-            tracker.record_file(100, &config).is_ok(),
+            tracker.reserve(100, &config).is_ok(),
             "file 1 should succeed"
         );
         assert!(
-            tracker.record_file(100, &config).is_ok(),
+            tracker.reserve(100, &config).is_ok(),
             "file 2 should succeed"
         );
         assert!(
-            tracker.record_file(100, &config).is_ok(),
+            tracker.reserve(100, &config).is_ok(),
             "file 3 should succeed"
         );
         assert_eq!(tracker.files_extracted(), 3, "should have 3 files");
 
         // One more should fail (exceeds limit)
-        let result = tracker.record_file(100, &config);
+        let result = tracker.reserve(100, &config);
         assert_matches!(
             result,
             Err(ArchiveError::QuotaExceeded {
@@ -229,14 +291,14 @@ mod tests {
         let config = config.validate().expect("valid config");
 
         // Add files up to exactly the limit
-        assert!(tracker.record_file(600, &config).is_ok());
+        assert!(tracker.reserve(600, &config).is_ok());
         assert_eq!(tracker.bytes_written(), 600);
 
-        assert!(tracker.record_file(400, &config).is_ok());
+        assert!(tracker.reserve(400, &config).is_ok());
         assert_eq!(tracker.bytes_written(), 1000, "should be exactly at limit");
 
         // One more byte should fail
-        let result = tracker.record_file(1, &config);
+        let result = tracker.reserve(1, &config);
         assert_matches!(
             result,
             Err(ArchiveError::QuotaExceeded {
@@ -260,12 +322,12 @@ mod tests {
 
         // File exactly at limit should succeed
         assert!(
-            tracker.record_file(5000, &config).is_ok(),
+            tracker.reserve(5000, &config).is_ok(),
             "file exactly at limit should succeed"
         );
 
         // File one byte over should fail
-        let result = tracker.record_file(5001, &config);
+        let result = tracker.reserve(5001, &config);
         assert_matches!(
             result,
             Err(ArchiveError::QuotaExceeded {
@@ -288,10 +350,10 @@ mod tests {
         let config = config.validate().expect("valid config");
 
         // First file should succeed
-        assert!(tracker.record_file(100, &config).is_ok());
+        assert!(tracker.reserve(100, &config).is_ok());
 
         // Second file should fail (max is 1)
-        let result = tracker.record_file(100, &config);
+        let result = tracker.reserve(100, &config);
         assert_matches!(result, Err(ArchiveError::QuotaExceeded { .. }));
     }
 
@@ -308,7 +370,7 @@ mod tests {
 
         for i in 1..=1000 {
             assert!(
-                tracker.record_file(1000, &config).is_ok(),
+                tracker.reserve(1000, &config).is_ok(),
                 "file {i} should succeed with unlimited quotas"
             );
         }
@@ -331,7 +393,7 @@ mod tests {
         tracker.bytes_written = u64::MAX - 100;
 
         // Adding 200 bytes should trigger overflow detection
-        let result = tracker.record_file(200, &config);
+        let result = tracker.reserve(200, &config);
         assert_matches!(
             result,
             Err(ArchiveError::QuotaExceeded {

--- a/crates/exarch-core/src/security/validator.rs
+++ b/crates/exarch-core/src/security/validator.rs
@@ -12,6 +12,7 @@ use crate::formats::common::DirCache;
 use crate::security::context::ValidationContext;
 use crate::security::hardlink::HardlinkTracker;
 use crate::security::permissions::sanitize_permissions;
+use crate::security::quota::QuotaPermit;
 use crate::security::quota::QuotaTracker;
 use crate::security::symlink::validate_symlink;
 use crate::security::zipbomb::validate_compression_ratio;
@@ -78,17 +79,24 @@ impl ValidatedEntry {
 
 /// Validated entry type variants.
 ///
-/// This enum alone does not carry the sealing guarantee — `File` and
-/// `Directory` are plain markers with no data, so they are directly
-/// constructible from any module (in or out of this crate) that can name the
-/// type. The guarantee instead comes from [`ValidatedEntry`]: its
-/// constructor is `pub(crate)`, so nothing outside this crate can assemble a
-/// `ValidatedEntry` at all, regardless of how its `ValidatedEntryType` field
-/// was produced. Within that guarantee, the `Symlink` and `Hardlink`
-/// variants add a second layer for their own payloads: they wrap
-/// [`SafeSymlink`] and [`SafePath`], which are independently sealed and can
-/// only be produced by their own validation routines, so even crate-internal
-/// code cannot forge a "validated" symlink/hardlink target.
+/// This enum alone does not carry the sealing guarantee — the external seal
+/// comes from [`ValidatedEntry`]: its constructor is `pub(crate)`, so
+/// nothing outside this crate can assemble a `ValidatedEntry` at all,
+/// regardless of how its `ValidatedEntryType` field was produced. Within
+/// that guarantee, several variants add a second, crate-internal layer for
+/// their own payloads:
+///
+/// - The `Symlink` and `Hardlink` variants wrap [`SafeSymlink`] and
+///   [`SafePath`], which are independently sealed and can only be produced by
+///   their own validation routines, so even crate-internal code cannot forge a
+///   "validated" symlink/hardlink target.
+/// - The `File` variant wraps [`QuotaPermit`], whose only producer is
+///   [`QuotaTracker::reserve`]: a `File` variant cannot be built without a
+///   quota reservation having actually succeeded. This is crate-internal
+///   discipline, not an external-construction barrier — enum variant fields are
+///   as visible as the enum itself, so `ValidatedEntryType::File(todo!())`
+///   compiles from outside this crate too; it just can never *run*, since
+///   nothing outside this crate can produce a genuine `QuotaPermit`.
 ///
 /// `#[non_exhaustive]` so a future variant is not a breaking change for
 /// downstream matches — [`ValidatedEntry::entry_type`] is the only way
@@ -97,8 +105,9 @@ impl ValidatedEntry {
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum ValidatedEntryType {
-    /// Regular file
-    File,
+    /// Regular file, carrying proof that its size was reserved against a
+    /// [`QuotaTracker`] before this entry was validated.
+    File(QuotaPermit),
 
     /// Directory
     Directory,
@@ -185,7 +194,8 @@ impl<'a> EntryValidator<'a> {
     ///
     /// This method orchestrates all security validations:
     /// 1. Path validation (traversal, depth, banned components)
-    /// 2. Quota checking (file size, count, total size)
+    /// 2. Quota checking (file size, count, total size) — `EntryType::File`
+    ///    only
     /// 3. Compression ratio validation (zip bomb detection)
     /// 4. Type-specific validation (symlink, hardlink, permissions)
     ///
@@ -220,30 +230,29 @@ impl<'a> EntryValidator<'a> {
 
         let safe_path = SafePath::validate_with_context(path, self.dest, self.config, &ctx)?;
 
-        if matches!(entry_type, EntryType::File) {
-            self.quota_tracker
-                .record_file(uncompressed_size, self.config)?;
-        }
-
-        if let Some(compressed) = compressed_size {
-            validate_compression_ratio(compressed, uncompressed_size, self.config)?;
-        }
-
         let (validated_type, sanitized_mode) = match entry_type {
             EntryType::File => {
+                let permit = self.quota_tracker.reserve(uncompressed_size, self.config)?;
+                self.check_ratio(compressed_size, uncompressed_size)?;
                 let sanitized = mode.map(|m| sanitize_permissions(m, self.config));
-                (ValidatedEntryType::File, sanitized)
+                (ValidatedEntryType::File(permit), sanitized)
             }
 
-            EntryType::Directory => (ValidatedEntryType::Directory, None),
+            EntryType::Directory => {
+                self.check_ratio(compressed_size, uncompressed_size)?;
+                (ValidatedEntryType::Directory, None)
+            }
 
             EntryType::Symlink { target } => {
+                self.check_ratio(compressed_size, uncompressed_size)?;
                 let safe_symlink = validate_symlink(&safe_path, target, self.dest, self.config)?;
                 self.symlink_seen = true;
                 (ValidatedEntryType::Symlink(safe_symlink), None)
             }
 
             EntryType::Hardlink { target } => {
+                self.check_ratio(compressed_size, uncompressed_size)?;
+
                 // Hardlink tracker validates: absolute paths, traversal, normalization, escapes
                 self.hardlink_tracker.validate_hardlink(
                     &safe_path,
@@ -272,7 +281,28 @@ impl<'a> EntryValidator<'a> {
         ))
     }
 
-    /// Records a hardlink's copied byte count against the shared quota tracker.
+    /// Validates the compression ratio (zip bomb detection) when a
+    /// compressed size is known.
+    ///
+    /// Extracted so [`validate_entry`](Self::validate_entry) can call it at
+    /// the exact ordering position each entry type requires relative to its
+    /// other checks, without duplicating the `if let Some(compressed) = ...`
+    /// pattern at every call site.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ArchiveError::ZipBomb`] if the compression ratio exceeds the
+    /// configured limit.
+    fn check_ratio(&self, compressed_size: Option<u64>, uncompressed_size: u64) -> Result<()> {
+        if let Some(compressed) = compressed_size {
+            validate_compression_ratio(compressed, uncompressed_size, self.config)?;
+        }
+        Ok(())
+    }
+
+    /// Reserves quota capacity for a hardlink's copied byte count against the
+    /// shared quota tracker, returning a capability token that proves the
+    /// reservation succeeded.
     ///
     /// Hardlinks are validated for path/target escape during the first pass
     /// (`validate_entry`), but their size is only known once the target file
@@ -285,8 +315,8 @@ impl<'a> EntryValidator<'a> {
     ///
     /// Returns [`ArchiveError::QuotaExceeded`] if recording this hardlink
     /// would exceed `max_file_size`, `max_file_count`, or `max_total_size`.
-    pub(crate) fn record_hardlink(&mut self, size: u64) -> Result<()> {
-        self.quota_tracker.record_file(size, self.config)
+    pub(crate) fn reserve_hardlink(&mut self, size: u64) -> Result<QuotaPermit> {
+        self.quota_tracker.reserve(size, self.config)
     }
 
     /// Finishes validation and returns a summary report.
@@ -359,7 +389,7 @@ mod tests {
         assert!(result.is_ok());
         let entry = result.unwrap();
         assert_eq!(entry.safe_path.as_path(), Path::new("file.txt"));
-        assert_matches!(entry.entry_type, ValidatedEntryType::File);
+        assert_matches!(entry.entry_type, ValidatedEntryType::File(_));
         assert_eq!(entry.mode, Some(0o644));
     }
 
@@ -809,7 +839,7 @@ mod tests {
     // Issue #426: hardlink quota bypass regression tests.
 
     #[test]
-    fn test_record_hardlink_exceeding_max_file_size_rejected() {
+    fn test_reserve_hardlink_exceeding_max_file_size_rejected() {
         let temp = TempDir::new().unwrap();
         let dest = DestDir::new(temp.path().to_path_buf()).unwrap();
         let mut config = SecurityConfig::default();
@@ -820,7 +850,7 @@ mod tests {
         // A single hardlink whose on-disk target size alone exceeds
         // max_file_size must be rejected, exactly like an oversized regular
         // file would be.
-        let result = validator.record_hardlink(1_000);
+        let result = validator.reserve_hardlink(1_000);
 
         assert_matches!(
             result,
@@ -832,7 +862,7 @@ mod tests {
     }
 
     #[test]
-    fn test_record_hardlink_shares_quota_tracker_with_files() {
+    fn test_reserve_hardlink_shares_quota_tracker_with_files() {
         let temp = TempDir::new().unwrap();
         let dest = DestDir::new(temp.path().to_path_buf()).unwrap();
         let mut config = SecurityConfig::default();
@@ -855,9 +885,9 @@ mod tests {
 
         // ...and a hardlink recorded afterwards must be charged against the
         // same tracker, not a separate/untracked counter.
-        assert!(validator.record_hardlink(100).is_ok());
+        assert!(validator.reserve_hardlink(100).is_ok());
 
-        let result = validator.record_hardlink(100);
+        let result = validator.reserve_hardlink(100);
         assert_matches!(
             result,
             Err(crate::ArchiveError::QuotaExceeded {
@@ -869,7 +899,7 @@ mod tests {
     }
 
     #[test]
-    fn test_record_hardlink_exceeding_max_file_count() {
+    fn test_reserve_hardlink_exceeding_max_file_count() {
         let temp = TempDir::new().unwrap();
         let dest = DestDir::new(temp.path().to_path_buf()).unwrap();
         let mut config = SecurityConfig::default();
@@ -877,10 +907,10 @@ mod tests {
         let config = config.validate().expect("valid config");
         let mut validator = EntryValidator::new(&config, &dest);
 
-        assert!(validator.record_hardlink(1).is_ok());
-        assert!(validator.record_hardlink(1).is_ok());
+        assert!(validator.reserve_hardlink(1).is_ok());
+        assert!(validator.reserve_hardlink(1).is_ok());
 
-        let result = validator.record_hardlink(1);
+        let result = validator.reserve_hardlink(1);
         assert_matches!(
             result,
             Err(crate::ArchiveError::QuotaExceeded {

--- a/crates/exarch-core/tests/property_tests.rs
+++ b/crates/exarch-core/tests/property_tests.rs
@@ -140,11 +140,11 @@ proptest! {
             if let Some(new_total) = expected_total.checked_add(size) {
                 expected_total = new_total;
                 expected_count += 1;
-                let result = tracker.record_file(size, &config);
+                let result = tracker.reserve(size, &config);
                 prop_assert!(result.is_ok(), "recording file should succeed when no overflow");
             } else {
                 // Overflow expected - tracker should detect it
-                let result = tracker.record_file(size, &config);
+                let result = tracker.reserve(size, &config);
                 prop_assert!(result.is_err(), "tracker should detect overflow");
                 break;
             }
@@ -169,7 +169,7 @@ proptest! {
 
         let mut success_count = 0;
         for _ in 0..num_files {
-            let result = tracker.record_file(100, &config);
+            let result = tracker.reserve(100, &config);
             if result.is_ok() {
                 success_count += 1;
             } else {
@@ -184,7 +184,7 @@ proptest! {
         );
 
         if num_files > max_files {
-            let result = tracker.record_file(100, &config);
+            let result = tracker.reserve(100, &config);
             prop_assert!(
                 matches!(result, Err(ArchiveError::QuotaExceeded { .. })),
                 "exceeding file count should fail"
@@ -210,7 +210,7 @@ proptest! {
         let config = config.validate().unwrap();
 
         for size in file_sizes {
-            let result = tracker.record_file(size, &config);
+            let result = tracker.reserve(size, &config);
 
             // Key security property: if quota would be exceeded, operation must fail
             if result.is_err() {
@@ -243,7 +243,7 @@ proptest! {
         config.max_file_count = usize::MAX;
         let config = config.validate().unwrap();
 
-        let result = tracker.record_file(file_size, &config);
+        let result = tracker.reserve(file_size, &config);
 
         if file_size <= max_file_size {
             prop_assert!(result.is_ok(), "file within size limit should succeed");
@@ -285,7 +285,7 @@ proptest! {
         }
 
         for size in file_sizes {
-            let result = tracker.record_file(size, &config);
+            let result = tracker.reserve(size, &config);
             if tracker.bytes_written().checked_add(size).is_some() {
                 prop_assert!(result.is_ok() || result.is_err(), "either succeeds or detects overflow");
             }

--- a/crates/exarch-core/tests/security/hardlink_quota_bypass.rs
+++ b/crates/exarch-core/tests/security/hardlink_quota_bypass.rs
@@ -8,10 +8,10 @@
 //! `max_file_size`, `max_file_count`, or `max_total_size` enforcement — a
 //! classic hardlink-bomb bypass of the same class as decompression bombs.
 //!
-//! The fix adds `EntryValidator::record_hardlink`, which charges each
+//! The fix adds `EntryValidator::reserve_hardlink`, which charges each
 //! hardlink's on-disk target size against the *same* `QuotaTracker` instance
-//! used for regular files, called before the parent-dir/duplicate checks and
-//! before `std::fs::copy` runs.
+//! used for regular files, called after the parent-dir/duplicate checks and
+//! before `common::copy_file_with_permit` runs.
 
 #![allow(clippy::unwrap_used, clippy::cast_possible_truncation)]
 

--- a/crates/exarch-core/tests/ui/quota_permit_forge_via_struct_literal.rs
+++ b/crates/exarch-core/tests/ui/quota_permit_forge_via_struct_literal.rs
@@ -1,0 +1,11 @@
+//! A `QuotaPermit` must not be assemblable from outside the crate via
+//! tuple-struct call syntax. Its single field is private, so
+//! `QuotaPermit(todo!())` cannot compile outside `exarch_core` — the only
+//! producer of a real `QuotaPermit` is `QuotaTracker::reserve`.
+
+use exarch_core::security::QuotaPermit;
+
+#[allow(unreachable_code)]
+fn main() {
+    let _permit = QuotaPermit(todo!());
+}

--- a/crates/exarch-core/tests/ui/quota_permit_forge_via_struct_literal.stderr
+++ b/crates/exarch-core/tests/ui/quota_permit_forge_via_struct_literal.stderr
@@ -1,0 +1,11 @@
+error[E0423]: cannot initialize a tuple struct which contains private fields
+  --> tests/ui/quota_permit_forge_via_struct_literal.rs:10:19
+   |
+10 |     let _permit = QuotaPermit(todo!());
+   |                   ^^^^^^^^^^^
+   |
+note: constructor is not visible here due to private fields
+  --> src/security/quota.rs
+   |
+   | pub struct QuotaPermit(PhantomData<()>);
+   |                        ^^^^^^^^^^^^^^^ private field

--- a/crates/exarch-core/tests/ui/validated_entry_forge_via_struct_literal.rs
+++ b/crates/exarch-core/tests/ui/validated_entry_forge_via_struct_literal.rs
@@ -5,13 +5,12 @@
 //! `EntryValidator::validate_entry`.
 
 use exarch_core::security::ValidatedEntry;
-use exarch_core::security::ValidatedEntryType;
 
 #[allow(unreachable_code)]
 fn main() {
     let _entry = ValidatedEntry {
         safe_path: todo!(),
-        entry_type: ValidatedEntryType::File,
+        entry_type: todo!(),
         mode: None,
     };
 }

--- a/crates/exarch-core/tests/ui/validated_entry_forge_via_struct_literal.stderr
+++ b/crates/exarch-core/tests/ui/validated_entry_forge_via_struct_literal.stderr
@@ -1,11 +1,11 @@
 error[E0451]: fields `safe_path`, `entry_type` and `mode` of struct `ValidatedEntry` are private
-  --> tests/ui/validated_entry_forge_via_struct_literal.rs:13:9
+  --> tests/ui/validated_entry_forge_via_struct_literal.rs:12:9
    |
-12 |     let _entry = ValidatedEntry {
+11 |     let _entry = ValidatedEntry {
    |                  -------------- in this type
-13 |         safe_path: todo!(),
+12 |         safe_path: todo!(),
    |         ^^^^^^^^^ private field
-14 |         entry_type: ValidatedEntryType::File,
+13 |         entry_type: todo!(),
    |         ^^^^^^^^^^ private field
-15 |         mode: None,
+14 |         mode: None,
    |         ^^^^ private field


### PR DESCRIPTION
## Summary

`QuotaTracker::record_file`/`record_hardlink` and the actual disk write (`fs::copy`, `io::copy`) were two separate calls linked only by a `// CRITICAL: Check quota BEFORE writing` comment and code review discipline across three independent call sites. This ordering has regressed in practice before — #428 was a hardlink extraction path writing bytes via `fs::copy` with zero quota tracking.

This PR replaces the comment-discipline convention with a compile-time capability token, `QuotaPermit`, following the same sealed-newtype idiom already used by `SafePath`/`SafeSymlink`/`DestDir` in this codebase.

## Changes

- `QuotaTracker::record_file` → `reserve`, returns `Result<QuotaPermit>` instead of `Result<()>`. `EntryValidator::record_hardlink` → `reserve_hardlink`, same treatment. Quota arithmetic, limits, and error conditions are byte-for-byte unchanged — only the name and return type changed.
- `ValidatedEntryType::File` now carries a `QuotaPermit` payload, minted exclusively inside `EntryValidator::validate_entry`. A `File`-typed validated entry with no quota charge is now unrepresentable.
- `extract_file_generic` (shared by TAR and ZIP) rejects any non-`File` entry before touching the filesystem — behavior-neutral, since every existing caller already passes a `File` entry.
- TAR's hardlink-copy path consumes its permit **by value** via a new `copy_file_with_permit` helper (replacing the bare `fs::copy`), so a single reservation cannot be spent twice.
- 7z's write path is pattern-updated to `File(_)` — it was already correctly gated behind the `File` arm; this PR does not add new structural enforcement there (see the `// TODO` comment left at the call site for a future follow-up extracting a shared `write_atomic(.., &QuotaPermit)` helper for parity with TAR/ZIP).

## Design process

This went through a full architect → critic → developer → (tester, security, impl-critic) → reviewer cycle, including one design revision after the critic caught that the issue's original premise didn't match the actual code (regular-file quota is charged upstream in `validate_entry`, not adjacent to the write; only the hardlink site had the reserve-then-write adjacency the issue described) and that a proposed lifetime-branding scheme to close a theoretical forgeability gap was unnecessary, since none of the permit-consuming call sites are reachable from outside the crate.

## Enforcement is asymmetric across formats (by design, noted so it isn't overclaimed)

- TAR hardlink path: compile-time, by-value consumption.
- TAR/ZIP regular files: runtime guard in `extract_file_generic` (unreachable in practice today, but now structural rather than a comment).
- 7z: unchanged pre-existing gate, no new enforcement in this PR.

## Testing

- New trybuild UI test (`quota_permit_forge_via_struct_literal.rs`) proving `QuotaPermit` cannot be constructed outside the crate.
- New unit test confirming `extract_file_generic` rejects a `Directory`-typed entry before any filesystem write.
- `tests/security/hardlink_quota_bypass.rs` (the #428 regression anchor) untouched in behavior, only doc/rename updates.
- Full check suite green: `cargo +nightly fmt --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo nextest run --workspace --all-features` (1054/1054), `cargo test --doc -p exarch-core --all-features` (101/101), rustdoc gate clean.

## Breaking changes

- `QuotaTracker::record_file` renamed to `reserve`, return type changed to `Result<QuotaPermit>`.
- `ValidatedEntryType::File` now carries a `QuotaPermit` payload.

Allowed pre-1.0 per project convention; documented in `CHANGELOG.md`.

Closes #436

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node`
- [x] `cargo test --doc --workspace --all-features` (scoped to exarch-core; workspace-wide doc-test run hits a pre-existing, unrelated exarch-python/pyo3 linking issue in this sandbox)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace`