### PR TITLE
fix(python): replace unconditional test skips with real assertions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,10 +218,18 @@ jobs:
     needs: [changes, format]
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # always() + explicit needs.format.result check is required here: a job
+    # with `needs: [format]` is skipped by GitHub Actions whenever `format`
+    # itself is skipped (e.g. on a Python-only PR, where rust == 'false'),
+    # regardless of what this job's own `if` says, unless always() overrides
+    # that default gating.
     if: |
-      needs.changes.outputs.python == 'true' ||
+      always() &&
+      needs.changes.result == 'success' &&
+      (needs.format.result == 'success' || needs.format.result == 'skipped') &&
+      (needs.changes.outputs.python == 'true' ||
       github.ref == 'refs/heads/main' ||
-      github.ref == 'refs/heads/develop'
+      github.ref == 'refs/heads/develop')
     strategy:
       fail-fast: false
       matrix:
@@ -310,9 +318,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     if: |
-      needs.changes.outputs.node == 'true' ||
+      always() &&
+      needs.changes.result == 'success' &&
+      (needs.format.result == 'success' || needs.format.result == 'skipped') &&
+      (needs.changes.outputs.node == 'true' ||
       github.ref == 'refs/heads/main' ||
-      github.ref == 'refs/heads/develop'
+      github.ref == 'refs/heads/develop')
     steps:
       - uses: actions/checkout@v7
 

--- a/crates/exarch-python/tests/README.md
+++ b/crates/exarch-python/tests/README.md
@@ -34,14 +34,15 @@ pytest -v tests/
 
 ## Test Status
 
-Currently, all tests are skipped with `pytest.skip()` because they require:
-
-1. The compiled Python extension module (`maturin develop`)
-2. Test fixture archives in `tests/fixtures/`
+Tests use `pytest.importorskip("exarch")` at module level, so they are skipped
+only when the compiled extension module isn't built yet (`maturin develop`)
+and run for real otherwise. Fixture archives are generated on the fly by
+fixtures in `conftest.py` (e.g. `sample_tar_gz`); malicious CVE-regression
+fixtures live in `tests/fixtures/` and are generated via
+`tests/fixtures/generate_fixtures.py`.
 
 ## TODO
 
-- [ ] Add test fixture archives (test.tar.gz, malicious.zip, etc.)
 - [ ] Integrate with CI pipeline
 - [ ] Add more comprehensive test cases
 - [ ] Add property-based tests with Hypothesis

--- a/crates/exarch-python/tests/test_extract_archive.py
+++ b/crates/exarch-python/tests/test_extract_archive.py
@@ -2,8 +2,8 @@
 
 import pytest
 
-# TODO: Import exarch module once the extension is built
-# from exarch import extract_archive, SecurityConfig
+pytest.importorskip("exarch")
+from exarch import SecurityConfig, SecurityViolationError, extract_archive  # noqa: E402
 
 
 class TestExtractArchive:
@@ -11,42 +11,39 @@ class TestExtractArchive:
 
     def test_path_validation_null_bytes(self):
         """Test path validation rejects null bytes."""
-        pytest.skip("Requires compiled Python extension module and test fixtures")
-        # with pytest.raises(ValueError, match="null bytes"):
-        #     extract_archive("test\x00.tar.gz", "/tmp/output")
+        with pytest.raises(SecurityViolationError, match="null bytes"):
+            extract_archive("test\x00.tar.gz", "/tmp/output")
 
     def test_path_validation_too_long(self):
         """Test path validation rejects overly long paths."""
-        pytest.skip("Requires compiled Python extension module")
-        # long_path = "x" * 5000
-        # with pytest.raises(ValueError, match="maximum length"):
-        #     extract_archive(long_path, "/tmp/output")
+        long_path = "x" * 5000
+        with pytest.raises(SecurityViolationError, match="maximum length"):
+            extract_archive(long_path, "/tmp/output")
 
-    def test_pathlib_support(self, temp_dir):
+    def test_pathlib_support(self, sample_tar_gz, temp_dir):
         """Test extraction with pathlib.Path objects."""
-        pytest.skip("Requires compiled Python extension module and test fixtures")
-        # archive = Path("tests/fixtures/test.tar.gz")
-        # output = temp_dir / "output"
-        # output.mkdir()
-        #
-        # report = extract_archive(archive, output)
-        # assert report.files_extracted > 0
+        output = temp_dir / "output"
+        output.mkdir()
 
-    def test_string_path_support(self, temp_dir):
+        report = extract_archive(sample_tar_gz, output)
+        assert report.files_extracted > 0
+
+    def test_string_path_support(self, sample_tar_gz, temp_dir):
         """Test extraction with string paths."""
-        pytest.skip("Requires compiled Python extension module and test fixtures")
-        # archive = "tests/fixtures/test.tar.gz"
-        # output = str(temp_dir / "output")
-        #
-        # report = extract_archive(archive, output)
-        # assert report.files_extracted > 0
+        archive = str(sample_tar_gz)
+        output_dir = temp_dir / "output"
+        output_dir.mkdir()
+        output = str(output_dir)
 
-    def test_custom_config(self, temp_dir):
+        report = extract_archive(archive, output)
+        assert report.files_extracted > 0
+
+    def test_custom_config(self, sample_tar_gz, temp_dir):
         """Test extraction with custom configuration."""
-        pytest.skip("Requires compiled Python extension module and test fixtures")
-        # config = SecurityConfig().max_file_size(100 * 1024 * 1024)
-        # archive = "tests/fixtures/test.tar.gz"
-        # output = str(temp_dir / "output")
-        #
-        # report = extract_archive(archive, output, config)
-        # assert report.files_extracted > 0
+        config = SecurityConfig().with_max_file_size(100 * 1024 * 1024)
+        output_dir = temp_dir / "output"
+        output_dir.mkdir()
+        output = str(output_dir)
+
+        report = extract_archive(sample_tar_gz, output, config)
+        assert report.files_extracted > 0

--- a/crates/exarch-python/tests/test_security_config.py
+++ b/crates/exarch-python/tests/test_security_config.py
@@ -2,8 +2,8 @@
 
 import pytest
 
-# TODO: Import exarch module once the extension is built
-# from exarch import SecurityConfig
+pytest.importorskip("exarch")
+from exarch import SecurityConfig  # noqa: E402
 
 
 class TestSecurityConfig:
@@ -11,143 +11,135 @@ class TestSecurityConfig:
 
     def test_default_values(self):
         """Test default configuration values."""
-        pytest.skip("Requires compiled Python extension module")
-        # config = SecurityConfig()
-        # assert config.max_file_size == 50 * 1024 * 1024
-        # assert config.max_total_size == 500 * 1024 * 1024
-        # assert config.max_compression_ratio == 100.0
-        # assert config.max_file_count == 10_000
-        # assert config.max_path_depth == 32
-        # assert config.preserve_permissions is False
-        # assert config.max_solid_block_memory == 512 * 1024 * 1024
+        config = SecurityConfig()
+        assert config.max_file_size == 50 * 1024 * 1024
+        assert config.max_total_size == 500 * 1024 * 1024
+        assert config.max_compression_ratio == 100.0
+        assert config.max_file_count == 10_000
+        assert config.max_path_depth == 32
+        assert config.preserve_permissions is False
+        assert config.max_solid_block_memory == 512 * 1024 * 1024
 
     def test_allow_getters_default_deny(self):
         """Test that allow_* getters return False by default (secure-by-default)."""
-        pytest.skip("Requires compiled Python extension module")
-        # config = SecurityConfig()
-        # assert config.allow_symlinks is False
-        # assert config.allow_hardlinks is False
-        # assert config.allow_absolute_paths is False
-        # assert config.allow_world_writable is False
-        # assert config.allow_solid_archives is False
+        config = SecurityConfig()
+        assert config.allow_symlinks is False
+        assert config.allow_hardlinks is False
+        assert config.allow_absolute_paths is False
+        assert config.allow_world_writable is False
+        assert config.allow_solid_archives is False
 
     def test_allow_getters_reflect_builder_state(self):
         """Test that allow_* getters return correct values after builder calls."""
-        pytest.skip("Requires compiled Python extension module")
-        # config = (SecurityConfig()
-        #     .with_allow_symlinks(True)
-        #     .with_allow_hardlinks(True)
-        #     .with_allow_absolute_paths(True)
-        #     .with_allow_world_writable(True)
-        #     .with_allow_solid_archives(True))
-        # assert config.allow_symlinks is True
-        # assert config.allow_hardlinks is True
-        # assert config.allow_absolute_paths is True
-        # assert config.allow_world_writable is True
-        # assert config.allow_solid_archives is True
+        config = (
+            SecurityConfig()
+            .with_allow_symlinks(True)
+            .with_allow_hardlinks(True)
+            .with_allow_absolute_paths(True)
+            .with_allow_world_writable(True)
+            .with_allow_solid_archives(True)
+        )
+        assert config.allow_symlinks is True
+        assert config.allow_hardlinks is True
+        assert config.allow_absolute_paths is True
+        assert config.allow_world_writable is True
+        assert config.allow_solid_archives is True
 
     def test_allow_getters_can_be_disabled(self):
         """Test that allow_* getters reflect False after explicit disable."""
-        pytest.skip("Requires compiled Python extension module")
-        # config = SecurityConfig().with_allow_symlinks(False)
-        # assert config.allow_symlinks is False
+        config = SecurityConfig().with_allow_symlinks(True).with_allow_symlinks(False)
+        assert config.allow_symlinks is False
 
     def test_permissive_allow_getters(self):
         """Test that SecurityConfig.permissive() returns True for all allow_* getters."""
-        pytest.skip("Requires compiled Python extension module")
-        # config = SecurityConfig.permissive()
-        # assert config.allow_symlinks is True
-        # assert config.allow_hardlinks is True
-        # assert config.allow_absolute_paths is True
-        # assert config.allow_world_writable is True
-        # assert config.allow_solid_archives is True
+        config = SecurityConfig.permissive()
+        assert config.allow_symlinks is True
+        assert config.allow_hardlinks is True
+        assert config.allow_absolute_paths is True
+        assert config.allow_world_writable is True
+        assert config.allow_solid_archives is True
 
     def test_numeric_property_getters_defaults(self):
         """Test that numeric property getters return correct default values."""
-        pytest.skip("Requires compiled Python extension module")
-        # config = SecurityConfig()
-        # assert config.max_file_size == 50 * 1024 * 1024
-        # assert config.max_total_size == 500 * 1024 * 1024
-        # assert config.max_compression_ratio == 100.0
-        # assert config.max_file_count == 10_000
-        # assert config.max_path_depth == 32
-        # assert config.preserve_permissions is False
-        # assert config.max_solid_block_memory == 512 * 1024 * 1024
+        config = SecurityConfig()
+        assert config.max_file_size == 50 * 1024 * 1024
+        assert config.max_total_size == 500 * 1024 * 1024
+        assert config.max_compression_ratio == 100.0
+        assert config.max_file_count == 10_000
+        assert config.max_path_depth == 32
+        assert config.preserve_permissions is False
+        assert config.max_solid_block_memory == 512 * 1024 * 1024
 
     def test_numeric_property_setters(self):
         """Test that numeric property setters update values correctly."""
-        pytest.skip("Requires compiled Python extension module")
-        # config = SecurityConfig()
-        # config.max_file_size = 100_000_000
-        # assert config.max_file_size == 100_000_000
-        # config.max_total_size = 2_000_000_000
-        # assert config.max_total_size == 2_000_000_000
-        # config.max_compression_ratio = 200.0
-        # assert config.max_compression_ratio == 200.0
-        # config.max_file_count = 20_000
-        # assert config.max_file_count == 20_000
-        # config.max_path_depth = 64
-        # assert config.max_path_depth == 64
-        # config.preserve_permissions = True
-        # assert config.preserve_permissions is True
-        # config.max_solid_block_memory = 256 * 1024 * 1024
-        # assert config.max_solid_block_memory == 256 * 1024 * 1024
+        config = SecurityConfig()
+        config.max_file_size = 100_000_000
+        assert config.max_file_size == 100_000_000
+        config.max_total_size = 2_000_000_000
+        assert config.max_total_size == 2_000_000_000
+        config.max_compression_ratio = 200.0
+        assert config.max_compression_ratio == 200.0
+        config.max_file_count = 20_000
+        assert config.max_file_count == 20_000
+        config.max_path_depth = 64
+        assert config.max_path_depth == 64
+        config.preserve_permissions = True
+        assert config.preserve_permissions is True
+        config.max_solid_block_memory = 256 * 1024 * 1024
+        assert config.max_solid_block_memory == 256 * 1024 * 1024
 
     def test_builder_pattern(self):
         """Test builder pattern method chaining."""
-        pytest.skip("Requires compiled Python extension module")
-        # config = (SecurityConfig()
-        #     .with_max_file_size(100_000_000)
-        #     .with_max_total_size(1_000_000_000)
-        #     .with_allow_symlinks(True))
-        # assert config.max_file_size == 100_000_000
-        # assert config.max_total_size == 1_000_000_000
-        # assert config.allow_symlinks is True
+        config = (
+            SecurityConfig()
+            .with_max_file_size(100_000_000)
+            .with_max_total_size(1_000_000_000)
+            .with_allow_symlinks(True)
+        )
+        assert config.max_file_size == 100_000_000
+        assert config.max_total_size == 1_000_000_000
+        assert config.allow_symlinks is True
 
     def test_permissive(self):
         """Test permissive configuration."""
-        pytest.skip("Requires compiled Python extension module")
-        # config = SecurityConfig.permissive()
-        # assert config.preserve_permissions is True
+        config = SecurityConfig.permissive()
+        assert config.preserve_permissions is True
 
     def test_repr(self):
         """Test string representation."""
-        pytest.skip("Requires compiled Python extension module")
-        # config = SecurityConfig()
-        # repr_str = repr(config)
-        # assert "SecurityConfig" in repr_str
-        # assert "max_file_size" in repr_str
+        config = SecurityConfig()
+        repr_str = repr(config)
+        assert "SecurityConfig" in repr_str
+        assert "max_file_size" in repr_str
 
     def test_compression_ratio_validation(self):
         """Test compression ratio validation."""
-        pytest.skip("Requires compiled Python extension module")
-        # config = SecurityConfig()
-        #
-        # # Should accept valid values
-        # config.with_max_compression_ratio(150.0)
-        #
-        # # Should reject invalid values
-        # with pytest.raises(ValueError):
-        #     config.with_max_compression_ratio(float('inf'))
-        #
-        # with pytest.raises(ValueError):
-        #     config.with_max_compression_ratio(float('nan'))
-        #
-        # with pytest.raises(ValueError):
-        #     config.with_max_compression_ratio(-10.0)
+        config = SecurityConfig()
+
+        # Should accept valid values
+        config.with_max_compression_ratio(150.0)
+
+        # Should reject invalid values
+        with pytest.raises(ValueError):
+            config.with_max_compression_ratio(float("inf"))
+
+        with pytest.raises(ValueError):
+            config.with_max_compression_ratio(float("nan"))
+
+        with pytest.raises(ValueError):
+            config.with_max_compression_ratio(-10.0)
 
     def test_extension_validation(self):
         """Test extension string validation."""
-        pytest.skip("Requires compiled Python extension module")
-        # config = SecurityConfig()
-        #
-        # # Should accept valid extension
-        # config.add_allowed_extension(".txt")
-        #
-        # # Should reject null bytes
-        # with pytest.raises(ValueError, match="null bytes"):
-        #     config.add_allowed_extension(".txt\x00")
-        #
-        # # Should reject overly long strings
-        # with pytest.raises(ValueError, match="maximum length"):
-        #     config.add_allowed_extension("x" * 300)
+        config = SecurityConfig()
+
+        # Should accept valid extension
+        config.add_allowed_extension(".txt")
+
+        # Should reject null bytes
+        with pytest.raises(ValueError, match="null bytes"):
+            config.add_allowed_extension(".txt\x00")
+
+        # Should reject overly long strings
+        with pytest.raises(ValueError, match="maximum length"):
+            config.add_allowed_extension("x" * 300)


### PR DESCRIPTION
## Summary

- `test_extract_archive.py` (5 tests) and `test_security_config.py` (12 tests) unconditionally called `pytest.skip(...)` in every test, with real assertions commented out — 17 tests reported as passing/skipped every CI run without exercising `extract_archive()` or `SecurityConfig` at all.
- Applied the same fix as issue #342/PR #344: `pytest.importorskip("exarch")` at module level plus the real assertions, uncommented and verified against current source.
- `test_extract_archive.py` needed two additional corrections beyond uncommenting: the fixture-based tests referenced a nonexistent `tests/fixtures/test.tar.gz` path (switched to the existing `sample_tar_gz`/`temp_dir` conftest fixtures), and the path-validation tests expected `ValueError` where the binding actually raises `SecurityViolationError`.
- Updated `tests/README.md`, which still documented the removed skip anti-pattern and stale TODOs.

## Test plan

- [x] `pytest tests/test_extract_archive.py tests/test_security_config.py -v` — 17/17 pass (no skips)
- [x] `pytest tests/ -v` — 44 passed, 1 pre-existing unrelated skip (`test_panic_safety.py`, gated on a Cargo feature)
- [x] `ruff format --check` / `ruff check` on changed files
- [x] Independently re-verified by a second pass (tester + adversarial critic), including confirming the `SecurityViolationError` exception-type change against `exarch-core`/`exarch-python` source and fixing a vacuous assertion (`test_allow_getters_can_be_disabled` originally asserted an already-default value)

Closes #441