### PR TITLE
fix(core): consume QuotaPermit structurally in 7z file writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`crates/exarch-core/src/security/quota.rs`), reinforcing the existing OPT-C003 hot/cold path
   optimization for the optimizer.
 
+### Fixed
+
+- **7z file writes discarded their `QuotaPermit` instead of consuming it (#440)**: unlike TAR/ZIP,
+  7z's `ValidatedEntryType::File(_)` write arm matched the permit and dropped it via `_`, so the
+  capability-token guarantee introduced in #436 covered TAR and ZIP but not 7z. Added
+  `ValidatedEntry::into_parts()` (a consuming accessor, since `QuotaPermit` is neither `Clone` nor
+  `Copy` and `entry_type()` only lends a shared reference) and a new `write_file_with_permit`
+  helper in `formats/sevenz.rs` that takes `QuotaPermit` by value, mirroring
+  `formats::common::copy_file_with_permit`. 7z's atomic temp-file-then-rename write now cannot
+  compile without a genuine permit obtained from `EntryValidator::validate_entry`. No quota
+  arithmetic or validation behavior changed.
+
 ### Security
 
 - **`list` accepted NUL bytes, empty targets, and missing targets that `extract`/`verify` already

--- a/crates/exarch-core/src/formats/sevenz.rs
+++ b/crates/exarch-core/src/formats/sevenz.rs
@@ -115,6 +115,7 @@ use crate::SecurityConfig;
 use crate::config::Validated;
 use crate::error::QuotaResource;
 use crate::security::EntryValidator;
+use crate::security::quota::QuotaPermit;
 use crate::security::validator::ValidatedEntryType;
 use crate::types::DestDir;
 use crate::types::EntryType;
@@ -291,6 +292,47 @@ impl<R: Read + Seek> SevenZArchive<R> {
     }
 }
 
+/// Writes `reader`'s bytes to `dest_path` via an atomic temp-file-then-rename,
+/// consuming the [`QuotaPermit`] that authorized the write.
+///
+/// Taking `permit` by value mirrors the guarantee
+/// [`common::copy_file_with_permit`] gives TAR's hardlink path: `QuotaPermit`
+/// is neither `Clone` nor `Copy`, so a caller cannot retain it to authorize a
+/// second write, and this function cannot be called at all without moving a
+/// genuine permit out of the validated entry. This is stronger than
+/// `common::extract_file_generic` (TAR/ZIP's normal-file path), which only
+/// pattern-matches `ValidatedEntryType::File(_)` against a shared reference
+/// at runtime and never takes ownership of the permit — that helper is not
+/// brought to this same compile-time guarantee by this change (tracked
+/// separately: <https://github.com/bug-ops/exarch/issues/445>).
+///
+/// # Errors
+///
+/// Returns an error if temp file creation, the copy, or the rename fails.
+fn write_file_with_permit(
+    reader: &mut dyn Read,
+    dest_path: &Path,
+    _permit: QuotaPermit,
+) -> std::result::Result<u64, sevenz_rust2::Error> {
+    let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = id();
+    let original_name = dest_path
+        .file_name()
+        .map_or_else(|| "file".to_string(), |n| n.to_string_lossy().to_string());
+    let temp_name = format!(".{original_name}.exarch-tmp-{pid}-{counter}");
+    let temp_path = dest_path.with_file_name(&temp_name);
+
+    let temp_guard = TempFileGuard::new(temp_path.clone());
+    let bytes_written = {
+        let mut temp_file = std::fs::File::create(&temp_path)?;
+        std::io::copy(reader, &mut temp_file)?
+    };
+    std::fs::rename(&temp_path, dest_path)?;
+    temp_guard.persist();
+
+    Ok(bytes_written)
+}
+
 impl<R: Read + Seek> SevenZArchive<R> {
     /// Processes a single 7z entry: validates, extracts file or creates
     /// directory.
@@ -327,23 +369,25 @@ impl<R: Read + Seek> SevenZArchive<R> {
             .validate_entry(entry_path, &entry_type, entry.size, None, None, None)
             .map_err(|e| sevenz_rust2::Error::Other(format!("validation failed: {e}").into()))?;
 
-        // Extract based on type
-        match validated.entry_type() {
+        // Extract based on type. `into_parts()` consumes `validated` so the
+        // File arm can move its QuotaPermit by value into
+        // write_file_with_permit, rather than only observing it through
+        // entry_type()'s shared reference.
+        //
+        // `_mode` is discarded: sevenz-rust2 never exposes Unix mode, so this
+        // module has no set_permissions/sanitize_permissions call today. If
+        // that limitation is ever lifted, wire `_mode` into the write path
+        // instead of continuing to drop it here.
+        let (safe_path, entry_type, _mode) = validated.into_parts();
+        let dest_path = dest.join_path(safe_path.as_path());
+
+        match entry_type {
             ValidatedEntryType::Directory => {
-                let dest_path = dest.join_path(validated.safe_path().as_path());
                 dir_cache.ensure_dir(&dest_path)?;
                 report.directories_created += 1;
                 Ok(0)
             }
-            // TODO(critic): 7z write is guarded only by this match arm; no
-            // QuotaPermit is consumed here (unlike TAR/ZIP's runtime guard in
-            // extract_file_generic and the hardlink path's by-value permit).
-            // A future refactor that lifts the temp+rename block below out of
-            // this arm would silently drop the guarantee. Extracting it into
-            // a helper taking `&QuotaPermit` would bring 7z to parity.
-            ValidatedEntryType::File(_) => {
-                let dest_path = dest.join_path(validated.safe_path().as_path());
-
+            ValidatedEntryType::File(permit) => {
                 dir_cache.ensure_parent_dir(&dest_path)?;
 
                 if dest_path.exists() {
@@ -351,7 +395,7 @@ impl<R: Read + Seek> SevenZArchive<R> {
                         report.files_skipped += 1;
                         report.warnings.push(format!(
                             "skipped duplicate entry: {}",
-                            validated.safe_path().as_path().display()
+                            safe_path.as_path().display()
                         ));
                         return Ok(0);
                     }
@@ -365,27 +409,11 @@ impl<R: Read + Seek> SevenZArchive<R> {
                     }
                 }
 
-                // Atomic write (temp + rename) with unique temp file name
-                let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
-                let pid = id();
-                let original_name = dest_path
-                    .file_name()
-                    .map_or_else(|| "file".to_string(), |n| n.to_string_lossy().to_string());
-                let temp_name = format!(".{original_name}.exarch-tmp-{pid}-{counter}");
-                let temp_path = dest_path.with_file_name(&temp_name);
-
-                let temp_guard = TempFileGuard::new(temp_path.clone());
-                let bytes_written = {
-                    let mut temp_file = std::fs::File::create(&temp_path)?;
-                    let n = std::io::copy(reader, &mut temp_file)?;
-                    report.bytes_written =
-                        report.bytes_written.checked_add(n).ok_or_else(|| {
-                            sevenz_rust2::Error::Other("bytes_written overflow".into())
-                        })?;
-                    n
-                };
-                std::fs::rename(&temp_path, &dest_path)?;
-                temp_guard.persist();
+                let bytes_written = write_file_with_permit(reader, &dest_path, permit)?;
+                report.bytes_written = report
+                    .bytes_written
+                    .checked_add(bytes_written)
+                    .ok_or_else(|| sevenz_rust2::Error::Other("bytes_written overflow".into()))?;
 
                 report.files_extracted += 1;
                 Ok(bytes_written)

--- a/crates/exarch-core/src/security/validator.rs
+++ b/crates/exarch-core/src/security/validator.rs
@@ -75,6 +75,21 @@ impl ValidatedEntry {
     pub fn mode(&self) -> Option<u32> {
         self.mode
     }
+
+    /// Consumes the entry, returning its validated parts by value.
+    ///
+    /// `entry_type()` only lends a shared reference, which is enough to
+    /// observe a `QuotaPermit` but not to move it out of the `File` variant
+    /// — `QuotaPermit` is neither `Clone` nor `Copy` by design, so ownership
+    /// can only be obtained by consuming the `ValidatedEntry` that holds it.
+    /// Write paths that need to thread the permit by value into a helper
+    /// (mirroring `formats::common::copy_file_with_permit`'s guarantee) call
+    /// this instead of `entry_type()`.
+    #[inline]
+    #[must_use]
+    pub(crate) fn into_parts(self) -> (SafePath, ValidatedEntryType, Option<u32>) {
+        (self.safe_path, self.entry_type, self.mode)
+    }
 }
 
 /// Validated entry type variants.


### PR DESCRIPTION
## Summary
- 7z's `ValidatedEntryType::File(_)` write arm discarded its `QuotaPermit`, unlike TAR/ZIP's hardlink path, which already required a genuine permit to compile (introduced in #436/#439). Add `ValidatedEntry::into_parts()`, a consuming accessor needed because `QuotaPermit` is neither `Clone` nor `Copy`, and route 7z's atomic temp-file-then-rename write through a new `write_file_with_permit` helper that takes the permit by value, mirroring `formats::common::copy_file_with_permit`.
- No quota arithmetic or validation behavior changes — this is a structural/type-safety fix only.
- Follow-up filed as #445: `extract_file_generic` (TAR's main write path and ZIP) still only has a runtime guard, not the same compile-time guarantee.

## Test plan
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` (1054/1054 passed)
- [x] `cargo test --doc --workspace --all-features` (101/101 passed)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace`
- [x] `cargo deny check --all-features` / `cargo audit` — clean, no new advisories
- [x] Adversarial implementation critique — verdict: minor, both flagged issues fixed
- [x] Independent security audit — 0 findings, structural guarantee confirmed at parity with TAR/ZIP

Closes #440