### PR TITLE
fix(node): require explicit bool for security-relevant setters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING: `exarch-node` boolean setters now take a mandatory `boolean` instead of an
+  optional one (#442)**: `SecurityConfig.setAllowSymlinks`, `setAllowHardlinks`,
+  `setAllowAbsolutePaths`, `setAllowWorldWritable`, `setAllowSolidArchives`,
+  `setPreservePermissions`; `CreationConfig.setPreservePermissions`, `setFollowSymlinks`,
+  `setIncludeHidden`; and `ExtractionOptions.withSkipDuplicates`, `withAtomic` no longer accept
+  `Option<bool>` resolved via `.unwrap_or(true)`. Previously, calling one of these setters with
+  zero arguments silently flipped the flag to the permissive `true` state instead of erroring,
+  violating this project's secure-by-default posture. Callers must now pass an explicit
+  `boolean`; omitting the argument is a compile-time TypeScript error and a runtime napi error
+  from plain JavaScript. Explicit `undefined` or `null` are rejected the same way, which also
+  catches the more realistic failure pattern of forwarding an optional property (e.g.
+  `cfg.setAllowSymlinks(userOpts.allowSymlinks)`) that was never actually set.
 - **BREAKING: `ValidatedEntryType::File` now carries a `QuotaPermit` capability token (#436)**:
   `QuotaTracker::record_file` is renamed to `reserve` and returns `Result<QuotaPermit>` instead
   of `Result<()>`; `EntryValidator::record_hardlink` is renamed to `reserve_hardlink` for the

--- a/crates/exarch-node/index.d.ts
+++ b/crates/exarch-node/index.d.ts
@@ -42,7 +42,7 @@ export declare class CreationConfig {
    *
    * Default: true.
    */
-  setPreservePermissions(preserve?: boolean | undefined | null): this
+  setPreservePermissions(preserve: boolean): this
   /**
    * Sets whether to follow symlinks when adding files.
    *
@@ -51,13 +51,13 @@ export declare class CreationConfig {
    * Security note: Following symlinks may include unintended files
    * from outside the source directory.
    */
-  setFollowSymlinks(follow?: boolean | undefined | null): this
+  setFollowSymlinks(follow: boolean): this
   /**
    * Sets whether to include hidden files (files starting with '.').
    *
    * Default: false.
    */
-  setIncludeHidden(include?: boolean | undefined | null): this
+  setIncludeHidden(include: boolean): this
   /**
    * Sets maximum size for a single file in bytes.
    *
@@ -122,7 +122,7 @@ export declare class ExtractionOptions {
    * When `true` (default), duplicate entries produce a warning in the
    * report. When `false`, a duplicate entry causes an error.
    */
-  withSkipDuplicates(skip?: boolean | undefined | null): this
+  withSkipDuplicates(skip: boolean): this
   /**
    * Sets whether extraction uses a temporary directory for atomic commits.
    *
@@ -136,7 +136,7 @@ export declare class ExtractionOptions {
    * output-already-exists error. Non-atomic mode extracts into an
    * existing directory without error.
    */
-  withAtomic(atomic?: boolean | undefined | null): this
+  withAtomic(atomic: boolean): this
   /** Finalizes the configuration (for API consistency). */
   build(): this
   /** Whether duplicate entries are skipped silently. */
@@ -212,13 +212,13 @@ export declare class SecurityConfig {
   /** Sets the maximum path depth. */
   setMaxPathDepth(depth: number): this
   /** Allows or denies symlinks. */
-  setAllowSymlinks(allow?: boolean | undefined | null): this
+  setAllowSymlinks(allow: boolean): this
   /** Allows or denies hardlinks. */
-  setAllowHardlinks(allow?: boolean | undefined | null): this
+  setAllowHardlinks(allow: boolean): this
   /** Allows or denies absolute paths. */
-  setAllowAbsolutePaths(allow?: boolean | undefined | null): this
+  setAllowAbsolutePaths(allow: boolean): this
   /** Allows or denies world-writable files. */
-  setAllowWorldWritable(allow?: boolean | undefined | null): this
+  setAllowWorldWritable(allow: boolean): this
   /**
    * Allows or denies solid 7z archives.
    *
@@ -226,7 +226,7 @@ export declare class SecurityConfig {
    * entry, which may allow a crafted archive to consume excessive
    * memory. Disabled by default.
    */
-  setAllowSolidArchives(allow?: boolean | undefined | null): this
+  setAllowSolidArchives(allow: boolean): this
   /**
    * Sets the maximum memory that may be used to decompress a solid 7z block.
    *
@@ -240,7 +240,7 @@ export declare class SecurityConfig {
    */
   setMaxSolidBlockMemory(size: number): this
   /** Sets whether to preserve permissions from archive. */
-  setPreservePermissions(preserve?: boolean | undefined | null): this
+  setPreservePermissions(preserve: boolean): this
   /**
    * Adds an allowed file extension.
    *

--- a/crates/exarch-node/src/config.rs
+++ b/crates/exarch-node/src/config.rs
@@ -134,29 +134,29 @@ impl SecurityConfig {
 
     /// Allows or denies symlinks.
     #[napi(js_name = "setAllowSymlinks")]
-    pub fn set_allow_symlinks(&mut self, allow: Option<bool>) -> &Self {
-        self.inner.allowed.symlinks = allow.unwrap_or(true);
+    pub fn set_allow_symlinks(&mut self, allow: bool) -> &Self {
+        self.inner.allowed.symlinks = allow;
         self
     }
 
     /// Allows or denies hardlinks.
     #[napi(js_name = "setAllowHardlinks")]
-    pub fn set_allow_hardlinks(&mut self, allow: Option<bool>) -> &Self {
-        self.inner.allowed.hardlinks = allow.unwrap_or(true);
+    pub fn set_allow_hardlinks(&mut self, allow: bool) -> &Self {
+        self.inner.allowed.hardlinks = allow;
         self
     }
 
     /// Allows or denies absolute paths.
     #[napi(js_name = "setAllowAbsolutePaths")]
-    pub fn set_allow_absolute_paths(&mut self, allow: Option<bool>) -> &Self {
-        self.inner.allowed.absolute_paths = allow.unwrap_or(true);
+    pub fn set_allow_absolute_paths(&mut self, allow: bool) -> &Self {
+        self.inner.allowed.absolute_paths = allow;
         self
     }
 
     /// Allows or denies world-writable files.
     #[napi(js_name = "setAllowWorldWritable")]
-    pub fn set_allow_world_writable(&mut self, allow: Option<bool>) -> &Self {
-        self.inner.allowed.world_writable = allow.unwrap_or(true);
+    pub fn set_allow_world_writable(&mut self, allow: bool) -> &Self {
+        self.inner.allowed.world_writable = allow;
         self
     }
 
@@ -166,8 +166,8 @@ impl SecurityConfig {
     /// entry, which may allow a crafted archive to consume excessive
     /// memory. Disabled by default.
     #[napi(js_name = "setAllowSolidArchives")]
-    pub fn set_allow_solid_archives(&mut self, allow: Option<bool>) -> &Self {
-        self.inner.allow_solid_archives = allow.unwrap_or(true);
+    pub fn set_allow_solid_archives(&mut self, allow: bool) -> &Self {
+        self.inner.allow_solid_archives = allow;
         self
     }
 
@@ -196,8 +196,8 @@ impl SecurityConfig {
 
     /// Sets whether to preserve permissions from archive.
     #[napi(js_name = "setPreservePermissions")]
-    pub fn set_preserve_permissions(&mut self, preserve: Option<bool>) -> &Self {
-        self.inner.preserve_permissions = preserve.unwrap_or(true);
+    pub fn set_preserve_permissions(&mut self, preserve: bool) -> &Self {
+        self.inner.preserve_permissions = preserve;
         self
     }
 
@@ -471,8 +471,8 @@ impl CreationConfig {
     ///
     /// Default: true.
     #[napi(js_name = "setPreservePermissions")]
-    pub fn set_preserve_permissions(&mut self, preserve: Option<bool>) -> &Self {
-        self.inner.preserve_permissions = preserve.unwrap_or(true);
+    pub fn set_preserve_permissions(&mut self, preserve: bool) -> &Self {
+        self.inner.preserve_permissions = preserve;
         self
     }
 
@@ -483,8 +483,8 @@ impl CreationConfig {
     /// Security note: Following symlinks may include unintended files
     /// from outside the source directory.
     #[napi(js_name = "setFollowSymlinks")]
-    pub fn set_follow_symlinks(&mut self, follow: Option<bool>) -> &Self {
-        self.inner.follow_symlinks = follow.unwrap_or(true);
+    pub fn set_follow_symlinks(&mut self, follow: bool) -> &Self {
+        self.inner.follow_symlinks = follow;
         self
     }
 
@@ -492,8 +492,8 @@ impl CreationConfig {
     ///
     /// Default: false.
     #[napi(js_name = "setIncludeHidden")]
-    pub fn set_include_hidden(&mut self, include: Option<bool>) -> &Self {
-        self.inner.include_hidden = include.unwrap_or(true);
+    pub fn set_include_hidden(&mut self, include: bool) -> &Self {
+        self.inner.include_hidden = include;
         self
     }
 
@@ -627,8 +627,8 @@ impl ExtractionOptions {
     /// When `true` (default), duplicate entries produce a warning in the
     /// report. When `false`, a duplicate entry causes an error.
     #[napi(js_name = "withSkipDuplicates")]
-    pub fn with_skip_duplicates(&mut self, skip: Option<bool>) -> &Self {
-        self.inner.skip_duplicates = skip.unwrap_or(true);
+    pub fn with_skip_duplicates(&mut self, skip: bool) -> &Self {
+        self.inner.skip_duplicates = skip;
         self
     }
 
@@ -644,8 +644,8 @@ impl ExtractionOptions {
     /// output-already-exists error. Non-atomic mode extracts into an
     /// existing directory without error.
     #[napi(js_name = "withAtomic")]
-    pub fn with_atomic(&mut self, atomic: Option<bool>) -> &Self {
-        self.inner.atomic = atomic.unwrap_or(true);
+    pub fn with_atomic(&mut self, atomic: bool) -> &Self {
+        self.inner.atomic = atomic;
         self
     }
 
@@ -922,7 +922,7 @@ mod tests {
         config.set_max_compression_ratio(250.0).unwrap();
         config.set_max_file_count(50_000);
         config.set_max_path_depth(64);
-        config.set_preserve_permissions(Some(true));
+        config.set_preserve_permissions(true);
 
         assert_eq!(
             config.get_max_file_size(),
@@ -964,7 +964,7 @@ mod tests {
         );
 
         let mut config = SecurityConfig::new();
-        config.set_allow_solid_archives(Some(true));
+        config.set_allow_solid_archives(true);
         assert!(
             config.get_allow_solid_archives(),
             "allow_solid_archives getter should reflect setter value"
@@ -1321,9 +1321,9 @@ mod tests {
     fn test_creation_config_builder() {
         let mut config = CreationConfig::new();
         config.set_compression_level(9).unwrap();
-        config.set_preserve_permissions(Some(false));
-        config.set_follow_symlinks(Some(true));
-        config.set_include_hidden(Some(true));
+        config.set_preserve_permissions(false);
+        config.set_follow_symlinks(true);
+        config.set_include_hidden(true);
         config.set_max_file_size(1_000_000).unwrap();
 
         assert_eq!(config.get_compression_level(), Some(9));

--- a/crates/exarch-node/tests/creation-config.test.js
+++ b/crates/exarch-node/tests/creation-config.test.js
@@ -40,6 +40,28 @@ describe('CreationConfig', () => {
       assert.strictEqual(config.preservePermissions, false);
     });
 
+    it('should set preserve permissions back to true', () => {
+      const config = new CreationConfig();
+      config.setPreservePermissions(false);
+      config.setPreservePermissions(true);
+
+      assert.strictEqual(config.preservePermissions, true);
+    });
+
+    it('should throw when setPreservePermissions is called with no argument, undefined, or null', () => {
+      const config = new CreationConfig();
+      config.setPreservePermissions(false);
+
+      assert.throws(() => config.setPreservePermissions());
+      assert.throws(() => config.setPreservePermissions(undefined));
+      assert.throws(() => config.setPreservePermissions(null));
+      assert.strictEqual(
+        config.preservePermissions,
+        false,
+        'a rejected call must not silently flip the flag'
+      );
+    });
+
     it('should set follow symlinks', () => {
       const config = new CreationConfig();
       config.setFollowSymlinks(true);
@@ -47,11 +69,55 @@ describe('CreationConfig', () => {
       assert.strictEqual(config.followSymlinks, true);
     });
 
+    it('should set follow symlinks back to false', () => {
+      const config = new CreationConfig();
+      config.setFollowSymlinks(true);
+      config.setFollowSymlinks(false);
+
+      assert.strictEqual(config.followSymlinks, false);
+    });
+
+    it('should throw when setFollowSymlinks is called with no argument, undefined, or null', () => {
+      const config = new CreationConfig();
+      config.setFollowSymlinks(true);
+
+      assert.throws(() => config.setFollowSymlinks());
+      assert.throws(() => config.setFollowSymlinks(undefined));
+      assert.throws(() => config.setFollowSymlinks(null));
+      assert.strictEqual(
+        config.followSymlinks,
+        true,
+        'a rejected call must not silently flip the flag'
+      );
+    });
+
     it('should set include hidden', () => {
       const config = new CreationConfig();
       config.setIncludeHidden(true);
 
       assert.strictEqual(config.includeHidden, true);
+    });
+
+    it('should set include hidden back to false', () => {
+      const config = new CreationConfig();
+      config.setIncludeHidden(true);
+      config.setIncludeHidden(false);
+
+      assert.strictEqual(config.includeHidden, false);
+    });
+
+    it('should throw when setIncludeHidden is called with no argument, undefined, or null', () => {
+      const config = new CreationConfig();
+      config.setIncludeHidden(true);
+
+      assert.throws(() => config.setIncludeHidden());
+      assert.throws(() => config.setIncludeHidden(undefined));
+      assert.throws(() => config.setIncludeHidden(null));
+      assert.strictEqual(
+        config.includeHidden,
+        true,
+        'a rejected call must not silently flip the flag'
+      );
     });
 
     it('should set max file size', () => {

--- a/crates/exarch-node/tests/extraction-options.test.js
+++ b/crates/exarch-node/tests/extraction-options.test.js
@@ -48,11 +48,17 @@ describe('ExtractionOptions', () => {
       assert.strictEqual(opts.skipDuplicates, true);
     });
 
-    it('should default to true when called with no argument', () => {
+    it('should throw when called with no argument, undefined, or null', () => {
       const opts = new ExtractionOptions();
       opts.withSkipDuplicates(false);
-      opts.withSkipDuplicates();
-      assert.strictEqual(opts.skipDuplicates, true);
+      assert.throws(() => opts.withSkipDuplicates());
+      assert.throws(() => opts.withSkipDuplicates(undefined));
+      assert.throws(() => opts.withSkipDuplicates(null));
+      assert.strictEqual(
+        opts.skipDuplicates,
+        false,
+        'a rejected call must not silently flip the flag'
+      );
     });
   });
 
@@ -74,6 +80,23 @@ describe('ExtractionOptions', () => {
       const opts = new ExtractionOptions();
       opts.withAtomic(true);
       assert.strictEqual(opts.atomic, true);
+    });
+
+    it('should set atomic back to false via withAtomic', () => {
+      const opts = new ExtractionOptions();
+      opts.withAtomic(true);
+      opts.withAtomic(false);
+      assert.strictEqual(opts.atomic, false);
+    });
+
+    it('should throw when withAtomic is called with no argument, undefined, or null', () => {
+      const opts = new ExtractionOptions();
+      opts.withAtomic(true);
+
+      assert.throws(() => opts.withAtomic());
+      assert.throws(() => opts.withAtomic(undefined));
+      assert.throws(() => opts.withAtomic(null));
+      assert.strictEqual(opts.atomic, true, 'a rejected call must not silently flip the flag');
     });
   });
 

--- a/crates/exarch-node/tests/security-config.test.js
+++ b/crates/exarch-node/tests/security-config.test.js
@@ -91,11 +91,55 @@ describe('SecurityConfig', () => {
       assert.strictEqual(config.allowSymlinks, true);
     });
 
+    it('should set allow symlinks back to false', () => {
+      const config = new SecurityConfig();
+      config.setAllowSymlinks(true);
+      config.setAllowSymlinks(false);
+
+      assert.strictEqual(config.allowSymlinks, false);
+    });
+
+    it('should throw when setAllowSymlinks is called with no argument, undefined, or null', () => {
+      const config = new SecurityConfig();
+      config.setAllowSymlinks(true);
+
+      assert.throws(() => config.setAllowSymlinks());
+      assert.throws(() => config.setAllowSymlinks(undefined));
+      assert.throws(() => config.setAllowSymlinks(null));
+      assert.strictEqual(
+        config.allowSymlinks,
+        true,
+        'a rejected call must not silently flip the flag'
+      );
+    });
+
     it('should set allow hardlinks', () => {
       const config = new SecurityConfig();
       config.setAllowHardlinks(true);
 
       assert.strictEqual(config.allowHardlinks, true);
+    });
+
+    it('should set allow hardlinks back to false', () => {
+      const config = new SecurityConfig();
+      config.setAllowHardlinks(true);
+      config.setAllowHardlinks(false);
+
+      assert.strictEqual(config.allowHardlinks, false);
+    });
+
+    it('should throw when setAllowHardlinks is called with no argument, undefined, or null', () => {
+      const config = new SecurityConfig();
+      config.setAllowHardlinks(true);
+
+      assert.throws(() => config.setAllowHardlinks());
+      assert.throws(() => config.setAllowHardlinks(undefined));
+      assert.throws(() => config.setAllowHardlinks(null));
+      assert.strictEqual(
+        config.allowHardlinks,
+        true,
+        'a rejected call must not silently flip the flag'
+      );
     });
 
     it('should set allow absolute paths', () => {
@@ -105,11 +149,55 @@ describe('SecurityConfig', () => {
       assert.strictEqual(config.allowAbsolutePaths, true);
     });
 
+    it('should set allow absolute paths back to false', () => {
+      const config = new SecurityConfig();
+      config.setAllowAbsolutePaths(true);
+      config.setAllowAbsolutePaths(false);
+
+      assert.strictEqual(config.allowAbsolutePaths, false);
+    });
+
+    it('should throw when setAllowAbsolutePaths is called with no argument, undefined, or null', () => {
+      const config = new SecurityConfig();
+      config.setAllowAbsolutePaths(true);
+
+      assert.throws(() => config.setAllowAbsolutePaths());
+      assert.throws(() => config.setAllowAbsolutePaths(undefined));
+      assert.throws(() => config.setAllowAbsolutePaths(null));
+      assert.strictEqual(
+        config.allowAbsolutePaths,
+        true,
+        'a rejected call must not silently flip the flag'
+      );
+    });
+
     it('should set allow world writable', () => {
       const config = new SecurityConfig();
       config.setAllowWorldWritable(true);
 
       assert.strictEqual(config.allowWorldWritable, true);
+    });
+
+    it('should set allow world writable back to false', () => {
+      const config = new SecurityConfig();
+      config.setAllowWorldWritable(true);
+      config.setAllowWorldWritable(false);
+
+      assert.strictEqual(config.allowWorldWritable, false);
+    });
+
+    it('should throw when setAllowWorldWritable is called with no argument, undefined, or null', () => {
+      const config = new SecurityConfig();
+      config.setAllowWorldWritable(true);
+
+      assert.throws(() => config.setAllowWorldWritable());
+      assert.throws(() => config.setAllowWorldWritable(undefined));
+      assert.throws(() => config.setAllowWorldWritable(null));
+      assert.strictEqual(
+        config.allowWorldWritable,
+        true,
+        'a rejected call must not silently flip the flag'
+      );
     });
 
     it('should default allowSolidArchives to false', () => {
@@ -125,11 +213,55 @@ describe('SecurityConfig', () => {
       assert.strictEqual(config.allowSolidArchives, true);
     });
 
+    it('should set allow solid archives back to false', () => {
+      const config = new SecurityConfig();
+      config.setAllowSolidArchives(true);
+      config.setAllowSolidArchives(false);
+
+      assert.strictEqual(config.allowSolidArchives, false);
+    });
+
+    it('should throw when setAllowSolidArchives is called with no argument, undefined, or null', () => {
+      const config = new SecurityConfig();
+      config.setAllowSolidArchives(true);
+
+      assert.throws(() => config.setAllowSolidArchives());
+      assert.throws(() => config.setAllowSolidArchives(undefined));
+      assert.throws(() => config.setAllowSolidArchives(null));
+      assert.strictEqual(
+        config.allowSolidArchives,
+        true,
+        'a rejected call must not silently flip the flag'
+      );
+    });
+
     it('should set preserve permissions', () => {
       const config = new SecurityConfig();
       config.setPreservePermissions(true);
 
       assert.strictEqual(config.preservePermissions, true);
+    });
+
+    it('should set preserve permissions back to false', () => {
+      const config = new SecurityConfig();
+      config.setPreservePermissions(true);
+      config.setPreservePermissions(false);
+
+      assert.strictEqual(config.preservePermissions, false);
+    });
+
+    it('should throw when setPreservePermissions is called with no argument, undefined, or null', () => {
+      const config = new SecurityConfig();
+      config.setPreservePermissions(true);
+
+      assert.throws(() => config.setPreservePermissions());
+      assert.throws(() => config.setPreservePermissions(undefined));
+      assert.throws(() => config.setPreservePermissions(null));
+      assert.strictEqual(
+        config.preservePermissions,
+        true,
+        'a rejected call must not silently flip the flag'
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

Eleven boolean setters on `SecurityConfig`, `CreationConfig`, and `ExtractionOptions` in `exarch-node` took `Option<bool>` and resolved a missing argument via `.unwrap_or(true)`. Because napi-rs maps `Option<bool>` to an optional JS/TS parameter, calling a setter with no argument (or an explicit `undefined`/`null`) silently flipped the flag to the permissive/insecure state instead of leaving the secure-by-default value unchanged.

This makes the parameter a mandatory `bool` on all eleven setters, matching the `exarch-python` binding's pattern. Omitting the argument, or passing `undefined`/`null`, is now a type error / runtime throw instead of a silent security downgrade.

- `SecurityConfig`: `setAllowSymlinks`, `setAllowHardlinks`, `setAllowAbsolutePaths`, `setAllowWorldWritable`, `setAllowSolidArchives`, `setPreservePermissions`
- `CreationConfig`: `setPreservePermissions`, `setFollowSymlinks`, `setIncludeHidden`
- `ExtractionOptions`: `setSkipDuplicates`, `setAtomic`

Regenerated `index.d.ts` so the generated TypeScript signatures reflect the mandatory parameter. Added regression tests for all eleven setters asserting that no-arg/`undefined`/`null` calls now throw and that the prior value is preserved (not silently mutated before the throw).

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` (1054/1054 passed)
- [x] `cargo test --doc --workspace --all-features --exclude exarch-python` (101/101 passed; exarch-python doc-tests skipped due to a pre-existing local pyo3 linker issue unrelated to this diff)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace`
- [x] `npm test` in `crates/exarch-node` (86/86 passed)
- [x] Live-verified via compiled napi binding that no coercion bypass exists: explicit `undefined`, `null`, `0`, `1`, `""`, `"false"`, `{}`, `NaN` all throw `BooleanExpected` rather than silently coercing to `true`

Closes #442