### PR TITLE
fix(core)!: enforce CreationConfig validation via typestate at compile time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   from plain JavaScript. Explicit `undefined` or `null` are rejected the same way, which also
   catches the more realistic failure pattern of forwarding an optional property (e.g.
   `cfg.setAllowSymlinks(userOpts.allowSymlinks)`) that was never actually set.
+- **BREAKING: `CreationConfig` is now a two-state typestate over `Unvalidated`/`Validated` (#443)**:
+  mirrors the `SecurityConfig` typestate from #433-#435. `CreationConfig<State = Unvalidated>`
+  carries a phantom marker (reusing the existing `Unvalidated`/`Validated` markers from
+  `crate::config`, not a new pair); the fluent `with_*` builders remain available only on
+  `CreationConfig<Unvalidated>`, and `CreationConfig::validate()` now consumes `self` and returns
+  `Result<CreationConfig<Validated>>` instead of `Result<()>`. The low-level
+  `creation::tar::*`/`creation::zip::*` functions and `FormatCreator::create` now require
+  `&CreationConfig<Validated>`, so a forged or unvalidated `compression_level` can no longer reach
+  `flate2`/`xz2`, closing a panic-based DoS: a hand-built `CreationConfig` with
+  `compression_level: Some(200)` previously bypassed the `InvalidCompressionLevel` contract
+  enforced only at the two high-level entry points and triggered an `assert!`/`unwrap()` panic
+  inside `flate2`'s `zlib-rs` backend and `xz2` respectively, instead of returning an error.
+  Fields are sealed behind a private inner `CreationConfigFields` struct
+  (`#[non_exhaustive]`), reachable read-only via `Deref` for both typestates but mutable
+  (`DerefMut`) only for `CreationConfig<Unvalidated>`. `creation::filters::should_skip` and
+  `creation::filters::compute_archive_path` also gained a `State` type parameter, so any external
+  caller invoking them with an explicit turbofish must update it. The top-level `create_archive*` functions
+  and `ArchiveCreator::create` are unaffected: they still accept `&CreationConfig`/`CreationConfig`
+  (defaulting to `Unvalidated`) and validate internally. `exarch-cli`, `exarch-python`, and
+  `exarch-node` need only the CLI's `create` command updated (it built a `CreationConfig` via
+  struct-literal syntax); both bindings mutate through `DerefMut` on `Unvalidated` and continue to
+  compile unchanged.
 - **BREAKING: `ValidatedEntryType::File` now carries a `QuotaPermit` capability token (#436)**:
   `QuotaTracker::record_file` is renamed to `reserve` and returns `Result<QuotaPermit>` instead
   of `Result<()>`; `EntryValidator::record_hardlink` is renamed to `reserve_hardlink` for the

--- a/crates/exarch-cli/src/commands/create.rs
+++ b/crates/exarch-cli/src/commands/create.rs
@@ -26,15 +26,17 @@ pub fn execute(args: &CreateArgs, formatter: &dyn OutputFormatter, quiet: bool) 
     }
 
     // Build config
-    let mut config = CreationConfig {
-        follow_symlinks: args.follow_symlinks,
-        include_hidden: args.include_hidden,
-        compression_level: args.compression_level,
-        strip_prefix: args.strip_prefix.clone(),
-        max_file_size: args.max_file_size,
-        preserve_permissions: args.preserve_permissions,
-        ..Default::default()
-    };
+    let mut config = CreationConfig::default()
+        .with_follow_symlinks(args.follow_symlinks)
+        .with_include_hidden(args.include_hidden)
+        .with_strip_prefix(args.strip_prefix.clone())
+        .with_max_file_size(args.max_file_size)
+        .with_preserve_permissions(args.preserve_permissions);
+    if let Some(level) = args.compression_level {
+        config = config
+            .with_compression_level(level)
+            .with_context(|| format!("invalid compression level: {level}"))?;
+    }
 
     // Add user exclude patterns to defaults
     config.exclude_patterns.extend(args.exclude.iter().cloned());

--- a/crates/exarch-core/benches/progress.rs
+++ b/crates/exarch-core/benches/progress.rs
@@ -81,7 +81,7 @@ fn benchmark_tar_with_noop_progress(c: &mut Criterion) {
     let source = TempDir::new().unwrap();
     create_test_directory(&source, 100, 1024); // 100 files, 1 KB each
 
-    let config = CreationConfig::default();
+    let config = CreationConfig::default().validate().unwrap();
 
     c.bench_function("tar_creation_noop_progress", |b| {
         b.iter(|| {
@@ -100,7 +100,7 @@ fn benchmark_tar_with_counting_progress(c: &mut Criterion) {
     let source = TempDir::new().unwrap();
     create_test_directory(&source, 100, 1024); // 100 files, 1 KB each
 
-    let config = CreationConfig::default();
+    let config = CreationConfig::default().validate().unwrap();
 
     c.bench_function("tar_creation_counting_progress", |b| {
         b.iter(|| {
@@ -137,7 +137,7 @@ fn benchmark_zip_with_noop_progress(c: &mut Criterion) {
     let source = TempDir::new().unwrap();
     create_test_directory(&source, 100, 1024); // 100 files, 1 KB each
 
-    let config = CreationConfig::default();
+    let config = CreationConfig::default().validate().unwrap();
 
     c.bench_function("zip_creation_noop_progress", |b| {
         b.iter(|| {
@@ -156,7 +156,7 @@ fn benchmark_zip_with_counting_progress(c: &mut Criterion) {
     let source = TempDir::new().unwrap();
     create_test_directory(&source, 100, 1024); // 100 files, 1 KB each
 
-    let config = CreationConfig::default();
+    let config = CreationConfig::default().validate().unwrap();
 
     c.bench_function("zip_creation_counting_progress", |b| {
         b.iter(|| {

--- a/crates/exarch-core/src/api.rs
+++ b/crates/exarch-core/src/api.rs
@@ -468,7 +468,8 @@ pub fn create_archive_with_progress<P: AsRef<Path>, Q: AsRef<Path>>(
     config: &CreationConfig,
     progress: &mut dyn ProgressCallback,
 ) -> Result<CreationReport> {
-    config.validate()?;
+    let config = config.clone().validate()?;
+    let config = &config;
 
     let output = output_path.as_ref();
 
@@ -625,7 +626,10 @@ fn reject_zip_family_creation(output: &Path) -> Result<()> {
 /// Uses extension-only detection; magic-byte detection is intentionally
 /// excluded so that a pre-existing output file with stale bytes cannot
 /// override the caller's intended format.
-fn determine_creation_format(output: &Path, config: &CreationConfig) -> Result<ArchiveType> {
+fn determine_creation_format<State>(
+    output: &Path,
+    config: &CreationConfig<State>,
+) -> Result<ArchiveType> {
     // If format explicitly set in config, use it
     if let Some(format) = config.format {
         return Ok(format);
@@ -752,20 +756,23 @@ mod tests {
 
     #[test]
     fn test_create_archive_invalid_compression_level_rejected_before_io() {
-        let dest = tempfile::TempDir::new().unwrap();
-        let archive_path = dest.path().join("output.tar.gz");
-        let config = CreationConfig {
-            compression_level: Some(15),
-            ..CreationConfig::default()
-        };
-        let result = create_archive(&archive_path, &[] as &[&str], &config);
-        assert_matches!(
-            result,
-            Err(ArchiveError::InvalidCompressionLevel { level: 15 }),
-            "expected InvalidCompressionLevel, got {result:?}",
-        );
-        // Verify no I/O happened — output file must not exist
-        assert!(!archive_path.exists(), "output file must not be created");
+        for ext in ["tar.gz", "tar.bz2", "tar.xz", "tar.zst"] {
+            let dest = tempfile::TempDir::new().unwrap();
+            let archive_path = dest.path().join(format!("output.{ext}"));
+            let mut config = CreationConfig::default();
+            config.compression_level = Some(200);
+            let result = create_archive(&archive_path, &[] as &[&str], &config);
+            assert_matches!(
+                result,
+                Err(ArchiveError::InvalidCompressionLevel { level: 200 }),
+                "{ext}: expected InvalidCompressionLevel, got {result:?}",
+            );
+            // Verify no I/O happened — output file must not exist
+            assert!(
+                !archive_path.exists(),
+                "{ext}: output file must not be created"
+            );
+        }
     }
 
     #[test]

--- a/crates/exarch-core/src/creation/compression.rs
+++ b/crates/exarch-core/src/creation/compression.rs
@@ -37,7 +37,7 @@ pub fn compression_level_to_flate2(level: Option<u8>) -> flate2::Compression {
         None | Some(6) => flate2::Compression::default(),
         Some(1..=3) => flate2::Compression::fast(),
         Some(7..=9) => flate2::Compression::best(),
-        Some(n) => flate2::Compression::new(u32::from(n)),
+        Some(n) => flate2::Compression::new(u32::from(n.min(9))),
     }
 }
 
@@ -75,7 +75,7 @@ pub fn compression_level_to_bzip2(level: Option<u8>) -> bzip2::Compression {
 /// # Mapping
 ///
 /// - `None` or `Some(6)`: Level 6 (default)
-/// - Other values: Literal level (0-9 range supported by xz)
+/// - Other values: Literal level (clamped to valid range 0-9)
 ///
 /// # Examples
 ///
@@ -90,7 +90,7 @@ pub fn compression_level_to_bzip2(level: Option<u8>) -> bzip2::Compression {
 pub fn compression_level_to_xz(level: Option<u8>) -> u32 {
     match level {
         None | Some(6) => 6,
-        Some(n) => u32::from(n),
+        Some(n) => u32::from(n.min(9)),
     }
 }
 
@@ -184,6 +184,15 @@ mod tests {
         assert_eq!(level, flate2::Compression::new(5));
     }
 
+    /// Regression test for #443: defense-in-depth clamping so this
+    /// primitive cannot panic even if called directly with an unvalidated
+    /// value, independent of the `CreationConfig` typestate guarantee.
+    #[test]
+    fn test_compression_level_to_flate2_out_of_range_does_not_panic() {
+        let level = compression_level_to_flate2(Some(200));
+        assert_eq!(level, flate2::Compression::new(9));
+    }
+
     #[test]
     fn test_compression_level_to_bzip2() {
         // Default
@@ -209,6 +218,14 @@ mod tests {
         assert_eq!(compression_level_to_xz(Some(6)), 6);
         assert_eq!(compression_level_to_xz(Some(1)), 1);
         assert_eq!(compression_level_to_xz(Some(9)), 9);
+    }
+
+    /// Regression test for #443: defense-in-depth clamping so this
+    /// primitive cannot panic even if called directly with an unvalidated
+    /// value, independent of the `CreationConfig` typestate guarantee.
+    #[test]
+    fn test_compression_level_to_xz_out_of_range_does_not_panic() {
+        assert_eq!(compression_level_to_xz(Some(200)), 9);
     }
 
     #[test]

--- a/crates/exarch-core/src/creation/config.rs
+++ b/crates/exarch-core/src/creation/config.rs
@@ -2,32 +2,25 @@
 
 use crate::ArchiveError;
 use crate::Result;
+use crate::config::Unvalidated;
+use crate::config::Validated;
 use crate::formats::detect::ArchiveType;
+use std::marker::PhantomData;
+use std::ops::Deref;
+use std::ops::DerefMut;
 use std::path::PathBuf;
 
-/// Configuration for archive creation operations.
+/// The field data of a [`CreationConfig`], reachable via [`Deref`]/[`DerefMut`]
+/// regardless of (or gated by) validation state.
 ///
-/// Controls how archives are created from filesystem sources, including
-/// security options, compression settings, and file filtering.
-///
-/// # Examples
-///
-/// ```
-/// use exarch_core::creation::CreationConfig;
-///
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// // Use secure defaults
-/// let config = CreationConfig::default();
-///
-/// // Customize for specific needs
-/// let custom = CreationConfig::default()
-///     .with_follow_symlinks(true)
-///     .with_compression_level(9)?;
-/// # Ok(())
-/// # }
-/// ```
+/// Mirrors [`SecurityConfigFields`](crate::config::SecurityConfigFields): a
+/// plain `#[non_exhaustive]` data bag that blocks external struct-literal
+/// forging, while [`CreationConfig`]'s own private `fields` member blocks
+/// re-wrapping a mutated bag into a `Validated` config. See that type's docs
+/// for the full rationale — the same sealing boundary applies here.
 #[derive(Debug, Clone)]
-pub struct CreationConfig {
+#[non_exhaustive]
+pub struct CreationConfigFields {
     /// Follow symlinks when adding files to archive.
     ///
     /// Default: `false` (store symlinks as symlinks).
@@ -87,18 +80,7 @@ pub struct CreationConfig {
     pub format: Option<ArchiveType>,
 }
 
-impl Default for CreationConfig {
-    /// Creates a `CreationConfig` with secure default settings.
-    ///
-    /// Default values:
-    /// - `follow_symlinks`: `false`
-    /// - `include_hidden`: `false`
-    /// - `max_file_size`: `None`
-    /// - `exclude_patterns`: `[".git", ".DS_Store", "*.tmp"]`
-    /// - `strip_prefix`: `None`
-    /// - `compression_level`: `Some(6)`
-    /// - `preserve_permissions`: `true`
-    /// - `format`: `None`
+impl Default for CreationConfigFields {
     fn default() -> Self {
         Self {
             follow_symlinks: false,
@@ -117,7 +99,97 @@ impl Default for CreationConfig {
     }
 }
 
-impl CreationConfig {
+/// Configuration for archive creation operations.
+///
+/// Controls how archives are created from filesystem sources, including
+/// security options, compression settings, and file filtering.
+///
+/// # Examples
+///
+/// ```
+/// use exarch_core::creation::CreationConfig;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// // Use secure defaults
+/// let config = CreationConfig::default();
+///
+/// // Customize for specific needs
+/// let custom = CreationConfig::default()
+///     .with_follow_symlinks(true)
+///     .with_compression_level(9)?;
+/// # Ok(())
+/// # }
+/// ```
+///
+/// # Typestate
+///
+/// `CreationConfig` carries a phantom `State` type parameter —
+/// [`Unvalidated`] (the default) or [`Validated`] — that tracks whether
+/// [`validate`](CreationConfig::validate) has been called. Builder methods
+/// are only available in the `Unvalidated` state; the low-level
+/// `creation::tar::*` / `creation::zip::*` functions and
+/// [`FormatCreator::create`](crate::formats::traits::FormatCreator::create)
+/// require `CreationConfig<Validated>`. This makes skipping validation a
+/// compile error instead of a runtime gap — a forged or hand-mutated
+/// `compression_level` can no longer reach the `flate2`/`xz2` backends,
+/// which panic on out-of-range values instead of returning an error.
+///
+/// # Sealing
+///
+/// Fields are private and reachable only through
+/// <code>[Deref]<Target = [CreationConfigFields]></code>, so
+/// `config.compression_level` continues to work as plain field access for
+/// both states. [`DerefMut`] is implemented only for
+/// `CreationConfig<Unvalidated>`, so a `CreationConfig<Validated>`'s fields
+/// cannot be reassigned after the fact — the only way to produce one is
+/// [`validate`](CreationConfig::validate) itself, and it stays that way for
+/// its entire lifetime.
+#[derive(Debug, Clone)]
+pub struct CreationConfig<State = Unvalidated> {
+    fields: CreationConfigFields,
+
+    /// Typestate marker — see the "Typestate" section on the type-level docs.
+    _marker: PhantomData<State>,
+}
+
+impl<State> Deref for CreationConfig<State> {
+    type Target = CreationConfigFields;
+
+    fn deref(&self) -> &CreationConfigFields {
+        &self.fields
+    }
+}
+
+/// Only `Unvalidated` configs are mutable — see the "Sealing" section on
+/// [`CreationConfig`]'s type-level docs for why this is the crux of the
+/// typestate guarantee.
+impl DerefMut for CreationConfig<Unvalidated> {
+    fn deref_mut(&mut self) -> &mut CreationConfigFields {
+        &mut self.fields
+    }
+}
+
+impl Default for CreationConfig<Unvalidated> {
+    /// Creates a `CreationConfig` with secure default settings.
+    ///
+    /// Default values:
+    /// - `follow_symlinks`: `false`
+    /// - `include_hidden`: `false`
+    /// - `max_file_size`: `None`
+    /// - `exclude_patterns`: `[".git", ".DS_Store", "*.tmp"]`
+    /// - `strip_prefix`: `None`
+    /// - `compression_level`: `Some(6)`
+    /// - `preserve_permissions`: `true`
+    /// - `format`: `None`
+    fn default() -> Self {
+        Self {
+            fields: CreationConfigFields::default(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl CreationConfig<Unvalidated> {
     /// Creates a new `CreationConfig` with default settings.
     #[must_use]
     pub fn new() -> Self {
@@ -125,37 +197,83 @@ impl CreationConfig {
     }
 
     /// Sets whether to follow symlinks.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exarch_core::creation::CreationConfig;
+    ///
+    /// let config = CreationConfig::default().with_follow_symlinks(true);
+    /// assert!(config.follow_symlinks);
+    /// ```
     #[must_use]
     pub fn with_follow_symlinks(mut self, follow: bool) -> Self {
-        self.follow_symlinks = follow;
+        self.fields.follow_symlinks = follow;
         self
     }
 
     /// Sets whether to include hidden files.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exarch_core::creation::CreationConfig;
+    ///
+    /// let config = CreationConfig::default().with_include_hidden(true);
+    /// assert!(config.include_hidden);
+    /// ```
     #[must_use]
     pub fn with_include_hidden(mut self, include: bool) -> Self {
-        self.include_hidden = include;
+        self.fields.include_hidden = include;
         self
     }
 
     /// Sets the maximum file size.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exarch_core::creation::CreationConfig;
+    ///
+    /// let config = CreationConfig::default().with_max_file_size(Some(1024 * 1024));
+    /// assert_eq!(config.max_file_size, Some(1024 * 1024));
+    /// ```
     #[must_use]
     pub fn with_max_file_size(mut self, max_size: Option<u64>) -> Self {
-        self.max_file_size = max_size;
+        self.fields.max_file_size = max_size;
         self
     }
 
     /// Sets the exclude patterns.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exarch_core::creation::CreationConfig;
+    ///
+    /// let config = CreationConfig::default().with_exclude_patterns(vec!["*.log".to_string()]);
+    /// assert_eq!(config.exclude_patterns, vec!["*.log".to_string()]);
+    /// ```
     #[must_use]
     pub fn with_exclude_patterns(mut self, patterns: Vec<String>) -> Self {
-        self.exclude_patterns = patterns;
+        self.fields.exclude_patterns = patterns;
         self
     }
 
     /// Sets the strip prefix.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exarch_core::creation::CreationConfig;
+    /// use std::path::PathBuf;
+    ///
+    /// let config = CreationConfig::default().with_strip_prefix(Some(PathBuf::from("/base")));
+    /// assert_eq!(config.strip_prefix, Some(PathBuf::from("/base")));
+    /// ```
     #[must_use]
     pub fn with_strip_prefix(mut self, prefix: Option<PathBuf>) -> Self {
-        self.strip_prefix = prefix;
+        self.fields.strip_prefix = prefix;
         self
     }
 
@@ -165,41 +283,91 @@ impl CreationConfig {
     ///
     /// Returns [`ArchiveError::InvalidCompressionLevel`] if `level` is not
     /// in the range 1–9.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exarch_core::creation::CreationConfig;
+    ///
+    /// let config = CreationConfig::default().with_compression_level(9)?;
+    /// assert_eq!(config.compression_level, Some(9));
+    /// # Ok::<(), exarch_core::ArchiveError>(())
+    /// ```
     pub fn with_compression_level(mut self, level: u8) -> Result<Self> {
         if !(1..=9).contains(&level) {
             return Err(ArchiveError::InvalidCompressionLevel { level });
         }
-        self.compression_level = Some(level);
+        self.fields.compression_level = Some(level);
         Ok(self)
     }
 
     /// Sets whether to preserve permissions.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exarch_core::creation::CreationConfig;
+    ///
+    /// let config = CreationConfig::default().with_preserve_permissions(false);
+    /// assert!(!config.preserve_permissions);
+    /// ```
     #[must_use]
     pub fn with_preserve_permissions(mut self, preserve: bool) -> Self {
-        self.preserve_permissions = preserve;
+        self.fields.preserve_permissions = preserve;
         self
     }
 
     /// Sets the archive format.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exarch_core::creation::CreationConfig;
+    /// use exarch_core::formats::detect::ArchiveType;
+    ///
+    /// let config = CreationConfig::default().with_format(Some(ArchiveType::TarGz));
+    /// assert_eq!(config.format, Some(ArchiveType::TarGz));
+    /// ```
     #[must_use]
     pub fn with_format(mut self, format: Option<ArchiveType>) -> Self {
-        self.format = format;
+        self.fields.format = format;
         self
     }
 
-    /// Validates the configuration.
+    /// Validates the configuration, transitioning to the [`Validated`]
+    /// typestate on success.
+    ///
+    /// Consumes `self`: the only way to obtain a `CreationConfig<Validated>`,
+    /// which is what the low-level `creation::tar::*` / `creation::zip::*`
+    /// functions and
+    /// [`FormatCreator::create`](crate::formats::traits::FormatCreator::create)
+    /// require. Once returned, the `Validated` config's fields can no longer
+    /// be reassigned (see the "Sealing" section on the type-level docs), so
+    /// this check can never be silently invalidated afterward.
     ///
     /// # Errors
     ///
-    /// Returns an error if:
-    /// - Compression level is set but not in range 1-9
-    pub fn validate(&self) -> Result<()> {
-        if let Some(level) = self.compression_level
+    /// Returns [`ArchiveError::InvalidCompressionLevel`] if `compression_level`
+    /// is set but not in the range 1–9.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exarch_core::creation::CreationConfig;
+    ///
+    /// let config = CreationConfig::default();
+    /// assert!(config.validate().is_ok());
+    /// ```
+    pub fn validate(self) -> Result<CreationConfig<Validated>> {
+        if let Some(level) = self.fields.compression_level
             && !(1..=9).contains(&level)
         {
             return Err(ArchiveError::InvalidCompressionLevel { level });
         }
-        Ok(())
+        Ok(CreationConfig {
+            fields: self.fields,
+            _marker: PhantomData,
+        })
     }
 }
 
@@ -249,7 +417,7 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::unwrap_used)]
+    #[allow(clippy::unwrap_used, clippy::field_reassign_with_default)]
     fn test_creation_config_validate_valid() {
         let config = CreationConfig::default();
         assert!(config.validate().is_ok());
@@ -260,20 +428,16 @@ mod tests {
         let config = CreationConfig::default().with_compression_level(9).unwrap();
         assert!(config.validate().is_ok());
 
-        let config = CreationConfig {
-            compression_level: None,
-            ..Default::default()
-        };
+        let mut config = CreationConfig::default();
+        config.compression_level = None;
         assert!(config.validate().is_ok());
     }
 
     #[test]
-    #[allow(clippy::unwrap_used)]
+    #[allow(clippy::unwrap_used, clippy::field_reassign_with_default)]
     fn test_creation_config_validate_invalid() {
-        let config = CreationConfig {
-            compression_level: Some(0),
-            ..Default::default()
-        };
+        let mut config = CreationConfig::default();
+        config.compression_level = Some(0);
         let result = config.validate();
         assert!(result.is_err());
         assert_matches!(
@@ -281,10 +445,8 @@ mod tests {
             ArchiveError::InvalidCompressionLevel { level: 0 }
         );
 
-        let config = CreationConfig {
-            compression_level: Some(10),
-            ..Default::default()
-        };
+        let mut config = CreationConfig::default();
+        config.compression_level = Some(10);
         let result = config.validate();
         assert!(result.is_err());
         assert_matches!(
@@ -332,6 +494,23 @@ mod tests {
         assert!(
             config.exclude_patterns.contains(&".git".to_string()),
             "should exclude .git by default"
+        );
+    }
+
+    /// Regression test for #443: a validated config must not let levels
+    /// 10-255 reach the `flate2`/`xz2` backends, which panic (rather than
+    /// error) on out-of-range values. `validate()` is the only path to
+    /// `CreationConfig<Validated>`, and it rejects out-of-range levels
+    /// regardless of how `compression_level` was set.
+    #[test]
+    #[allow(clippy::field_reassign_with_default)]
+    fn test_validate_rejects_forged_out_of_range_compression_level() {
+        let mut config = CreationConfig::default();
+        config.compression_level = Some(200);
+        let result = config.validate();
+        assert_matches!(
+            result,
+            Err(ArchiveError::InvalidCompressionLevel { level: 200 })
         );
     }
 }

--- a/crates/exarch-core/src/creation/creator.rs
+++ b/crates/exarch-core/src/creation/creator.rs
@@ -267,9 +267,7 @@ impl ArchiveCreator {
             });
         }
 
-        // Validate configuration
-        self.config.validate()?;
-
+        // Configuration is validated inside `create_archive`.
         crate::api::create_archive(&output_path, &self.sources, &self.config)
     }
 }

--- a/crates/exarch-core/src/creation/filters.rs
+++ b/crates/exarch-core/src/creation/filters.rs
@@ -31,7 +31,7 @@ use std::path::PathBuf;
 /// assert!(!filters::should_skip(normal_file, &config));
 /// ```
 #[must_use]
-pub fn should_skip(path: &Path, config: &CreationConfig) -> bool {
+pub fn should_skip<State>(path: &Path, config: &CreationConfig<State>) -> bool {
     // Skip hidden files unless configured to include them
     if !config.include_hidden && is_hidden(path) {
         return true;
@@ -164,10 +164,10 @@ fn pattern_matches(s: &str, pattern: &str) -> bool {
 /// let archive_path = filters::compute_archive_path(source, root, &config).unwrap();
 /// assert_eq!(archive_path, Path::new("src/main.rs"));
 /// ```
-pub fn compute_archive_path(
+pub fn compute_archive_path<State>(
     source_path: &Path,
     root: &Path,
-    config: &CreationConfig,
+    config: &CreationConfig<State>,
 ) -> Result<PathBuf> {
     // Compute relative path from root
     let relative = source_path

--- a/crates/exarch-core/src/creation/tar.rs
+++ b/crates/exarch-core/src/creation/tar.rs
@@ -5,6 +5,7 @@
 
 use crate::ProgressCallback;
 use crate::Result;
+use crate::config::Validated;
 use crate::creation::compression::compression_level_to_bzip2;
 use crate::creation::compression::compression_level_to_flate2;
 use crate::creation::compression::compression_level_to_xz;
@@ -76,7 +77,7 @@ use tar::Header;
 ///     }
 /// }
 ///
-/// let config = CreationConfig::default();
+/// let config = CreationConfig::default().validate()?;
 /// let mut progress = SimpleProgress;
 /// let report = create_tar_with_progress(
 ///     Path::new("output.tar"),
@@ -97,7 +98,7 @@ use tar::Header;
 pub fn create_tar_with_progress<P: AsRef<Path>, Q: AsRef<Path>>(
     output: P,
     sources: &[Q],
-    config: &CreationConfig,
+    config: &CreationConfig<Validated>,
     progress: &mut dyn ProgressCallback,
 ) -> Result<CreationReport> {
     let file = File::create(output.as_ref())?;
@@ -120,7 +121,7 @@ pub fn create_tar_with_progress<P: AsRef<Path>, Q: AsRef<Path>>(
 pub fn create_tar_gz_with_progress<P: AsRef<Path>, Q: AsRef<Path>>(
     output: P,
     sources: &[Q],
-    config: &CreationConfig,
+    config: &CreationConfig<Validated>,
     progress: &mut dyn ProgressCallback,
 ) -> Result<CreationReport> {
     let file = File::create(output.as_ref())?;
@@ -146,7 +147,7 @@ pub fn create_tar_gz_with_progress<P: AsRef<Path>, Q: AsRef<Path>>(
 pub fn create_tar_bz2_with_progress<P: AsRef<Path>, Q: AsRef<Path>>(
     output: P,
     sources: &[Q],
-    config: &CreationConfig,
+    config: &CreationConfig<Validated>,
     progress: &mut dyn ProgressCallback,
 ) -> Result<CreationReport> {
     let file = File::create(output.as_ref())?;
@@ -172,7 +173,7 @@ pub fn create_tar_bz2_with_progress<P: AsRef<Path>, Q: AsRef<Path>>(
 pub fn create_tar_xz_with_progress<P: AsRef<Path>, Q: AsRef<Path>>(
     output: P,
     sources: &[Q],
-    config: &CreationConfig,
+    config: &CreationConfig<Validated>,
     progress: &mut dyn ProgressCallback,
 ) -> Result<CreationReport> {
     let file = File::create(output.as_ref())?;
@@ -198,7 +199,7 @@ pub fn create_tar_xz_with_progress<P: AsRef<Path>, Q: AsRef<Path>>(
 pub fn create_tar_zst_with_progress<P: AsRef<Path>, Q: AsRef<Path>>(
     output: P,
     sources: &[Q],
-    config: &CreationConfig,
+    config: &CreationConfig<Validated>,
     progress: &mut dyn ProgressCallback,
 ) -> Result<CreationReport> {
     let file = File::create(output.as_ref())?;
@@ -221,7 +222,7 @@ pub fn create_tar_zst_with_progress<P: AsRef<Path>, Q: AsRef<Path>>(
 fn create_tar_internal_with_progress<W: Write, P: AsRef<Path>>(
     writer: W,
     sources: &[P],
-    config: &CreationConfig,
+    config: &CreationConfig<Validated>,
     progress: &mut dyn ProgressCallback,
 ) -> Result<(CreationReport, W)> {
     let mut builder = Builder::new(writer);
@@ -300,7 +301,7 @@ fn add_directory_to_tar<W: Write>(
     builder: &mut Builder<W>,
     dir_path: &Path,
     archive_path: &Path,
-    config: &CreationConfig,
+    config: &CreationConfig<Validated>,
     report: &mut CreationReport,
 ) -> Result<()> {
     if archive_path.as_os_str().is_empty() {
@@ -339,7 +340,7 @@ fn add_file_to_tar_with_progress_impl<W: Write>(
     builder: &mut Builder<W>,
     file_path: &Path,
     archive_path: &Path,
-    config: &CreationConfig,
+    config: &CreationConfig<Validated>,
     report: &mut CreationReport,
     progress: &mut dyn ProgressCallback,
 ) -> Result<()> {
@@ -449,7 +450,7 @@ impl crate::formats::traits::FormatCreator for TarCreator {
         &self,
         output: &Path,
         sources: &[&Path],
-        config: &CreationConfig,
+        config: &CreationConfig<Validated>,
         progress: &mut dyn ProgressCallback,
     ) -> crate::Result<crate::creation::CreationReport> {
         create_tar_with_progress(output, sources, config, progress)
@@ -465,7 +466,7 @@ impl crate::formats::traits::FormatCreator for TarGzCreator {
         &self,
         output: &Path,
         sources: &[&Path],
-        config: &CreationConfig,
+        config: &CreationConfig<Validated>,
         progress: &mut dyn ProgressCallback,
     ) -> crate::Result<crate::creation::CreationReport> {
         create_tar_gz_with_progress(output, sources, config, progress)
@@ -481,7 +482,7 @@ impl crate::formats::traits::FormatCreator for TarBz2Creator {
         &self,
         output: &Path,
         sources: &[&Path],
-        config: &CreationConfig,
+        config: &CreationConfig<Validated>,
         progress: &mut dyn ProgressCallback,
     ) -> crate::Result<crate::creation::CreationReport> {
         create_tar_bz2_with_progress(output, sources, config, progress)
@@ -497,7 +498,7 @@ impl crate::formats::traits::FormatCreator for TarXzCreator {
         &self,
         output: &Path,
         sources: &[&Path],
-        config: &CreationConfig,
+        config: &CreationConfig<Validated>,
         progress: &mut dyn ProgressCallback,
     ) -> crate::Result<crate::creation::CreationReport> {
         create_tar_xz_with_progress(output, sources, config, progress)
@@ -513,7 +514,7 @@ impl crate::formats::traits::FormatCreator for TarZstCreator {
         &self,
         output: &Path,
         sources: &[&Path],
-        config: &CreationConfig,
+        config: &CreationConfig<Validated>,
         progress: &mut dyn ProgressCallback,
     ) -> crate::Result<crate::creation::CreationReport> {
         create_tar_zst_with_progress(output, sources, config, progress)
@@ -674,6 +675,13 @@ mod tests {
         assert_eq!(&data[0..4], &[0x28, 0xB5, 0x2F, 0xFD]); // zstd magic bytes
     }
 
+    /// Regression test for #443: sweeps every tar compression backend
+    /// (flate2, bzip2, xz2, zstd) across the full 1-9 level range through
+    /// the validated `create_archive` path. This is the test that would
+    /// have caught the flate2 1.1.9 backend swap that panicked on
+    /// out-of-range levels — a level-1-and-9-only sweep on tar.gz alone
+    /// does not exercise `xz2::Stream::new_easy_encoder`, one of the two
+    /// confirmed panic sites, at any level but the default.
     #[test]
     fn test_create_tar_compression_levels() {
         let temp = TempDir::new().unwrap();
@@ -681,17 +689,24 @@ mod tests {
         let source_dir = TempDir::new().unwrap();
         fs::write(source_dir.path().join("test.txt"), "a".repeat(10000)).unwrap();
 
-        for level in [1, 6, 9] {
-            let output = temp.path().join(format!("output_{level}.tar.gz"));
-            let config = CreationConfig::default()
-                .with_exclude_patterns(vec![])
-                .with_compression_level(level)
-                .unwrap()
-                .with_format(Some(ArchiveType::TarGz));
+        for format in [
+            ArchiveType::TarGz,
+            ArchiveType::TarBz2,
+            ArchiveType::TarXz,
+            ArchiveType::TarZst,
+        ] {
+            for level in 1..=9 {
+                let output = temp.path().join(format!("output_{format:?}_{level}.tar"));
+                let config = CreationConfig::default()
+                    .with_exclude_patterns(vec![])
+                    .with_compression_level(level)
+                    .unwrap()
+                    .with_format(Some(format));
 
-            let report = create_archive(&output, &[source_dir.path()], &config).unwrap();
-            assert_eq!(report.files_added, 1);
-            assert!(output.exists());
+                let report = create_archive(&output, &[source_dir.path()], &config).unwrap();
+                assert_eq!(report.files_added, 1, "{format:?} level {level}");
+                assert!(output.exists(), "{format:?} level {level}");
+            }
         }
     }
 
@@ -909,7 +924,9 @@ mod tests {
 
         let config = CreationConfig::default()
             .with_exclude_patterns(vec![])
-            .with_format(Some(ArchiveType::TarZst));
+            .with_format(Some(ArchiveType::TarZst))
+            .validate()
+            .unwrap();
 
         // Allow enough bytes for the zstd header but fail mid-stream so that
         // encoder.finish() must flush remaining data and hits the limit.
@@ -976,7 +993,9 @@ mod tests {
 
         let config = CreationConfig::default()
             .with_exclude_patterns(vec![])
-            .with_include_hidden(true);
+            .with_include_hidden(true)
+            .validate()
+            .unwrap();
 
         let mut progress = TestProgress::default();
 
@@ -1040,7 +1059,10 @@ mod tests {
         let source_dir = TempDir::new().unwrap();
         fs::write(source_dir.path().join("test.txt"), "zstd progress finish").unwrap();
 
-        let config = CreationConfig::default().with_exclude_patterns(vec![]);
+        let config = CreationConfig::default()
+            .with_exclude_patterns(vec![])
+            .validate()
+            .unwrap();
         let mut noop = crate::NoopProgress;
         let report =
             create_tar_zst_with_progress(&output, &[source_dir.path()], &config, &mut noop)

--- a/crates/exarch-core/src/creation/walker.rs
+++ b/crates/exarch-core/src/creation/walker.rs
@@ -38,12 +38,12 @@ use walkdir::WalkDir;
 ///     println!("Would add: {}", entry.archive_path.display());
 /// }
 /// ```
-pub struct FilteredWalker<'a> {
+pub struct FilteredWalker<'a, State> {
     root: &'a Path,
-    config: &'a CreationConfig,
+    config: &'a CreationConfig<State>,
 }
 
-impl<'a> FilteredWalker<'a> {
+impl<'a, State> FilteredWalker<'a, State> {
     /// Creates a new filtered walker for the given root directory.
     ///
     /// # Examples
@@ -57,7 +57,7 @@ impl<'a> FilteredWalker<'a> {
     /// let walker = FilteredWalker::new(Path::new("."), &config);
     /// ```
     #[must_use]
-    pub fn new(root: &'a Path, config: &'a CreationConfig) -> Self {
+    pub fn new(root: &'a Path, config: &'a CreationConfig<State>) -> Self {
         Self { root, config }
     }
 
@@ -217,9 +217,9 @@ pub enum EntryType {
 /// - Source path does not exist
 /// - Directory traversal fails
 /// - File metadata cannot be read
-pub fn collect_entries<P: AsRef<Path>>(
+pub fn collect_entries<P: AsRef<Path>, State>(
     sources: &[P],
-    config: &CreationConfig,
+    config: &CreationConfig<State>,
 ) -> Result<Vec<FilteredEntry>> {
     let mut entries = Vec::new();
 

--- a/crates/exarch-core/src/creation/zip.rs
+++ b/crates/exarch-core/src/creation/zip.rs
@@ -7,6 +7,7 @@ use crate::ArchiveError;
 use crate::NoopProgress;
 use crate::ProgressCallback;
 use crate::Result;
+use crate::config::Validated;
 use crate::creation::config::CreationConfig;
 use crate::creation::progress::ProgressTracker;
 use crate::creation::report::CreationReport;
@@ -30,7 +31,7 @@ use zip::write::SimpleFileOptions;
 /// use exarch_core::creation::zip::create_zip;
 /// use std::path::Path;
 ///
-/// let config = CreationConfig::default();
+/// let config = CreationConfig::default().validate()?;
 /// let report = create_zip(Path::new("output.zip"), &[Path::new("src")], &config)?;
 /// println!("Added {} files", report.files_added);
 /// # Ok::<(), exarch_core::ArchiveError>(())
@@ -45,7 +46,7 @@ use zip::write::SimpleFileOptions;
 pub fn create_zip<P: AsRef<Path>, Q: AsRef<Path>>(
     output: P,
     sources: &[Q],
-    config: &CreationConfig,
+    config: &CreationConfig<Validated>,
 ) -> Result<CreationReport> {
     let file = File::create(output.as_ref())?;
     let (mut report, file) = create_zip_internal(file, sources, config)?;
@@ -109,7 +110,7 @@ pub fn create_zip<P: AsRef<Path>, Q: AsRef<Path>>(
 ///     }
 /// }
 ///
-/// let config = CreationConfig::default();
+/// let config = CreationConfig::default().validate()?;
 /// let mut progress = SimpleProgress;
 /// let report = create_zip_with_progress(
 ///     Path::new("output.zip"),
@@ -130,7 +131,7 @@ pub fn create_zip<P: AsRef<Path>, Q: AsRef<Path>>(
 pub fn create_zip_with_progress<P: AsRef<Path>, Q: AsRef<Path>>(
     output: P,
     sources: &[Q],
-    config: &CreationConfig,
+    config: &CreationConfig<Validated>,
     progress: &mut dyn ProgressCallback,
 ) -> Result<CreationReport> {
     let file = File::create(output.as_ref())?;
@@ -148,22 +149,20 @@ pub fn create_zip_with_progress<P: AsRef<Path>, Q: AsRef<Path>>(
 fn create_zip_internal_with_progress<W: Write + Seek, P: AsRef<Path>>(
     writer: W,
     sources: &[P],
-    config: &CreationConfig,
+    config: &CreationConfig<Validated>,
     progress: &mut dyn ProgressCallback,
 ) -> Result<(CreationReport, W)> {
     let mut zip = ZipWriter::new(writer);
     let mut report = CreationReport::default();
     let start = std::time::Instant::now();
 
-    // Configure ZIP file options with compression level
-    let options = if config.compression_level == Some(0) {
-        SimpleFileOptions::default().compression_method(CompressionMethod::Stored)
-    } else {
-        let level = config.compression_level.unwrap_or(6);
-        SimpleFileOptions::default()
-            .compression_method(CompressionMethod::Deflated)
-            .compression_level(Some(i64::from(level)))
-    };
+    // Configure ZIP file options with compression level. `compression_level`
+    // is guaranteed to be `None` or `Some(1..=9)` by `CreationConfig::validate`,
+    // so `Stored` (level 0) is unreachable through the public API.
+    let level = config.compression_level.unwrap_or(6);
+    let options = SimpleFileOptions::default()
+        .compression_method(CompressionMethod::Deflated)
+        .compression_level(Some(i64::from(level)));
 
     // Single-pass collection of entries (avoids double directory traversal)
     let entries = collect_entries(sources, config)?;
@@ -227,7 +226,7 @@ fn create_zip_internal_with_progress<W: Write + Seek, P: AsRef<Path>>(
 fn create_zip_internal<W: Write + Seek, P: AsRef<Path>>(
     writer: W,
     sources: &[P],
-    config: &CreationConfig,
+    config: &CreationConfig<Validated>,
 ) -> Result<(CreationReport, W)> {
     create_zip_internal_with_progress(writer, sources, config, &mut NoopProgress)
 }
@@ -239,7 +238,7 @@ fn add_file_to_zip_with_progress_and_buffer<W: Write + Seek>(
     zip: &mut ZipWriter<W>,
     file_path: &Path,
     archive_path: &Path,
-    config: &CreationConfig,
+    config: &CreationConfig<Validated>,
     report: &mut CreationReport,
     options: &SimpleFileOptions,
     progress: &mut dyn ProgressCallback,
@@ -331,7 +330,7 @@ impl crate::formats::traits::FormatCreator for ZipCreator {
         &self,
         output: &std::path::Path,
         sources: &[&std::path::Path],
-        config: &CreationConfig,
+        config: &CreationConfig<Validated>,
         progress: &mut dyn ProgressCallback,
     ) -> crate::Result<crate::creation::CreationReport> {
         create_zip_with_progress(output, sources, config, progress)
@@ -361,7 +360,9 @@ mod tests {
 
         let config = CreationConfig::default()
             .with_exclude_patterns(vec![])
-            .with_include_hidden(true);
+            .with_include_hidden(true)
+            .validate()
+            .unwrap();
 
         let report = create_zip(&output, &[source_dir.path().join("test.txt")], &config).unwrap();
 
@@ -384,7 +385,9 @@ mod tests {
 
         let config = CreationConfig::default()
             .with_exclude_patterns(vec![])
-            .with_include_hidden(true);
+            .with_include_hidden(true)
+            .validate()
+            .unwrap();
 
         let report = create_zip(&output, &[source_dir.path()], &config).unwrap();
 
@@ -408,6 +411,8 @@ mod tests {
         let config = CreationConfig::default()
             .with_exclude_patterns(vec![])
             .with_compression_level(9)
+            .unwrap()
+            .validate()
             .unwrap();
 
         let report = create_zip(&output, &[source_dir.path()], &config).unwrap();
@@ -434,6 +439,8 @@ mod tests {
             let config = CreationConfig::default()
                 .with_exclude_patterns(vec![])
                 .with_compression_level(level)
+                .unwrap()
+                .validate()
                 .unwrap();
 
             let report = create_zip(&output, &[source_dir.path()], &config).unwrap();
@@ -455,7 +462,9 @@ mod tests {
 
         let config = CreationConfig::default()
             .with_exclude_patterns(vec![])
-            .with_include_hidden(true);
+            .with_include_hidden(true)
+            .validate()
+            .unwrap();
 
         let report = create_zip(&output, &[source_dir.path()], &config).unwrap();
 
@@ -496,7 +505,9 @@ mod tests {
 
         let config = CreationConfig::default()
             .with_exclude_patterns(vec![])
-            .with_preserve_permissions(true);
+            .with_preserve_permissions(true)
+            .validate()
+            .unwrap();
 
         let report = create_zip(&output, &[source_dir.path()], &config).unwrap();
         assert_eq!(report.files_added, 1);
@@ -529,7 +540,9 @@ mod tests {
 
         let config = CreationConfig::default()
             .with_exclude_patterns(vec![])
-            .with_include_hidden(true);
+            .with_include_hidden(true)
+            .validate()
+            .unwrap();
 
         let report = create_zip(&output, &[source_dir.path()], &config).unwrap();
 
@@ -553,7 +566,9 @@ mod tests {
 
         let config = CreationConfig::default()
             .with_exclude_patterns(vec![])
-            .with_include_hidden(true);
+            .with_include_hidden(true)
+            .validate()
+            .unwrap();
 
         // Create archive
         let report = create_zip(&output, &[source_dir.path()], &config).unwrap();
@@ -600,7 +615,9 @@ mod tests {
 
         let config = CreationConfig::default()
             .with_exclude_patterns(vec![])
-            .with_include_hidden(true);
+            .with_include_hidden(true)
+            .validate()
+            .unwrap();
 
         create_zip(&output, &[source_dir.path()], &config).unwrap();
 
@@ -628,7 +645,7 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let output = temp.path().join("output.zip");
 
-        let config = CreationConfig::default();
+        let config = CreationConfig::default().validate().unwrap();
         let result = create_zip(&output, &[Path::new("/nonexistent/path")], &config);
 
         assert!(result.is_err());
@@ -680,7 +697,9 @@ mod tests {
         // Set max file size to 100 bytes
         let config = CreationConfig::default()
             .with_exclude_patterns(vec![])
-            .with_max_file_size(Some(100));
+            .with_max_file_size(Some(100))
+            .validate()
+            .unwrap();
 
         let report = create_zip(&output, &[source_dir.path()], &config).unwrap();
 
@@ -708,7 +727,9 @@ mod tests {
         // Don't follow symlinks (default)
         let config = CreationConfig::default()
             .with_exclude_patterns(vec![])
-            .with_include_hidden(true);
+            .with_include_hidden(true)
+            .validate()
+            .unwrap();
 
         let report = create_zip(&output, &[source_dir.path()], &config).unwrap();
 
@@ -763,7 +784,9 @@ mod tests {
 
         let config = CreationConfig::default()
             .with_exclude_patterns(vec![])
-            .with_include_hidden(true);
+            .with_include_hidden(true)
+            .validate()
+            .unwrap();
 
         let mut progress = TestProgress::default();
 

--- a/crates/exarch-core/src/formats/traits.rs
+++ b/crates/exarch-core/src/formats/traits.rs
@@ -77,6 +77,7 @@ pub trait ArchiveFormat {
 /// ```
 /// use exarch_core::ProgressCallback;
 /// use exarch_core::Result;
+/// use exarch_core::config::Validated;
 /// use exarch_core::creation::CreationConfig;
 /// use exarch_core::creation::CreationReport;
 /// use exarch_core::formats::traits::FormatCreator;
@@ -89,7 +90,7 @@ pub trait ArchiveFormat {
 ///         &self,
 ///         _output: &Path,
 ///         _sources: &[&Path],
-///         _config: &CreationConfig,
+///         _config: &CreationConfig<Validated>,
 ///         _progress: &mut dyn ProgressCallback,
 ///     ) -> Result<CreationReport> {
 ///         Ok(CreationReport::default())
@@ -104,14 +105,14 @@ pub trait ArchiveFormat {
 ///     creator: &dyn FormatCreator,
 ///     output: &Path,
 ///     sources: &[&Path],
-///     config: &CreationConfig,
+///     config: &CreationConfig<Validated>,
 ///     progress: &mut dyn ProgressCallback,
 /// ) -> Result<CreationReport> {
 ///     creator.create(output, sources, config, progress)
 /// }
 ///
 /// let creator = NoopCreator;
-/// let config = CreationConfig::default();
+/// let config = CreationConfig::default().validate().unwrap();
 /// let mut noop = exarch_core::NoopProgress;
 /// create_via_trait(&creator, Path::new("out.tar.gz"), &[], &config, &mut noop).unwrap();
 /// ```
@@ -126,7 +127,7 @@ pub trait FormatCreator {
         &self,
         output: &Path,
         sources: &[&Path],
-        config: &CreationConfig,
+        config: &CreationConfig<Validated>,
         progress: &mut dyn ProgressCallback,
     ) -> Result<CreationReport>;
 

--- a/crates/exarch-core/tests/ui/creation_config_forge_via_struct_literal.rs
+++ b/crates/exarch-core/tests/ui/creation_config_forge_via_struct_literal.rs
@@ -1,0 +1,17 @@
+//! Regression for #443: the original PoC forged a `CreationConfig` past both
+//! `with_compression_level()`'s 1-9 gate and `validate()` via struct-literal
+//! syntax (`CreationConfig { compression_level: Some(200), ..Default::default() }`),
+//! reaching `flate2`/`xz2` with an out-of-range level and triggering a panic
+//! instead of an error. `CreationConfig`'s own `fields` member is private, so
+//! `compression_level` is not a field of `CreationConfig` itself (it lives on
+//! the wrapped `CreationConfigFields` instead, reachable only through
+//! `Deref`/`DerefMut`); the struct-literal syntax is therefore rejected at
+//! compile time with E0560, without needing to reach `CreationConfigFields`'s
+//! own `#[non_exhaustive]` seal.
+
+fn main() {
+    let _forged = exarch_core::creation::CreationConfig {
+        compression_level: Some(200),
+        ..Default::default()
+    };
+}

--- a/crates/exarch-core/tests/ui/creation_config_forge_via_struct_literal.stderr
+++ b/crates/exarch-core/tests/ui/creation_config_forge_via_struct_literal.stderr
@@ -1,0 +1,7 @@
+error[E0560]: struct `CreationConfig<_>` has no field named `compression_level`
+  --> tests/ui/creation_config_forge_via_struct_literal.rs:14:9
+   |
+14 |         compression_level: Some(200),
+   |         ^^^^^^^^^^^^^^^^^ `CreationConfig<_>` does not have this field
+   |
+   = note: all struct fields are already assigned

--- a/crates/exarch-core/tests/ui/validated_creation_config_field_mutation.rs
+++ b/crates/exarch-core/tests/ui/validated_creation_config_field_mutation.rs
@@ -1,0 +1,16 @@
+//! Regression for #443: a legitimately obtained `CreationConfig<Validated>`
+//! must not be mutable afterward. If it were, `cfg.compression_level =
+//! Some(200)` here would reintroduce the exact panic the typestate exists to
+//! prevent — a forged out-of-range compression level reaching `flate2`'s or
+//! `xz2`'s `assert!`/`unwrap()` instead of being rejected by `validate()`.
+//! `DerefMut` is implemented only for `CreationConfig<Unvalidated>`, so this
+//! must be a compile error.
+
+#[allow(unused_mut)]
+fn main() {
+    let mut cfg = exarch_core::creation::CreationConfig::new()
+        .validate()
+        .unwrap();
+
+    cfg.compression_level = Some(200);
+}

--- a/crates/exarch-core/tests/ui/validated_creation_config_field_mutation.stderr
+++ b/crates/exarch-core/tests/ui/validated_creation_config_field_mutation.stderr
@@ -1,0 +1,7 @@
+error[E0594]: cannot assign to data in dereference of `CreationConfig<Validated>`
+  --> tests/ui/validated_creation_config_field_mutation.rs:15:5
+   |
+15 |     cfg.compression_level = Some(200);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot assign
+   |
+   = help: trait `DerefMut` is required to modify through a dereference, but it is not implemented for `CreationConfig<Validated>`

--- a/crates/exarch-core/tests/zip_family_integration.rs
+++ b/crates/exarch-core/tests/zip_family_integration.rs
@@ -182,10 +182,8 @@ fn explicit_format_override_allows_zip_family_creation() {
     let dest = TempDir::new().unwrap();
     let src = dest.path().join("source.txt");
     std::fs::write(&src, b"hello").unwrap();
-    let config = CreationConfig {
-        format: Some(ArchiveType::Zip),
-        ..CreationConfig::default()
-    };
+    let mut config = CreationConfig::default();
+    config.format = Some(ArchiveType::Zip);
     let output = dest.path().join("out.apk");
     create_archive(&output, &[&src], &config)
         .expect("explicit ArchiveType::Zip should bypass the guard");


### PR DESCRIPTION
## Summary

- `CreationConfig` had all-public fields and a runtime-only `validate(&self)` check that only the two high-level entry points (`create_archive_with_progress`, `ArchiveCreator::create`) actually called. The seven low-level `creation::tar::*` / `creation::zip::*` functions were directly reachable by external Rust consumers of `exarch-core` and skipped validation entirely.
- A forged `CreationConfig { compression_level: Some(200), .. }` passed to a low-level function reached `flate2`/`xz2` unvalidated and **panicked** (assertion failure in flate2's `zlib-rs` backend; `unwrap()` on `LZMA_OPTIONS_ERROR` in `xz2`) — a panic-based DoS on the public API of a `deny(unwrap_used)` crate, silently introduced by a `flate2` 1.1.9 dependency bump.
- Applies the same `Unvalidated`/`Validated` typestate pattern already used for `SecurityConfig` (#437): `CreationConfigFields` is now `#[non_exhaustive]` and private behind `CreationConfig<State>`; `validate(self)` consumes the config and returns `CreationConfig<Validated>`. All low-level creation functions and `FormatCreator::create` now require a validated config, closing the gap structurally instead of relying on every call site remembering to check.
- As defense in depth, `compression_level_to_flate2`/`compression_level_to_xz` now clamp out-of-range input via `.min(9)`, matching the existing bzip2/zstd converters, so the panic cannot resurface even if an internal caller bypasses the type-level guarantee.
- `exarch-python` and `exarch-node` bindings required no changes (both already gate compression level to 1-9 themselves and only call the validated top-level `create_archive*` API). `exarch-cli` needed one call site updated from a struct literal to the builder chain.

## Breaking change

`CreationConfig` fields are no longer public; use the `with_*` builders. `validate()` now consumes `self` and returns `CreationConfig<Validated>`. `creation::tar::*`, `creation::zip::*`, `creation::filters::should_skip`/`compute_archive_path`, and `FormatCreator::create` now require `&CreationConfig<Validated>`.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` (1057/1057)
- [x] `cargo test --doc --workspace --all-features` (110/110)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace`
- [x] `cargo check -p exarch-python --all-features` / `cargo check -p exarch-node --all-features`
- [x] New trybuild compile-fail fixtures: struct-literal forge of `CreationConfig` rejected (E0560), mutation of a `Validated` config rejected (E0594)
- [x] New regression test parametrized over all 4 tar variants (gz/bz2/xz/zst) x compression levels 1-9, exercising the exact code path that previously panicked
- [x] New non-panic regression tests pinning `compression_level_to_flate2(Some(200))` / `compression_level_to_xz(Some(200))`

Closes #443