### PR TITLE
fix(core)!: validate allowed_extensions and banned_path_components entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING: `SecurityConfig::validate()` now rejects malformed `allowed_extensions`/
+  `banned_path_components` entries (#449)**: a new `validate_config_entry` helper in
+  `exarch-core::security::boundary` (re-exported as `exarch_core::validate_config_entry`,
+  alongside `MAX_CONFIG_ENTRY_LENGTH`) is called per-entry from `SecurityConfig::validate()`,
+  which now returns `ArchiveError::InvalidConfiguration` for any entry that is empty, contains a
+  null byte, or exceeds 255 bytes — configs that previously passed `validate()` with such entries
+  now fail. `exarch-python`'s `add_allowed_extension`/`add_banned_component` and
+  `exarch-node`'s `addAllowedExtension`/`addBannedComponent` now delegate to the same helper
+  instead of duplicating the length/null-byte checks, so both bindings additionally reject empty
+  entries eagerly (previously accepted) and report length in bytes rather than the previously
+  inaccurate "characters" wording for multi-byte input. `exarch-node`'s error messages for these
+  two setters now carry the crate-wide `INVALID_CONFIGURATION: invalid configuration: ` prefix
+  (previously a bare reason string), matching every other error path in the binding.
 - **BREAKING: `exarch-node` boolean setters now take a mandatory `boolean` instead of an
   optional one (#442)**: `SecurityConfig.setAllowSymlinks`, `setAllowHardlinks`,
   `setAllowAbsolutePaths`, `setAllowWorldWritable`, `setAllowSolidArchives`,

--- a/crates/exarch-cli/src/commands/extract.rs
+++ b/crates/exarch-cli/src/commands/extract.rs
@@ -43,6 +43,19 @@ fn parse_extensions(raw: &[String]) -> Vec<String> {
         .collect()
 }
 
+/// Drops empty entries from raw `--banned-component` values.
+///
+/// `SecurityConfig::validate()` rejects empty entries, but an empty value is
+/// the documented idiom for disabling the default ban list (see the
+/// `--banned-component` clap help), so it must never reach `validate()`.
+/// The caller keeps checking `args.banned_components.is_empty()` on the raw,
+/// unfiltered values to decide whether to override the default ban list at
+/// all; this only strips empties out of the values passed once that
+/// decision is made.
+fn filter_banned_components(raw: &[String]) -> Vec<String> {
+    raw.iter().filter(|c| !c.is_empty()).cloned().collect()
+}
+
 pub fn execute(
     args: &ExtractArgs,
     formatter: &dyn OutputFormatter,
@@ -73,7 +86,7 @@ pub fn execute(
     let config = if args.banned_components.is_empty() {
         config
     } else {
-        config.with_banned_path_components(args.banned_components.clone())
+        config.with_banned_path_components(filter_banned_components(&args.banned_components))
     };
 
     // list_config shares quota and path-filtering params with config but uses
@@ -214,5 +227,17 @@ mod tests {
     fn parse_extensions_mixed_repeatable_and_comma() {
         let raw = vec!["zip,tar".to_string(), ".GZ".to_string()];
         assert_eq!(parse_extensions(&raw), vec!["zip", "tar", "gz"]);
+    }
+
+    #[test]
+    fn filter_banned_components_drops_empty_entries() {
+        let raw = vec![String::new()];
+        assert_eq!(filter_banned_components(&raw), Vec::<String>::new());
+    }
+
+    #[test]
+    fn filter_banned_components_keeps_non_empty_entries() {
+        let raw = vec![".git".to_string(), String::new(), ".ssh".to_string()];
+        assert_eq!(filter_banned_components(&raw), vec![".git", ".ssh"]);
     }
 }

--- a/crates/exarch-cli/tests/cli_tests.rs
+++ b/crates/exarch-cli/tests/cli_tests.rs
@@ -2229,6 +2229,34 @@ fn test_extract_security_violation_text_reason_appears_once() {
     );
 }
 
+/// Regression test for issue #449: `--banned-component ""` is a documented
+/// idiom (see clap help on `ExtractArgs::banned_components`) for disabling
+/// the default ban list entirely. `SecurityConfig::validate()` now rejects
+/// empty entries, so the CLI must filter them out before building the
+/// config rather than passing the raw, unfiltered flag values through.
+#[test]
+fn test_extract_banned_component_empty_string_disables_default_ban_list() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let archive_path = temp.path().join("git.tar.gz");
+    create_tar_gz_with_component(&archive_path, ".git");
+    let out_dir = temp.path().join("out");
+    std::fs::create_dir_all(&out_dir).expect("create out dir");
+
+    exarch_cmd()
+        .arg("extract")
+        .arg(&archive_path)
+        .arg(&out_dir)
+        .arg("--banned-component")
+        .arg("")
+        .assert()
+        .success();
+
+    assert!(
+        out_dir.join(".git").join("file.txt").exists(),
+        "empty --banned-component should disable the default ban list, allowing .git/ through"
+    );
+}
+
 /// Encodes `n` as a classic octal numeric field of `width` bytes (including
 /// the trailing NUL), or `None` if it does not fit in `width - 1` digits.
 fn octal_field(n: u64, width: usize) -> Option<Vec<u8>> {

--- a/crates/exarch-core/src/config.rs
+++ b/crates/exarch-core/src/config.rs
@@ -377,6 +377,9 @@ impl SecurityConfig<Unvalidated> {
     /// - `max_file_count` is zero
     /// - `max_solid_block_memory` is zero
     /// - `max_tar_metadata_bytes` is zero
+    /// - any entry in `allowed_extensions` or `banned_path_components` is
+    ///   empty, contains a null byte, or exceeds
+    ///   [`crate::MAX_CONFIG_ENTRY_LENGTH`] bytes
     ///
     /// # Examples
     ///
@@ -424,6 +427,12 @@ impl SecurityConfig<Unvalidated> {
             return Err(crate::ArchiveError::InvalidConfiguration {
                 reason: "max_tar_metadata_bytes must not be zero".into(),
             });
+        }
+        for extension in &self.fields.allowed_extensions {
+            crate::security::boundary::validate_config_entry(extension, "allowed extension")?;
+        }
+        for component in &self.fields.banned_path_components {
+            crate::security::boundary::validate_config_entry(component, "banned path component")?;
         }
         Ok(SecurityConfig {
             fields: self.fields,
@@ -1168,6 +1177,45 @@ mod tests {
     fn test_validate_rejects_zero_max_tar_metadata_bytes() {
         let mut cfg = SecurityConfig::default();
         cfg.max_tar_metadata_bytes = 0;
+        assert!(cfg.validate().is_err());
+    }
+
+    // Regression tests for #449: SecurityConfig::validate() must reject
+    // malformed allowed_extensions/banned_path_components entries.
+
+    #[test]
+    fn test_validate_permissive_is_ok() {
+        assert!(SecurityConfig::permissive().validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_accepts_empty_allowed_extensions_vec() {
+        let cfg = SecurityConfig::default().with_allowed_extensions(Vec::new());
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_rejects_empty_allowed_extension_entry() {
+        let cfg = SecurityConfig::default().with_allowed_extensions(vec![String::new()]);
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_rejects_empty_banned_path_component_entry() {
+        let cfg = SecurityConfig::default().with_banned_path_components(vec![String::new()]);
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_rejects_null_byte_in_allowed_extension() {
+        let cfg = SecurityConfig::default().with_allowed_extensions(vec!["bad\0ext".to_string()]);
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_rejects_overlong_banned_path_component() {
+        let long_component = "x".repeat(256);
+        let cfg = SecurityConfig::default().with_banned_path_components(vec![long_component]);
         assert!(cfg.validate().is_err());
     }
 

--- a/crates/exarch-core/src/lib.rs
+++ b/crates/exarch-core/src/lib.rs
@@ -78,9 +78,16 @@ pub use inspection::VerificationStatus;
 /// Summary statistics produced by the validation pipeline; see
 /// [`security::ValidationReport`].
 pub use security::ValidationReport;
+/// Maximum length, in bytes, of a single `SecurityConfig` entry — an
+/// allowed extension or a banned path component. Shared by `exarch-python`
+/// and `exarch-node`.
+pub use security::boundary::MAX_CONFIG_ENTRY_LENGTH;
 /// Maximum length, in bytes, of a raw path string accepted at the FFI
 /// boundary. Shared by `exarch-python` and `exarch-node`.
 pub use security::boundary::MAX_PATH_LENGTH;
+/// Validates a single caller-supplied `SecurityConfig` entry string.
+/// Shared by `exarch-python` and `exarch-node`.
+pub use security::boundary::validate_config_entry;
 /// Validates a raw, caller-supplied path string before it enters the
 /// archive pipeline. Shared by `exarch-python` and `exarch-node`.
 pub use security::boundary::validate_raw_path_str;

--- a/crates/exarch-core/src/security/boundary.rs
+++ b/crates/exarch-core/src/security/boundary.rs
@@ -1,10 +1,13 @@
-//! Raw path string validation shared by FFI bindings.
+//! Raw path string and config entry validation shared by FFI bindings.
 //!
 //! Both `exarch-python` and `exarch-node` accept archive/output paths as
 //! plain strings from their host language before any `Path`, `DestDir`, or
 //! `SecurityConfig` exists to run them through [`super::path::validate_path`].
-//! This module centralizes that pre-flight check so the two bindings cannot
-//! drift on what counts as a well-formed path string.
+//! They also accept caller-supplied `SecurityConfig` entries — allowed
+//! extensions, banned path components — as plain strings before
+//! [`crate::config::SecurityConfig::validate`] exists to check them. This
+//! module centralizes both pre-flight checks so the two bindings cannot
+//! drift on what counts as a well-formed input string.
 
 use crate::error::ArchiveError;
 use crate::error::Result;
@@ -75,6 +78,70 @@ pub fn validate_raw_path_str(path: &str) -> Result<()> {
     Ok(())
 }
 
+/// Maximum length, in bytes, of a single `SecurityConfig` entry — an
+/// allowed extension or a banned path component.
+pub const MAX_CONFIG_ENTRY_LENGTH: usize = 255;
+
+/// Validates a single caller-supplied `SecurityConfig` entry string.
+///
+/// This is the shared boundary check for `exarch-python` and `exarch-node`
+/// entry points that build `allowed_extensions` and `banned_path_components`
+/// (`add_allowed_extension`, `add_banned_component`, and their `with_*`
+/// equivalents), and is also called per-entry from
+/// [`crate::config::SecurityConfig::validate`] as the backstop every entry
+/// point funnels through. `field` names the caller's field for the error
+/// message (e.g. `"extension"`, `"banned path component"`).
+///
+/// # Check order
+///
+/// 1. Length, checked before scanning for a null byte, for the same
+///    O(1)-before-O(n) reason as [`validate_raw_path_str`].
+/// 2. Null byte.
+/// 3. Emptiness — unlike [`validate_raw_path_str`], which accepts `""`, an
+///    empty entry is rejected here: in `banned_path_components` it is inert,
+///    and in `allowed_extensions` it silently flips the config from "allow all"
+///    to an allowlist that matches nothing.
+///
+/// # Errors
+///
+/// Returns [`ArchiveError::InvalidConfiguration`] if `value` exceeds
+/// [`MAX_CONFIG_ENTRY_LENGTH`] bytes, contains a null byte, or is empty.
+///
+/// # Examples
+///
+/// ```
+/// use exarch_core::validate_config_entry;
+///
+/// assert!(validate_config_entry("txt", "extension").is_ok());
+/// assert!(validate_config_entry("", "extension").is_err());
+/// assert!(validate_config_entry("bad\0ext", "extension").is_err());
+/// assert!(validate_config_entry(&"x".repeat(256), "extension").is_err());
+/// ```
+pub fn validate_config_entry(value: &str, field: &str) -> Result<()> {
+    if value.len() > MAX_CONFIG_ENTRY_LENGTH {
+        return Err(ArchiveError::InvalidConfiguration {
+            reason: format!(
+                "{field} exceeds maximum length of {MAX_CONFIG_ENTRY_LENGTH} bytes (got {} bytes)",
+                value.len()
+            ),
+        });
+    }
+
+    if value.contains('\0') {
+        return Err(ArchiveError::InvalidConfiguration {
+            reason: format!("{field} contains null bytes - potential security issue"),
+        });
+    }
+
+    if value.is_empty() {
+        return Err(ArchiveError::InvalidConfiguration {
+            reason: format!("{field} must not be empty"),
+        });
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
@@ -138,5 +205,93 @@ mod tests {
     fn test_validate_raw_path_str_accepts_max_length() {
         let max_path = "x".repeat(MAX_PATH_LENGTH);
         assert!(validate_raw_path_str(&max_path).is_ok());
+    }
+
+    #[test]
+    fn test_validate_config_entry_accepts_normal() {
+        assert!(validate_config_entry("txt", "extension").is_ok());
+        assert!(validate_config_entry(".git", "banned path component").is_ok());
+    }
+
+    #[test]
+    fn test_validate_config_entry_rejects_empty() {
+        let err = validate_config_entry("", "extension").expect_err("empty");
+        match err {
+            ArchiveError::InvalidConfiguration { reason } => {
+                assert_eq!(reason, "extension must not be empty");
+            }
+            other => panic!("expected InvalidConfiguration, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_validate_config_entry_rejects_null_bytes() {
+        let err = validate_config_entry("bad\0ext", "extension").expect_err("null byte");
+        match err {
+            ArchiveError::InvalidConfiguration { reason } => {
+                assert_eq!(
+                    reason,
+                    "extension contains null bytes - potential security issue"
+                );
+            }
+            other => panic!("expected InvalidConfiguration, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_validate_config_entry_accepts_max_length() {
+        let max_entry = "x".repeat(MAX_CONFIG_ENTRY_LENGTH);
+        assert!(validate_config_entry(&max_entry, "extension").is_ok());
+    }
+
+    #[test]
+    fn test_validate_config_entry_rejects_too_long() {
+        let long_entry = "x".repeat(MAX_CONFIG_ENTRY_LENGTH + 1);
+        let err = validate_config_entry(&long_entry, "extension").expect_err("too long");
+        match err {
+            ArchiveError::InvalidConfiguration { reason } => {
+                assert_eq!(
+                    reason,
+                    format!(
+                        "extension exceeds maximum length of {MAX_CONFIG_ENTRY_LENGTH} bytes (got {} bytes)",
+                        long_entry.len()
+                    )
+                );
+            }
+            other => panic!("expected InvalidConfiguration, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_validate_config_entry_rejects_multibyte_over_length() {
+        // "日" is 3 bytes in UTF-8; 100 repeats is 300 bytes but only 100 chars.
+        let multibyte_entry = "日".repeat(100);
+        assert!(multibyte_entry.chars().count() < MAX_CONFIG_ENTRY_LENGTH);
+        let err =
+            validate_config_entry(&multibyte_entry, "extension").expect_err("too long in bytes");
+        match err {
+            ArchiveError::InvalidConfiguration { reason } => {
+                assert!(
+                    reason.contains("bytes"),
+                    "message must use byte-length wording: {reason}"
+                );
+            }
+            other => panic!("expected InvalidConfiguration, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_validate_config_entry_checks_length_before_null_byte() {
+        let long_entry_with_null = format!("{}\0", "x".repeat(MAX_CONFIG_ENTRY_LENGTH));
+        let err = validate_config_entry(&long_entry_with_null, "extension").expect_err("too long");
+        match err {
+            ArchiveError::InvalidConfiguration { reason } => {
+                assert!(
+                    reason.contains("maximum length"),
+                    "length check should run first: {reason}"
+                );
+            }
+            other => panic!("expected InvalidConfiguration, got: {other:?}"),
+        }
     }
 }

--- a/crates/exarch-node/index.d.ts
+++ b/crates/exarch-node/index.d.ts
@@ -246,8 +246,8 @@ export declare class SecurityConfig {
    *
    * # Errors
    *
-   * Returns error if extension exceeds maximum length or contains null
-   * bytes.
+   * Returns error if the extension is empty, exceeds maximum length, or
+   * contains null bytes.
    */
   addAllowedExtension(ext: string): this
   /**
@@ -255,8 +255,8 @@ export declare class SecurityConfig {
    *
    * # Errors
    *
-   * Returns error if component exceeds maximum length or contains null
-   * bytes.
+   * Returns error if the component is empty, exceeds maximum length, or
+   * contains null bytes.
    */
   addBannedComponent(component: string): this
   /**

--- a/crates/exarch-node/src/config.rs
+++ b/crates/exarch-node/src/config.rs
@@ -1,15 +1,12 @@
 //! Node.js bindings for `SecurityConfig` and `ExtractionOptions`.
 
 use exarch_core::SecurityConfig as CoreConfig;
+use exarch_core::validate_config_entry;
 use napi::bindgen_prelude::Error;
 use napi::bindgen_prelude::Result;
 use napi_derive::napi;
 
-/// Maximum length for file extension strings (e.g., ".tar.gz")
-const MAX_EXTENSION_LENGTH: usize = 255;
-
-/// Maximum length for path component strings
-const MAX_COMPONENT_LENGTH: usize = 255;
+use crate::error::convert_error;
 
 /// Security configuration for archive extraction.
 ///
@@ -205,20 +202,11 @@ impl SecurityConfig {
     ///
     /// # Errors
     ///
-    /// Returns error if extension exceeds maximum length or contains null
-    /// bytes.
+    /// Returns error if the extension is empty, exceeds maximum length, or
+    /// contains null bytes.
     #[napi]
     pub fn add_allowed_extension(&mut self, ext: String) -> Result<&Self> {
-        if ext.contains('\0') {
-            return Err(Error::from_reason(
-                "extension contains null bytes - potential security issue",
-            ));
-        }
-        if ext.len() > MAX_EXTENSION_LENGTH {
-            return Err(Error::from_reason(format!(
-                "extension exceeds maximum length of {MAX_EXTENSION_LENGTH} characters"
-            )));
-        }
+        validate_config_entry(&ext, "extension").map_err(convert_error)?;
         self.inner.allowed_extensions.push(ext);
         Ok(self)
     }
@@ -227,20 +215,11 @@ impl SecurityConfig {
     ///
     /// # Errors
     ///
-    /// Returns error if component exceeds maximum length or contains null
-    /// bytes.
+    /// Returns error if the component is empty, exceeds maximum length, or
+    /// contains null bytes.
     #[napi]
     pub fn add_banned_component(&mut self, component: String) -> Result<&Self> {
-        if component.contains('\0') {
-            return Err(Error::from_reason(
-                "component contains null bytes - potential security issue",
-            ));
-        }
-        if component.len() > MAX_COMPONENT_LENGTH {
-            return Err(Error::from_reason(format!(
-                "component exceeds maximum length of {MAX_COMPONENT_LENGTH} characters"
-            )));
-        }
+        validate_config_entry(&component, "banned path component").map_err(convert_error)?;
         self.inner.banned_path_components.push(component);
         Ok(self)
     }
@@ -687,6 +666,8 @@ impl ExtractionOptions {
     clippy::uninlined_format_args
 )]
 mod tests {
+    use exarch_core::MAX_CONFIG_ENTRY_LENGTH;
+
     use super::*;
 
     #[test]
@@ -783,8 +764,15 @@ mod tests {
     #[test]
     fn test_add_allowed_extension_rejects_too_long() {
         let mut config = SecurityConfig::new();
-        let long_ext = "x".repeat(MAX_EXTENSION_LENGTH + 1);
+        let long_ext = "x".repeat(MAX_CONFIG_ENTRY_LENGTH + 1);
         let result = config.add_allowed_extension(long_ext);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_add_allowed_extension_rejects_empty() {
+        let mut config = SecurityConfig::new();
+        let result = config.add_allowed_extension(String::new());
         assert!(result.is_err());
     }
 
@@ -810,8 +798,15 @@ mod tests {
     #[test]
     fn test_add_banned_component_rejects_too_long() {
         let mut config = SecurityConfig::new();
-        let long_component = "x".repeat(MAX_COMPONENT_LENGTH + 1);
+        let long_component = "x".repeat(MAX_CONFIG_ENTRY_LENGTH + 1);
         let result = config.add_banned_component(long_component);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_add_banned_component_rejects_empty() {
+        let mut config = SecurityConfig::new();
+        let result = config.add_banned_component(String::new());
         assert!(result.is_err());
     }
 

--- a/crates/exarch-python/src/config.rs
+++ b/crates/exarch-python/src/config.rs
@@ -4,14 +4,11 @@
 use exarch_core::ExtractionOptions as CoreExtractionOptions;
 use exarch_core::SecurityConfig as CoreSecurityConfig;
 use exarch_core::creation::CreationConfig as CoreCreationConfig;
+use exarch_core::validate_config_entry;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
-/// Maximum length for file extension strings (e.g., ".tar.gz")
-const MAX_EXTENSION_LENGTH: usize = 255;
-
-/// Maximum length for path component strings
-const MAX_COMPONENT_LENGTH: usize = 255;
+use crate::error::convert_error;
 
 /// Security configuration for archive extraction.
 ///
@@ -200,22 +197,13 @@ impl PySecurityConfig {
     ///
     /// # Errors
     ///
-    /// Returns `ValueError` if extension exceeds maximum length or contains
-    /// null bytes.
+    /// Returns `ValueError` if the extension is empty, exceeds maximum
+    /// length, or contains null bytes.
     fn add_allowed_extension(
         mut slf: PyRefMut<'_, Self>,
         ext: String,
     ) -> PyResult<PyRefMut<'_, Self>> {
-        if ext.contains('\0') {
-            return Err(PyValueError::new_err(
-                "extension contains null bytes - potential security issue",
-            ));
-        }
-        if ext.len() > MAX_EXTENSION_LENGTH {
-            return Err(PyValueError::new_err(format!(
-                "extension exceeds maximum length of {MAX_EXTENSION_LENGTH} characters"
-            )));
-        }
+        validate_config_entry(&ext, "extension").map_err(convert_error)?;
         slf.inner.allowed_extensions.push(ext);
         Ok(slf)
     }
@@ -224,22 +212,13 @@ impl PySecurityConfig {
     ///
     /// # Errors
     ///
-    /// Returns `ValueError` if component exceeds maximum length or contains
-    /// null bytes.
+    /// Returns `ValueError` if the component is empty, exceeds maximum
+    /// length, or contains null bytes.
     fn add_banned_component(
         mut slf: PyRefMut<'_, Self>,
         component: String,
     ) -> PyResult<PyRefMut<'_, Self>> {
-        if component.contains('\0') {
-            return Err(PyValueError::new_err(
-                "component contains null bytes - potential security issue",
-            ));
-        }
-        if component.len() > MAX_COMPONENT_LENGTH {
-            return Err(PyValueError::new_err(format!(
-                "component exceeds maximum length of {MAX_COMPONENT_LENGTH} characters"
-            )));
-        }
+        validate_config_entry(&component, "banned path component").map_err(convert_error)?;
         slf.inner.banned_path_components.push(component);
         Ok(slf)
     }
@@ -767,6 +746,8 @@ impl PyExtractionOptions {
     clippy::float_cmp
 )]
 mod tests {
+    use exarch_core::MAX_CONFIG_ENTRY_LENGTH;
+
     use super::*;
 
     #[test]
@@ -1043,12 +1024,25 @@ mod tests {
             let py_config = Py::new(py, config).expect("Failed to create Py object");
             let obj = py_config.bind(py);
 
-            let long_ext = "x".repeat(MAX_EXTENSION_LENGTH + 1);
+            let long_ext = "x".repeat(MAX_CONFIG_ENTRY_LENGTH + 1);
             let result = obj.call_method1("add_allowed_extension", (long_ext,));
             assert!(
                 result.is_err(),
                 "Should reject extension exceeding max length"
             );
+        });
+    }
+
+    #[test]
+    fn test_add_allowed_extension_rejects_empty() {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
+            let config = PySecurityConfig::new();
+            let py_config = Py::new(py, config).expect("Failed to create Py object");
+            let obj = py_config.bind(py);
+
+            let result = obj.call_method1("add_allowed_extension", ("",));
+            assert!(result.is_err(), "Should reject empty extension");
         });
     }
 
@@ -1092,12 +1086,25 @@ mod tests {
             let py_config = Py::new(py, config).expect("Failed to create Py object");
             let obj = py_config.bind(py);
 
-            let long_component = "x".repeat(MAX_COMPONENT_LENGTH + 1);
+            let long_component = "x".repeat(MAX_CONFIG_ENTRY_LENGTH + 1);
             let result = obj.call_method1("add_banned_component", (long_component,));
             assert!(
                 result.is_err(),
                 "Should reject component exceeding max length"
             );
+        });
+    }
+
+    #[test]
+    fn test_add_banned_component_rejects_empty() {
+        pyo3::Python::initialize();
+        Python::attach(|py| {
+            let config = PySecurityConfig::new();
+            let py_config = Py::new(py, config).expect("Failed to create Py object");
+            let obj = py_config.bind(py);
+
+            let result = obj.call_method1("add_banned_component", ("",));
+            assert!(result.is_err(), "Should reject empty component");
         });
     }
 

--- a/crates/exarch-python/tests/test_security_config.py
+++ b/crates/exarch-python/tests/test_security_config.py
@@ -143,3 +143,26 @@ class TestSecurityConfig:
         # Should reject overly long strings
         with pytest.raises(ValueError, match="maximum length"):
             config.add_allowed_extension("x" * 300)
+
+        # Should reject empty strings
+        with pytest.raises(ValueError, match="empty"):
+            config.add_allowed_extension("")
+
+    def test_banned_component_validation(self):
+        """Test banned path component string validation."""
+        config = SecurityConfig()
+
+        # Should accept valid component
+        config.add_banned_component("node_modules")
+
+        # Should reject null bytes
+        with pytest.raises(ValueError, match="null bytes"):
+            config.add_banned_component("bad\x00component")
+
+        # Should reject overly long strings
+        with pytest.raises(ValueError, match="maximum length"):
+            config.add_banned_component("x" * 300)
+
+        # Should reject empty strings
+        with pytest.raises(ValueError, match="empty"):
+            config.add_banned_component("")


### PR DESCRIPTION
## Summary
- `SecurityConfig::validate()` did not check `allowed_extensions`/`banned_path_components` for null bytes, empty entries, or length, unlike every other config field and unlike the (duplicated) checks already present in the Python and Node bindings.
- Adds `validate_config_entry()` (+ `MAX_CONFIG_ENTRY_LENGTH = 255`) to `exarch-core::security::boundary`, called per-entry from `SecurityConfig::validate()`, so the check now lives once at the single source of truth instead of being duplicated in each binding.
- Both bindings now delegate to the core helper instead of hand-rolling the check, and additionally reject empty entries eagerly.
- Fixes a regression caught during review: the CLI's documented `--banned-component ""` idiom (disable all component banning) would have hard-failed under the new empty-entry check; `extract.rs` now filters empties before validation so the documented behavior is preserved exactly.

## Breaking change
Configs with an empty, null-byte-containing, or >255-byte entry in `allowed_extensions`/`banned_path_components` now fail `validate()` where they previously passed silently.

## Test plan
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` (1070/1070)
- [x] `cargo test --doc --workspace --all-features` (102/102, including new `validate_config_entry` doctest)
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --all-features`
- [x] `cargo nextest run -p exarch-cli -- banned_component` — new end-to-end regression test for `--banned-component ""`
- [x] `maturin develop --features abi3` + `pytest` (45 passed, 1 pre-existing unrelated skip)
- [x] `npm run build` + `npm test` (86/86 passed)

Closes #449