### PR TITLE
fix(python,node)!: redact host paths in release-build error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,8 +126,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   integer-overflow branches in `QuotaTracker::record_file`/`record_file_checked`
   (`crates/exarch-core/src/security/quota.rs`), reinforcing the existing OPT-C003 hot/cold path
   optimization for the optimizer.
+- Internal: `exarch-python`'s `extract_archive`, `create_archive`, `list_archive`, and
+  `verify_archive`, and `exarch-node`'s async/sync `extract_archive(_sync)`,
+  `create_archive(_sync)`, `list_archive(_sync)`, and `verify_archive(_sync)` now route through
+  the existing `catch_panic_as_py_err`/`catch_panic_as_js_err` panic-catch helpers (#395) instead
+  of each reimplementing the identical `catch_unwind(...).map_err(...)` sequence inline (#454).
+  Pure deduplication — no change to panic-catching semantics or error messages.
+- **User-visible**: in release builds of `exarch-python` and `exarch-node`, an I/O error
+  (`CoreError::Io`) raised by either binding now reports only the `std::io::ErrorKind`
+  description (e.g. "permission denied") instead of the full underlying `io::Error` message text;
+  the full message is still shown in debug builds. See the `#453` entry below for why.
 
 ### Fixed
+
+- **`exarch-python` error messages leaked full absolute paths in release builds, and both
+  bindings leaked host paths embedded in `CoreError::Io` messages (#453)**:
+  `crates/exarch-python/src/error.rs` called `path.display()` directly and unconditionally for
+  every path-carrying `ArchiveError` variant (`PathTraversal`, `SymlinkEscape`, `HardlinkEscape`,
+  `InvalidPermissions`, `SourceNotFound`, `SourceNotAccessible`, `OutputExists`,
+  `UnknownFormat`), unlike `exarch-node`'s equivalent module which already redacted paths to just
+  the filename in release builds. Added a profile-gated `sanitize_path_for_error` helper matching
+  `exarch-node`'s behavior (full path under `debug_assertions`, filename only otherwise) and
+  routed every path-carrying variant through it. Separately, `CoreError::Io` was found to bypass
+  redaction in **both** bindings: `exarch-core`'s `DestDir` validation (e.g. "directory is not
+  writable: `{canonical_path}`") embeds a fully-canonicalized host path directly in the `io::Error`
+  message text, reachable from every extraction call via `DestDir::new_or_create`, and neither
+  binding's `Io` arm redacted it. Since the message is free-form text with no structured path
+  field, added a `sanitize_io_error_for_error` helper to both bindings that keeps the full
+  `Display` output under `debug_assertions` but reduces it to just the `std::io::ErrorKind`
+  description in release builds, closing the same leak class at the one variant that had been
+  missed. Neither `exarch-python` nor `exarch-node` now leaks internal directory structure in
+  release-build error messages.
 
 - **7z file writes discarded their `QuotaPermit` instead of consuming it (#440)**: unlike TAR/ZIP,
   7z's `ValidatedEntryType::File(_)` write arm matched the permit and dropped it via `_`, so the

--- a/crates/exarch-node/src/error.rs
+++ b/crates/exarch-node/src/error.rs
@@ -17,10 +17,26 @@ fn sanitize_path_for_error(path: &Path) -> String {
 
 #[cfg(not(debug_assertions))]
 fn sanitize_path_for_error(path: &Path) -> String {
-    path.file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("<unknown>")
-        .to_string()
+    path.file_name().map_or_else(
+        || "<unknown>".to_string(),
+        |n| n.to_string_lossy().into_owned(),
+    )
+}
+
+/// Sanitizes I/O error messages for error reporting.
+///
+/// In debug builds, returns the full `Display` output (which may embed a
+/// host path, e.g. from `DestDir`'s validation messages). In release builds,
+/// returns only the [`std::io::ErrorKind`] description, since the free-form
+/// message text has no structured path field to redact.
+#[cfg(debug_assertions)]
+fn sanitize_io_error_for_error(e: &std::io::Error) -> String {
+    e.to_string()
+}
+
+#[cfg(not(debug_assertions))]
+fn sanitize_io_error_for_error(e: &std::io::Error) -> String {
+    e.kind().to_string()
 }
 
 /// Converts Rust extraction errors to JavaScript exceptions.
@@ -130,7 +146,7 @@ pub fn convert_error(err: CoreError) -> Error {
             Error::new(Status::GenericFailure, msg)
         }
         CoreError::Io(e) => {
-            let e_str = e.to_string();
+            let e_str = sanitize_io_error_for_error(&e);
             let mut msg = String::with_capacity(10 + e_str.len());
             msg.push_str("IO_ERROR: ");
             msg.push_str(&e_str);
@@ -202,7 +218,10 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
+    /// Asserts the full attacker-supplied path is present, which only holds
+    /// under `debug_assertions` (see `sanitize_path_for_error`).
     #[test]
+    #[cfg(debug_assertions)]
     fn test_path_traversal_conversion() {
         let err = CoreError::PathTraversal {
             path: PathBuf::from("../etc/passwd"),
@@ -214,7 +233,10 @@ mod tests {
         assert!(err_str.contains("../etc/passwd"));
     }
 
+    /// Asserts the full path is present, which only holds under
+    /// `debug_assertions` (see `sanitize_path_for_error`).
     #[test]
+    #[cfg(debug_assertions)]
     fn test_symlink_escape_conversion() {
         let err = CoreError::SymlinkEscape {
             path: PathBuf::from("/etc/passwd"),
@@ -226,7 +248,10 @@ mod tests {
         assert!(err_str.contains("/etc/passwd"));
     }
 
+    /// Asserts the full path is present, which only holds under
+    /// `debug_assertions` (see `sanitize_path_for_error`).
     #[test]
+    #[cfg(debug_assertions)]
     fn test_hardlink_escape_conversion() {
         let err = CoreError::HardlinkEscape {
             path: PathBuf::from("/etc/shadow"),
@@ -352,7 +377,10 @@ mod tests {
         assert!(err_str.contains("corrupted header"));
     }
 
+    /// Asserts the original custom message is present, which only holds
+    /// under `debug_assertions` (see `sanitize_io_error_for_error`).
     #[test]
+    #[cfg(debug_assertions)]
     fn test_io_error_conversion() {
         let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "file not found");
         let err = CoreError::Io(io_err);
@@ -360,6 +388,40 @@ mod tests {
         let err_str = napi_err.to_string();
         assert!(err_str.contains("IO_ERROR"));
         assert!(err_str.contains("file not found"));
+    }
+
+    /// Regression test for #453 follow-up: in release builds,
+    /// `sanitize_path_for_error` must strip the path down to the filename,
+    /// not leak the full host path.
+    #[test]
+    #[cfg(not(debug_assertions))]
+    fn test_sanitize_path_for_error_strips_directory_in_release() {
+        let path = PathBuf::from("/srv/secret/app/x.txt");
+        assert_eq!(sanitize_path_for_error(&path), "x.txt");
+    }
+
+    /// Regression test for #453 follow-up: `CoreError::Io` carries free-form
+    /// messages (e.g. from `DestDir`'s validation) that can embed a host
+    /// path. In release builds the message must be reduced to the
+    /// `ErrorKind` description so no such path can leak through it.
+    #[test]
+    #[cfg(not(debug_assertions))]
+    fn test_io_error_conversion_redacts_message_in_release() {
+        let io_err = std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "directory is not writable: /srv/secret/app/private-output",
+        );
+        let err = CoreError::Io(io_err);
+        let napi_err = convert_error(err);
+        let err_str = napi_err.to_string();
+        assert!(
+            !err_str.contains("/srv/secret/app"),
+            "Expected host path to be redacted, got: {err_str}"
+        );
+        assert!(
+            err_str.contains("permission denied"),
+            "Expected ErrorKind description in error message, got: {err_str}"
+        );
     }
 
     /// Regression test for #251 + #210: `convert_error` must preserve the

--- a/crates/exarch-node/src/lib.rs
+++ b/crates/exarch-node/src/lib.rs
@@ -181,7 +181,7 @@ pub async fn extract_archive(
     // For maximum security with untrusted archives, use extractArchiveSync()
     // or ensure exclusive file access (e.g., flock) during extraction.
     let report = tokio::task::spawn_blocking(move || {
-        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        catch_panic_as_js_err("archive extraction", || {
             exarch_core::extract_archive_with_options(
                 &archive_path,
                 &output_dir,
@@ -189,9 +189,7 @@ pub async fn extract_archive(
                 &options_owned,
             )
             .map_err(convert_error)
-        }))
-        .map_err(|_| Error::from_reason("Internal panic during archive extraction"))
-        .flatten()
+        })
     })
     .await
     .map_err(|e| Error::from_reason(format!("task join error: {e}")))
@@ -254,16 +252,15 @@ pub fn extract_archive_sync(
 
     // Run extraction synchronously with panic safety
     // CRITICAL: Never panic across FFI boundary
-    let report = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+    let report = catch_panic_as_js_err("archive extraction", || {
         exarch_core::extract_archive_with_options(
             &archive_path,
             &output_dir,
             config_ref,
             options_ref,
         )
-    }))
-    .map_err(|_| Error::from_reason("Internal panic during archive extraction"))?
-    .map_err(convert_error)?;
+        .map_err(convert_error)
+    })?;
 
     Ok(ExtractionReport::from(report))
 }
@@ -313,13 +310,11 @@ pub async fn create_archive(
         config.map(|c| c.as_core().clone()).unwrap_or_default();
 
     let report = tokio::task::spawn_blocking(move || {
-        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        catch_panic_as_js_err("archive creation", || {
             let sources_refs: Vec<&str> = sources.iter().map(String::as_str).collect();
             exarch_core::create_archive(&output_path, &sources_refs, &config_owned)
                 .map_err(convert_error)
-        }))
-        .map_err(|_| Error::from_reason("Internal panic during archive creation"))
-        .flatten()
+        })
     })
     .await
     .map_err(|e| Error::from_reason(format!("task join error: {e}")))
@@ -372,11 +367,9 @@ pub fn create_archive_sync(
 
     let sources_refs: Vec<&str> = sources.iter().map(String::as_str).collect();
 
-    let report = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        exarch_core::create_archive(&output_path, &sources_refs, config_ref)
-    }))
-    .map_err(|_| Error::from_reason("Internal panic during archive creation"))?
-    .map_err(convert_error)?;
+    let report = catch_panic_as_js_err("archive creation", || {
+        exarch_core::create_archive(&output_path, &sources_refs, config_ref).map_err(convert_error)
+    })?;
 
     Ok(CreationReport::from(report))
 }
@@ -418,11 +411,9 @@ pub async fn list_archive(
         config.map(|c| c.as_core().clone()).unwrap_or_default();
 
     let manifest = tokio::task::spawn_blocking(move || {
-        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        catch_panic_as_js_err("archive listing", || {
             exarch_core::list_archive(&archive_path, &config_owned).map_err(convert_error)
-        }))
-        .map_err(|_| Error::from_reason("Internal panic during archive listing"))
-        .flatten()
+        })
     })
     .await
     .map_err(|e| Error::from_reason(format!("task join error: {e}")))
@@ -469,11 +460,9 @@ pub fn list_archive_sync(
     let default_config = exarch_core::SecurityConfig::default();
     let config_ref = config.map_or(&default_config, |c| c.as_core());
 
-    let manifest = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        exarch_core::list_archive(&archive_path, config_ref)
-    }))
-    .map_err(|_| Error::from_reason("Internal panic during archive listing"))?
-    .map_err(convert_error)?;
+    let manifest = catch_panic_as_js_err("archive listing", || {
+        exarch_core::list_archive(&archive_path, config_ref).map_err(convert_error)
+    })?;
 
     Ok(ArchiveManifest::from(manifest))
 }
@@ -519,11 +508,9 @@ pub async fn verify_archive(
         config.map(|c| c.as_core().clone()).unwrap_or_default();
 
     let report = tokio::task::spawn_blocking(move || {
-        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        catch_panic_as_js_err("archive verification", || {
             exarch_core::verify_archive(&archive_path, &config_owned).map_err(convert_error)
-        }))
-        .map_err(|_| Error::from_reason("Internal panic during archive verification"))
-        .flatten()
+        })
     })
     .await
     .map_err(|e| Error::from_reason(format!("task join error: {e}")))
@@ -570,11 +557,9 @@ pub fn verify_archive_sync(
     let default_config = exarch_core::SecurityConfig::default();
     let config_ref = config.map_or(&default_config, |c| c.as_core());
 
-    let report = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        exarch_core::verify_archive(&archive_path, config_ref)
-    }))
-    .map_err(|_| Error::from_reason("Internal panic during archive verification"))?
-    .map_err(convert_error)?;
+    let report = catch_panic_as_js_err("archive verification", || {
+        exarch_core::verify_archive(&archive_path, config_ref).map_err(convert_error)
+    })?;
 
     Ok(VerificationReport::from(report))
 }

--- a/crates/exarch-python/src/error.rs
+++ b/crates/exarch-python/src/error.rs
@@ -7,6 +7,41 @@ use pyo3::exceptions::PyException;
 use pyo3::exceptions::PyIOError;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
+use std::path::Path;
+
+/// Sanitizes path information for error messages.
+///
+/// In debug builds, returns the full path for detailed diagnostics.
+/// In release builds, returns only the filename to avoid leaking internal
+/// directory structures to potential attackers.
+#[cfg(debug_assertions)]
+fn sanitize_path_for_error(path: &Path) -> String {
+    path.display().to_string()
+}
+
+#[cfg(not(debug_assertions))]
+fn sanitize_path_for_error(path: &Path) -> String {
+    path.file_name().map_or_else(
+        || "<unknown>".to_string(),
+        |n| n.to_string_lossy().into_owned(),
+    )
+}
+
+/// Sanitizes I/O error messages for error reporting.
+///
+/// In debug builds, returns the full `Display` output (which may embed a
+/// host path, e.g. from `DestDir`'s validation messages). In release builds,
+/// returns only the [`std::io::ErrorKind`] description, since the free-form
+/// message text has no structured path field to redact.
+#[cfg(debug_assertions)]
+fn sanitize_io_error_for_error(e: &std::io::Error) -> String {
+    e.to_string()
+}
+
+#[cfg(not(debug_assertions))]
+fn sanitize_io_error_for_error(e: &std::io::Error) -> String {
+    e.kind().to_string()
+}
 
 // Base exception for all extraction errors
 create_exception!(exarch, ArchiveError, PyException);
@@ -36,16 +71,21 @@ create_exception!(exarch, InvalidArchiveError, ArchiveError);
 pub fn convert_error(err: CoreError) -> PyErr {
     match err {
         CoreError::PathTraversal { path } => {
-            PathTraversalError::new_err(format!("path traversal detected: {}", path.display()))
+            let path_str = sanitize_path_for_error(&path);
+            PathTraversalError::new_err(format!("path traversal detected: {path_str}"))
         }
-        CoreError::SymlinkEscape { path } => SymlinkEscapeError::new_err(format!(
-            "symlink target outside extraction directory: {}",
-            path.display()
-        )),
-        CoreError::HardlinkEscape { path } => HardlinkEscapeError::new_err(format!(
-            "hardlink target outside extraction directory: {}",
-            path.display()
-        )),
+        CoreError::SymlinkEscape { path } => {
+            let path_str = sanitize_path_for_error(&path);
+            SymlinkEscapeError::new_err(format!(
+                "symlink target outside extraction directory: {path_str}"
+            ))
+        }
+        CoreError::HardlinkEscape { path } => {
+            let path_str = sanitize_path_for_error(&path);
+            HardlinkEscapeError::new_err(format!(
+                "hardlink target outside extraction directory: {path_str}"
+            ))
+        }
         CoreError::ZipBomb {
             compressed,
             uncompressed,
@@ -53,11 +93,12 @@ pub fn convert_error(err: CoreError) -> PyErr {
         } => ZipBombError::new_err(format!(
             "potential zip bomb: compressed={compressed} bytes, uncompressed={uncompressed} bytes (ratio: {ratio:.2})"
         )),
-        CoreError::InvalidPermissions { path, mode } => InvalidPermissionsError::new_err(format!(
-            "invalid permissions for {}: {:#o}",
-            path.display(),
-            mode
-        )),
+        CoreError::InvalidPermissions { path, mode } => {
+            let path_str = sanitize_path_for_error(&path);
+            InvalidPermissionsError::new_err(format!(
+                "invalid permissions for {path_str}: {mode:#o}"
+            ))
+        }
         CoreError::QuotaExceeded { resource } => {
             let msg = match resource {
                 CoreQuotaResource::FileCount { current, max } => {
@@ -81,23 +122,29 @@ pub fn convert_error(err: CoreError) -> PyErr {
         CoreError::InvalidArchive(msg) => {
             InvalidArchiveError::new_err(format!("invalid archive: {msg}"))
         }
-        CoreError::Io(e) => PyErr::from(e),
+        CoreError::Io(e) => {
+            let msg = sanitize_io_error_for_error(&e);
+            PyErr::from(std::io::Error::new(e.kind(), msg))
+        }
         CoreError::SourceNotFound { path } => {
-            PyIOError::new_err(format!("source path not found: {}", path.display()))
+            let path_str = sanitize_path_for_error(&path);
+            PyIOError::new_err(format!("source path not found: {path_str}"))
         }
         CoreError::SourceNotAccessible { path } => {
-            PyIOError::new_err(format!("source path is not accessible: {}", path.display()))
+            let path_str = sanitize_path_for_error(&path);
+            PyIOError::new_err(format!("source path is not accessible: {path_str}"))
         }
         CoreError::OutputExists { path } => {
-            PyIOError::new_err(format!("output file already exists: {}", path.display()))
+            let path_str = sanitize_path_for_error(&path);
+            PyIOError::new_err(format!("output file already exists: {path_str}"))
         }
         CoreError::InvalidCompressionLevel { level } => {
             PyValueError::new_err(format!("invalid compression level {level}, must be 1-9"))
         }
-        CoreError::UnknownFormat { path } => UnknownFormatError::new_err(format!(
-            "cannot determine archive format from: {}",
-            path.display()
-        )),
+        CoreError::UnknownFormat { path } => {
+            let path_str = sanitize_path_for_error(&path);
+            UnknownFormatError::new_err(format!("cannot determine archive format from: {path_str}"))
+        }
         CoreError::InvalidConfiguration { reason } => {
             PyValueError::new_err(format!("invalid configuration: {reason}"))
         }
@@ -171,7 +218,10 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
+    /// Asserts the full attacker-supplied path is present, which only holds
+    /// under `debug_assertions` (see `sanitize_path_for_error`).
     #[test]
+    #[cfg(debug_assertions)]
     fn test_path_traversal_conversion() {
         let err = CoreError::PathTraversal {
             path: PathBuf::from("../etc/passwd"),
@@ -190,7 +240,10 @@ mod tests {
         );
     }
 
+    /// Asserts the full path is present, which only holds under
+    /// `debug_assertions` (see `sanitize_path_for_error`).
     #[test]
+    #[cfg(debug_assertions)]
     fn test_symlink_escape_conversion() {
         let err = CoreError::SymlinkEscape {
             path: PathBuf::from("/etc/passwd"),
@@ -209,7 +262,10 @@ mod tests {
         );
     }
 
+    /// Asserts the full path is present, which only holds under
+    /// `debug_assertions` (see `sanitize_path_for_error`).
     #[test]
+    #[cfg(debug_assertions)]
     fn test_hardlink_escape_conversion() {
         let err = CoreError::HardlinkEscape {
             path: PathBuf::from("/etc/shadow"),
@@ -428,7 +484,10 @@ mod tests {
         );
     }
 
+    /// Asserts the original custom message is present, which only holds
+    /// under `debug_assertions` (see `sanitize_io_error_for_error`).
     #[test]
+    #[cfg(debug_assertions)]
     fn test_io_error_conversion() {
         let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "file not found");
         let err = CoreError::Io(io_err);
@@ -437,6 +496,61 @@ mod tests {
         assert!(
             err_str.contains("file not found"),
             "Expected 'file not found' in error message, got: {}",
+            err_str
+        );
+    }
+
+    /// Regression test for #453 follow-up: in release builds,
+    /// `sanitize_path_for_error` must strip the path down to the filename,
+    /// not leak the full host path.
+    #[test]
+    #[cfg(not(debug_assertions))]
+    fn test_sanitize_path_for_error_strips_directory_in_release() {
+        let path = PathBuf::from("/srv/secret/app/x.txt");
+        assert_eq!(sanitize_path_for_error(&path), "x.txt");
+    }
+
+    /// Regression test for #453 follow-up: `CoreError::Io` carries free-form
+    /// messages (e.g. from `DestDir`'s validation) that can embed a host
+    /// path. In release builds the message must be reduced to the
+    /// `ErrorKind` description so no such path can leak through it.
+    #[test]
+    #[cfg(not(debug_assertions))]
+    fn test_io_error_conversion_redacts_message_in_release() {
+        let io_err = std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "directory is not writable: /srv/secret/app/private-output",
+        );
+        let err = CoreError::Io(io_err);
+        let py_err = convert_error(err);
+        let err_str = py_err.to_string();
+        assert!(
+            !err_str.contains("/srv/secret/app"),
+            "Expected host path to be redacted, got: {}",
+            err_str
+        );
+        assert!(
+            err_str.contains("permission denied"),
+            "Expected ErrorKind description in error message, got: {}",
+            err_str
+        );
+    }
+
+    #[test]
+    fn test_source_not_found_conversion() {
+        let err = CoreError::SourceNotFound {
+            path: PathBuf::from("missing_source.tar.gz"),
+        };
+        let py_err = convert_error(err);
+        let err_str = py_err.to_string();
+        assert!(
+            err_str.contains("source path not found"),
+            "Expected 'source path not found' in error message, got: {}",
+            err_str
+        );
+        assert!(
+            err_str.contains("missing_source.tar.gz"),
+            "Expected filename in error message, got: {}",
             err_str
         );
     }

--- a/crates/exarch-python/src/lib.rs
+++ b/crates/exarch-python/src/lib.rs
@@ -126,7 +126,7 @@ fn extract_archive(
     // NOTE: TOCTOU race condition - archive contents can change between check and
     // extraction. This is an accepted limitation when releasing the GIL for
     // performance.
-    let report = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+    let report = catch_panic_as_py_err("extraction", || {
         py.detach(|| {
             exarch_core::extract_archive_with_options(
                 &archive_path,
@@ -135,11 +135,7 @@ fn extract_archive(
                 options_ref,
             )
         })
-    }))
-    .map_err(|_| {
-        PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Internal panic during extraction")
-    })?
-    .map_err(convert_error)?;
+    })?;
 
     Ok(PyExtractionReport::from(report))
 }
@@ -256,13 +252,9 @@ fn create_archive(
     let default_config = exarch_core::creation::CreationConfig::default();
     let config_ref = config.map_or(&default_config, |c| c.as_core());
 
-    let report = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+    let report = catch_panic_as_py_err("archive creation", || {
         py.detach(|| exarch_core::create_archive(&output_path, &source_paths, config_ref))
-    }))
-    .map_err(|_| {
-        PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Internal panic during archive creation")
-    })?
-    .map_err(convert_error)?;
+    })?;
 
     Ok(PyCreationReport::from(report))
 }
@@ -305,13 +297,9 @@ fn list_archive(
     let default_config = exarch_core::SecurityConfig::default();
     let config_ref = config.map_or(&default_config, |c| c.as_core());
 
-    let manifest = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+    let manifest = catch_panic_as_py_err("archive listing", || {
         py.detach(|| exarch_core::list_archive(&archive_path, config_ref))
-    }))
-    .map_err(|_| {
-        PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Internal panic during archive listing")
-    })?
-    .map_err(convert_error)?;
+    })?;
 
     Ok(PyArchiveManifest::from(manifest))
 }
@@ -357,15 +345,9 @@ fn verify_archive(
     let default_config = exarch_core::SecurityConfig::default();
     let config_ref = config.map_or(&default_config, |c| c.as_core());
 
-    let report = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+    let report = catch_panic_as_py_err("archive verification", || {
         py.detach(|| exarch_core::verify_archive(&archive_path, config_ref))
-    }))
-    .map_err(|_| {
-        PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
-            "Internal panic during archive verification",
-        )
-    })?
-    .map_err(convert_error)?;
+    })?;
 
     Ok(PyVerificationReport::from(report))
 }


### PR DESCRIPTION
## Summary
- exarch-python leaked full absolute host paths in release builds for 8 path-carrying error variants; add a sanitize_path_for_error helper matching exarch-node's existing redaction.
- CoreError::Io bypassed redaction in both bindings, leaking canonicalized host paths from exarch-core's DestDir validation on the mainline extract path; add sanitize_io_error_for_error to reduce it to the ErrorKind description in release builds.
- Dedup: extract_archive/create_archive/list_archive/verify_archive (+ node's _sync variants) now route through the existing catch_panic_as_py_err/catch_panic_as_js_err helpers instead of inlining catch_unwind.

BREAKING CHANGE: release-build I/O error messages from either binding now show only the ErrorKind description, not the full io::Error text.

## Test plan
- [x] cargo +nightly fmt --all -- --check
- [x] cargo clippy --workspace --all-targets --all-features -- -D warnings
- [x] cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node (1054 passed)
- [x] cargo test --doc --workspace --all-features (exarch-python doctest skipped: pre-existing local linker issue, unrelated to this change; exarch-core/cli/node doctests pass standalone)
- [x] cargo clippy -p exarch-python / -p exarch-node --all-features --all-targets [--release] -- -D warnings (dev and release, both clean)
- [x] RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace
- [x] New regression tests for release-mode path/Io redaction in both bindings

Closes #453
Closes #454