### PR TITLE
fix(cli): dedupe output formatting and fix TB-size rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   inaccurate "characters" wording for multi-byte input. `exarch-node`'s error messages for these
   two setters now carry the crate-wide `INVALID_CONFIGURATION: invalid configuration: ` prefix
   (previously a bare reason string), matching every other error path in the binding.
+- **`exarch-cli` output formatters now write through an injectable writer (#452)**:
+  `OutputFormatter`'s six trait methods take `&mut self` instead of `&self`.
+  `HumanFormatter<O: Write = Term, E: Write = Term>` writes non-error output to `O` and errors to
+  `E` (`HumanFormatter::new` keeps the stdout/stderr default; `HumanFormatter::with_writers` injects
+  custom writers and an explicit `use_colors` flag for deterministic tests). `JsonFormatter<W: Write
+  = Stdout>` gained the same shape (`JsonFormatter::stdout()` replaces the old unit-struct
+  constructor; `JsonFormatter::with_writer` injects a custom writer). `create_formatter`'s signature
+  is unchanged. This unlocks unit tests that capture formatter output into an in-memory buffer
+  instead of requiring a subprocess. `HumanFormatter` renders each line into a `String` first and
+  issues a single `write_all` per line (`output::human::emit_line`/`emit_blank`) rather than calling
+  `writeln!` directly on the writer, which would otherwise turn one multi-argument format line into
+  several separate small writes against `console::Term` (no internal buffering) — output throughput
+  on large manifests is unchanged from the pre-refactor `Term::write_line` behavior.
+- **CLI size-limit defaults are no longer re-literalized across commands (#450)**: added
+  `commands::apply_size_limits(config, max_total, max_file)` in `crates/exarch-cli/src/commands/mod.rs`,
+  applying `--max-total-size`/`--max-file-size` overrides only when provided and otherwise leaving
+  `SecurityConfig::default()`'s own limits in place. `extract`, `list`, and `verify` now route
+  through this helper instead of each hardcoding `.unwrap_or(500 * 1024 * 1024)` /
+  `.unwrap_or(50 * 1024 * 1024)`. No behavior change.
 - **BREAKING: `exarch-node` boolean setters now take a mandatory `boolean` instead of an
   optional one (#442)**: `SecurityConfig.setAllowSymlinks`, `setAllowHardlinks`,
   `setAllowAbsolutePaths`, `setAllowWorldWritable`, `setAllowSolidArchives`,
@@ -157,7 +176,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   description in release builds, closing the same leak class at the one variant that had been
   missed. Neither `exarch-python` nor `exarch-node` now leaks internal directory structure in
   release-build error messages.
-
+- **`exarch-cli` human-readable sizes >= 1 TB rendered as an inflated GB figure instead of TB
+  (#451)**: `HumanFormatter::format_size` (`crates/exarch-cli/src/output/human.rs`) and
+  `progress::humanize_bytes` (`crates/exarch-cli/src/progress.rs`) were two independent
+  byte-humanization implementations; only the `progress` copy had a TB tier. Consolidated both into
+  a single `output::humanize_bytes` (`crates/exarch-cli/src/output/mod.rs`) with the TB-inclusive
+  ladder, so `extract`/`list --long --human-readable` output for archives or entries at or above 1
+  TB now shows `"... TB"` instead of a misleadingly large GB number (e.g. `u64::MAX` bytes now
+  renders `"16777216.0 TB"`, not `"17179869184.0 GB"`).
 - **7z file writes discarded their `QuotaPermit` instead of consuming it (#440)**: unlike TAR/ZIP,
   7z's `ValidatedEntryType::File(_)` write arm matched the permit and dropped it via `_`, so the
   capability-token guarantee introduced in #436 covered TAR and ZIP but not 7z. Added

--- a/crates/exarch-cli/src/commands/create.rs
+++ b/crates/exarch-cli/src/commands/create.rs
@@ -9,7 +9,7 @@ use exarch_core::CreationConfig;
 use exarch_core::NoopProgress;
 use exarch_core::create_archive_with_progress;
 
-pub fn execute(args: &CreateArgs, formatter: &dyn OutputFormatter, quiet: bool) -> Result<()> {
+pub fn execute(args: &CreateArgs, formatter: &mut dyn OutputFormatter, quiet: bool) -> Result<()> {
     // Check if output exists
     if args.output.exists() && !args.force {
         anyhow::bail!(
@@ -90,30 +90,30 @@ mod tests {
     }
 
     impl OutputFormatter for SpyFormatter {
-        fn format_extraction_result(&self, _: &ExtractionReport) -> Result<()> {
+        fn format_extraction_result(&mut self, _: &ExtractionReport) -> Result<()> {
             Ok(())
         }
 
-        fn format_creation_result(&self, _: &Path, _: &CreationReport) -> Result<()> {
+        fn format_creation_result(&mut self, _: &Path, _: &CreationReport) -> Result<()> {
             if !self.quiet {
                 self.called.set(true);
             }
             Ok(())
         }
 
-        fn format_manifest_short(&self, _: &ArchiveManifest) -> Result<()> {
+        fn format_manifest_short(&mut self, _: &ArchiveManifest) -> Result<()> {
             Ok(())
         }
 
-        fn format_manifest_long(&self, _: &ArchiveManifest, _: bool) -> Result<()> {
+        fn format_manifest_long(&mut self, _: &ArchiveManifest, _: bool) -> Result<()> {
             Ok(())
         }
 
-        fn format_verification_report(&self, _: &VerificationReport) -> Result<()> {
+        fn format_verification_report(&mut self, _: &VerificationReport) -> Result<()> {
             Ok(())
         }
 
-        fn format_error(&self, _: &str, _: &anyhow::Error) {}
+        fn format_error(&mut self, _: &str, _: &anyhow::Error) {}
     }
 
     /// `JsonFormatter` always calls `format_creation_result` regardless of
@@ -135,28 +135,28 @@ mod tests {
     }
 
     impl OutputFormatter for AlwaysCallSpyFormatter {
-        fn format_extraction_result(&self, _: &ExtractionReport) -> Result<()> {
+        fn format_extraction_result(&mut self, _: &ExtractionReport) -> Result<()> {
             Ok(())
         }
 
-        fn format_creation_result(&self, _: &Path, _: &CreationReport) -> Result<()> {
+        fn format_creation_result(&mut self, _: &Path, _: &CreationReport) -> Result<()> {
             self.called.set(true);
             Ok(())
         }
 
-        fn format_manifest_short(&self, _: &ArchiveManifest) -> Result<()> {
+        fn format_manifest_short(&mut self, _: &ArchiveManifest) -> Result<()> {
             Ok(())
         }
 
-        fn format_manifest_long(&self, _: &ArchiveManifest, _: bool) -> Result<()> {
+        fn format_manifest_long(&mut self, _: &ArchiveManifest, _: bool) -> Result<()> {
             Ok(())
         }
 
-        fn format_verification_report(&self, _: &VerificationReport) -> Result<()> {
+        fn format_verification_report(&mut self, _: &VerificationReport) -> Result<()> {
             Ok(())
         }
 
-        fn format_error(&self, _: &str, _: &anyhow::Error) {}
+        fn format_error(&mut self, _: &str, _: &anyhow::Error) {}
     }
 
     fn make_args(output: PathBuf, source: PathBuf) -> CreateArgs {
@@ -184,9 +184,9 @@ mod tests {
         let out = tmp.path().join("out.tar.gz");
 
         let args = make_args(out, src);
-        let formatter = AlwaysCallSpyFormatter::new();
+        let mut formatter = AlwaysCallSpyFormatter::new();
 
-        execute(&args, &formatter, true).unwrap();
+        execute(&args, &mut formatter, true).unwrap();
 
         assert!(
             formatter.was_called(),
@@ -202,9 +202,9 @@ mod tests {
         let out = tmp.path().join("out.tar.gz");
 
         let args = make_args(out, src);
-        let formatter = AlwaysCallSpyFormatter::new();
+        let mut formatter = AlwaysCallSpyFormatter::new();
 
-        execute(&args, &formatter, false).unwrap();
+        execute(&args, &mut formatter, false).unwrap();
 
         assert!(formatter.was_called());
     }
@@ -219,9 +219,9 @@ mod tests {
         let out = tmp.path().join("out.tar.gz");
 
         let args = make_args(out, src);
-        let formatter = SpyFormatter::new(true);
+        let mut formatter = SpyFormatter::new(true);
 
-        execute(&args, &formatter, true).unwrap();
+        execute(&args, &mut formatter, true).unwrap();
 
         assert!(
             !formatter.was_called(),

--- a/crates/exarch-cli/src/commands/extract.rs
+++ b/crates/exarch-cli/src/commands/extract.rs
@@ -1,6 +1,7 @@
 //! Extract command implementation.
 
 use crate::cli::ExtractArgs;
+use crate::commands::apply_size_limits;
 use crate::error::add_archive_context;
 use crate::output::OutputFormatter;
 use crate::progress::CliProgress;
@@ -58,7 +59,7 @@ fn filter_banned_components(raw: &[String]) -> Vec<String> {
 
 pub fn execute(
     args: &ExtractArgs,
-    formatter: &dyn OutputFormatter,
+    formatter: &mut dyn OutputFormatter,
     verbose: bool,
     quiet: bool,
 ) -> Result<()> {
@@ -69,19 +70,20 @@ pub fn execute(
 
     let allowed_extensions = parse_extensions(&args.allowed_extensions);
 
-    let config = SecurityConfig::default()
-        .with_max_file_count(args.max_files)
-        .with_max_total_size(args.max_total_size.unwrap_or(500 * 1024 * 1024))
-        .with_max_file_size(args.max_file_size.unwrap_or(50 * 1024 * 1024))
-        .with_max_compression_ratio(f64::from(args.max_compression_ratio))
-        .with_max_path_depth(args.max_path_depth)
-        .with_allow_symlinks(args.allow_symlinks)
-        .with_allow_hardlinks(args.allow_hardlinks)
-        .with_allow_absolute_paths(args.allow_absolute_paths)
-        .with_allow_world_writable(args.allow_world_writable)
-        .with_preserve_permissions(args.preserve_permissions)
-        .with_allow_solid_archives(args.allow_solid_archives)
-        .with_allowed_extensions(allowed_extensions);
+    let config = apply_size_limits(
+        SecurityConfig::default().with_max_file_count(args.max_files),
+        args.max_total_size,
+        args.max_file_size,
+    )
+    .with_max_compression_ratio(f64::from(args.max_compression_ratio))
+    .with_max_path_depth(args.max_path_depth)
+    .with_allow_symlinks(args.allow_symlinks)
+    .with_allow_hardlinks(args.allow_hardlinks)
+    .with_allow_absolute_paths(args.allow_absolute_paths)
+    .with_allow_world_writable(args.allow_world_writable)
+    .with_preserve_permissions(args.preserve_permissions)
+    .with_allow_solid_archives(args.allow_solid_archives)
+    .with_allowed_extensions(allowed_extensions);
 
     let config = if args.banned_components.is_empty() {
         config

--- a/crates/exarch-cli/src/commands/list.rs
+++ b/crates/exarch-cli/src/commands/list.rs
@@ -1,17 +1,19 @@
 //! List command implementation
 
 use crate::cli::ListArgs;
+use crate::commands::apply_size_limits;
 use crate::output::OutputFormatter;
 use anyhow::Result;
 use exarch_core::SecurityConfig;
 use exarch_core::list_archive;
 
-pub fn execute(args: &ListArgs, formatter: &dyn OutputFormatter) -> Result<()> {
-    let config = SecurityConfig::default()
-        .with_max_file_count(args.max_files)
-        .with_max_total_size(args.max_total_size.unwrap_or(500 * 1024 * 1024))
-        .with_max_file_size(args.max_file_size.unwrap_or(50 * 1024 * 1024))
-        .with_allow_solid_archives(args.allow_solid_archives);
+pub fn execute(args: &ListArgs, formatter: &mut dyn OutputFormatter) -> Result<()> {
+    let config = apply_size_limits(
+        SecurityConfig::default().with_max_file_count(args.max_files),
+        args.max_total_size,
+        args.max_file_size,
+    )
+    .with_allow_solid_archives(args.allow_solid_archives);
 
     // List archive
     let manifest = list_archive(&args.archive, &config)?;

--- a/crates/exarch-cli/src/commands/mod.rs
+++ b/crates/exarch-cli/src/commands/mod.rs
@@ -5,3 +5,72 @@ pub mod create;
 pub mod extract;
 pub mod list;
 pub mod verify;
+
+use exarch_core::SecurityConfig;
+
+/// Applies CLI-provided size-limit overrides to a [`SecurityConfig`],
+/// leaving `SecurityConfig::default()`'s own limits in place when an
+/// override is not supplied.
+pub fn apply_size_limits(
+    config: SecurityConfig,
+    max_total: Option<u64>,
+    max_file: Option<u64>,
+) -> SecurityConfig {
+    let config = match max_total {
+        Some(v) => config.with_max_total_size(v),
+        None => config,
+    };
+    match max_file {
+        Some(v) => config.with_max_file_size(v),
+        None => config,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::apply_size_limits;
+    use exarch_core::SecurityConfig;
+
+    #[test]
+    fn both_none_keeps_defaults() {
+        let defaults = SecurityConfig::default();
+        let (default_total, default_file) = (defaults.max_total_size, defaults.max_file_size);
+
+        let config = apply_size_limits(SecurityConfig::default(), None, None);
+
+        assert_eq!(config.max_total_size, default_total);
+        assert_eq!(config.max_file_size, default_file);
+    }
+
+    #[test]
+    fn both_some_overrides_both() {
+        let config = apply_size_limits(
+            SecurityConfig::default(),
+            Some(10 * 1024 * 1024 * 1024),
+            Some(1024 * 1024 * 1024),
+        );
+
+        assert_eq!(config.max_total_size, 10 * 1024 * 1024 * 1024);
+        assert_eq!(config.max_file_size, 1024 * 1024 * 1024);
+    }
+
+    #[test]
+    fn total_some_file_none_overrides_only_total() {
+        let default_file = SecurityConfig::default().max_file_size;
+
+        let config = apply_size_limits(SecurityConfig::default(), Some(1024), None);
+
+        assert_eq!(config.max_total_size, 1024);
+        assert_eq!(config.max_file_size, default_file);
+    }
+
+    #[test]
+    fn total_none_file_some_overrides_only_file() {
+        let default_total = SecurityConfig::default().max_total_size;
+
+        let config = apply_size_limits(SecurityConfig::default(), None, Some(2048));
+
+        assert_eq!(config.max_total_size, default_total);
+        assert_eq!(config.max_file_size, 2048);
+    }
+}

--- a/crates/exarch-cli/src/commands/verify.rs
+++ b/crates/exarch-cli/src/commands/verify.rs
@@ -1,6 +1,7 @@
 //! Verify command implementation
 
 use crate::cli::VerifyArgs;
+use crate::commands::apply_size_limits;
 use crate::error::StrictWarning;
 use crate::error::VerificationFailed;
 use crate::output::OutputFormatter;
@@ -9,12 +10,13 @@ use exarch_core::SecurityConfig;
 use exarch_core::VerificationStatus;
 use exarch_core::verify_archive;
 
-pub fn execute(args: &VerifyArgs, formatter: &dyn OutputFormatter) -> Result<()> {
-    let config = SecurityConfig::default()
-        .with_max_file_count(args.max_files)
-        .with_max_total_size(args.max_total_size.unwrap_or(500 * 1024 * 1024))
-        .with_max_file_size(args.max_file_size.unwrap_or(50 * 1024 * 1024))
-        .with_allow_solid_archives(args.allow_solid_archives);
+pub fn execute(args: &VerifyArgs, formatter: &mut dyn OutputFormatter) -> Result<()> {
+    let config = apply_size_limits(
+        SecurityConfig::default().with_max_file_count(args.max_files),
+        args.max_total_size,
+        args.max_file_size,
+    )
+    .with_allow_solid_archives(args.allow_solid_archives);
 
     let report = verify_archive(&args.archive, &config)?;
 

--- a/crates/exarch-cli/src/main.rs
+++ b/crates/exarch-cli/src/main.rs
@@ -13,7 +13,7 @@ use error::VerificationFailed;
 use output::OutputFormatter;
 use std::process;
 
-fn run(cli: &cli::Cli, formatter: &dyn OutputFormatter) -> (anyhow::Result<()>, &'static str) {
+fn run(cli: &cli::Cli, formatter: &mut dyn OutputFormatter) -> (anyhow::Result<()>, &'static str) {
     match &cli.command {
         cli::Commands::Extract(args) => (
             commands::extract::execute(args, formatter, cli.verbose, cli.quiet),
@@ -34,9 +34,9 @@ fn run(cli: &cli::Cli, formatter: &dyn OutputFormatter) -> (anyhow::Result<()>, 
 
 fn main() {
     let cli = cli::Cli::parse();
-    let formatter = output::create_formatter(cli.json, cli.verbose, cli.quiet);
+    let mut formatter = output::create_formatter(cli.json, cli.verbose, cli.quiet);
 
-    let (result, operation) = run(&cli, &*formatter);
+    let (result, operation) = run(&cli, formatter.as_mut());
     if let Err(err) = result {
         if err.is::<StrictWarning>() {
             process::exit(2);

--- a/crates/exarch-cli/src/output/formatter.rs
+++ b/crates/exarch-cli/src/output/formatter.rs
@@ -11,22 +11,27 @@ use std::path::Path;
 /// Common output formatter trait
 pub trait OutputFormatter {
     /// Format extraction result
-    fn format_extraction_result(&self, report: &ExtractionReport) -> Result<()>;
+    fn format_extraction_result(&mut self, report: &ExtractionReport) -> Result<()>;
 
     /// Format archive creation result
-    fn format_creation_result(&self, output_path: &Path, report: &CreationReport) -> Result<()>;
+    fn format_creation_result(&mut self, output_path: &Path, report: &CreationReport)
+    -> Result<()>;
 
     /// Format archive manifest (short format - paths only)
-    fn format_manifest_short(&self, manifest: &ArchiveManifest) -> Result<()>;
+    fn format_manifest_short(&mut self, manifest: &ArchiveManifest) -> Result<()>;
 
     /// Format archive manifest (long format - detailed)
-    fn format_manifest_long(&self, manifest: &ArchiveManifest, human_readable: bool) -> Result<()>;
+    fn format_manifest_long(
+        &mut self,
+        manifest: &ArchiveManifest,
+        human_readable: bool,
+    ) -> Result<()>;
 
     /// Format verification report
-    fn format_verification_report(&self, report: &VerificationReport) -> Result<()>;
+    fn format_verification_report(&mut self, report: &VerificationReport) -> Result<()>;
 
     /// Format error message for the given operation
-    fn format_error(&self, operation: &str, error: &anyhow::Error);
+    fn format_error(&mut self, operation: &str, error: &anyhow::Error);
 }
 
 /// Generic JSON output structure

--- a/crates/exarch-cli/src/output/human.rs
+++ b/crates/exarch-cli/src/output/human.rs
@@ -1,6 +1,7 @@
 //! Human-readable output formatter with colors and styling.
 
 use super::formatter::OutputFormatter;
+use super::humanize_bytes;
 use anyhow::Result;
 use console::Term;
 use console::style;
@@ -9,39 +10,61 @@ use exarch_core::CreationReport;
 use exarch_core::ExtractionReport;
 use exarch_core::IssueSeverity;
 use exarch_core::VerificationReport;
+use std::io::Write;
 use std::path::Path;
 
-pub struct HumanFormatter {
+/// Human-readable formatter writing non-error output to `O` and error output
+/// to `E`. Defaults to the process stdout/stderr terminals; tests can inject
+/// in-memory writers via [`HumanFormatter::with_writers`] to capture output.
+pub struct HumanFormatter<O: Write = Term, E: Write = Term> {
     verbose: bool,
     quiet: bool,
     use_colors: bool,
-    term: Term,
+    out: O,
+    err: E,
 }
 
-impl HumanFormatter {
+impl HumanFormatter<Term, Term> {
+    /// Creates a formatter writing to the process stdout/stderr terminals,
+    /// with colors auto-detected from the environment.
     pub fn new(verbose: bool, quiet: bool) -> Self {
         Self {
             verbose,
             quiet,
             use_colors: console::colors_enabled(),
-            term: Term::stdout(),
+            out: Term::stdout(),
+            err: Term::stderr(),
+        }
+    }
+}
+
+impl<O: Write, E: Write> HumanFormatter<O, E> {
+    /// Creates a formatter writing to the given writers, with `use_colors`
+    /// set explicitly rather than auto-detected — lets tests assert on
+    /// deterministic output regardless of TTY state.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn with_writers(out: O, err: E, verbose: bool, quiet: bool, use_colors: bool) -> Self {
+        Self {
+            verbose,
+            quiet,
+            use_colors,
+            out,
+            err,
         }
     }
 
-    fn format_size(bytes: u64) -> String {
-        const KB: u64 = 1024;
-        const MB: u64 = KB * 1024;
-        const GB: u64 = MB * 1024;
+    /// Returns a reference to the non-error output writer.
+    #[must_use]
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn out(&self) -> &O {
+        &self.out
+    }
 
-        if bytes >= GB {
-            format!("{:.1} GB", bytes as f64 / GB as f64)
-        } else if bytes >= MB {
-            format!("{:.1} MB", bytes as f64 / MB as f64)
-        } else if bytes >= KB {
-            format!("{:.1} KB", bytes as f64 / KB as f64)
-        } else {
-            format!("{bytes} B")
-        }
+    /// Returns a reference to the error output writer.
+    #[must_use]
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn err(&self) -> &E {
+        &self.err
     }
 
     fn format_number(n: usize) -> String {
@@ -62,139 +85,195 @@ impl HumanFormatter {
     }
 }
 
-impl OutputFormatter for HumanFormatter {
-    fn format_extraction_result(&self, report: &ExtractionReport) -> Result<()> {
+/// Renders `args` to a line and issues a single [`Write::write_all`] call.
+///
+/// `write!`/`writeln!` on a multi-argument format string invoke the
+/// underlying writer once per formatted fragment; for [`Term`], each of
+/// those calls flushes independently (`console::Term`'s `Write` impl has no
+/// internal buffering), turning one logical line into several syscalls.
+/// Formatting into a `String` first and writing it in one call restores the
+/// single-write-per-line behavior of the old `Term::write_line`.
+fn emit_line<W: Write>(writer: &mut W, args: std::fmt::Arguments<'_>) {
+    use std::fmt::Write as _;
+    let mut line = String::new();
+    let _ = line.write_fmt(args);
+    line.push('\n');
+    let _ = writer.write_all(line.as_bytes());
+}
+
+/// Writes a single blank line in one call. See [`emit_line`].
+fn emit_blank<W: Write>(writer: &mut W) {
+    let _ = writer.write_all(b"\n");
+}
+
+impl<O: Write, E: Write> OutputFormatter for HumanFormatter<O, E> {
+    fn format_extraction_result(&mut self, report: &ExtractionReport) -> Result<()> {
         if self.quiet {
             return Ok(());
         }
 
         if self.use_colors {
-            let _ = self.term.write_line(&format!(
-                "{} Extraction complete",
-                style("✓").green().bold()
-            ));
+            emit_line(
+                &mut self.out,
+                format_args!("{} Extraction complete", style("✓").green().bold()),
+            );
         } else {
-            let _ = self.term.write_line("Extraction complete");
+            emit_line(&mut self.out, format_args!("Extraction complete"));
         }
 
-        let _ = self
-            .term
-            .write_line(&format!("  Files extracted: {}", report.files_extracted));
-        let _ = self
-            .term
-            .write_line(&format!("  Directories: {}", report.directories_created));
-        let _ = self.term.write_line(&format!(
-            "  Total size: {}",
-            Self::format_size(report.bytes_written)
-        ));
+        emit_line(
+            &mut self.out,
+            format_args!("  Files extracted: {}", report.files_extracted),
+        );
+        emit_line(
+            &mut self.out,
+            format_args!("  Directories: {}", report.directories_created),
+        );
+        emit_line(
+            &mut self.out,
+            format_args!("  Total size: {}", humanize_bytes(report.bytes_written)),
+        );
 
         if self.verbose {
-            let _ = self
-                .term
-                .write_line(&format!("  Symlinks: {}", report.symlinks_created));
-            let _ = self
-                .term
-                .write_line(&format!("  Duration: {:?}", report.duration));
+            emit_line(
+                &mut self.out,
+                format_args!("  Symlinks: {}", report.symlinks_created),
+            );
+            emit_line(
+                &mut self.out,
+                format_args!("  Duration: {:?}", report.duration),
+            );
         }
 
         Ok(())
     }
 
-    fn format_creation_result(&self, output_path: &Path, report: &CreationReport) -> Result<()> {
+    fn format_creation_result(
+        &mut self,
+        output_path: &Path,
+        report: &CreationReport,
+    ) -> Result<()> {
         if self.quiet {
             return Ok(());
         }
 
         if self.use_colors {
-            let _ = self.term.write_line(&format!(
-                "{} Archive created: {}",
-                style("✓").green().bold(),
-                output_path.display()
-            ));
+            emit_line(
+                &mut self.out,
+                format_args!(
+                    "{} Archive created: {}",
+                    style("✓").green().bold(),
+                    output_path.display()
+                ),
+            );
         } else {
-            let _ = self
-                .term
-                .write_line(&format!("Archive created: {}", output_path.display()));
+            emit_line(
+                &mut self.out,
+                format_args!("Archive created: {}", output_path.display()),
+            );
         }
 
-        let _ = self.term.write_line("");
-        let _ = self.term.write_line(&format!(
-            "  Files added:      {}",
-            Self::format_number(report.files_added)
-        ));
-        let _ = self.term.write_line(&format!(
-            "  Directories:      {}",
-            Self::format_number(report.directories_added)
-        ));
-        let _ = self.term.write_line(&format!(
-            "  Total size:       {}",
-            Self::format_size(report.bytes_written)
-        ));
+        emit_blank(&mut self.out);
+        emit_line(
+            &mut self.out,
+            format_args!(
+                "  Files added:      {}",
+                Self::format_number(report.files_added)
+            ),
+        );
+        emit_line(
+            &mut self.out,
+            format_args!(
+                "  Directories:      {}",
+                Self::format_number(report.directories_added)
+            ),
+        );
+        emit_line(
+            &mut self.out,
+            format_args!(
+                "  Total size:       {}",
+                humanize_bytes(report.bytes_written)
+            ),
+        );
 
         if report.bytes_compressed > 0 {
-            let _ = self.term.write_line(&format!(
-                "  Compressed size:  {}",
-                Self::format_size(report.bytes_compressed)
-            ));
-            let _ = self.term.write_line(&format!(
-                "  Compression:      {:.1}%",
-                report.compression_percentage()
-            ));
+            emit_line(
+                &mut self.out,
+                format_args!(
+                    "  Compressed size:  {}",
+                    humanize_bytes(report.bytes_compressed)
+                ),
+            );
+            emit_line(
+                &mut self.out,
+                format_args!(
+                    "  Compression:      {:.1}%",
+                    report.compression_percentage()
+                ),
+            );
         }
 
         if report.files_skipped > 0 {
-            let _ = self
-                .term
-                .write_line(&format!("  Files skipped:    {}", report.files_skipped));
+            emit_line(
+                &mut self.out,
+                format_args!("  Files skipped:    {}", report.files_skipped),
+            );
         }
 
         if report.has_warnings() {
-            let _ = self.term.write_line("");
+            emit_blank(&mut self.out);
             if self.use_colors {
-                let _ = self
-                    .term
-                    .write_line(&format!("{}", style("Warnings:").yellow().bold()));
+                emit_line(
+                    &mut self.out,
+                    format_args!("{}", style("Warnings:").yellow().bold()),
+                );
             } else {
-                let _ = self.term.write_line("Warnings:");
+                emit_line(&mut self.out, format_args!("Warnings:"));
             }
             for warning in &report.warnings {
-                let _ = self.term.write_line(&format!("  - {warning}"));
+                emit_line(&mut self.out, format_args!("  - {warning}"));
             }
         }
 
         Ok(())
     }
 
-    fn format_error(&self, _operation: &str, error: &anyhow::Error) {
+    fn format_error(&mut self, _operation: &str, error: &anyhow::Error) {
         // Always show errors on stderr, even in quiet mode
-        let stderr = Term::stderr();
         if self.use_colors {
-            let _ = stderr.write_line(&format!("{} {error:#}", style("Error:").red().bold()));
+            emit_line(
+                &mut self.err,
+                format_args!("{} {error:#}", style("Error:").red().bold()),
+            );
         } else {
-            let _ = stderr.write_line(&format!("Error: {error:#}"));
+            emit_line(&mut self.err, format_args!("Error: {error:#}"));
         }
     }
 
-    fn format_manifest_short(&self, manifest: &ArchiveManifest) -> Result<()> {
+    fn format_manifest_short(&mut self, manifest: &ArchiveManifest) -> Result<()> {
         if self.quiet {
             return Ok(());
         }
 
         for entry in &manifest.entries {
-            let _ = self.term.write_line(&format!("{}", entry.path.display()));
+            emit_line(&mut self.out, format_args!("{}", entry.path.display()));
         }
 
         Ok(())
     }
 
-    fn format_manifest_long(&self, manifest: &ArchiveManifest, human_readable: bool) -> Result<()> {
+    fn format_manifest_long(
+        &mut self,
+        manifest: &ArchiveManifest,
+        human_readable: bool,
+    ) -> Result<()> {
         if self.quiet {
             return Ok(());
         }
 
         for entry in &manifest.entries {
             let size_str = if human_readable {
-                Self::format_size(entry.size)
+                humanize_bytes(entry.size)
             } else {
                 entry.size.to_string()
             };
@@ -216,36 +295,45 @@ impl OutputFormatter for HumanFormatter {
                 _ => None,
             };
             if let Some(target) = link_target {
-                let _ = self.term.write_line(&format!(
-                    "{}{:<6} {:>10}  {} -> {}",
-                    type_char,
-                    mode_str,
-                    size_str,
-                    entry.path.display(),
-                    target.display()
-                ));
+                emit_line(
+                    &mut self.out,
+                    format_args!(
+                        "{}{:<6} {:>10}  {} -> {}",
+                        type_char,
+                        mode_str,
+                        size_str,
+                        entry.path.display(),
+                        target.display()
+                    ),
+                );
             } else {
-                let _ = self.term.write_line(&format!(
-                    "{}{:<6} {:>10}  {}",
-                    type_char,
-                    mode_str,
-                    size_str,
-                    entry.path.display()
-                ));
+                emit_line(
+                    &mut self.out,
+                    format_args!(
+                        "{}{:<6} {:>10}  {}",
+                        type_char,
+                        mode_str,
+                        size_str,
+                        entry.path.display()
+                    ),
+                );
             }
         }
 
-        let _ = self.term.write_line("");
-        let _ = self.term.write_line(&format!(
-            "Total: {} files, {}",
-            Self::format_number(manifest.total_entries),
-            Self::format_size(manifest.total_size)
-        ));
+        emit_blank(&mut self.out);
+        emit_line(
+            &mut self.out,
+            format_args!(
+                "Total: {} files, {}",
+                Self::format_number(manifest.total_entries),
+                humanize_bytes(manifest.total_size)
+            ),
+        );
 
         Ok(())
     }
 
-    fn format_verification_report(&self, report: &VerificationReport) -> Result<()> {
+    fn format_verification_report(&mut self, report: &VerificationReport) -> Result<()> {
         if self.quiet {
             return Ok(());
         }
@@ -257,38 +345,45 @@ impl OutputFormatter for HumanFormatter {
                 exarch_core::VerificationStatus::Warning => style("WARNING").yellow().bold(),
                 exarch_core::VerificationStatus::Fail => style("FAILED").red().bold(),
             };
-            let _ = self
-                .term
-                .write_line(&format!("Archive verification: {status_str}"));
+            emit_line(
+                &mut self.out,
+                format_args!("Archive verification: {status_str}"),
+            );
         } else {
-            let _ = self
-                .term
-                .write_line(&format!("Archive verification: {}", report.status));
+            emit_line(
+                &mut self.out,
+                format_args!("Archive verification: {}", report.status),
+            );
         }
 
         // Summary
-        let _ = self
-            .term
-            .write_line(&format!("  Integrity: {}", report.integrity_status));
-        let _ = self
-            .term
-            .write_line(&format!("  Security: {}", report.security_status));
-        let _ = self.term.write_line(&format!(
-            "  Total entries: {}",
-            Self::format_number(report.total_entries)
-        ));
+        emit_line(
+            &mut self.out,
+            format_args!("  Integrity: {}", report.integrity_status),
+        );
+        emit_line(
+            &mut self.out,
+            format_args!("  Security: {}", report.security_status),
+        );
+        emit_line(
+            &mut self.out,
+            format_args!(
+                "  Total entries: {}",
+                Self::format_number(report.total_entries)
+            ),
+        );
 
         if report.suspicious_entries > 0 {
-            let _ = self.term.write_line(&format!(
-                "  Suspicious entries: {}",
-                report.suspicious_entries
-            ));
+            emit_line(
+                &mut self.out,
+                format_args!("  Suspicious entries: {}", report.suspicious_entries),
+            );
         }
 
         // Issues
         if !report.issues.is_empty() {
-            let _ = self.term.write_line("");
-            let _ = self.term.write_line("Issues:");
+            emit_blank(&mut self.out);
+            emit_line(&mut self.out, format_args!("Issues:"));
 
             for issue in &report.issues {
                 let severity_str = if self.use_colors {
@@ -304,16 +399,15 @@ impl OutputFormatter for HumanFormatter {
                 };
 
                 if let Some(ref path) = issue.entry_path {
-                    let _ = self.term.write_line(&format!(
-                        "  {} {}: {}",
-                        severity_str,
-                        path.display(),
-                        issue.message
-                    ));
+                    emit_line(
+                        &mut self.out,
+                        format_args!("  {} {}: {}", severity_str, path.display(), issue.message),
+                    );
                 } else {
-                    let _ = self
-                        .term
-                        .write_line(&format!("  {} {}", severity_str, issue.message));
+                    emit_line(
+                        &mut self.out,
+                        format_args!("  {} {}", severity_str, issue.message),
+                    );
                 }
             }
         }
@@ -327,76 +421,50 @@ impl OutputFormatter for HumanFormatter {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_format_size_bytes() {
-        assert_eq!(HumanFormatter::format_size(0), "0 B");
-        assert_eq!(HumanFormatter::format_size(512), "512 B");
-        assert_eq!(HumanFormatter::format_size(1023), "1023 B");
+    fn formatter(verbose: bool, quiet: bool, use_colors: bool) -> HumanFormatter<Vec<u8>, Vec<u8>> {
+        HumanFormatter::with_writers(Vec::new(), Vec::new(), verbose, quiet, use_colors)
     }
 
-    #[test]
-    fn test_format_size_kilobytes() {
-        assert_eq!(HumanFormatter::format_size(1024), "1.0 KB");
-        assert_eq!(HumanFormatter::format_size(2048), "2.0 KB");
-        assert_eq!(HumanFormatter::format_size(1536), "1.5 KB");
+    fn out_text(f: &HumanFormatter<Vec<u8>, Vec<u8>>) -> String {
+        String::from_utf8(f.out().clone()).unwrap()
     }
 
-    #[test]
-    fn test_format_size_megabytes() {
-        assert_eq!(HumanFormatter::format_size(1024 * 1024), "1.0 MB");
-        assert_eq!(HumanFormatter::format_size(2 * 1024 * 1024), "2.0 MB");
-        assert_eq!(HumanFormatter::format_size(1536 * 1024), "1.5 MB");
+    fn err_text(f: &HumanFormatter<Vec<u8>, Vec<u8>>) -> String {
+        String::from_utf8(f.err().clone()).unwrap()
     }
 
-    #[test]
-    fn test_format_size_gigabytes() {
-        assert_eq!(HumanFormatter::format_size(1024 * 1024 * 1024), "1.0 GB");
-        assert_eq!(
-            HumanFormatter::format_size(2 * 1024 * 1024 * 1024),
-            "2.0 GB"
-        );
-        assert_eq!(HumanFormatter::format_size(1536 * 1024 * 1024), "1.5 GB");
-    }
-
-    #[test]
-    fn test_format_size_edge_cases() {
-        // u64::MAX = 18446744073709551615 bytes ≈ 17179869184 GB
-        assert_eq!(HumanFormatter::format_size(u64::MAX), "17179869184.0 GB");
-    }
+    type TestFormatter = HumanFormatter<Vec<u8>, Vec<u8>>;
 
     #[test]
     fn test_format_number_small() {
-        assert_eq!(HumanFormatter::format_number(0), "0");
-        assert_eq!(HumanFormatter::format_number(1), "1");
-        assert_eq!(HumanFormatter::format_number(42), "42");
-        assert_eq!(HumanFormatter::format_number(999), "999");
+        assert_eq!(TestFormatter::format_number(0), "0");
+        assert_eq!(TestFormatter::format_number(1), "1");
+        assert_eq!(TestFormatter::format_number(42), "42");
+        assert_eq!(TestFormatter::format_number(999), "999");
     }
 
     #[test]
     fn test_format_number_thousands() {
-        assert_eq!(HumanFormatter::format_number(1000), "1,000");
-        assert_eq!(HumanFormatter::format_number(1234), "1,234");
-        assert_eq!(HumanFormatter::format_number(9999), "9,999");
+        assert_eq!(TestFormatter::format_number(1000), "1,000");
+        assert_eq!(TestFormatter::format_number(1234), "1,234");
+        assert_eq!(TestFormatter::format_number(9999), "9,999");
     }
 
     #[test]
     fn test_format_number_millions() {
-        assert_eq!(HumanFormatter::format_number(1_000_000), "1,000,000");
-        assert_eq!(HumanFormatter::format_number(1_234_567), "1,234,567");
-        assert_eq!(HumanFormatter::format_number(42_000_000), "42,000,000");
+        assert_eq!(TestFormatter::format_number(1_000_000), "1,000,000");
+        assert_eq!(TestFormatter::format_number(1_234_567), "1,234,567");
+        assert_eq!(TestFormatter::format_number(42_000_000), "42,000,000");
     }
 
     #[test]
     fn test_format_number_large() {
+        assert_eq!(TestFormatter::format_number(1_000_000_000), "1,000,000,000");
         assert_eq!(
-            HumanFormatter::format_number(1_000_000_000),
-            "1,000,000,000"
-        );
-        assert_eq!(
-            HumanFormatter::format_number(123_456_789_012),
+            TestFormatter::format_number(123_456_789_012),
             "123,456,789,012"
         );
-        assert_eq!(HumanFormatter::format_number(usize::MAX), {
+        assert_eq!(TestFormatter::format_number(usize::MAX), {
             let s = usize::MAX.to_string();
             let mut result = String::new();
             let mut count = 0;
@@ -412,30 +480,339 @@ mod tests {
         });
     }
 
+    fn sample_extraction_report() -> ExtractionReport {
+        ExtractionReport {
+            files_extracted: 3,
+            directories_created: 1,
+            symlinks_created: 0,
+            bytes_written: 2048,
+            duration: std::time::Duration::from_secs(1),
+            ..Default::default()
+        }
+    }
+
+    fn sample_creation_report() -> CreationReport {
+        CreationReport {
+            files_added: 2,
+            directories_added: 1,
+            symlinks_added: 0,
+            bytes_written: 1024,
+            bytes_compressed: 0,
+            files_skipped: 0,
+            duration: std::time::Duration::from_secs(1),
+            warnings: vec![],
+        }
+    }
+
     #[test]
-    fn test_human_format_error_does_not_panic() {
-        let formatter = HumanFormatter::new(false, false);
+    fn format_extraction_result_no_colors() {
+        let mut f = formatter(false, false, false);
+        f.format_extraction_result(&sample_extraction_report())
+            .unwrap();
+        let text = out_text(&f);
+        assert!(text.contains("Extraction complete"));
+        assert!(
+            !text.contains('✓'),
+            "no-colors branch must not print the check mark"
+        );
+        assert!(text.contains("Files extracted: 3"));
+        assert!(text.contains("Directories: 1"));
+        assert!(text.contains("Total size: 2.0 KB"));
+        assert!(!text.contains("Symlinks:"));
+    }
+
+    #[test]
+    fn format_extraction_result_verbose() {
+        let mut f = formatter(true, false, false);
+        f.format_extraction_result(&sample_extraction_report())
+            .unwrap();
+        let text = out_text(&f);
+        assert!(text.contains("Symlinks: 0"));
+        assert!(text.contains("Duration:"));
+    }
+
+    #[test]
+    fn format_extraction_result_quiet_suppresses_output() {
+        let mut f = formatter(false, true, false);
+        f.format_extraction_result(&sample_extraction_report())
+            .unwrap();
+        assert!(out_text(&f).is_empty());
+    }
+
+    #[test]
+    fn format_extraction_result_with_colors() {
+        let mut f = formatter(false, false, true);
+        f.format_extraction_result(&sample_extraction_report())
+            .unwrap();
+        // A reset escape sits between the styled "✓" and the following
+        // literal text, so the two are never byte-adjacent when real ANSI
+        // codes are rendered (e.g. under `CLICOLOR_FORCE=1`); strip them
+        // before asserting so the check holds regardless of whether colors
+        // actually rendered in this environment.
+        let text = console::strip_ansi_codes(&out_text(&f)).into_owned();
+        assert!(
+            text.contains("✓ Extraction complete"),
+            "colors branch must prefix the success line with the check mark: {text}"
+        );
+    }
+
+    #[test]
+    fn format_creation_result_no_colors() {
+        let mut f = formatter(false, false, false);
+        let path = Path::new("out.tar.gz");
+        f.format_creation_result(path, &sample_creation_report())
+            .unwrap();
+        let text = out_text(&f);
+        assert!(text.contains("Archive created: out.tar.gz"));
+        assert!(text.contains("Files added:      2"));
+        assert!(text.contains("Directories:      1"));
+        assert!(text.contains("Total size:       1.0 KB"));
+    }
+
+    #[test]
+    fn format_creation_result_with_compression_and_warnings() {
+        let mut f = formatter(false, false, false);
+        let mut report = sample_creation_report();
+        report.bytes_compressed = 512;
+        report.files_skipped = 1;
+        report.warnings.push("skipped a broken symlink".to_string());
+        f.format_creation_result(Path::new("out.tar.gz"), &report)
+            .unwrap();
+        let text = out_text(&f);
+        assert!(text.contains("Compressed size:  512 B"));
+        assert!(text.contains("Compression:"));
+        assert!(text.contains("Files skipped:    1"));
+        assert!(text.contains("Warnings:"));
+        assert!(text.contains("skipped a broken symlink"));
+    }
+
+    #[test]
+    fn format_creation_result_quiet_suppresses_output() {
+        let mut f = formatter(false, true, false);
+        f.format_creation_result(Path::new("out.tar.gz"), &sample_creation_report())
+            .unwrap();
+        assert!(out_text(&f).is_empty());
+    }
+
+    #[test]
+    fn format_error_writes_to_stderr_not_stdout() {
+        let mut f = formatter(false, false, false);
         let err = anyhow::anyhow!(exarch_core::ArchiveError::ZipBomb {
             compressed: 1000,
             uncompressed: 1_000_000,
             ratio: 1000.0,
         });
-        // Must not panic; output goes to terminal (not captured in unit tests)
-        formatter.format_error("extract", &err);
+        f.format_error("extract", &err);
+        assert!(out_text(&f).is_empty());
+        let text = err_text(&f);
+        assert!(text.starts_with("Error: "));
+        assert!(!text.contains('{'), "human errors are plain text, not JSON");
+    }
+
+    // `format_error`'s two branches emit the identical literal "Error: " prefix
+    // (unlike the extraction/verification branches, which use different
+    // literals) — the only actual difference is the ANSI escape codes that
+    // `style(..)` emits, and those are gated on console's *global*
+    // `colors_enabled()`, not on `HumanFormatter::use_colors`. Force the
+    // global flag for the duration of this test (nextest runs each test in
+    // its own process, so this cannot leak into other tests) to make the
+    // color branch observably different from the no-colors branch.
+    #[test]
+    fn format_error_with_colors() {
+        let previous = console::colors_enabled();
+        console::set_colors_enabled(true);
+
+        let mut f = formatter(false, false, true);
+        let err = anyhow::anyhow!("boom");
+        f.format_error("extract", &err);
+
+        console::set_colors_enabled(previous);
+
+        let text = err_text(&f);
+        assert!(text.contains("boom"));
+        assert!(
+            text.contains("\x1b["),
+            "colors branch must emit ANSI escape codes when colors are enabled: {text:?}"
+        );
     }
 
     #[test]
-    fn test_human_format_error_plain_text_not_json() {
-        use exarch_core::ArchiveError;
-        use std::path::PathBuf;
+    fn format_error_ignores_quiet() {
+        let mut f = formatter(false, true, false);
+        let err = anyhow::anyhow!("boom");
+        f.format_error("extract", &err);
+        assert!(err_text(&f).contains("boom"));
+    }
 
-        let formatter = HumanFormatter::new(false, false);
-        let err = anyhow::anyhow!(ArchiveError::PathTraversal {
-            path: PathBuf::from("../etc/passwd"),
-        });
-        // format_error does not return a value; verify it completes without panic.
-        // The human formatter writes plain "error: ..." text (not JSON) to the
-        // terminal.
-        formatter.format_error("extract", &err);
+    fn sample_manifest() -> ArchiveManifest {
+        use exarch_core::ArchiveEntry;
+        use exarch_core::ManifestEntryType;
+        use exarch_core::formats::detect::ArchiveType;
+
+        ArchiveManifest {
+            format: ArchiveType::TarGz,
+            total_entries: 2,
+            total_size: 1536,
+            entries: vec![
+                ArchiveEntry {
+                    path: std::path::PathBuf::from("file.txt"),
+                    entry_type: ManifestEntryType::File,
+                    size: 1024,
+                    compressed_size: None,
+                    mode: Some(0o644),
+                    modified: None,
+                    symlink_target: None,
+                    hardlink_target: None,
+                },
+                ArchiveEntry {
+                    path: std::path::PathBuf::from("link.txt"),
+                    entry_type: ManifestEntryType::Symlink,
+                    size: 512,
+                    compressed_size: None,
+                    mode: Some(0o777),
+                    modified: None,
+                    symlink_target: Some(std::path::PathBuf::from("file.txt")),
+                    hardlink_target: None,
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn format_manifest_short_lists_paths_only() {
+        let mut f = formatter(false, false, false);
+        f.format_manifest_short(&sample_manifest()).unwrap();
+        let text = out_text(&f);
+        assert!(text.contains("file.txt"));
+        assert!(text.contains("link.txt"));
+        assert!(!text.contains("Total:"));
+    }
+
+    #[test]
+    fn format_manifest_short_quiet_suppresses_output() {
+        let mut f = formatter(false, true, false);
+        f.format_manifest_short(&sample_manifest()).unwrap();
+        assert!(out_text(&f).is_empty());
+    }
+
+    #[test]
+    fn format_manifest_long_human_readable_size() {
+        let mut f = formatter(false, false, false);
+        f.format_manifest_long(&sample_manifest(), true).unwrap();
+        let text = out_text(&f);
+        assert!(text.contains("1.0 KB"));
+        assert!(text.contains("512 B"));
+        assert!(text.contains("Total: 2 files, 1.5 KB"));
+    }
+
+    #[test]
+    fn format_manifest_long_raw_size() {
+        let mut f = formatter(false, false, false);
+        f.format_manifest_long(&sample_manifest(), false).unwrap();
+        let text = out_text(&f);
+        assert!(text.contains("1024"));
+        assert!(text.contains("512"));
+    }
+
+    #[test]
+    fn format_manifest_long_shows_symlink_target() {
+        let mut f = formatter(false, false, false);
+        f.format_manifest_long(&sample_manifest(), true).unwrap();
+        let text = out_text(&f);
+        assert!(text.contains("link.txt -> file.txt"));
+    }
+
+    #[test]
+    fn format_manifest_long_shows_hardlink_target() {
+        use exarch_core::ArchiveEntry;
+        use exarch_core::ManifestEntryType;
+        use exarch_core::formats::detect::ArchiveType;
+
+        let manifest = ArchiveManifest {
+            format: ArchiveType::TarGz,
+            total_entries: 1,
+            total_size: 256,
+            entries: vec![ArchiveEntry {
+                path: std::path::PathBuf::from("hard.txt"),
+                entry_type: ManifestEntryType::Hardlink,
+                size: 256,
+                compressed_size: None,
+                mode: Some(0o644),
+                modified: None,
+                symlink_target: None,
+                hardlink_target: Some(std::path::PathBuf::from("original.txt")),
+            }],
+        };
+
+        let mut f = formatter(false, false, false);
+        f.format_manifest_long(&manifest, true).unwrap();
+        let text = out_text(&f);
+        assert!(text.contains("hard.txt -> original.txt"));
+    }
+
+    #[test]
+    fn format_manifest_long_quiet_suppresses_output() {
+        let mut f = formatter(false, true, false);
+        f.format_manifest_long(&sample_manifest(), true).unwrap();
+        assert!(out_text(&f).is_empty());
+    }
+
+    fn sample_verification_report(status: exarch_core::VerificationStatus) -> VerificationReport {
+        use exarch_core::CheckStatus;
+        use exarch_core::formats::detect::ArchiveType;
+
+        VerificationReport {
+            status,
+            integrity_status: CheckStatus::Pass,
+            security_status: CheckStatus::Pass,
+            total_entries: 5,
+            suspicious_entries: 0,
+            total_size: 4096,
+            format: ArchiveType::TarGz,
+            issues: vec![],
+        }
+    }
+
+    #[test]
+    fn format_verification_report_pass_no_colors() {
+        let mut f = formatter(false, false, false);
+        f.format_verification_report(&sample_verification_report(
+            exarch_core::VerificationStatus::Pass,
+        ))
+        .unwrap();
+        let text = out_text(&f);
+        assert!(text.contains("Archive verification: PASS\n"));
+        assert!(
+            !text.contains("PASSED"),
+            "no-colors branch must use the terse Display form, not the colored literal: {text}"
+        );
+        assert!(text.contains("Total entries: 5"));
+    }
+
+    #[test]
+    fn format_verification_report_with_colors() {
+        let mut f = formatter(false, false, true);
+        f.format_verification_report(&sample_verification_report(
+            exarch_core::VerificationStatus::Pass,
+        ))
+        .unwrap();
+        // See the comment in `format_extraction_result_with_colors`: the
+        // leading fg/attr escapes sit directly before "PASSED", so strip
+        // ANSI codes before asserting adjacency.
+        let text = console::strip_ansi_codes(&out_text(&f)).into_owned();
+        assert!(
+            text.contains("Archive verification: PASSED"),
+            "colors branch must use the longer colored literal, not the terse Display form: {text}"
+        );
+    }
+
+    #[test]
+    fn format_verification_report_quiet_suppresses_output() {
+        let mut f = formatter(false, true, false);
+        f.format_verification_report(&sample_verification_report(
+            exarch_core::VerificationStatus::Pass,
+        ))
+        .unwrap();
+        assert!(out_text(&f).is_empty());
     }
 }

--- a/crates/exarch-cli/src/output/json.rs
+++ b/crates/exarch-cli/src/output/json.rs
@@ -11,6 +11,7 @@ use exarch_core::CreationReport;
 use exarch_core::ExtractionReport;
 use exarch_core::VerificationReport;
 use serde::Serialize;
+use std::io::Stdout;
 use std::io::Write;
 use std::io::{self};
 use std::path::Path;
@@ -37,18 +38,44 @@ fn extraction_error_kind(err: &ArchiveError) -> String {
     .to_string()
 }
 
-pub struct JsonFormatter;
+/// JSON formatter writing envelopes to `W`. Defaults to process stdout;
+/// tests can inject an in-memory writer via [`JsonFormatter::with_writer`]
+/// to capture output.
+pub struct JsonFormatter<W: Write = Stdout> {
+    out: W,
+}
 
-impl JsonFormatter {
-    fn output<T: Serialize>(value: &T) -> Result<()> {
+impl JsonFormatter<Stdout> {
+    /// Creates a formatter writing to the process stdout.
+    #[must_use]
+    pub fn stdout() -> Self {
+        Self { out: io::stdout() }
+    }
+}
+
+impl<W: Write> JsonFormatter<W> {
+    /// Creates a formatter writing to the given writer.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn with_writer(out: W) -> Self {
+        Self { out }
+    }
+
+    /// Returns a reference to the underlying writer.
+    #[must_use]
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn writer(&self) -> &W {
+        &self.out
+    }
+
+    fn output<T: Serialize>(&mut self, value: &T) -> Result<()> {
         let json = serde_json::to_string_pretty(value)?;
-        writeln!(io::stdout(), "{json}")?;
+        writeln!(self.out, "{json}")?;
         Ok(())
     }
 }
 
-impl OutputFormatter for JsonFormatter {
-    fn format_extraction_result(&self, report: &ExtractionReport) -> Result<()> {
+impl<W: Write> OutputFormatter for JsonFormatter<W> {
+    fn format_extraction_result(&mut self, report: &ExtractionReport) -> Result<()> {
         #[derive(Serialize)]
         struct ExtractionOutput {
             files_extracted: usize,
@@ -67,10 +94,14 @@ impl OutputFormatter for JsonFormatter {
         };
 
         let output = JsonOutput::success("extract", data);
-        Self::output(&output)
+        self.output(&output)
     }
 
-    fn format_creation_result(&self, output_path: &Path, report: &CreationReport) -> Result<()> {
+    fn format_creation_result(
+        &mut self,
+        output_path: &Path,
+        report: &CreationReport,
+    ) -> Result<()> {
         #[derive(Serialize)]
         struct CreationOutput {
             output_path: String,
@@ -101,10 +132,10 @@ impl OutputFormatter for JsonFormatter {
         };
 
         let output = JsonOutput::success("create", data);
-        Self::output(&output)
+        self.output(&output)
     }
 
-    fn format_error(&self, operation: &str, error: &anyhow::Error) {
+    fn format_error(&mut self, operation: &str, error: &anyhow::Error) {
         let extraction_err = error.chain().find_map(|e| e.downcast_ref::<ArchiveError>());
 
         let kind = extraction_err.map_or_else(|| "Error".to_string(), extraction_error_kind);
@@ -131,10 +162,10 @@ impl OutputFormatter for JsonFormatter {
         } else {
             JsonOutput::<()>::error(operation, kind, message)
         };
-        let _ = Self::output(&output);
+        let _ = self.output(&output);
     }
 
-    fn format_manifest_short(&self, manifest: &ArchiveManifest) -> Result<()> {
+    fn format_manifest_short(&mut self, manifest: &ArchiveManifest) -> Result<()> {
         #[derive(Serialize)]
         struct ManifestEntry {
             path: String,
@@ -162,11 +193,11 @@ impl OutputFormatter for JsonFormatter {
         };
 
         let output = JsonOutput::success("list", data);
-        Self::output(&output)
+        self.output(&output)
     }
 
     fn format_manifest_long(
-        &self,
+        &mut self,
         manifest: &ArchiveManifest,
         _human_readable: bool,
     ) -> Result<()> {
@@ -222,10 +253,10 @@ impl OutputFormatter for JsonFormatter {
         };
 
         let output = JsonOutput::success("list", data);
-        Self::output(&output)
+        self.output(&output)
     }
 
-    fn format_verification_report(&self, report: &VerificationReport) -> Result<()> {
+    fn format_verification_report(&mut self, report: &VerificationReport) -> Result<()> {
         #[derive(Serialize)]
         struct VerificationIssue {
             severity: String,
@@ -271,7 +302,7 @@ impl OutputFormatter for JsonFormatter {
         };
 
         let output = JsonOutput::success("verify", data);
-        Self::output(&output)
+        self.output(&output)
     }
 }
 
@@ -468,5 +499,129 @@ mod tests {
             display_occurrences <= 1,
             "JSON message duplicates ArchiveError display text ({display_occurrences} occurrences): {message}"
         );
+    }
+
+    fn parsed(formatter: &JsonFormatter<Vec<u8>>) -> serde_json::Value {
+        serde_json::from_slice(formatter.writer()).unwrap()
+    }
+
+    #[test]
+    fn format_extraction_result_writes_success_envelope() {
+        let mut f = JsonFormatter::with_writer(Vec::new());
+        let report = ExtractionReport {
+            files_extracted: 3,
+            directories_created: 1,
+            symlinks_created: 0,
+            bytes_written: 2048,
+            duration: std::time::Duration::from_secs(1),
+            ..Default::default()
+        };
+        f.format_extraction_result(&report).unwrap();
+        let v = parsed(&f);
+        assert_eq!(v["operation"], "extract");
+        assert_eq!(v["status"], "success");
+        assert_eq!(v["data"]["files_extracted"], 3);
+        assert_eq!(v["data"]["bytes_written"], 2048);
+    }
+
+    #[test]
+    fn format_creation_result_writes_success_envelope() {
+        let mut f = JsonFormatter::with_writer(Vec::new());
+        let report = CreationReport {
+            files_added: 2,
+            directories_added: 1,
+            symlinks_added: 0,
+            bytes_written: 1024,
+            bytes_compressed: 0,
+            duration: std::time::Duration::from_secs(1),
+            ..Default::default()
+        };
+        f.format_creation_result(Path::new("out.tar.gz"), &report)
+            .unwrap();
+        let v = parsed(&f);
+        assert_eq!(v["operation"], "create");
+        assert_eq!(v["status"], "success");
+        assert_eq!(v["data"]["output_path"], "out.tar.gz");
+        assert_eq!(v["data"]["files_added"], 2);
+    }
+
+    #[test]
+    fn format_error_writes_error_envelope() {
+        let mut f = JsonFormatter::with_writer(Vec::new());
+        let err = anyhow::anyhow!(ArchiveError::ZipBomb {
+            compressed: 1000,
+            uncompressed: 1_000_000,
+            ratio: 1000.0,
+        });
+        f.format_error("extract", &err);
+        let v = parsed(&f);
+        assert_eq!(v["operation"], "extract");
+        assert_eq!(v["status"], "error");
+        assert_eq!(v["error"]["kind"], "ZipBomb");
+    }
+
+    fn sample_manifest() -> ArchiveManifest {
+        use exarch_core::ArchiveEntry;
+        use exarch_core::ManifestEntryType;
+        use exarch_core::formats::detect::ArchiveType;
+
+        ArchiveManifest {
+            format: ArchiveType::TarGz,
+            total_entries: 1,
+            total_size: 1024,
+            entries: vec![ArchiveEntry {
+                path: PathBuf::from("file.txt"),
+                entry_type: ManifestEntryType::File,
+                size: 1024,
+                compressed_size: None,
+                mode: Some(0o644),
+                modified: None,
+                symlink_target: None,
+                hardlink_target: None,
+            }],
+        }
+    }
+
+    #[test]
+    fn format_manifest_short_writes_paths_only() {
+        let mut f = JsonFormatter::with_writer(Vec::new());
+        f.format_manifest_short(&sample_manifest()).unwrap();
+        let v = parsed(&f);
+        assert_eq!(v["operation"], "list");
+        assert_eq!(v["data"]["entries"][0]["path"], "file.txt");
+        assert!(v["data"]["entries"][0].get("size").is_none());
+    }
+
+    #[test]
+    fn format_manifest_long_writes_full_detail() {
+        let mut f = JsonFormatter::with_writer(Vec::new());
+        f.format_manifest_long(&sample_manifest(), true).unwrap();
+        let v = parsed(&f);
+        assert_eq!(v["data"]["entries"][0]["size"], 1024);
+        assert_eq!(v["data"]["entries"][0]["entry_type"], "File");
+        assert_eq!(v["data"]["total_size"], 1024);
+    }
+
+    #[test]
+    fn format_verification_report_writes_full_report() {
+        use exarch_core::CheckStatus;
+        use exarch_core::VerificationStatus;
+        use exarch_core::formats::detect::ArchiveType;
+
+        let mut f = JsonFormatter::with_writer(Vec::new());
+        let report = VerificationReport {
+            status: VerificationStatus::Pass,
+            integrity_status: CheckStatus::Pass,
+            security_status: CheckStatus::Pass,
+            total_entries: 5,
+            suspicious_entries: 0,
+            total_size: 4096,
+            format: ArchiveType::TarGz,
+            issues: vec![],
+        };
+        f.format_verification_report(&report).unwrap();
+        let v = parsed(&f);
+        assert_eq!(v["operation"], "verify");
+        assert_eq!(v["data"]["total_entries"], 5);
     }
 }

--- a/crates/exarch-cli/src/output/mod.rs
+++ b/crates/exarch-cli/src/output/mod.rs
@@ -12,8 +12,73 @@ use json::JsonFormatter;
 /// Creates an output formatter based on CLI flags
 pub fn create_formatter(json: bool, verbose: bool, quiet: bool) -> Box<dyn OutputFormatter> {
     if json {
-        Box::new(JsonFormatter)
+        Box::new(JsonFormatter::stdout())
     } else {
         Box::new(HumanFormatter::new(verbose, quiet))
+    }
+}
+
+/// Converts a byte count into a human-readable string using binary
+/// (1024-based) units, tiered from bytes up to terabytes.
+pub fn humanize_bytes(bytes: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = KB * 1024;
+    const GB: u64 = MB * 1024;
+    const TB: u64 = GB * 1024;
+
+    if bytes >= TB {
+        format!("{:.1} TB", bytes as f64 / TB as f64)
+    } else if bytes >= GB {
+        format!("{:.1} GB", bytes as f64 / GB as f64)
+    } else if bytes >= MB {
+        format!("{:.1} MB", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{:.1} KB", bytes as f64 / KB as f64)
+    } else {
+        format!("{bytes} B")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::humanize_bytes;
+
+    #[test]
+    fn test_humanize_bytes_bytes() {
+        assert_eq!(humanize_bytes(0), "0 B");
+        assert_eq!(humanize_bytes(512), "512 B");
+        assert_eq!(humanize_bytes(1023), "1023 B");
+    }
+
+    #[test]
+    fn test_humanize_bytes_kilobytes() {
+        assert_eq!(humanize_bytes(1024), "1.0 KB");
+        assert_eq!(humanize_bytes(1536), "1.5 KB");
+        assert_eq!(humanize_bytes(2048), "2.0 KB");
+    }
+
+    #[test]
+    fn test_humanize_bytes_megabytes() {
+        assert_eq!(humanize_bytes(1024 * 1024), "1.0 MB");
+        assert_eq!(humanize_bytes(1536 * 1024), "1.5 MB");
+        assert_eq!(humanize_bytes(2 * 1024 * 1024), "2.0 MB");
+    }
+
+    #[test]
+    fn test_humanize_bytes_gigabytes() {
+        assert_eq!(humanize_bytes(1024 * 1024 * 1024), "1.0 GB");
+        assert_eq!(humanize_bytes(1536 * 1024 * 1024), "1.5 GB");
+        assert_eq!(humanize_bytes(2 * 1024 * 1024 * 1024), "2.0 GB");
+    }
+
+    #[test]
+    fn test_humanize_bytes_terabytes() {
+        assert_eq!(humanize_bytes(1024_u64.pow(4)), "1.0 TB");
+    }
+
+    #[test]
+    fn test_humanize_bytes_edge_cases() {
+        // u64::MAX = 18446744073709551615 bytes = 16777216.0 TB (TB = 1024^4)
+        assert_eq!(humanize_bytes(u64::MAX), "16777216.0 TB");
     }
 }

--- a/crates/exarch-cli/src/progress.rs
+++ b/crates/exarch-cli/src/progress.rs
@@ -1,5 +1,6 @@
 //! Progress bar implementation for CLI operations.
 
+use crate::output::humanize_bytes;
 use console::Term;
 use exarch_core::ProgressCallback;
 use indicatif::ProgressBar;
@@ -121,40 +122,9 @@ impl ProgressCallback for VerboseProgress {
     fn on_complete(&mut self) {}
 }
 
-/// Converts bytes to human-readable format (KB, MB, GB, TB).
-fn humanize_bytes(bytes: u64) -> String {
-    const KB: u64 = 1024;
-    const MB: u64 = KB * 1024;
-    const GB: u64 = MB * 1024;
-    const TB: u64 = GB * 1024;
-
-    if bytes >= TB {
-        format!("{:.1} TB", bytes as f64 / TB as f64)
-    } else if bytes >= GB {
-        format!("{:.1} GB", bytes as f64 / GB as f64)
-    } else if bytes >= MB {
-        format!("{:.1} MB", bytes as f64 / MB as f64)
-    } else if bytes >= KB {
-        format!("{:.1} KB", bytes as f64 / KB as f64)
-    } else {
-        format!("{bytes} B")
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_humanize_bytes() {
-        assert_eq!(humanize_bytes(0), "0 B");
-        assert_eq!(humanize_bytes(512), "512 B");
-        assert_eq!(humanize_bytes(1024), "1.0 KB");
-        assert_eq!(humanize_bytes(1536), "1.5 KB");
-        assert_eq!(humanize_bytes(1024 * 1024), "1.0 MB");
-        assert_eq!(humanize_bytes(1024 * 1024 * 1024), "1.0 GB");
-        assert_eq!(humanize_bytes(1024_u64.pow(4)), "1.0 TB");
-    }
 
     #[test]
     fn test_verbose_progress_no_panic() {


### PR DESCRIPTION
## Summary

Groups three related exarch-cli defects, all in the output/config layer:

- `OutputFormatter`'s six trait methods wrote directly to a fixed `console::Term`/`io::stdout` sink with no injectable writer, so none of them could be unit-tested without spawning a subprocess.
- Byte-size humanization was implemented twice (`HumanFormatter::format_size` and `progress::humanize_bytes`) with diverging tier ladders — only one had a TB tier, so archives at or above 1 TB rendered inconsistently between the live progress bar and the final report.
- The 500 MB / 50 MB default size limits were re-literalized as magic numbers in three separate command modules (`extract.rs`, `list.rs`, `verify.rs`) instead of deferring to `SecurityConfig::default()`.

## Changes

- `OutputFormatter`'s methods now take `&mut self`; `HumanFormatter<O: Write, E: Write>` and `JsonFormatter<W: Write>` are generic over an injectable writer (defaulting to the real stdout/stderr), unlocking in-process unit tests that capture formatted output text. `use_colors` is now a constructor parameter instead of TTY-autodetection at the call site (autodetection still happens once in `main.rs`). Output is still assembled into a `String` and written with a single `write_all` per line, preserving the original `Term::write_line` write-per-line behavior (verified: no throughput regression on large manifests).
- Added a single `output::humanize_bytes` (TB-inclusive tier ladder) used by both the progress bar and the human-readable report; `u64::MAX` now renders `"16777216.0 TB"` instead of the previous `"17179869184.0 GB"`.
- Added `commands::apply_size_limits(config, max_total, max_file)`, applying `--max-total-size`/`--max-file-size` overrides only when provided; `extract`, `list`, and `verify` now route through it instead of each hardcoding the same two literals.

Closes #452
Closes #451
Closes #450

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` (1101 passed)
- [x] `cargo test --doc --workspace --all-features --exclude exarch-python --exclude exarch-node` (111 passed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --all-features --workspace`
- [x] `cargo audit` / `cargo deny check` clean, no new dependencies
- [x] Live-tested `create`/`list`/`list --long --human-readable`/`list --json`/`extract`/`verify`/`verify --json`, error paths (human + JSON), `--quiet`, `CLICOLOR_FORCE` color rendering, EPIPE tolerance under `| head`, and `--max-file-size`/`--max-total-size` overrides