### PR TITLE
feat(node): add createArchiveWithProgress and test progress callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `exarch-core` criterion benchmarks (`--all-features`, covering the
   `testing`-gated `validation` bench) without running them, catching
   benchmark compilation breakage in a fast parallel job.
+- `exarch-node`: add `createArchiveWithProgress` and
+  `createArchiveWithProgressSync`, mirroring the existing
+  `extractArchiveWithProgress` async/sync pattern and `exarch-python`'s
+  `create_archive_with_progress`. Both reuse `exarch_core::create_archive_with_progress`
+  and the existing `NodeProgressAdapter` threadsafe-function bridge — no new
+  core security logic (#455).
+- `exarch-node`: add JS integration tests for `extractArchiveWithProgress`,
+  `createArchiveWithProgress`, and `createArchiveWithProgressSync` covering
+  the per-entry callback shape and the `progress=null`/omitted paths, closing
+  a coverage gap where these APIs had no test exercising them (#456).
 
 ### Changed
 

--- a/crates/exarch-node/README.md
+++ b/crates/exarch-node/README.md
@@ -161,9 +161,15 @@ interface ExtractionReport {
 }
 ```
 
-### `extractArchiveWithProgress(archivePath, outputDir, config?, progress?)`
+### `extractArchiveWithProgress(archivePath, outputDir, config?, options?, progress?)`
 
-Async extraction with an optional progress callback.
+Async extraction with an optional progress callback, invoked once per entry.
+
+`progress` uses napi's standard threadsafe-function calling convention:
+`(err, arg)`, where `err` is always `null` and `arg` is the `[path, total,
+current, bytesWritten]` tuple — **not** four separate arguments.
+`bytesWritten` is always `0`: the callback only fires from the entry-start
+event, before any bytes for that entry have been counted.
 
 ```typescript
 import { extractArchiveWithProgress } from 'exarch-rs';
@@ -172,8 +178,9 @@ const result = await extractArchiveWithProgress(
   'archive.tar.gz',
   '/output/path',
   undefined,  // SecurityConfig or undefined
-  (path, total, current, bytesWritten) => {
-    console.log(`[${current}/${total}] ${path} (${bytesWritten} bytes)`);
+  undefined,  // ExtractionOptions or undefined
+  (err, [path, total, current, bytesWritten]) => {
+    console.log(`[${current}/${total}] ${path}`);
   }
 );
 ```
@@ -185,9 +192,80 @@ const result = await extractArchiveWithProgress(
 | `archivePath` | `string` | Path to the archive file |
 | `outputDir` | `string` | Directory where files will be extracted |
 | `config` | `SecurityConfig \| undefined` | Optional security configuration |
-| `progress` | `(path: string, total: bigint, current: bigint, bytesWritten: bigint) => void \| undefined` | Optional progress callback |
+| `options` | `ExtractionOptions \| undefined` | Optional extraction options |
+| `progress` | `(err: Error \| null, arg: [path: string, total: number, current: number, bytesWritten: number]) => void \| undefined` | Optional progress callback |
 
 **Returns:** `Promise<ExtractionReport>`
+
+### `createArchiveWithProgress(outputPath, sources, config?, progress?)`
+
+Async archive creation with an optional progress callback, invoked once per entry.
+
+`progress` uses the same `(err, arg)` calling convention as
+`extractArchiveWithProgress` above — `arg` is `[path, total, current,
+bytesWritten]`, and `bytesWritten` is always `0` for the same reason.
+
+```typescript
+import { createArchiveWithProgress } from 'exarch-rs';
+
+const result = await createArchiveWithProgress(
+  'backup.tar.gz',
+  ['src/', 'package.json'],
+  undefined,  // CreationConfig or undefined
+  (err, [path, total, current, bytesWritten]) => {
+    console.log(`[${current}/${total}] ${path}`);
+  }
+);
+```
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `outputPath` | `string` | Path to the output archive file |
+| `sources` | `string[]` | Source files/directories to include |
+| `config` | `CreationConfig \| undefined` | Optional creation configuration |
+| `progress` | `(err: Error \| null, arg: [path: string, total: number, current: number, bytesWritten: number]) => void \| undefined` | Optional progress callback |
+
+**Returns:** `Promise<CreationReport>`
+
+### `createArchiveWithProgressSync(outputPath, sources, config?, progress?)`
+
+Synchronous version. Blocks the event loop until creation completes.
+
+**`progress` does not report live during this call.** It is dispatched
+through the same threadsafe-function mechanism as the async variant, which
+only ever delivers calls on a turn of the Node.js event loop. Because this
+function blocks that same event loop until it returns, every queued call is
+delivered only *after* `createArchiveWithProgressSync` has already
+returned — none of them fire while creation is running. Use
+`createArchiveWithProgress` instead if you need live progress updates.
+
+```typescript
+import { createArchiveWithProgressSync } from 'exarch-rs';
+
+const result = createArchiveWithProgressSync(
+  'backup.tar.gz',
+  ['src/', 'package.json'],
+  undefined,  // CreationConfig or undefined
+  (err, [path, total, current, bytesWritten]) => {
+    // Fires only after createArchiveWithProgressSync has already returned.
+    console.log(`[${current}/${total}] ${path}`);
+  }
+);
+console.log(`Created archive with ${result.filesAdded} files`);
+```
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `outputPath` | `string` | Path to the output archive file |
+| `sources` | `string[]` | Source files/directories to include |
+| `config` | `CreationConfig \| undefined` | Optional creation configuration |
+| `progress` | `(err: Error \| null, arg: [path: string, total: number, current: number, bytesWritten: number]) => void \| undefined` | Optional progress callback. See the note above: calls arrive only after this function returns. |
+
+**Returns:** `CreationReport`
 
 ### `SecurityConfig`
 

--- a/crates/exarch-node/index.d.ts
+++ b/crates/exarch-node/index.d.ts
@@ -426,6 +426,111 @@ export declare function createArchive(outputPath: string, sources: Array<string>
 export declare function createArchiveSync(outputPath: string, sources: Array<string>, config?: CreationConfig | undefined | null): CreationReport
 
 /**
+ * Create an archive from source files and directories with a progress
+ * callback (async).
+ *
+ * The `progress` callback is called once per entry, receiving `(err,
+ * [path, total, current, bytesWritten])` (napi's standard threadsafe
+ * function calling convention: `err` is always `null`, the entry data
+ * arrives as a single array argument) where:
+ * - `path` — entry path being added to the archive
+ * - `total` — total number of entries as `number`
+ * - `current` — 1-based index of the current entry as `number`
+ * - `bytesWritten` — always `0`. The callback only fires from the entry-start
+ *   event, which resets the running per-entry byte counter immediately before
+ *   dispatching; the separate byte-accumulation event never triggers a
+ *   dispatch of its own, so no call ever observes a nonzero value.
+ *
+ * Creation runs on the tokio blocking thread pool. The progress callback is
+ * dispatched back to the JavaScript thread via a threadsafe function.
+ *
+ * # Arguments
+ *
+ * * `output_path` - Path to output archive file
+ * * `sources` - Array of source files/directories to include
+ * * `config` - Optional `CreationConfig` (uses defaults if omitted)
+ * * `progress` - Optional progress callback `(err: Error | null, arg: [path:
+ *   string, total: number, current: number, bytesWritten: number]) => void`
+ *
+ * # Returns
+ *
+ * Promise resolving to `CreationReport` with creation statistics
+ *
+ * # Errors
+ *
+ * Returns error if path validation fails, archive creation fails, or I/O
+ * errors occur. See `createArchive` for the full list of error codes.
+ *
+ * # Examples
+ *
+ * ```javascript
+ * const report = await createArchiveWithProgress(
+ *   'output.tar.gz',
+ *   ['source_dir/'],
+ *   null,
+ *   (err, [path, total, current, bytesWritten]) => {
+ *     console.log(`${current}/${total}: ${path}`);
+ *   },
+ * );
+ * console.log(`Created archive with ${report.filesAdded} files`);
+ * ```
+ */
+export declare function createArchiveWithProgress(outputPath: string, sources: Array<string>, config?: CreationConfig | undefined | null, progress?: (((err: Error | null, arg: [string, number, number, number]) => any)) | undefined | null): Promise<CreationReport>
+
+/**
+ * Create an archive from source files and directories with a progress
+ * callback (sync).
+ *
+ * Synchronous version of `createArchiveWithProgress`. Blocks the event loop
+ * until creation completes. Prefer the async version for most use cases.
+ *
+ * # `progress` does not report live during this call
+ *
+ * `progress` is dispatched through the same threadsafe-function mechanism as
+ * the async variant, which only ever delivers calls on a turn of the Node.js
+ * event loop. Because this function blocks that same event loop until it
+ * returns, **every queued call is delivered only after
+ * `createArchiveWithProgressSync` has already returned** — none of them fire
+ * during the call, so `progress` cannot be used to report *live* progress
+ * here. Use `createArchiveWithProgress` instead if you need progress updates
+ * while creation is still running.
+ *
+ * # Arguments
+ *
+ * * `output_path` - Path to output archive file
+ * * `sources` - Array of source files/directories to include
+ * * `config` - Optional `CreationConfig` (uses defaults if omitted)
+ * * `progress` - Optional progress callback `(err: Error | null, arg: [path:
+ *   string, total: number, current: number, bytesWritten: number]) => void`.
+ *   See the section above: calls arrive only after this function returns.
+ *
+ * # Returns
+ *
+ * `CreationReport` with creation statistics
+ *
+ * # Errors
+ *
+ * Returns error if path validation fails, archive creation fails, or I/O
+ * errors occur. See `createArchive` for the full list of error codes.
+ *
+ * # Examples
+ *
+ * ```javascript
+ * const report = createArchiveWithProgressSync(
+ *   'output.tar.gz',
+ *   ['source_dir/'],
+ *   null,
+ *   (err, [path, total, current, bytesWritten]) => {
+ *     // Fires only after createArchiveWithProgressSync has already returned.
+ *     console.log(`${current}/${total}: ${path}`);
+ *   },
+ * );
+ * console.log(`Created archive with ${report.filesAdded} files`);
+ * ```
+ */
+export declare function createArchiveWithProgressSync(outputPath: string, sources: Array<string>, config?: CreationConfig | undefined | null, progress?: (((err: Error | null, arg: [string, number, number, number]) => any)) | undefined | null): CreationReport
+
+/**
  * Report of an archive creation operation.
  *
  * Contains statistics and metadata about the creation process.
@@ -556,15 +661,18 @@ export declare function extractArchiveSync(archivePath: string, outputDir: strin
  * Extract an archive to the specified directory with a progress callback
  * (async).
  *
- * The `progress` callback is called once per entry with
- * `(path, total, current, bytesWritten)` where:
+ * The `progress` callback is called once per entry, receiving `(err,
+ * [path, total, current, bytesWritten])` (napi's standard threadsafe
+ * function calling convention: `err` is always `null`, the entry data
+ * arrives as a single array argument) where:
  * - `path` — entry path inside the archive
  * - `total` — total number of entries as `number` (0 for TAR-family formats
  *   because the entry count is unknown until the stream is fully read)
  * - `current` — 1-based index of the current entry as `number`
- * - `bytesWritten` — cumulative bytes written to disk so far as `number`
- *   (always 0 during extraction because the core library does not emit
- *   byte-level progress events for extraction; only entry-level events fire)
+ * - `bytesWritten` — always `0`. The callback only fires from the entry-start
+ *   event, which resets the running per-entry byte counter immediately before
+ *   dispatching; the separate byte-accumulation event never triggers a
+ *   dispatch of its own, so no call ever observes a nonzero value.
  *
  * Extraction runs on the tokio blocking thread pool. The progress callback is
  * dispatched back to the JavaScript thread via a threadsafe function.
@@ -575,8 +683,8 @@ export declare function extractArchiveSync(archivePath: string, outputDir: strin
  * * `output_dir` - Directory where files will be extracted
  * * `config` - Optional `SecurityConfig` (uses secure defaults if omitted)
  * * `options` - Optional `ExtractionOptions` (uses defaults if omitted)
- * * `progress` - Optional progress callback `(path: string, total: number,
- *   current: number, bytesWritten: number) => void`
+ * * `progress` - Optional progress callback `(err: Error | null, arg: [path:
+ *   string, total: number, current: number, bytesWritten: number]) => void`
  *
  * # Returns
  *
@@ -596,7 +704,7 @@ export declare function extractArchiveSync(archivePath: string, outputDir: strin
  *   '/tmp/output',
  *   null,
  *   null,
- *   (path, total, current, bytesWritten) => {
+ *   (err, [path, total, current, bytesWritten]) => {
  *     console.log(`${current}/${total}: ${path}`);
  *   },
  * );

--- a/crates/exarch-node/src/lib.rs
+++ b/crates/exarch-node/src/lib.rs
@@ -374,6 +374,179 @@ pub fn create_archive_sync(
     Ok(CreationReport::from(report))
 }
 
+/// Create an archive from source files and directories with a progress
+/// callback (async).
+///
+/// The `progress` callback is called once per entry, receiving `(err,
+/// [path, total, current, bytesWritten])` (napi's standard threadsafe
+/// function calling convention: `err` is always `null`, the entry data
+/// arrives as a single array argument) where:
+/// - `path` — entry path being added to the archive
+/// - `total` — total number of entries as `number`
+/// - `current` — 1-based index of the current entry as `number`
+/// - `bytesWritten` — always `0`. The callback only fires from the entry-start
+///   event, which resets the running per-entry byte counter immediately before
+///   dispatching; the separate byte-accumulation event never triggers a
+///   dispatch of its own, so no call ever observes a nonzero value.
+///
+/// Creation runs on the tokio blocking thread pool. The progress callback is
+/// dispatched back to the JavaScript thread via a threadsafe function.
+///
+/// # Arguments
+///
+/// * `output_path` - Path to output archive file
+/// * `sources` - Array of source files/directories to include
+/// * `config` - Optional `CreationConfig` (uses defaults if omitted)
+/// * `progress` - Optional progress callback `(err: Error | null, arg: [path:
+///   string, total: number, current: number, bytesWritten: number]) => void`
+///
+/// # Returns
+///
+/// Promise resolving to `CreationReport` with creation statistics
+///
+/// # Errors
+///
+/// Returns error if path validation fails, archive creation fails, or I/O
+/// errors occur. See `createArchive` for the full list of error codes.
+///
+/// # Examples
+///
+/// ```javascript
+/// const report = await createArchiveWithProgress(
+///   'output.tar.gz',
+///   ['source_dir/'],
+///   null,
+///   (err, [path, total, current, bytesWritten]) => {
+///     console.log(`${current}/${total}: ${path}`);
+///   },
+/// );
+/// console.log(`Created archive with ${report.filesAdded} files`);
+/// ```
+#[napi]
+#[allow(clippy::needless_pass_by_value, clippy::trailing_empty_array)]
+pub async fn create_archive_with_progress(
+    output_path: String,
+    sources: Vec<String>,
+    config: Option<&CreationConfig>,
+    progress: Option<ThreadsafeFunction<(String, i64, i64, i64)>>,
+) -> Result<CreationReport> {
+    validate_path(&output_path)?;
+    for source in &sources {
+        validate_path(source)?;
+    }
+
+    let config_owned: exarch_core::creation::CreationConfig =
+        config.map(|c| c.as_core().clone()).unwrap_or_default();
+
+    let report = tokio::task::spawn_blocking(move || {
+        catch_panic_as_js_err("archive creation with progress", || {
+            let sources_refs: Vec<&str> = sources.iter().map(String::as_str).collect();
+            run_create_with_optional_progress(&output_path, &sources_refs, &config_owned, progress)
+                .map_err(convert_error)
+        })
+    })
+    .await
+    .map_err(|e| Error::from_reason(format!("task join error: {e}")))
+    .flatten()?;
+
+    Ok(CreationReport::from(report))
+}
+
+/// Create an archive from source files and directories with a progress
+/// callback (sync).
+///
+/// Synchronous version of `createArchiveWithProgress`. Blocks the event loop
+/// until creation completes. Prefer the async version for most use cases.
+///
+/// # `progress` does not report live during this call
+///
+/// `progress` is dispatched through the same threadsafe-function mechanism as
+/// the async variant, which only ever delivers calls on a turn of the Node.js
+/// event loop. Because this function blocks that same event loop until it
+/// returns, **every queued call is delivered only after
+/// `createArchiveWithProgressSync` has already returned** — none of them fire
+/// during the call, so `progress` cannot be used to report *live* progress
+/// here. Use `createArchiveWithProgress` instead if you need progress updates
+/// while creation is still running.
+///
+/// # Arguments
+///
+/// * `output_path` - Path to output archive file
+/// * `sources` - Array of source files/directories to include
+/// * `config` - Optional `CreationConfig` (uses defaults if omitted)
+/// * `progress` - Optional progress callback `(err: Error | null, arg: [path:
+///   string, total: number, current: number, bytesWritten: number]) => void`.
+///   See the section above: calls arrive only after this function returns.
+///
+/// # Returns
+///
+/// `CreationReport` with creation statistics
+///
+/// # Errors
+///
+/// Returns error if path validation fails, archive creation fails, or I/O
+/// errors occur. See `createArchive` for the full list of error codes.
+///
+/// # Examples
+///
+/// ```javascript
+/// const report = createArchiveWithProgressSync(
+///   'output.tar.gz',
+///   ['source_dir/'],
+///   null,
+///   (err, [path, total, current, bytesWritten]) => {
+///     // Fires only after createArchiveWithProgressSync has already returned.
+///     console.log(`${current}/${total}: ${path}`);
+///   },
+/// );
+/// console.log(`Created archive with ${report.filesAdded} files`);
+/// ```
+#[napi]
+#[allow(clippy::needless_pass_by_value)]
+pub fn create_archive_with_progress_sync(
+    output_path: String,
+    sources: Vec<String>,
+    config: Option<&CreationConfig>,
+    progress: Option<ThreadsafeFunction<(String, i64, i64, i64)>>,
+) -> Result<CreationReport> {
+    validate_path(&output_path)?;
+    for source in &sources {
+        validate_path(source)?;
+    }
+
+    let default_config = exarch_core::creation::CreationConfig::default();
+    let config_ref = config.map_or(&default_config, |c| c.as_core());
+
+    let sources_refs: Vec<&str> = sources.iter().map(String::as_str).collect();
+
+    let report = catch_panic_as_js_err("archive creation with progress", || {
+        run_create_with_optional_progress(&output_path, &sources_refs, config_ref, progress)
+            .map_err(convert_error)
+    })?;
+
+    Ok(CreationReport::from(report))
+}
+
+/// Runs `create_archive_with_progress` routing to the JS callback when
+/// present or to [`exarch_core::NoopProgress`] when absent.
+fn run_create_with_optional_progress(
+    output_path: &str,
+    sources: &[&str],
+    config: &exarch_core::creation::CreationConfig,
+    progress: Option<ThreadsafeFunction<(String, i64, i64, i64)>>,
+) -> exarch_core::Result<exarch_core::creation::CreationReport> {
+    progress.map_or_else(
+        || {
+            let mut noop = exarch_core::NoopProgress;
+            exarch_core::create_archive_with_progress(output_path, sources, config, &mut noop)
+        },
+        |tsfn| {
+            let mut callback = NodeProgressAdapter::new(tsfn);
+            exarch_core::create_archive_with_progress(output_path, sources, config, &mut callback)
+        },
+    )
+}
+
 /// List archive contents without extracting (async).
 ///
 /// # Arguments
@@ -567,15 +740,18 @@ pub fn verify_archive_sync(
 /// Extract an archive to the specified directory with a progress callback
 /// (async).
 ///
-/// The `progress` callback is called once per entry with
-/// `(path, total, current, bytesWritten)` where:
+/// The `progress` callback is called once per entry, receiving `(err,
+/// [path, total, current, bytesWritten])` (napi's standard threadsafe
+/// function calling convention: `err` is always `null`, the entry data
+/// arrives as a single array argument) where:
 /// - `path` — entry path inside the archive
 /// - `total` — total number of entries as `number` (0 for TAR-family formats
 ///   because the entry count is unknown until the stream is fully read)
 /// - `current` — 1-based index of the current entry as `number`
-/// - `bytesWritten` — cumulative bytes written to disk so far as `number`
-///   (always 0 during extraction because the core library does not emit
-///   byte-level progress events for extraction; only entry-level events fire)
+/// - `bytesWritten` — always `0`. The callback only fires from the entry-start
+///   event, which resets the running per-entry byte counter immediately before
+///   dispatching; the separate byte-accumulation event never triggers a
+///   dispatch of its own, so no call ever observes a nonzero value.
 ///
 /// Extraction runs on the tokio blocking thread pool. The progress callback is
 /// dispatched back to the JavaScript thread via a threadsafe function.
@@ -586,8 +762,8 @@ pub fn verify_archive_sync(
 /// * `output_dir` - Directory where files will be extracted
 /// * `config` - Optional `SecurityConfig` (uses secure defaults if omitted)
 /// * `options` - Optional `ExtractionOptions` (uses defaults if omitted)
-/// * `progress` - Optional progress callback `(path: string, total: number,
-///   current: number, bytesWritten: number) => void`
+/// * `progress` - Optional progress callback `(err: Error | null, arg: [path:
+///   string, total: number, current: number, bytesWritten: number]) => void`
 ///
 /// # Returns
 ///
@@ -607,7 +783,7 @@ pub fn verify_archive_sync(
 ///   '/tmp/output',
 ///   null,
 ///   null,
-///   (path, total, current, bytesWritten) => {
+///   (err, [path, total, current, bytesWritten]) => {
 ///     console.log(`${current}/${total}: ${path}`);
 ///   },
 /// );
@@ -684,11 +860,12 @@ fn run_extract_with_optional_progress(
 
 /// Adapter that calls a JavaScript progress callback from a Rust worker thread.
 ///
-/// The JavaScript callback receives `(path: string, total: number, current:
-/// number, bytesWritten: number)` where `bytesWritten` is the number of bytes
-/// written **for the current entry so far** (starts at 0 when the entry begins,
-/// grows as chunks are flushed to disk; always 0 during extraction because the
-/// core library does not emit byte-level progress events for extraction).
+/// Shared by extraction and creation. The JavaScript callback receives `(err:
+/// Error | null, [path, total, current, bytesWritten])`. `bytesWritten` is
+/// always `0`: only `on_entry_start` dispatches a call, and it resets
+/// `current_entry_bytes` to `0` immediately before doing so. `on_bytes_written`
+/// does accumulate per-chunk writes (during creation; extraction also emits
+/// these events for some formats), but never triggers a dispatch of its own.
 struct NodeProgressAdapter {
     tsfn: ThreadsafeFunction<(String, i64, i64, i64)>,
     current_entry_bytes: i64,

--- a/crates/exarch-node/tests/progress.test.js
+++ b/crates/exarch-node/tests/progress.test.js
@@ -1,0 +1,275 @@
+/**
+ * Tests for the *WithProgress functions (extractArchiveWithProgress,
+ * createArchiveWithProgress, createArchiveWithProgressSync).
+ *
+ * Covers both the callback-invoked path (per-entry callback shape) and the
+ * progress=null/undefined path (callback omission must not throw).
+ */
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const {
+  extractArchiveWithProgress,
+  createArchiveWithProgress,
+  createArchiveWithProgressSync,
+  createArchiveSync,
+} = require('../index.js');
+
+function createTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'exarch-progress-test-'));
+}
+
+function createTestFiles(dir) {
+  fs.writeFileSync(path.join(dir, 'file1.txt'), 'Content of file 1');
+  fs.writeFileSync(path.join(dir, 'file2.txt'), 'Content of file 2');
+}
+
+// The progress ThreadsafeFunction uses the standard napi (err, arg) calling
+// convention: err is always null (Ok is used on the Rust side), and arg is
+// the [path, total, current, bytesWritten] tuple documented in index.d.ts.
+function assertProgressCallShape(err, arg) {
+  assert.strictEqual(err, null);
+  const [entryPath, total, current, bytesWritten] = arg;
+  assert.strictEqual(typeof entryPath, 'string');
+  assert.strictEqual(typeof total, 'number');
+  assert.strictEqual(typeof current, 'number');
+  assert.strictEqual(typeof bytesWritten, 'number');
+}
+
+// ThreadsafeFunction dispatches callbacks via NonBlocking mode, so calls
+// queued during a *Sync function are only flushed on later event loop turns
+// even though the Rust call itself already returned. Poll until the queued
+// callbacks have run instead of guessing how many turns are needed.
+async function waitUntil(conditionFn, { timeoutMs = 2000, intervalMs = 5 } = {}) {
+  const start = Date.now();
+  while (!conditionFn()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error('timed out waiting for condition');
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, intervalMs);
+    });
+  }
+}
+
+describe('extractArchiveWithProgress', () => {
+  let tempDir;
+  let archivePath;
+  let outputDir;
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+    archivePath = path.join(tempDir, 'test.tar.gz');
+    outputDir = path.join(tempDir, 'output');
+    fs.mkdirSync(outputDir);
+
+    const sourceDir = path.join(tempDir, 'source');
+    fs.mkdirSync(sourceDir);
+    createTestFiles(sourceDir);
+    createArchiveSync(archivePath, [sourceDir]);
+  });
+
+  afterEach(() => {
+    if (tempDir && fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('invokes the callback exactly once per entry with (path, total, current, bytesWritten)', async () => {
+    const calls = [];
+    const report = await extractArchiveWithProgress(
+      archivePath,
+      outputDir,
+      null,
+      null,
+      (err, arg) => {
+        calls.push(arg);
+        assertProgressCallShape(err, arg);
+      }
+    );
+
+    assert.ok(report.filesExtracted >= 1);
+    // Fixture has exactly the 2 files from createTestFiles; extraction does
+    // not surface a directory entry, so the callback fires exactly twice.
+    assert.strictEqual(calls.length, 2, 'expected exactly one callback per extracted entry');
+
+    // current is a 1-based, gapless sequence in call order.
+    const currents = calls.map(([, , current]) => current);
+    assert.deepStrictEqual(currents, [1, 2]);
+  });
+
+  it('extracts normally when progress is null', async () => {
+    const report = await extractArchiveWithProgress(archivePath, outputDir, null, null, null);
+
+    assert.ok(report.filesExtracted >= 1);
+    assert.ok(fs.existsSync(path.join(outputDir, 'file1.txt')));
+  });
+
+  it('extracts normally when progress is undefined', async () => {
+    const report = await extractArchiveWithProgress(archivePath, outputDir);
+
+    assert.ok(report.filesExtracted >= 1);
+    assert.ok(fs.existsSync(path.join(outputDir, 'file1.txt')));
+  });
+});
+
+describe('createArchiveWithProgress (async)', () => {
+  let tempDir;
+  let sourceDir;
+  let outputPath;
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+    sourceDir = path.join(tempDir, 'source');
+    fs.mkdirSync(sourceDir);
+    createTestFiles(sourceDir);
+    outputPath = path.join(tempDir, 'output.tar.gz');
+  });
+
+  afterEach(() => {
+    if (tempDir && fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('invokes the callback exactly once per entry with (path, total, current, bytesWritten)', async () => {
+    const calls = [];
+    const report = await createArchiveWithProgress(outputPath, [sourceDir], null, (err, arg) => {
+      calls.push(arg);
+      assertProgressCallShape(err, arg);
+    });
+
+    assert.ok(report.filesAdded >= 2);
+    assert.ok(fs.existsSync(outputPath));
+    // Fixture has the 2 files from createTestFiles plus the source directory
+    // itself, which creation also emits an entry for (unlike extraction).
+    assert.strictEqual(calls.length, 3, 'expected exactly one callback per created entry');
+
+    const currents = calls.map(([, , current]) => current);
+    assert.deepStrictEqual(currents, [1, 2, 3]);
+  });
+
+  it('creates the archive normally when progress is null', async () => {
+    const report = await createArchiveWithProgress(outputPath, [sourceDir], null, null);
+
+    assert.ok(report.filesAdded >= 2);
+    assert.ok(fs.existsSync(outputPath));
+  });
+
+  it('creates the archive normally when progress is undefined', async () => {
+    const report = await createArchiveWithProgress(outputPath, [sourceDir]);
+
+    assert.ok(report.filesAdded >= 2);
+    assert.ok(fs.existsSync(outputPath));
+  });
+});
+
+describe('createArchiveWithProgressSync', () => {
+  let tempDir;
+  let sourceDir;
+  let outputPath;
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+    sourceDir = path.join(tempDir, 'source');
+    fs.mkdirSync(sourceDir);
+    createTestFiles(sourceDir);
+    outputPath = path.join(tempDir, 'output.tar.gz');
+  });
+
+  afterEach(() => {
+    if (tempDir && fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('invokes the callback exactly once per entry with (path, total, current, bytesWritten)', async () => {
+    const calls = [];
+    const report = createArchiveWithProgressSync(outputPath, [sourceDir], null, (err, arg) => {
+      calls.push(arg);
+      assertProgressCallShape(err, arg);
+    });
+
+    assert.ok(report.filesAdded >= 2);
+    assert.ok(fs.existsSync(outputPath));
+
+    // The ThreadsafeFunction is dispatched via NonBlocking mode, so queued
+    // calls are only flushed on later event loop turns even though this
+    // *Sync call has already returned. Same fixture as the async variant:
+    // the source directory plus its 2 files means 3 calls.
+    await waitUntil(() => calls.length >= 3);
+    assert.strictEqual(calls.length, 3, 'expected exactly one callback per created entry');
+
+    const currents = calls.map(([, , current]) => current);
+    assert.deepStrictEqual(currents, [1, 2, 3]);
+  });
+
+  it('creates the archive normally when progress is null', () => {
+    const report = createArchiveWithProgressSync(outputPath, [sourceDir], null, null);
+
+    assert.ok(report.filesAdded >= 2);
+    assert.ok(fs.existsSync(outputPath));
+  });
+
+  it('creates the archive normally when progress is undefined', () => {
+    const report = createArchiveWithProgressSync(outputPath, [sourceDir]);
+
+    assert.ok(report.filesAdded >= 2);
+    assert.ok(fs.existsSync(outputPath));
+  });
+});
+
+describe('createArchiveWithProgress bytesWritten staleness (parity with exarch-python #285)', () => {
+  let tempDir;
+
+  afterEach(() => {
+    if (tempDir && fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('reports bytesWritten === 0 at entry start even after a large preceding entry', async () => {
+    // Regression test for exarch-python#285, ported to exarch-node: the
+    // Python PyProgressAdapter used to pass a stale bytesWritten (accumulated
+    // from all previously written entries) at on_entry_start. The fix resets
+    // the running per-entry byte counter to 0 before dispatching that event.
+    // NodeProgressAdapter has the identical current_entry_bytes reset logic
+    // (crates/exarch-node/src/lib.rs) and nothing previously guarded it here.
+    tempDir = createTempDir();
+    const sourceDir = path.join(tempDir, 'source');
+    fs.mkdirSync(sourceDir);
+    fs.writeFileSync(path.join(sourceDir, 'small.txt'), 'x'.repeat(1024));
+    fs.writeFileSync(path.join(sourceDir, 'large.txt'), 'y'.repeat(100 * 1024));
+    const outputPath = path.join(tempDir, 'two_files.tar.gz');
+
+    // entryStartBytes[name] = bytesWritten received at that entry's first callback.
+    const entryStartBytes = {};
+    await createArchiveWithProgress(
+      outputPath,
+      [sourceDir],
+      null,
+      (_err, [entryPath, , , bytesWritten]) => {
+        const name = entryPath.split('/').pop();
+        if (!(name in entryStartBytes)) {
+          entryStartBytes[name] = bytesWritten;
+        }
+      }
+    );
+
+    assert.ok('small.txt' in entryStartBytes, 'callback never fired for small.txt');
+    assert.ok('large.txt' in entryStartBytes, 'callback never fired for large.txt');
+
+    assert.strictEqual(
+      entryStartBytes['small.txt'],
+      0,
+      'small.txt: expected bytesWritten=0 at entry start'
+    );
+    assert.strictEqual(
+      entryStartBytes['large.txt'],
+      0,
+      'large.txt: expected bytesWritten=0 at entry start (stale value would indicate the #285-class bug)'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add `createArchiveWithProgress` (async) and `createArchiveWithProgressSync` to `exarch-node`, reusing `exarch_core::create_archive_with_progress` and the existing `NodeProgressAdapter` — closes the API-surface gap with `exarch-python`'s `create_archive_with_progress`
- Add JS integration tests for `extractArchiveWithProgress`, `createArchiveWithProgress`, and `createArchiveWithProgressSync` covering per-entry callback shape, exact call counts, the `progress=null`/omitted path, and a regression guard for stale `bytesWritten` (mirroring python's #285 fix) — `extractArchiveWithProgress` previously had zero test coverage
- Fix pre-existing doc inaccuracies inherited by the new create-side docs: wrong callback arity (`(path, total, current, bytesWritten)` vs the real `(err, [path, total, current, bytesWritten])`), a claim that `bytesWritten` is cumulative when it's always 0 by design, and a missing `options` arg in the extract-side README example

## Notes
- `createArchiveWithProgressSync`'s progress callback only delivers queued calls after the function has already returned (documented in README/doc comments) — it cannot report live progress while blocking the event loop
- A pre-existing issue was found and filed separately as #465 (P1): a throwing JS progress callback uncatchably crashes the process, affecting both `extractArchiveWithProgress` and the new create-side functions via the shared `NodeProgressAdapter`. Out of scope here — needs a design decision beyond this PR's thin-binding scope

Closes #455
Closes #456

## Test plan
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` (1073 passed)
- [x] `cargo test --doc -p exarch-core -p exarch-cli -p exarch-node --all-features` (111 passed; workspace-wide doctest run hits a pre-existing local PyO3/maturin linker issue unrelated to this diff)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace --exclude exarch-python`
- [x] `npm run build:debug && npm test` in `crates/exarch-node` (96/96 passed)