### PR TITLE
fix(core): close symlink-escape write and thread QuotaPermit by value in TAR/ZIP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ladder, so `extract`/`list --long --human-readable` output for archives or entries at or above 1
   TB now shows `"... TB"` instead of a misleadingly large GB number (e.g. `u64::MAX` bytes now
   renders `"16777216.0 TB"`, not `"17179869184.0 GB"`).
+- **TAR/ZIP file writes only observed their `QuotaPermit` by shared reference instead of
+  consuming it (#445)**: unlike 7z's `write_file_with_permit` (#440), `formats::common`'s shared
+  `extract_file_generic` runtime-guarded `ValidatedEntryType::File(_)` against `&ValidatedEntry`
+  and never took ownership of the permit. Renamed it to `extract_file_with_permit`, taking
+  `safe_path: &SafePath`, `mode: Option<u32>`, and `permit: QuotaPermit` by value instead of
+  `&ValidatedEntry`; `formats::common::create_directory` narrows to `&SafePath` for the same
+  reason (its body only ever read `validated.safe_path()`). TAR's extraction dispatch now matches
+  exhaustively on `ValidatedEntry::into_parts()`, so only the `File` arm can even bind a
+  `QuotaPermit` — a compiler-enforced impossibility, not a runtime check. ZIP's dispatch also
+  calls `into_parts()` and moves the permit by value, but retains a runtime
+  `let ValidatedEntryType::File(permit) = entry_type else { return Err(..) }` fail-closed guard,
+  since ZIP's file/directory/symlink branches aren't a single exhaustive match; this relies on
+  `EntryValidator::validate_entry(&EntryType::File, ..)` always producing
+  `ValidatedEntryType::File`, an invariant covered by the existing `test_validate_file_entry`. No
+  quota arithmetic or validation behavior changed for either format.
+
 - **7z file writes discarded their `QuotaPermit` instead of consuming it (#440)**: unlike TAR/ZIP,
   7z's `ValidatedEntryType::File(_)` write arm matched the permit and dropped it via `_`, so the
   capability-token guarantee introduced in #436 covered TAR and ZIP but not 7z. Added
@@ -204,7 +220,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   compile without a genuine permit obtained from `EntryValidator::validate_entry`. No quota
   arithmetic or validation behavior changed.
 
+### Performance
+
+- **Extracting archives with many small files regressed ~15.8% after #436/#437/#439 (#446,
+  partial recovery)**: `formats::common::extract_file_with_permit`'s duplicate-detection now
+  folds the existence check into the file-creation `open()` call (see the `O_EXCL`/`O_NOFOLLOW`
+  entry under Security below) instead of a separate `output_path.exists()` stat followed by a
+  truncating create — one fewer syscall per extracted file. This is primarily the security fix
+  described below; the syscall reduction is a side-benefit, not the reason it was made. Also added
+  `#[inline]` to `EntryValidator::validate_entry`/`check_ratio` and `SecurityConfig`'s
+  `Deref::deref`, on the hot per-entry validation path. Re-verified via a controlled same-session
+  A/B (`criterion --save-baseline`): `many_small_files/10000` improved -8.3% to -8.9%
+  (p <= 0.01, reproduced twice); `/100` and `/1000` showed no significant change. This is a
+  **partial**, not full, recovery of the confirmed +15.8% regression — the regression's root cause
+  was not otherwise identified, and full parity against the original CI baseline still needs
+  confirmation on CI hardware rather than local benchmarks (which showed >20% same-commit swings
+  during this investigation).
+
 ### Security
+
+- **Dangling symlink at the extraction destination bypassed the duplicate-check and allowed
+  writing outside the destination root (#459, pre-existing, TAR and ZIP)**: the duplicate-existence
+  check used `Path::exists()`, which follows symlinks and returns `false` for a dangling one. A
+  symlink already present at the destination path — planted by something other than the archive
+  being extracted, since `SafeSymlink::validate` already prevents an in-archive symlink entry from
+  escaping `dest` — was therefore treated as "no duplicate," and a plain `File::create` followed
+  the link, writing the entry's content outside the extraction root. Fixed by opening the
+  destination file with `O_EXCL` (via `OpenOptions::create_new`, already required for the
+  `skip_duplicates=true` duplicate-detection path) and, on Unix, unconditionally with `O_NOFOLLOW`
+  (`OpenOptionsExt::custom_flags`): both reject an existing symlink, dangling or not, instead of
+  following it, closing the escape on both `skip_duplicates` values (the `skip_duplicates=false`
+  overwrite path previously had no protection at all). Added regression tests planting a dangling
+  symlink at the destination path before extraction for both `skip_duplicates` settings.
+  Precondition is an attacker-writable destination directory, not a malicious archive alone.
 
 - **`list` accepted NUL bytes, empty targets, and missing targets that `extract`/`verify` already
   rejected (#430)**: `list_tar_entries` and `list_zip_reader` validated entry paths for path

--- a/crates/exarch-core/src/config.rs
+++ b/crates/exarch-core/src/config.rs
@@ -290,6 +290,7 @@ pub struct SecurityConfig<State = Unvalidated> {
 impl<State> Deref for SecurityConfig<State> {
     type Target = SecurityConfigFields;
 
+    #[inline]
     fn deref(&self) -> &SecurityConfigFields {
         &self.fields
     }

--- a/crates/exarch-core/src/formats/common.rs
+++ b/crates/exarch-core/src/formats/common.rs
@@ -6,7 +6,7 @@
 //!
 //! # Functions
 //!
-//! - [`extract_file_generic`]: Generic file extraction with buffered I/O
+//! - [`extract_file_with_permit`]: Generic file extraction with buffered I/O
 //! - [`create_directory`]: Directory creation (idempotent)
 //! - [`create_symlink`]: Symbolic link creation (Unix only)
 //! - [`check_extension_allowed`]: Extension allowlist filtering
@@ -30,9 +30,8 @@ use crate::copy::CopyBuffer;
 use crate::copy::copy_with_buffer;
 use crate::error::QuotaResource;
 use crate::security::quota::QuotaPermit;
-use crate::security::validator::ValidatedEntry;
-use crate::security::validator::ValidatedEntryType;
 use crate::types::DestDir;
+use crate::types::SafePath;
 use crate::types::SafeSymlink;
 
 /// RAII guard that calls `on_entry_complete` when dropped.
@@ -378,6 +377,25 @@ pub fn check_extension_allowed(
 ///
 /// On non-Unix platforms, permissions are not supported and mode is ignored.
 ///
+/// When `create_new` is `true`, the file is opened with `O_EXCL` semantics
+/// (`OpenOptions::create_new`): the call atomically fails with
+/// `ErrorKind::AlreadyExists` if `path` already exists, instead of truncating
+/// it. This folds the caller's duplicate-detection into the `open()` syscall
+/// itself rather than requiring a separate `exists()` stat beforehand.
+///
+/// # Security - Symlink-at-Destination Rejection (issue #459)
+///
+/// On Unix, every open passes `O_NOFOLLOW`: if `path`'s final component is a
+/// symlink (dangling or not — planted by something other than this
+/// extraction, since `SafeSymlink::validate` already prevents an in-archive
+/// symlink entry from escaping `dest`), the call fails with `ELOOP` instead
+/// of following the link. Without this, `path.exists()` (used by the old,
+/// now-removed pre-check) returns `false` for a dangling symlink, and a plain
+/// `File::create` follows it, writing archive content outside the
+/// extraction root. `create_new`'s `O_EXCL` already rejects any existing
+/// path including symlinks, so `O_NOFOLLOW` is redundant there; it is the
+/// only guard on the `create`+`truncate` (`create_new = false`) branch.
+///
 /// # Performance
 ///
 /// - Unix: 2 syscalls (open with mode hint + `set_permissions` to bypass umask)
@@ -404,20 +422,38 @@ pub fn check_extension_allowed(
 ///
 /// * `path` - Path where file should be created
 /// * `mode` - Optional Unix file mode (must be pre-sanitized by caller)
+/// * `create_new` - If `true`, fail with `AlreadyExists` instead of truncating
+///   an existing file at `path`
 ///
 /// # Errors
 ///
-/// Returns an I/O error if file creation fails.
+/// Returns an I/O error if file creation fails, including
+/// `ErrorKind::AlreadyExists` when `create_new` is `true` and `path` already
+/// exists, or `ELOOP` (via `custom_flags(O_NOFOLLOW)`) when `path`'s final
+/// component is a symlink on any branch.
 #[inline]
 #[cfg(unix)]
-fn create_file_with_mode(path: &Path, mode: Option<u32>) -> std::io::Result<File> {
+fn create_file_with_mode(
+    path: &Path,
+    mode: Option<u32>,
+    create_new: bool,
+) -> std::io::Result<File> {
     use std::fs::OpenOptions;
     use std::fs::Permissions;
     use std::os::unix::fs::OpenOptionsExt;
     use std::os::unix::fs::PermissionsExt;
 
     let mut opts = OpenOptions::new();
-    opts.write(true).create(true).truncate(true);
+    opts.write(true);
+    // O_NOFOLLOW rejects a symlink at `path` on every branch (issue #459);
+    // `create_new`'s O_EXCL already implies this, but the create+truncate
+    // branch below has no other protection against a planted symlink.
+    opts.custom_flags(libc::O_NOFOLLOW);
+    if create_new {
+        opts.create_new(true);
+    } else {
+        opts.create(true).truncate(true);
+    }
 
     if let Some(m) = mode {
         // Apply sanitized mode during open (already stripped setuid/setgid)
@@ -445,14 +481,29 @@ fn create_file_with_mode(path: &Path, mode: Option<u32>) -> std::io::Result<File
 ///
 /// * `path` - Path where file should be created
 /// * `_mode` - Ignored on non-Unix platforms
+/// * `create_new` - If `true`, fail with `AlreadyExists` instead of truncating
+///   an existing file at `path`
 ///
 /// # Errors
 ///
-/// Returns an I/O error if file creation fails.
+/// Returns an I/O error if file creation fails, including
+/// `ErrorKind::AlreadyExists` when `create_new` is `true` and `path` already
+/// exists.
 #[inline]
 #[cfg(not(unix))]
-fn create_file_with_mode(path: &Path, _mode: Option<u32>) -> std::io::Result<File> {
-    File::create(path)
+fn create_file_with_mode(
+    path: &Path,
+    _mode: Option<u32>,
+    create_new: bool,
+) -> std::io::Result<File> {
+    if create_new {
+        std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(path)
+    } else {
+        File::create(path)
+    }
 }
 
 /// Generic file extraction implementation used by all format adapters.
@@ -472,10 +523,14 @@ fn create_file_with_mode(path: &Path, _mode: Option<u32>) -> std::io::Result<Fil
 /// # Correctness
 ///
 /// The quota charge for this entry already happened during
-/// `EntryValidator::validate_entry`, proven by the [`QuotaPermit`] held in
-/// `validated`'s `ValidatedEntryType::File`; this function only rejects
-/// non-`File` entries and guards `report.bytes_written` against overflow
-/// before writing.
+/// `EntryValidator::validate_entry`, proven by the [`QuotaPermit`] passed in
+/// by value: a `QuotaPermit` is neither `Clone` nor `Copy`, so this function
+/// cannot be called at all without the caller having moved a genuine permit
+/// out of a `ValidatedEntryType::File` via [`ValidatedEntry::into_parts`]
+/// (mirrors 7z's `write_file_with_permit`, issue #445). This guards
+/// `report.bytes_written` against overflow before writing.
+///
+/// [`ValidatedEntry::into_parts`]: crate::security::validator::ValidatedEntry::into_parts
 ///
 /// # Type Parameters
 ///
@@ -484,7 +539,10 @@ fn create_file_with_mode(path: &Path, _mode: Option<u32>) -> std::io::Result<Fil
 /// # Arguments
 ///
 /// * `reader` - Source data stream
-/// * `validated` - Validated entry metadata (path, mode, etc.)
+/// * `safe_path` - Validated destination-relative path
+/// * `mode` - Sanitized Unix file mode, if any
+/// * `_permit` - Proof that this file's size was already reserved against the
+///   quota tracker; consumed by value and otherwise unused
 /// * `dest` - Destination directory
 /// * `report` - Extraction statistics (updated)
 /// * `expected_size` - Expected file size (if known) for quota pre-check
@@ -500,9 +558,11 @@ fn create_file_with_mode(path: &Path, _mode: Option<u32>) -> std::io::Result<Fil
 /// - I/O error during copy
 #[allow(clippy::too_many_arguments)]
 #[inline]
-pub fn extract_file_generic<R: Read>(
+pub fn extract_file_with_permit<R: Read>(
     reader: &mut R,
-    validated: &ValidatedEntry,
+    safe_path: &SafePath,
+    mode: Option<u32>,
+    _permit: QuotaPermit,
     dest: &DestDir,
     report: &mut ExtractionReport,
     expected_size: Option<u64>,
@@ -511,30 +571,16 @@ pub fn extract_file_generic<R: Read>(
     skip_duplicates: bool,
     progress: &mut dyn ProgressCallback,
 ) -> Result<()> {
-    let output_path = dest.join(validated.safe_path());
-
-    let ValidatedEntryType::File(_) = validated.entry_type() else {
-        return Err(ArchiveError::SecurityViolation {
-            reason: "extract_file_generic called with a non-File validated entry".into(),
-        });
-    };
+    let output_path = dest.join(safe_path);
 
     // Create parent directories if needed using cache
     dir_cache.ensure_parent_dir(&output_path)?;
 
-    if output_path.exists() && skip_duplicates {
-        report.files_skipped += 1;
-        report.warnings.push(format!(
-            "skipped duplicate entry: {}",
-            validated.safe_path().as_path().display()
-        ));
-        return Ok(());
-    }
-
     // The size was already reserved against QuotaTracker during
-    // validate_entry (proven by the QuotaPermit held in `validated`'s
-    // ValidatedEntryType::File); this only guards report.bytes_written,
-    // a different quantity, against overflow before writing.
+    // validate_entry (proven by the QuotaPermit consumed above); this only
+    // guards report.bytes_written, a different quantity, against overflow.
+    // Checked before any filesystem mutation so a rejected entry never
+    // leaves a zero-byte file on disk (restores the pre-#446 ordering).
     if let Some(size) = expected_size {
         report
             .bytes_written
@@ -544,9 +590,23 @@ pub fn extract_file_generic<R: Read>(
             })?;
     }
 
-    // Create file and enforce exact sanitized permissions (Unix only).
-    // set_permissions() is called inside create_file_with_mode to bypass umask.
-    let output_file = create_file_with_mode(&output_path, validated.mode())?;
+    // Folds the duplicate-existence check into the open() syscall itself
+    // (create_new(true) atomically fails with AlreadyExists) instead of a
+    // separate exists() stat followed by a truncating create — one syscall
+    // per extracted file instead of two.
+    let output_file = match create_file_with_mode(&output_path, mode, skip_duplicates) {
+        Ok(file) => file,
+        Err(e) if skip_duplicates && e.kind() == std::io::ErrorKind::AlreadyExists => {
+            report.files_skipped += 1;
+            report.warnings.push(format!(
+                "skipped duplicate entry: {}",
+                safe_path.as_path().display()
+            ));
+            return Ok(());
+        }
+        Err(e) => return Err(e.into()),
+    };
+
     let mut buffered_writer = BufWriter::with_capacity(64 * 1024, output_file);
     let bytes_written = copy_with_buffer(reader, &mut buffered_writer, copy_buffer)?;
     buffered_writer.flush()?;
@@ -584,7 +644,7 @@ pub fn extract_file_generic<R: Read>(
 ///
 /// # Arguments
 ///
-/// * `validated` - Validated entry metadata
+/// * `safe_path` - Validated destination-relative path of the directory
 /// * `dest` - Destination directory
 /// * `report` - Extraction statistics (updated)
 /// * `dir_cache` - Directory cache to reduce redundant mkdir syscalls
@@ -593,12 +653,12 @@ pub fn extract_file_generic<R: Read>(
 ///
 /// Returns an error if directory creation fails due to I/O errors.
 pub fn create_directory(
-    validated: &ValidatedEntry,
+    safe_path: &SafePath,
     dest: &DestDir,
     report: &mut ExtractionReport,
     dir_cache: &mut DirCache,
 ) -> Result<()> {
-    let dir_path = dest.join(validated.safe_path());
+    let dir_path = dest.join(safe_path);
 
     // Use cache to avoid redundant mkdir syscalls
     dir_cache.ensure_dir(&dir_path)?;
@@ -709,16 +769,13 @@ mod tests {
     use crate::SecurityConfig;
     use crate::copy::CopyBuffer;
     use crate::security::quota::QuotaTracker;
-    use crate::security::validator::ValidatedEntry;
-    use crate::security::validator::ValidatedEntryType;
-    use crate::types::SafePath;
     use std::assert_matches;
     use std::io::Cursor;
     use std::path::PathBuf;
     use tempfile::TempDir;
 
     #[test]
-    fn test_extract_file_generic_integer_overflow_check() {
+    fn test_extract_file_with_permit_integer_overflow_check() {
         let temp = TempDir::new().expect("failed to create temp dir");
         let dest = DestDir::new(temp.path().to_path_buf()).expect("failed to create dest");
         let mut report = ExtractionReport::default();
@@ -735,18 +792,16 @@ mod tests {
         let permit = QuotaTracker::new()
             .reserve(0, &config)
             .expect("reservation should succeed");
-        let validated = ValidatedEntry::new(
-            SafePath::validate(&PathBuf::from("test.txt"), &dest, &config)
-                .expect("path should be valid"),
-            ValidatedEntryType::File(permit),
-            Some(0o644),
-        );
+        let safe_path = SafePath::validate(&PathBuf::from("test.txt"), &dest, &config)
+            .expect("path should be valid");
 
         let mut reader = Cursor::new(b"test data");
 
-        let result = extract_file_generic(
+        let result = extract_file_with_permit(
             &mut reader,
-            &validated,
+            &safe_path,
+            Some(0o644),
+            permit,
             &dest,
             &mut report,
             expected_size,
@@ -764,45 +819,12 @@ mod tests {
                 resource: QuotaResource::IntegerOverflow
             }
         );
-    }
-
-    /// A `Directory`-typed validated entry must be rejected by
-    /// `extract_file_generic` before any filesystem side effect, proving the
-    /// non-`File` guard is live and not just structurally implied.
-    #[test]
-    fn test_extract_file_generic_rejects_non_file_entry() {
-        let temp = TempDir::new().expect("failed to create temp dir");
-        let dest = DestDir::new(temp.path().to_path_buf()).expect("failed to create dest");
-        let mut report = ExtractionReport::default();
-        let mut copy_buffer = CopyBuffer::new();
-        let mut dir_cache = DirCache::new();
-
-        let config = SecurityConfig::default().validate().expect("valid config");
-        let validated = ValidatedEntry::new(
-            SafePath::validate(&PathBuf::from("dir_entry"), &dest, &config)
-                .expect("path should be valid"),
-            ValidatedEntryType::Directory,
-            None,
-        );
-
-        let mut reader = Cursor::new(b"");
-
-        let result = extract_file_generic(
-            &mut reader,
-            &validated,
-            &dest,
-            &mut report,
-            None,
-            &mut copy_buffer,
-            &mut dir_cache,
-            true,
-            &mut NoopProgress,
-        );
-
-        assert_matches!(result, Err(ArchiveError::SecurityViolation { .. }));
+        // The overflow check now runs before the file is created (issue
+        // #446 review): a rejected entry must not leave a zero-byte file on
+        // disk.
         assert!(
-            !temp.path().join("dir_entry").exists(),
-            "non-File entry must not touch the filesystem"
+            !temp.path().join("test.txt").exists(),
+            "overflow-rejected entry must not touch the filesystem"
         );
     }
 
@@ -1017,7 +1039,8 @@ mod tests {
         let file_path = temp.path().join("test_0o644.txt");
 
         // Create file with mode 0o644
-        let file = create_file_with_mode(&file_path, Some(0o644)).expect("should create file");
+        let file =
+            create_file_with_mode(&file_path, Some(0o644), false).expect("should create file");
         drop(file);
 
         // Verify file exists
@@ -1045,7 +1068,8 @@ mod tests {
         let file_path = temp.path().join("test_0o755.txt");
 
         // Create file with mode 0o755
-        let file = create_file_with_mode(&file_path, Some(0o755)).expect("should create file");
+        let file =
+            create_file_with_mode(&file_path, Some(0o755), false).expect("should create file");
         drop(file);
 
         // Verify file exists
@@ -1073,7 +1097,8 @@ mod tests {
         let file_path = temp.path().join("test_0o600.txt");
 
         // Create file with mode 0o600
-        let file = create_file_with_mode(&file_path, Some(0o600)).expect("should create file");
+        let file =
+            create_file_with_mode(&file_path, Some(0o600), false).expect("should create file");
         drop(file);
 
         // Verify file exists
@@ -1099,7 +1124,7 @@ mod tests {
         let file_path = temp.path().join("test_none.txt");
 
         // Create file with mode=None (should use system defaults)
-        let file = create_file_with_mode(&file_path, None).expect("should create file");
+        let file = create_file_with_mode(&file_path, None, false).expect("should create file");
         drop(file);
 
         // Verify file exists
@@ -1121,7 +1146,7 @@ mod tests {
         let file_path = temp.path().join("test_none_unix.txt");
 
         // Create file with mode=None
-        let file = create_file_with_mode(&file_path, None).expect("should create file");
+        let file = create_file_with_mode(&file_path, None, false).expect("should create file");
         drop(file);
 
         // Verify file exists
@@ -1164,18 +1189,16 @@ mod tests {
         let permit = QuotaTracker::new()
             .reserve(0, &config)
             .expect("reservation should succeed");
-        let validated = ValidatedEntry::new(
-            SafePath::validate(&PathBuf::from("perm_test.txt"), &dest, &config)
-                .expect("path should be valid"),
-            ValidatedEntryType::File(permit),
-            Some(sanitized_mode),
-        );
+        let safe_path = SafePath::validate(&PathBuf::from("perm_test.txt"), &dest, &config)
+            .expect("path should be valid");
 
         let mut reader = Cursor::new(b"content");
 
-        extract_file_generic(
+        extract_file_with_permit(
             &mut reader,
-            &validated,
+            &safe_path,
+            Some(sanitized_mode),
+            permit,
             &dest,
             &mut report,
             None,
@@ -1221,7 +1244,7 @@ mod tests {
         // process-global but safe to mutate here. Restored unconditionally.
         let previous_umask = unsafe { libc::umask(0o077) };
 
-        let result = create_file_with_mode(&file_path, Some(0o755));
+        let result = create_file_with_mode(&file_path, Some(0o755), false);
 
         // Restore previous umask unconditionally before any assert.
         unsafe { libc::umask(previous_umask) };

--- a/crates/exarch-core/src/formats/sevenz.rs
+++ b/crates/exarch-core/src/formats/sevenz.rs
@@ -296,15 +296,12 @@ impl<R: Read + Seek> SevenZArchive<R> {
 /// consuming the [`QuotaPermit`] that authorized the write.
 ///
 /// Taking `permit` by value mirrors the guarantee
-/// [`common::copy_file_with_permit`] gives TAR's hardlink path: `QuotaPermit`
-/// is neither `Clone` nor `Copy`, so a caller cannot retain it to authorize a
-/// second write, and this function cannot be called at all without moving a
-/// genuine permit out of the validated entry. This is stronger than
-/// `common::extract_file_generic` (TAR/ZIP's normal-file path), which only
-/// pattern-matches `ValidatedEntryType::File(_)` against a shared reference
-/// at runtime and never takes ownership of the permit — that helper is not
-/// brought to this same compile-time guarantee by this change (tracked
-/// separately: <https://github.com/bug-ops/exarch/issues/445>).
+/// [`common::copy_file_with_permit`] gives TAR's hardlink path, and the
+/// guarantee [`common::extract_file_with_permit`] gives TAR/ZIP's normal-file
+/// path (issue #445): `QuotaPermit` is neither `Clone` nor `Copy`, so a
+/// caller cannot retain it to authorize a second write, and this function
+/// cannot be called at all without moving a genuine permit out of the
+/// validated entry.
 ///
 /// # Errors
 ///

--- a/crates/exarch-core/src/formats/tar.rs
+++ b/crates/exarch-core/src/formats/tar.rs
@@ -123,8 +123,8 @@ use crate::Result;
 use crate::SecurityConfig;
 use crate::config::Validated;
 use crate::copy::CopyBuffer;
+use crate::security::quota::QuotaPermit;
 use crate::security::validator::EntryValidator;
-use crate::security::validator::ValidatedEntry;
 use crate::security::validator::ValidatedEntryType;
 use crate::types::DestDir;
 use crate::types::EntryType;
@@ -241,20 +241,24 @@ impl<R: Read> TarArchive<R> {
             Some(ctx.dir_cache),
         )?;
 
-        match validated.entry_type() {
-            ValidatedEntryType::File(_) => {
-                Self::extract_file(entry, &validated, ctx)?;
+        // `into_parts()` consumes `validated` so the File arm can move its
+        // QuotaPermit by value into extract_file (mirrors 7z's
+        // process_entry_inner, issue #445), rather than only observing it
+        // through entry_type()'s shared reference.
+        match validated.into_parts() {
+            (safe_path, ValidatedEntryType::File(permit), mode) => {
+                Self::extract_file(entry, &safe_path, mode, permit, ctx)?;
                 Ok(None)
             }
 
-            ValidatedEntryType::Directory => {
-                common::create_directory(&validated, ctx.dest, ctx.report, ctx.dir_cache)?;
+            (safe_path, ValidatedEntryType::Directory, _) => {
+                common::create_directory(&safe_path, ctx.dest, ctx.report, ctx.dir_cache)?;
                 Ok(None)
             }
 
-            ValidatedEntryType::Symlink(safe_symlink) => {
+            (_, ValidatedEntryType::Symlink(safe_symlink), _) => {
                 common::create_symlink(
-                    safe_symlink,
+                    &safe_symlink,
                     ctx.dest,
                     ctx.report,
                     ctx.dir_cache,
@@ -263,11 +267,11 @@ impl<R: Read> TarArchive<R> {
                 Ok(None)
             }
 
-            ValidatedEntryType::Hardlink { target } => {
+            (safe_path, ValidatedEntryType::Hardlink { target }, _) => {
                 // Two-pass: defer hardlink creation until target files exist
                 Ok(Some(HardlinkInfo {
-                    link_path: validated.safe_path().clone(),
-                    target_path: target.clone(),
+                    link_path: safe_path,
+                    target_path: target,
                 }))
             }
         }
@@ -276,13 +280,17 @@ impl<R: Read> TarArchive<R> {
     /// Extracts a regular file to disk.
     fn extract_file<ER: Read>(
         entry: &mut tar::Entry<'_, ER>,
-        validated: &ValidatedEntry,
+        safe_path: &SafePath,
+        mode: Option<u32>,
+        permit: QuotaPermit,
         ctx: &mut ExtractionContext<'_, '_>,
     ) -> Result<()> {
         let size = Some(entry.size());
-        common::extract_file_generic(
+        common::extract_file_with_permit(
             entry,
-            validated,
+            safe_path,
+            mode,
+            permit,
             ctx.dest,
             ctx.report,
             size,

--- a/crates/exarch-core/src/formats/tar_metadata_limit.rs
+++ b/crates/exarch-core/src/formats/tar_metadata_limit.rs
@@ -87,7 +87,7 @@
 //! allowlist rejecting the entry (`common::check_extension_allowed`, see the
 //! "Cumulative synthetic-byte budget" section below) and `skip_duplicates`
 //! finding the destination path already exists
-//! (`common::extract_file_generic`, `formats/common.rs`) — both return
+//! (`common::extract_file_with_permit`, `formats/common.rs`) — both return
 //! before the entry's content is ever read. Only an extract call that
 //! actually reads the entry (no pre-read skip of any kind) is unaffected,
 //! since the guard's drain then finds nothing left to do.
@@ -105,7 +105,7 @@
 //! check there specifically to stop quota from double-counting files that
 //! end up skipped); `skip_duplicates` skips an already-extracted path after
 //! quota has run but still before the entry is read
-//! (`common::extract_file_generic`); and `list_archive`/`verify_archive`
+//! (`common::extract_file_with_permit`); and `list_archive`/`verify_archive`
 //! skip *every* entry unconditionally regardless of any allowlist.
 //! `max_total_size`/`max_file_count` therefore provide no cumulative bound
 //! across many such skips: an archive of many small GNU sparse entries, each

--- a/crates/exarch-core/src/formats/zip.rs
+++ b/crates/exarch-core/src/formats/zip.rs
@@ -135,9 +135,11 @@ use crate::SecurityConfig;
 use crate::config::Validated;
 use crate::copy::CopyBuffer;
 use crate::security::EntryValidator;
+use crate::security::quota::QuotaPermit;
 use crate::security::validator::ValidatedEntryType;
 use crate::types::DestDir;
 use crate::types::EntryType;
+use crate::types::SafePath;
 
 use super::common;
 use super::common::EntryCompleteGuard;
@@ -356,7 +358,7 @@ impl<R: Read + Seek> ZipArchive<R> {
                 mode,
                 Some(ctx.dir_cache),
             )?;
-            common::create_directory(&validated, ctx.dest, ctx.report, ctx.dir_cache)?;
+            common::create_directory(validated.safe_path(), ctx.dest, ctx.report, ctx.dir_cache)?;
         } else if ZipEntryAdapter::is_symlink_from_mode(mode) {
             let target = ZipEntryAdapter::read_symlink_target(&mut zip_file)?;
             drop(zip_file);
@@ -392,7 +394,25 @@ impl<R: Read + Seek> ZipArchive<R> {
                 mode,
                 Some(ctx.dir_cache),
             )?;
-            Self::extract_file(&mut zip_file, &validated, uncompressed_size, ctx)?;
+            // into_parts() moves the QuotaPermit out by value into
+            // extract_file (mirrors 7z's process_entry_inner, issue #445),
+            // rather than only observing it through entry_type()'s shared
+            // reference. validate_entry(&EntryType::File, ..) always yields
+            // ValidatedEntryType::File, never another variant.
+            let (safe_path, entry_type, sanitized_mode) = validated.into_parts();
+            let ValidatedEntryType::File(permit) = entry_type else {
+                return Err(ArchiveError::SecurityViolation {
+                    reason: "validate_entry(EntryType::File) returned a non-File variant".into(),
+                });
+            };
+            Self::extract_file(
+                &mut zip_file,
+                &safe_path,
+                sanitized_mode,
+                permit,
+                uncompressed_size,
+                ctx,
+            )?;
         }
 
         Ok(())
@@ -401,13 +421,17 @@ impl<R: Read + Seek> ZipArchive<R> {
     /// Extracts a regular file to disk.
     fn extract_file(
         zip_file: &mut zip::read::ZipFile<'_, R>,
-        validated: &crate::security::validator::ValidatedEntry,
+        safe_path: &SafePath,
+        mode: Option<u32>,
+        permit: QuotaPermit,
         file_size: u64,
         ctx: &mut ZipExtractionContext<'_>,
     ) -> Result<()> {
-        common::extract_file_generic(
+        common::extract_file_with_permit(
             zip_file,
-            validated,
+            safe_path,
+            mode,
+            permit,
             ctx.dest,
             ctx.report,
             Some(file_size),

--- a/crates/exarch-core/src/security/validator.rs
+++ b/crates/exarch-core/src/security/validator.rs
@@ -226,6 +226,7 @@ impl<'a> EntryValidator<'a> {
     /// - `ArchiveError::SymlinkEscape` - Symlink target escapes
     /// - `ArchiveError::HardlinkEscape` - Hardlink target escapes
     /// - `ArchiveError::InvalidPermissions` - Dangerous permissions
+    #[inline]
     pub fn validate_entry(
         &mut self,
         path: &Path,
@@ -308,6 +309,7 @@ impl<'a> EntryValidator<'a> {
     ///
     /// Returns [`ArchiveError::ZipBomb`] if the compression ratio exceeds the
     /// configured limit.
+    #[inline]
     fn check_ratio(&self, compressed_size: Option<u64>, uncompressed_size: u64) -> Result<()> {
         if let Some(compressed) = compressed_size {
             validate_compression_ratio(compressed, uncompressed_size, self.config)?;

--- a/crates/exarch-core/tests/skip_duplicates_integration.rs
+++ b/crates/exarch-core/tests/skip_duplicates_integration.rs
@@ -50,6 +50,7 @@ fn write_tar(data: &[u8]) -> NamedTempFile {
 }
 
 /// Build a TAR archive in memory containing a single file entry.
+#[cfg(unix)]
 fn make_tar_single(path: &str, content: &[u8]) -> Vec<u8> {
     let mut builder = tar::Builder::new(Vec::new());
     let mut hdr = tar::Header::new_gnu();

--- a/crates/exarch-core/tests/skip_duplicates_integration.rs
+++ b/crates/exarch-core/tests/skip_duplicates_integration.rs
@@ -49,6 +49,17 @@ fn write_tar(data: &[u8]) -> NamedTempFile {
     f
 }
 
+/// Build a TAR archive in memory containing a single file entry.
+fn make_tar_single(path: &str, content: &[u8]) -> Vec<u8> {
+    let mut builder = tar::Builder::new(Vec::new());
+    let mut hdr = tar::Header::new_gnu();
+    hdr.set_size(content.len() as u64);
+    hdr.set_mode(0o644);
+    hdr.set_cksum();
+    builder.append_data(&mut hdr, path, content).unwrap();
+    builder.into_inner().unwrap()
+}
+
 /// `skip_duplicates=true` (the default): the second entry is skipped and the
 /// file on disk retains the content of the first entry.
 #[test]
@@ -210,4 +221,100 @@ fn tar_skip_duplicates_false_overwrites_nested_path() {
 
     let content = std::fs::read(dest.path().join("subdir/nested.txt")).unwrap();
     assert_eq!(content, b"overwritten");
+}
+
+// ============================================================================
+// Symlink-at-destination regression tests (issue #459)
+// ============================================================================
+//
+// Before the #446 fix, the duplicate-existence check used `Path::exists()`,
+// which follows symlinks and returns `false` for a *dangling* one. A dangling
+// symlink planted at the destination path (by something other than this
+// extraction — an in-archive symlink entry cannot escape `dest`, since
+// `SafeSymlink::validate` already rejects that) therefore looked like "no
+// duplicate" and a plain `File::create` wrote the archive's content straight
+// through the link, landing outside the extraction root. The fix folds the
+// check into `open()` with `O_EXCL`/`O_NOFOLLOW`, which reject an existing
+// symlink (dangling or not) without following it, on both `skip_duplicates`
+// values.
+
+/// `skip_duplicates=true` (default): a dangling symlink at the destination
+/// path must be treated as an existing entry and skipped — not followed.
+#[cfg(unix)]
+#[test]
+fn tar_dangling_symlink_at_destination_skipped_not_followed() {
+    use std::os::unix::fs::symlink;
+
+    let dest = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+    let escape_target = outside.path().join("escaped.txt");
+
+    // Plant a dangling symlink at the path the archive entry targets,
+    // pointing outside the destination directory.
+    symlink(&escape_target, dest.path().join("file.txt")).unwrap();
+    assert!(
+        !escape_target.exists(),
+        "symlink target must be dangling before extraction"
+    );
+
+    let data = make_tar_single("file.txt", b"payload");
+    let archive = write_tar(&data);
+    let config = SecurityConfig::default();
+    let options = ExtractionOptions::default(); // skip_duplicates = true (default)
+
+    let report = extract_archive_with_options(archive.path(), dest.path(), &config, &options)
+        .expect("skip_duplicates=true must skip the symlinked path, not error");
+
+    assert_eq!(
+        report.files_skipped, 1,
+        "the symlinked path must be counted as skipped"
+    );
+    assert_eq!(report.files_extracted, 0);
+    assert!(
+        !escape_target.exists(),
+        "payload must never land outside dest via the dangling symlink"
+    );
+    assert!(
+        dest.path()
+            .join("file.txt")
+            .symlink_metadata()
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "the planted symlink must be left untouched, not replaced"
+    );
+}
+
+/// `skip_duplicates=false`: a symlink at the destination path must still be
+/// rejected rather than followed and overwritten-through.
+#[cfg(unix)]
+#[test]
+fn tar_dangling_symlink_at_destination_rejected_when_overwrite_requested() {
+    use std::os::unix::fs::symlink;
+
+    let dest = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+    let escape_target = outside.path().join("escaped.txt");
+
+    symlink(&escape_target, dest.path().join("file.txt")).unwrap();
+    assert!(
+        !escape_target.exists(),
+        "symlink target must be dangling before extraction"
+    );
+
+    let data = make_tar_single("file.txt", b"payload");
+    let archive = write_tar(&data);
+    let config = SecurityConfig::default();
+    let options = ExtractionOptions::default().with_skip_duplicates(false);
+
+    let result = extract_archive_with_options(archive.path(), dest.path(), &config, &options);
+
+    assert!(
+        result.is_err(),
+        "writing through a symlink at the destination must be rejected, not silently followed"
+    );
+    assert!(
+        !escape_target.exists(),
+        "payload must never land outside dest via the dangling symlink"
+    );
 }


### PR DESCRIPTION
## Summary

- Renames `formats::common::extract_file_generic` to `extract_file_with_permit`, taking `QuotaPermit` by value instead of only observing it through `&ValidatedEntry` — mirrors 7z's `write_file_with_permit` (#440) for TAR/ZIP's shared main-file write path. TAR's dispatch is now a compiler-enforced exhaustive match; ZIP keeps a fail-closed runtime guard backed by the existing `test_validate_file_entry`.
- Fixes a real symlink-escape vulnerability (#459): the old duplicate-detection used `Path::exists()`, which follows symlinks and returns `false` for a dangling one, so a symlink already present at the destination path was treated as "no duplicate" and `File::create` wrote through it, landing content outside the extraction root. Duplicate detection now opens the destination with `OpenOptions::create_new` and, on unix, `O_NOFOLLOW` unconditionally — both `skip_duplicates` values are now symlink-proof. Precondition is an attacker-writable destination directory, not a malicious archive alone.
- Partially recovers the `many_small_files` extraction perf regression (#446): folding the existence check into `open()` removes one syscall per extracted file; added `#[inline]` on the per-entry validation hot path. Re-verified via a controlled same-session A/B: `many_small_files/10000` improved -8.3% to -8.9% (p<=0.01, reproduced twice); `/100`/`/1000` unchanged. This is a **partial**, not full, recovery of the confirmed +15.8% regression — root cause was not otherwise identified (the diff between the pre- and post-regression commits shows no logic change on this path, only zero-cost typestate/capability-token threading), and full parity against the CI-recorded baseline needs confirmation on reference hardware. **#446 is intentionally left open** pending that confirmation.

## Issues

Closes #445
Closes #459

Related, not closed by this PR:
- #446 (partial recovery only, see above — recommend a follow-up CI benchmark cycle before closing)
- #460 (path-based `set_permissions` TOCTOU, pre-existing, shares a precondition with #459 but is a separate, lower-severity follow-up)

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` (1055/1055 passed, incl. 2 new dangling-symlink-at-destination regression tests covering both `skip_duplicates` values)
- [x] `cargo test --doc -p exarch-core -p exarch-cli --all-features` (101 passed; the workspace-wide `exarch-python` doctest link failure is pre-existing/environment-only — reproduces identically on `origin/main`, unrelated to this diff)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace`
- [x] `cargo bench -p exarch-core --bench extraction -- many_small_files` re-verification (see Summary)
- [x] CHANGELOG.md updated (`Fixed`/`Performance`/`Security` entries under `[Unreleased]`)