### PR TITLE
fix(core): apply sanitized permissions via fchmod instead of path-based chmod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,6 +254,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   symlink at the destination path before extraction for both `skip_duplicates` settings.
   Precondition is an attacker-writable destination directory, not a malicious archive alone.
 
+- **File permissions were applied via a path-based `set_permissions()` after `open()`, reopening a
+  TOCTOU window (#460)**: the same `formats::common::create_file_with_mode` helper enforced the
+  sanitized (setuid/setgid-stripped) mode with `std::fs::set_permissions(path, ..)`, which
+  re-resolves `path` from the filesystem root rather than operating on the already-open file
+  descriptor, letting a concurrent attacker swap the path for a symlink between `open()` and
+  `set_permissions()`. Switched to `File::set_permissions(&file, ..)`, which applies the mode via
+  `fchmod` on the open descriptor and cannot be redirected by a later filesystem change.
+
 - **`list` accepted NUL bytes, empty targets, and missing targets that `extract`/`verify` already
   rejected (#430)**: `list_tar_entries` and `list_zip_reader` validated entry paths for path
   traversal but not embedded NUL bytes, unlike `SafePath::validate` (used by `extract`). For TAR,

--- a/crates/exarch-core/src/formats/common.rs
+++ b/crates/exarch-core/src/formats/common.rs
@@ -370,10 +370,14 @@ pub fn check_extension_allowed(
 /// Creates a file with permissions enforced after creation to bypass umask.
 ///
 /// On Unix platforms, this function uses `OpenOptions::mode()` to hint the
-/// desired mode during `open()`, then calls `set_permissions()` to enforce
-/// the exact sanitized mode. The second call is required because
-/// `OpenOptions::mode()` is subject to the process umask and the resulting
-/// permissions may be narrower than requested.
+/// desired mode during `open()`, then calls `File::set_permissions()` on the
+/// already-open file descriptor (`fchmod`) to enforce the exact sanitized
+/// mode. The second call is required because `OpenOptions::mode()` is
+/// subject to the process umask and the resulting permissions may be
+/// narrower than requested. Operating on the open descriptor rather than
+/// `std::fs::set_permissions(path, ..)` avoids re-resolving `path` from the
+/// filesystem root a second time, which would otherwise reopen a TOCTOU
+/// window between file creation and permission enforcement (issue #460).
 ///
 /// On non-Unix platforms, permissions are not supported and mode is ignored.
 ///
@@ -398,11 +402,11 @@ pub fn check_extension_allowed(
 ///
 /// # Performance
 ///
-/// - Unix: 2 syscalls (open with mode hint + `set_permissions` to bypass umask)
-/// - Non-Unix: 1 syscall (create)
-///
-/// For archives with 1000 files, this reduces 2000 syscalls to 1000 syscalls
-/// (50% reduction in permission-related syscalls).
+/// - Unix, `mode.is_some()`: 2 syscalls (`open` with mode hint + `fchmod` to
+///   bypass umask)
+/// - Unix, `mode.is_none()`: 1 syscall (`open`, no permission enforcement to
+///   perform)
+/// - Non-Unix: 1 syscall (`open`)
 ///
 /// # Security - Mode Sanitization Requirement
 ///
@@ -464,9 +468,13 @@ fn create_file_with_mode(
 
     // OpenOptions::mode() is subject to the process umask, which may reduce
     // the requested permissions. Call set_permissions() explicitly to enforce
-    // the exact sanitized mode, bypassing umask.
+    // the exact sanitized mode, bypassing umask. Applied to the already-open
+    // file descriptor (fchmod) rather than std::fs::set_permissions(path, ..),
+    // which would re-resolve path from the filesystem root and reopen a
+    // TOCTOU window between this open() and the permission change (issue
+    // #460).
     if let Some(m) = mode {
-        std::fs::set_permissions(path, Permissions::from_mode(m))?;
+        file.set_permissions(Permissions::from_mode(m))?;
     }
 
     Ok(file)
@@ -511,14 +519,18 @@ fn create_file_with_mode(
 /// This function consolidates file extraction logic to ensure consistent:
 /// - Directory creation with caching
 /// - Buffered I/O (64KB buffer)
-/// - Permission preservation (Unix only, set atomically during file creation)
+/// - Exclusive file creation with permission enforcement (Unix only)
 /// - Quota tracking with overflow protection
 ///
 /// # Permission Enforcement
 ///
-/// On Unix, file permissions are enforced via `set_permissions()` after
-/// creation to bypass the process umask. This ensures the exact sanitized
-/// mode from `SecurityConfig` is applied, regardless of the caller's umask.
+/// On Unix, file permissions are enforced via `File::set_permissions()` on
+/// the already-open file descriptor (`fchmod`), not a path-based
+/// `std::fs::set_permissions()` call, to bypass the process umask without
+/// reopening a TOCTOU window between file creation and permission
+/// enforcement (issue #460). This ensures the exact sanitized mode from
+/// `SecurityConfig` is applied, regardless of the caller's umask. See
+/// [`create_file_with_mode`] for the full contract.
 ///
 /// # Correctness
 ///


### PR DESCRIPTION
## Summary

- `create_file_with_mode`'s permission-enforcement step used `std::fs::set_permissions(path, ..)`, which re-resolves `path` from the filesystem root rather than operating on the already-open file descriptor. A concurrent attacker with write access to the extraction destination directory could swap the path for a symlink between `open()` and `set_permissions()`, redirecting the sanitized-mode chmod to an arbitrary target outside the destination.
- The `O_NOFOLLOW`/`O_EXCL` protection merged in #470 does not mitigate this: it guards the `open()` call, not a later path-based syscall against the same path.
- Switched to `File::set_permissions(&file, ..)`, applying the mode via `fchmod` on the open descriptor, which cannot be redirected by a subsequent filesystem change.
- Updated doc comments on `create_file_with_mode` and `extract_file_with_permit` to describe the fchmod-based approach, and fixed a stale/self-contradictory `# Performance` note left over from an earlier revision.

This PR closes #460 only. #459 was already closed by #470, merged concurrently with this work — no #459-related changes are included here.

Related, unaddressed vectors tracked separately (not in scope for this PR):
- #467 — the same dangling-symlink-at-destination class is still exploitable via TAR's hardlink write path (`create_hardlink` in `tar.rs`).
- #468 — 7z's `skip_duplicates` check has an analogous false-negative on a dangling symlink (non-exploitable: `rename` doesn't follow symlinks).
- #471 — 7z's temp-file-then-rename write path has a predictable temp-file name and a non-exclusive open, an independent symlink-follow exposure from the final `rename` step.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` (1102/1102)
- [x] `cargo test --doc --workspace --all-features` (`exarch-core` doctests 111/111; workspace-level `exarch-python` doctest failure confirmed pre-existing pyo3/arm64 linker issue, unrelated to this diff)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace`
- [x] Mandatory `rust-security-maintenance` review: PASS, verified by PoC that the old path-based call could be redirected to chmod a file outside the destination to `0o777`, and that the new fchmod-based call cannot.

Closes #460