### PR TITLE
fix(core,node,python): fix uncatchable progress-callback crash and lossy io error redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -253,7 +253,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   napi-rs 3.12.0 defect where `call_async_catch`'s dispatcher escalates the `napi_invalid_arg`
   from `napi_create_reference()` on a primitive exception value into a fatal exception. Throw an
   `Error` instance (or any non-primitive) from a progress callback to get the documented
-  rejection behavior.
+  rejection behavior. Tracked upstream in #473.
 
 - **`exarch-python` error messages leaked full absolute paths in release builds, and both
   bindings leaked host paths embedded in `CoreError::Io` messages (#453)**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,6 +205,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   messages for `PathTraversal`, `SymlinkEscape`, `HardlinkEscape`, and `InvalidPermissions` now
   include the full archive entry path where they
   previously showed only the filename.
+
+- **`io::Error::other(...)` call sites collapsed to the uninformative "other error" message in
+  release builds after #453's redaction fix (#464)**: `#453` reduced `CoreError::Io` messages to
+  their `std::io::ErrorKind` description in release builds to close a host-path leak, which is
+  sound for OS-originated `ErrorKind`s but degraded every `ErrorKind::Other` call site (built via
+  `std::io::Error::other(...)` in `creation::walker`, `creation::zip`, and the I/O-class branch of
+  `formats::sevenz`'s error mapping) to the fixed string "other error", losing all diagnostic
+  value. Added `exarch_core::IoContext`, which pairs a static, non-path-bearing summary (e.g.
+  "failed to read entry metadata") with the dynamic detail (which may embed a host path) at each
+  of those call sites. `exarch-core`'s shared `sanitize_io_error_for_error` (see the `#463`/`#462`
+  entry above, which hoisted it out of both bindings into `error::redaction`) now recognizes
+  `IoContext` via `io::Error::get_ref` downcasting and surfaces its static `context` in release
+  builds instead of the generic `ErrorKind` description, while debug builds continue to show the
+  full detail. Because both bindings call that one shared function, they pick this up without
+  binding-local logic. No host path can leak through `context`, since it is always a `&'static
+  str` fixed at the call site. The redaction itself is unit-tested in `error::redaction`, and the
+  release-mode behaviour is asserted end-to-end against the compiled bindings by `exarch-python`'s
+  `tests/test_error_redaction.py` and `exarch-node`'s `tests/error-redaction.test.js`, which
+  trigger a real walkdir failure through `create_archive` and check that the `IoContext` summary
+  survives while the host path and raw OS detail do not.
+
+- **`exarch-node`: a throwing progress callback crashed the process uncatchably (#465)**:
+  `extractArchiveWithProgress`'s `NodeProgressAdapter` dispatched the JS progress callback via
+  `ThreadsafeFunction::call` in fire-and-forget `NonBlocking` mode, which routes a JS throw
+  through `napi_fatal_exception` — terminating the process with an uncatchable
+  `uncaughtException`, even when the call site was wrapped in `try`/`catch`. The adapter now
+  awaits `ThreadsafeFunction::call_async_catch` (via `Handle::block_on`, since the dispatch runs
+  on a `spawn_blocking` worker thread) and captures a JS throw into the adapter instead; the
+  captured error now rejects the returned promise rather than crashing the host process.
+  Because extraction cannot be aborted from a progress callback (the `ProgressCallback` contract
+  has no cancellation signal), a callback throw and a core extraction failure can both occur in
+  the same run — neither is discarded. When extraction also failed, the core error stays primary
+  and keeps its error-code prefix (`SYMLINK_ESCAPE`, `QUOTA_EXCEEDED`, …) at the start of the
+  message with a fixed ` | progressCallbackError: see cause` marker appended, so a throwing
+  callback cannot mask a security violation from callers matching on that prefix. When extraction
+  succeeded, the rejection is prefixed `PROGRESS_CALLBACK_ERROR` and carries
+  `filesExtracted=N, bytesWritten=M`, so callers can still tell what was written to disk. In both
+  cases the original JS exception is preserved as the rejection's `cause` property, retaining its
+  class and stack; its text and stack are never copied into the message, since the stack embeds an
+  absolute host path (which #453 redacts everywhere else in release builds) and the throw content
+  is attacker-influenced whenever the callback echoes archive entry data — read `cause` for the
+  callback's detail rather than parsing it out of `message`.
+  Known limitation, now documented on `extractArchiveWithProgress` and pinned by a child-process
+  test: this only covers non-primitive throws. Throwing a bare string, number, or boolean
+  (`throw 'oops'`) still crashes the process and leaves the promise unsettled, due to an upstream
+  napi-rs 3.12.0 defect where `call_async_catch`'s dispatcher escalates the `napi_invalid_arg`
+  from `napi_create_reference()` on a primitive exception value into a fatal exception. Throw an
+  `Error` instance (or any non-primitive) from a progress callback to get the documented
+  rejection behavior.
+
 - **`exarch-python` error messages leaked full absolute paths in release builds, and both
   bindings leaked host paths embedded in `CoreError::Io` messages (#453)**:
   `crates/exarch-python/src/error.rs` called `path.display()` directly and unconditionally for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -227,33 +227,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   survives while the host path and raw OS detail do not.
 
 - **`exarch-node`: a throwing progress callback crashed the process uncatchably (#465)**:
-  `extractArchiveWithProgress`'s `NodeProgressAdapter` dispatched the JS progress callback via
-  `ThreadsafeFunction::call` in fire-and-forget `NonBlocking` mode, which routes a JS throw
-  through `napi_fatal_exception` — terminating the process with an uncatchable
-  `uncaughtException`, even when the call site was wrapped in `try`/`catch`. The adapter now
-  awaits `ThreadsafeFunction::call_async_catch` (via `Handle::block_on`, since the dispatch runs
-  on a `spawn_blocking` worker thread) and captures a JS throw into the adapter instead; the
-  captured error now rejects the returned promise rather than crashing the host process.
-  Because extraction cannot be aborted from a progress callback (the `ProgressCallback` contract
-  has no cancellation signal), a callback throw and a core extraction failure can both occur in
-  the same run — neither is discarded. When extraction also failed, the core error stays primary
-  and keeps its error-code prefix (`SYMLINK_ESCAPE`, `QUOTA_EXCEEDED`, …) at the start of the
-  message with a fixed ` | progressCallbackError: see cause` marker appended, so a throwing
-  callback cannot mask a security violation from callers matching on that prefix. When extraction
-  succeeded, the rejection is prefixed `PROGRESS_CALLBACK_ERROR` and carries
-  `filesExtracted=N, bytesWritten=M`, so callers can still tell what was written to disk. In both
-  cases the original JS exception is preserved as the rejection's `cause` property, retaining its
-  class and stack; its text and stack are never copied into the message, since the stack embeds an
-  absolute host path (which #453 redacts everywhere else in release builds) and the throw content
-  is attacker-influenced whenever the callback echoes archive entry data — read `cause` for the
-  callback's detail rather than parsing it out of `message`.
-  Known limitation, now documented on `extractArchiveWithProgress` and pinned by a child-process
-  test: this only covers non-primitive throws. Throwing a bare string, number, or boolean
+  `NodeProgressAdapter` dispatched the JS progress callback via `ThreadsafeFunction::call` in
+  fire-and-forget `NonBlocking` mode, which routes a JS throw through `napi_fatal_exception` —
+  terminating the process with an uncatchable `uncaughtException`, even when the call site was
+  wrapped in `try`/`catch`. The adapter now awaits `ThreadsafeFunction::call_async_catch` (via
+  `Handle::block_on`, since the dispatch runs on a `spawn_blocking` worker thread) and captures a
+  JS throw into the adapter instead; the captured error now rejects the returned promise rather
+  than crashing the host process. This covers both `extractArchiveWithProgress` and — since the
+  create-side progress API landed in #469 — `createArchiveWithProgress`, which share the adapter.
+  Because the operation cannot be aborted from a progress callback (the `ProgressCallback`
+  contract has no cancellation signal), a callback throw and a core failure can both occur in
+  the same run — neither is discarded. When the core operation also failed, its error stays
+  primary and keeps its error-code prefix (`SYMLINK_ESCAPE`, `QUOTA_EXCEEDED`, `IO_ERROR`, …) at
+  the start of the message with a fixed ` | progressCallbackError: see cause` marker appended, so
+  a throwing callback cannot mask a security violation from callers matching on that prefix. When
+  the operation succeeded, the rejection is prefixed `PROGRESS_CALLBACK_ERROR` and carries
+  `filesExtracted=N, bytesWritten=M` (extraction) or `filesAdded=N, bytesWritten=M` (creation), so
+  callers can still tell what was written to disk. In both cases the original JS exception is
+  preserved as the rejection's `cause` property, retaining its class and stack; its text and stack
+  are never copied into the message, since the stack embeds an absolute host path (which #453
+  redacts everywhere else in release builds) and the throw content is attacker-influenced whenever
+  the callback echoes archive entry data — read `cause` for the callback's detail rather than
+  parsing it out of `message`.
+  Known limitation, now documented on both `*WithProgress` functions and pinned by child-process
+  tests: this only covers non-primitive throws. Throwing a bare string, number, or boolean
   (`throw 'oops'`) still crashes the process and leaves the promise unsettled, due to an upstream
   napi-rs 3.12.0 defect where `call_async_catch`'s dispatcher escalates the `napi_invalid_arg`
   from `napi_create_reference()` on a primitive exception value into a fatal exception. Throw an
   `Error` instance (or any non-primitive) from a progress callback to get the documented
   rejection behavior. Tracked upstream in #473.
+  `createArchiveWithProgressSync` cannot use the awaiting dispatch at all: it runs on the JS
+  thread, so no tokio runtime is entered (`Handle::current()` panicked) and awaiting a call that
+  only the blocked event loop can deliver would deadlock. It now dispatches unawaited and is
+  documented accordingly — every call arrives after the function has already returned its
+  `CreationReport`, so a throw cannot be merged into the result and instead surfaces as an
+  ordinary `uncaughtException`, observable via `process.on('uncaughtException', …)`. Because that
+  path never enters `call_async_catch`, the primitive-throw crash above does not apply to it.
 
 - **`exarch-python` error messages leaked full absolute paths in release builds, and both
   bindings leaked host paths embedded in `CoreError::Io` messages (#453)**:

--- a/crates/exarch-core/src/creation/walker.rs
+++ b/crates/exarch-core/src/creation/walker.rs
@@ -5,6 +5,7 @@
 //! limits.
 
 use crate::ArchiveError;
+use crate::IoContext;
 use crate::Result;
 use crate::creation::config::CreationConfig;
 use crate::creation::filters;
@@ -99,9 +100,9 @@ impl<'a, State> FilteredWalker<'a, State> {
                 }
                 Err(e) => {
                     // Convert walkdir error to ArchiveError
-                    Some(Err(ArchiveError::Io(std::io::Error::other(format!(
-                        "walkdir error: {e}"
-                    )))))
+                    Some(Err(ArchiveError::Io(std::io::Error::other(
+                        IoContext::new("directory walk failed", e.to_string()),
+                    ))))
                 }
             }
         })
@@ -114,18 +115,18 @@ impl<'a, State> FilteredWalker<'a, State> {
     fn build_filtered_entry(&self, entry: &walkdir::DirEntry) -> Result<Option<FilteredEntry>> {
         let path = entry.path().to_path_buf();
         let metadata = entry.metadata().map_err(|e| {
-            ArchiveError::Io(std::io::Error::other(format!(
-                "cannot read metadata for {}: {e}",
-                path.display()
+            ArchiveError::Io(std::io::Error::other(IoContext::new(
+                "failed to read entry metadata",
+                format!("{}: {e}", path.display()),
             )))
         })?;
 
         // Determine entry type
         let entry_type = if metadata.is_symlink() {
             let target = std::fs::read_link(&path).map_err(|e| {
-                ArchiveError::Io(std::io::Error::other(format!(
-                    "cannot read symlink target for {}: {e}",
-                    path.display()
+                ArchiveError::Io(std::io::Error::other(IoContext::new(
+                    "failed to read symlink target",
+                    format!("{}: {e}", path.display()),
                 )))
             })?;
             EntryType::Symlink { target }
@@ -260,9 +261,9 @@ pub fn collect_entries<P: AsRef<Path>, State>(
             } else {
                 path.file_name()
                     .ok_or_else(|| {
-                        ArchiveError::Io(std::io::Error::other(format!(
-                            "cannot determine filename for {}",
-                            path.display()
+                        ArchiveError::Io(std::io::Error::other(IoContext::new(
+                            "cannot determine filename for source path",
+                            path.display().to_string(),
                         )))
                     })?
                     .into()

--- a/crates/exarch-core/src/creation/zip.rs
+++ b/crates/exarch-core/src/creation/zip.rs
@@ -4,6 +4,7 @@
 //! compression levels and security options.
 
 use crate::ArchiveError;
+use crate::IoContext;
 use crate::NoopProgress;
 use crate::ProgressCallback;
 use crate::Result;
@@ -194,7 +195,10 @@ fn create_zip_internal_with_progress<W: Write + Seek, P: AsRef<Path>>(
                 if !entry.archive_path.as_os_str().is_empty() {
                     let dir_path = format!("{}/", normalize_zip_path(&entry.archive_path)?);
                     zip.add_directory(&dir_path, options).map_err(|e| {
-                        std::io::Error::other(format!("failed to add directory: {e}"))
+                        std::io::Error::other(IoContext::new(
+                            "failed to add directory to zip archive",
+                            e.to_string(),
+                        ))
                     })?;
                     report.directories_added += 1;
                 }
@@ -212,9 +216,12 @@ fn create_zip_internal_with_progress<W: Write + Seek, P: AsRef<Path>>(
     }
 
     // Finish writing ZIP
-    let writer = zip
-        .finish()
-        .map_err(|e| std::io::Error::other(format!("failed to finish ZIP archive: {e}")))?;
+    let writer = zip.finish().map_err(|e| {
+        std::io::Error::other(IoContext::new(
+            "failed to finish zip archive",
+            e.to_string(),
+        ))
+    })?;
 
     report.duration = start.elapsed();
 
@@ -278,8 +285,12 @@ fn add_file_to_zip_with_progress_and_buffer<W: Write + Seek>(
 
     let archive_name = normalize_zip_path(archive_path)?;
 
-    zip.start_file(&archive_name, file_options)
-        .map_err(|e| std::io::Error::other(format!("failed to start file in ZIP: {e}")))?;
+    zip.start_file(&archive_name, file_options).map_err(|e| {
+        std::io::Error::other(IoContext::new(
+            "failed to start file in zip archive",
+            e.to_string(),
+        ))
+    })?;
 
     // Copy file contents with progress tracking and reusable buffer
     let mut bytes_written = 0u64;
@@ -306,9 +317,9 @@ fn add_file_to_zip_with_progress_and_buffer<W: Write + Seek>(
 fn normalize_zip_path(path: &Path) -> Result<String> {
     // Convert to string
     let path_str = path.to_str().ok_or_else(|| {
-        ArchiveError::Io(std::io::Error::other(format!(
-            "path is not valid UTF-8: {}",
-            path.display()
+        ArchiveError::Io(std::io::Error::other(IoContext::new(
+            "archive path is not valid UTF-8",
+            path.display().to_string(),
         )))
     })?;
 

--- a/crates/exarch-core/src/error/io_context.rs
+++ b/crates/exarch-core/src/error/io_context.rs
@@ -1,0 +1,109 @@
+//! Structured context for `std::io::Error::other` call sites.
+
+use std::error::Error as StdError;
+use std::fmt;
+
+/// Pairs a static, non-path-bearing summary with the dynamic detail of an
+/// I/O failure constructed via [`std::io::Error::other`].
+///
+/// FFI bindings redact `ArchiveError::Io` messages down to their
+/// [`std::io::ErrorKind`] description in release builds, since free-form
+/// messages have no structured path field to sanitize. For errors built
+/// from `ErrorKind::Other`, that redaction collapses to the fixed string
+/// "other error", discarding all diagnostic value. Wrapping the detail in
+/// `IoContext` lets bindings recognize the error (via
+/// [`std::io::Error::get_ref`] and downcasting) and surface `context`
+/// instead — safe to show even in release builds because it is always a
+/// `&'static str` fixed at the call site, never built from path or archive
+/// entry data.
+///
+/// # Examples
+///
+/// ```
+/// use exarch_core::IoContext;
+/// use std::io;
+///
+/// let err = io::Error::other(IoContext::new(
+///     "failed to read entry metadata",
+///     "/tmp/x: denied",
+/// ));
+/// assert_eq!(
+///     err.to_string(),
+///     "failed to read entry metadata: /tmp/x: denied"
+/// );
+///
+/// let ctx = err
+///     .get_ref()
+///     .and_then(|inner| inner.downcast_ref::<IoContext>())
+///     .expect("IoContext downcast");
+/// assert_eq!(ctx.context, "failed to read entry metadata");
+/// ```
+#[derive(Debug)]
+pub struct IoContext {
+    /// Static summary of the failure. Never carries path or archive entry
+    /// data — safe to surface in release builds.
+    pub context: &'static str,
+    /// Full dynamic detail (may embed a host path). Shown only in debug
+    /// builds via `ArchiveError::Io`'s `Display`.
+    pub detail: String,
+}
+
+impl IoContext {
+    /// Creates a new `IoContext` pairing a static summary with dynamic
+    /// detail.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exarch_core::IoContext;
+    ///
+    /// let ctx = IoContext::new("failed to start file in zip archive", "boom");
+    /// assert_eq!(ctx.context, "failed to start file in zip archive");
+    /// assert_eq!(ctx.detail, "boom");
+    /// ```
+    #[must_use]
+    pub fn new(context: &'static str, detail: impl Into<String>) -> Self {
+        Self {
+            context,
+            detail: detail.into(),
+        }
+    }
+}
+
+impl fmt::Display for IoContext {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}: {}", self.context, self.detail)
+    }
+}
+
+impl StdError for IoContext {}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)] // Allow expect in tests for brevity
+mod tests {
+    use super::IoContext;
+    use std::io;
+
+    #[test]
+    fn display_includes_context_and_detail() {
+        let ctx = IoContext::new("failed to read entry metadata", "/tmp/x: denied");
+        assert_eq!(
+            ctx.to_string(),
+            "failed to read entry metadata: /tmp/x: denied"
+        );
+    }
+
+    #[test]
+    fn roundtrips_through_io_error_other() {
+        let err = io::Error::other(IoContext::new("failed to finish zip archive", "disk full"));
+        assert_eq!(err.kind(), io::ErrorKind::Other);
+        assert_eq!(err.to_string(), "failed to finish zip archive: disk full");
+
+        let ctx = err
+            .get_ref()
+            .and_then(|inner| inner.downcast_ref::<IoContext>())
+            .expect("IoContext should be downcastable from io::Error");
+        assert_eq!(ctx.context, "failed to finish zip archive");
+        assert_eq!(ctx.detail, "disk full");
+    }
+}

--- a/crates/exarch-core/src/error/mod.rs
+++ b/crates/exarch-core/src/error/mod.rs
@@ -1,9 +1,11 @@
 //! Error types for archive operations.
 
+pub mod io_context;
 pub mod messages;
 pub mod redaction;
 pub mod types;
 
+pub use io_context::IoContext;
 pub use messages::FfiErrorMessage;
 pub use types::ArchiveError;
 pub use types::QuotaResource;

--- a/crates/exarch-core/src/error/redaction.rs
+++ b/crates/exarch-core/src/error/redaction.rs
@@ -14,8 +14,8 @@
 //! This module owns the two redaction algorithms — [`sanitize_path_for_error`]
 //! for genuinely host-derived paths and [`format_entry_path_for_error`] for
 //! archive-relative, attacker-authored paths — plus
-//! [`sanitize_io_error_for_error`] for I/O error messages (see #463). Both
-//! bindings call these algorithms directly, per variant, in their own
+//! [`sanitize_io_error_for_error`] for I/O error messages (see #463, #464).
+//! Both bindings call these algorithms directly, per variant, in their own
 //! `convert_error`; [`ArchiveError::to_ffi_message`] uses them via
 //! [`ArchiveError::redacted_path`]. The mapping from variant to algorithm is
 //! therefore still applied independently in three places — here (via
@@ -123,6 +123,14 @@ pub fn format_entry_path_for_error(path: &Path) -> String {
 /// builds, returns only the [`std::io::ErrorKind`] description, since the
 /// free-form message text has no structured path field to redact.
 ///
+/// Exception: errors carrying an [`IoContext`](super::IoContext) — used at
+/// [`std::io::Error::other`] call sites whose [`std::io::ErrorKind::Other`]
+/// description would otherwise redact to the uninformative "other error"
+/// (see #464) — surface [`IoContext::context`](super::IoContext::context) in
+/// release builds instead. That is safe because `context` is always a
+/// `&'static str` fixed at the call site, never built from path or archive
+/// entry data.
+///
 /// # Examples
 ///
 /// ```
@@ -145,6 +153,14 @@ pub fn sanitize_io_error_for_error(e: &std::io::Error) -> String {
 /// builds, returns only the [`std::io::ErrorKind`] description, since the
 /// free-form message text has no structured path field to redact.
 ///
+/// Exception: errors carrying an [`IoContext`](super::IoContext) — used at
+/// [`std::io::Error::other`] call sites whose [`std::io::ErrorKind::Other`]
+/// description would otherwise redact to the uninformative "other error"
+/// (see #464) — surface [`IoContext::context`](super::IoContext::context) in
+/// release builds instead. That is safe because `context` is always a
+/// `&'static str` fixed at the call site, never built from path or archive
+/// entry data.
+///
 /// # Examples
 ///
 /// ```
@@ -157,7 +173,9 @@ pub fn sanitize_io_error_for_error(e: &std::io::Error) -> String {
 #[cfg(not(debug_assertions))]
 #[must_use]
 pub fn sanitize_io_error_for_error(e: &std::io::Error) -> String {
-    e.kind().to_string()
+    e.get_ref()
+        .and_then(|inner| inner.downcast_ref::<super::IoContext>())
+        .map_or_else(|| e.kind().to_string(), |ctx| ctx.context.to_string())
 }
 
 impl ArchiveError {
@@ -275,6 +293,33 @@ mod tests {
         let msg = sanitize_io_error_for_error(&err);
         assert!(!msg.contains("/srv/secret/app"));
         assert!(msg.contains("permission denied"));
+    }
+
+    /// Regression test for #464: `ErrorKind::Other` would otherwise redact to
+    /// the uninformative "other error", so an `IoContext` payload surfaces its
+    /// static `context` instead — without leaking the dynamic detail.
+    #[test]
+    #[cfg(not(debug_assertions))]
+    fn test_sanitize_io_error_for_error_surfaces_io_context_in_release() {
+        let err = std::io::Error::other(crate::IoContext::new(
+            "failed to read entry metadata",
+            "/srv/secret/app/x.txt: permission denied",
+        ));
+        let msg = sanitize_io_error_for_error(&err);
+        assert_eq!(msg, "failed to read entry metadata");
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    fn test_sanitize_io_error_for_error_keeps_io_context_detail_in_debug() {
+        let err = std::io::Error::other(crate::IoContext::new(
+            "failed to read entry metadata",
+            "/srv/secret/app/x.txt: permission denied",
+        ));
+        assert_eq!(
+            sanitize_io_error_for_error(&err),
+            "failed to read entry metadata: /srv/secret/app/x.txt: permission denied"
+        );
     }
 
     /// Regression test for #462: every `ArchiveError` variant carrying an

--- a/crates/exarch-core/src/formats/sevenz.rs
+++ b/crates/exarch-core/src/formats/sevenz.rs
@@ -109,6 +109,7 @@ static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 use crate::ArchiveError;
 use crate::ExtractionOptions;
 use crate::ExtractionReport;
+use crate::IoContext;
 use crate::ProgressCallback;
 use crate::Result;
 use crate::SecurityConfig;
@@ -801,7 +802,10 @@ impl From<sevenz_rust2::Error> for ArchiveError {
 
         // Check for I/O errors
         if err_lower.contains("i/o") || err_lower.contains("read") || err_lower.contains("write") {
-            return Self::Io(std::io::Error::other(err_str));
+            return Self::Io(std::io::Error::other(IoContext::new(
+                "7z I/O error",
+                err_str,
+            )));
         }
 
         // Default: InvalidArchive
@@ -1384,6 +1388,38 @@ mod tests {
                 );
             }
             other => panic!("expected SecurityViolation, got {other:?}"),
+        }
+    }
+
+    /// Regression test for #464: the I/O-class branch of the sevenz-rust2
+    /// error mapping must wrap its detail in `IoContext` so bindings can
+    /// surface an actionable reason in release builds instead of the
+    /// generic `ErrorKind::Other` message "other error".
+    #[test]
+    fn test_sevenz_io_error_maps_to_io_context() {
+        let inner = std::io::Error::new(
+            std::io::ErrorKind::UnexpectedEof,
+            "unexpected EOF while reading entry data",
+        );
+        let sevenz_err = sevenz_rust2::Error::Io(inner, "test.7z".into());
+
+        let archive_err: ArchiveError = sevenz_err.into();
+
+        match archive_err {
+            ArchiveError::Io(io_err) => {
+                assert_eq!(io_err.kind(), std::io::ErrorKind::Other);
+                let ctx = io_err
+                    .get_ref()
+                    .and_then(|inner| inner.downcast_ref::<IoContext>())
+                    .expect("expected IoContext to be attached to the io::Error");
+                assert_eq!(ctx.context, "7z I/O error");
+                assert!(
+                    ctx.detail.contains("unexpected EOF"),
+                    "detail should retain the original sevenz-rust2 message, got: {}",
+                    ctx.detail
+                );
+            }
+            other => panic!("expected ArchiveError::Io, got {other:?}"),
         }
     }
 

--- a/crates/exarch-core/src/lib.rs
+++ b/crates/exarch-core/src/lib.rs
@@ -51,6 +51,7 @@ pub use config::Unvalidated;
 pub use config::Validated;
 pub use error::ArchiveError;
 pub use error::FfiErrorMessage;
+pub use error::IoContext;
 pub use error::QuotaResource;
 pub use error::Result;
 /// Formats an archive-relative, attacker-authored path for an FFI error

--- a/crates/exarch-node/index.d.ts
+++ b/crates/exarch-node/index.d.ts
@@ -696,6 +696,44 @@ export declare function extractArchiveSync(archivePath: string, outputDir: strin
  * prefixed with error codes for discrimination in JavaScript. See
  * `extractArchive` for the full list of error codes.
  *
+ * If `progress` throws, the returned promise rejects instead of crashing the
+ * process (see issue #465). Extraction has already run to completion (or
+ * failure) by the time the rejection is observed — a throwing callback cannot
+ * abort the extraction early, since the progress callback contract has no
+ * cancellation signal. The rejection therefore reports both signals:
+ *
+ * - Extraction succeeded: the message is prefixed with
+ *   `PROGRESS_CALLBACK_ERROR` and carries `filesExtracted=N, bytesWritten=M`,
+ *   so the caller can still see what was written to disk.
+ * - Extraction also failed: the core error stays primary and keeps its
+ *   error-code prefix, with a fixed ` | progressCallbackError: see cause`
+ *   marker appended. A throwing callback can never mask a security error such
+ *   as `SYMLINK_ESCAPE`.
+ *
+ * In both cases the original JS exception is available as the `cause`
+ * property of the rejection value. The throw's own text and stack are never
+ * copied into the message — read `cause` for the callback's error detail
+ * rather than parsing it out of `message`.
+ *
+ * ## Known limitation: primitive throws still crash the process
+ *
+ * The catchable-rejection behavior above only holds when the callback throws a
+ * non-primitive value (`Error` and subclasses, plain objects, arrays, `null`,
+ * `undefined`, `Symbol`). Throwing a bare string, number, or boolean —
+ * `throw 'oops'` — still aborts the host process uncatchably with
+ * `Call JavaScript callback failed in threadsafe function`, and the promise
+ * never settles.
+ *
+ * This is an upstream defect in napi-rs 3.12.0: the dispatcher behind
+ * `call_async_catch` overwrites its own status with the result of
+ * `napi_create_reference()`, which reports `napi_invalid_arg` for a primitive
+ * exception value, and that status is then escalated to a fatal exception even
+ * though the error was already delivered to the channel. It cannot be worked
+ * around from this crate.
+ *
+ * Always throw an `Error` instance (or any non-primitive) from a progress
+ * callback to get the documented rejection behavior.
+ *
  * # Examples
  *
  * ```javascript

--- a/crates/exarch-node/index.d.ts
+++ b/crates/exarch-node/index.d.ts
@@ -461,6 +461,34 @@ export declare function createArchiveSync(outputPath: string, sources: Array<str
  * Returns error if path validation fails, archive creation fails, or I/O
  * errors occur. See `createArchive` for the full list of error codes.
  *
+ * If `progress` throws, the returned promise rejects instead of crashing the
+ * process (see issue #465). Creation has already run to completion (or
+ * failure) by the time the rejection is observed — a throwing callback cannot
+ * abort creation early, since the progress callback contract has no
+ * cancellation signal. The rejection therefore reports both signals:
+ *
+ * - Creation succeeded: the message is prefixed with `PROGRESS_CALLBACK_ERROR`
+ *   and carries `filesAdded=N, bytesWritten=M`, so the caller can still see
+ *   that an archive was written and needs cleaning up.
+ * - Creation also failed: the core error stays primary and keeps its
+ *   error-code prefix, with a fixed ` | progressCallbackError: see cause`
+ *   marker appended. A throwing callback can never mask a core error.
+ *
+ * In both cases the original JS exception is available as the `cause`
+ * property of the rejection value. The throw's own text and stack are never
+ * copied into the message — read `cause` for the callback's error detail
+ * rather than parsing it out of `message`.
+ *
+ * ## Known limitation: primitive throws still crash the process
+ *
+ * Identical to `extractArchiveWithProgress`: the catchable-rejection behavior
+ * holds only for non-primitive throws. `throw 'oops'` from the callback still
+ * aborts the host process uncatchably with `Call JavaScript callback failed in
+ * threadsafe function`, and the promise never settles. Both functions dispatch
+ * through the same `call_async_catch` path, so they share the upstream
+ * napi-rs 3.12.0 defect described there. Always throw an `Error` instance.
+ * Tracked in <https://github.com/bug-ops/exarch/issues/473>.
+ *
  * # Examples
  *
  * ```javascript
@@ -495,6 +523,24 @@ export declare function createArchiveWithProgress(outputPath: string, sources: A
  * here. Use `createArchiveWithProgress` instead if you need progress updates
  * while creation is still running.
  *
+ * ## A throwing `progress` surfaces as an `uncaughtException`
+ *
+ * Because every call is delivered after this function has already returned,
+ * there is no return value left to carry a callback throw: this function has
+ * resolved with its `CreationReport` by then. A throw therefore propagates the
+ * way any throw from a deferred callback does — as a process-level
+ * `uncaughtException` on the turn that delivered the call, observable via
+ * `process.on('uncaughtException', ...)`. It is never merged into a
+ * `PROGRESS_CALLBACK_ERROR` result the way `createArchiveWithProgress` merges
+ * it, and it cannot be caught by wrapping this call in `try`/`catch`.
+ *
+ * The primitive-throw crash documented on `createArchiveWithProgress` does
+ * **not** apply here: that defect lives in the await-the-result dispatch path,
+ * which this function cannot use (awaiting a call that only the blocked event
+ * loop can deliver would deadlock). Queued calls take the plain dispatch path
+ * instead, where a thrown primitive reaches `uncaughtException` intact just
+ * like a thrown `Error`.
+ *
  * # Arguments
  *
  * * `output_path` - Path to output archive file
@@ -502,7 +548,8 @@ export declare function createArchiveWithProgress(outputPath: string, sources: A
  * * `config` - Optional `CreationConfig` (uses defaults if omitted)
  * * `progress` - Optional progress callback `(err: Error | null, arg: [path:
  *   string, total: number, current: number, bytesWritten: number]) => void`.
- *   See the section above: calls arrive only after this function returns.
+ *   See the sections above: calls arrive only after this function returns, and
+ *   a throw becomes an `uncaughtException` rather than an error from here.
  *
  * # Returns
  *
@@ -732,7 +779,8 @@ export declare function extractArchiveSync(archivePath: string, outputDir: strin
  * around from this crate.
  *
  * Always throw an `Error` instance (or any non-primitive) from a progress
- * callback to get the documented rejection behavior.
+ * callback to get the documented rejection behavior. Tracked upstream in
+ * <https://github.com/bug-ops/exarch/issues/473>.
  *
  * # Examples
  *

--- a/crates/exarch-node/src/error.rs
+++ b/crates/exarch-node/src/error.rs
@@ -390,9 +390,7 @@ mod tests {
             CoreError::SymlinkEscape {
                 path: nested.clone(),
             },
-            CoreError::HardlinkEscape {
-                path: nested.clone(),
-            },
+            CoreError::HardlinkEscape { path: nested },
         ];
         for err in variants {
             let err_str = convert_error(err).to_string();

--- a/crates/exarch-node/src/lib.rs
+++ b/crates/exarch-node/src/lib.rs
@@ -45,6 +45,7 @@
 
 use napi::bindgen_prelude::*;
 use napi::threadsafe_function::ThreadsafeFunction;
+use napi::threadsafe_function::ThreadsafeFunctionCallMode;
 use napi_derive::napi;
 
 mod config;
@@ -408,6 +409,34 @@ pub fn create_archive_sync(
 /// Returns error if path validation fails, archive creation fails, or I/O
 /// errors occur. See `createArchive` for the full list of error codes.
 ///
+/// If `progress` throws, the returned promise rejects instead of crashing the
+/// process (see issue #465). Creation has already run to completion (or
+/// failure) by the time the rejection is observed — a throwing callback cannot
+/// abort creation early, since the progress callback contract has no
+/// cancellation signal. The rejection therefore reports both signals:
+///
+/// - Creation succeeded: the message is prefixed with `PROGRESS_CALLBACK_ERROR`
+///   and carries `filesAdded=N, bytesWritten=M`, so the caller can still see
+///   that an archive was written and needs cleaning up.
+/// - Creation also failed: the core error stays primary and keeps its
+///   error-code prefix, with a fixed ` | progressCallbackError: see cause`
+///   marker appended. A throwing callback can never mask a core error.
+///
+/// In both cases the original JS exception is available as the `cause`
+/// property of the rejection value. The throw's own text and stack are never
+/// copied into the message — read `cause` for the callback's error detail
+/// rather than parsing it out of `message`.
+///
+/// ## Known limitation: primitive throws still crash the process
+///
+/// Identical to `extractArchiveWithProgress`: the catchable-rejection behavior
+/// holds only for non-primitive throws. `throw 'oops'` from the callback still
+/// aborts the host process uncatchably with `Call JavaScript callback failed in
+/// threadsafe function`, and the promise never settles. Both functions dispatch
+/// through the same `call_async_catch` path, so they share the upstream
+/// napi-rs 3.12.0 defect described there. Always throw an `Error` instance.
+/// Tracked in <https://github.com/bug-ops/exarch/issues/473>.
+///
 /// # Examples
 ///
 /// ```javascript
@@ -440,8 +469,14 @@ pub async fn create_archive_with_progress(
     let report = tokio::task::spawn_blocking(move || {
         catch_panic_as_js_err("archive creation with progress", || {
             let sources_refs: Vec<&str> = sources.iter().map(String::as_str).collect();
-            run_create_with_optional_progress(&output_path, &sources_refs, &config_owned, progress)
-                .map_err(convert_error)
+            run_create_with_optional_progress(
+                &output_path,
+                &sources_refs,
+                &config_owned,
+                progress,
+                ProgressDispatch::Awaited,
+            )
+            .map_err(|err| Error::from(*err))
         })
     })
     .await
@@ -468,6 +503,24 @@ pub async fn create_archive_with_progress(
 /// here. Use `createArchiveWithProgress` instead if you need progress updates
 /// while creation is still running.
 ///
+/// ## A throwing `progress` surfaces as an `uncaughtException`
+///
+/// Because every call is delivered after this function has already returned,
+/// there is no return value left to carry a callback throw: this function has
+/// resolved with its `CreationReport` by then. A throw therefore propagates the
+/// way any throw from a deferred callback does — as a process-level
+/// `uncaughtException` on the turn that delivered the call, observable via
+/// `process.on('uncaughtException', ...)`. It is never merged into a
+/// `PROGRESS_CALLBACK_ERROR` result the way `createArchiveWithProgress` merges
+/// it, and it cannot be caught by wrapping this call in `try`/`catch`.
+///
+/// The primitive-throw crash documented on `createArchiveWithProgress` does
+/// **not** apply here: that defect lives in the await-the-result dispatch path,
+/// which this function cannot use (awaiting a call that only the blocked event
+/// loop can deliver would deadlock). Queued calls take the plain dispatch path
+/// instead, where a thrown primitive reaches `uncaughtException` intact just
+/// like a thrown `Error`.
+///
 /// # Arguments
 ///
 /// * `output_path` - Path to output archive file
@@ -475,7 +528,8 @@ pub async fn create_archive_with_progress(
 /// * `config` - Optional `CreationConfig` (uses defaults if omitted)
 /// * `progress` - Optional progress callback `(err: Error | null, arg: [path:
 ///   string, total: number, current: number, bytesWritten: number]) => void`.
-///   See the section above: calls arrive only after this function returns.
+///   See the sections above: calls arrive only after this function returns, and
+///   a throw becomes an `uncaughtException` rather than an error from here.
 ///
 /// # Returns
 ///
@@ -519,8 +573,14 @@ pub fn create_archive_with_progress_sync(
     let sources_refs: Vec<&str> = sources.iter().map(String::as_str).collect();
 
     let report = catch_panic_as_js_err("archive creation with progress", || {
-        run_create_with_optional_progress(&output_path, &sources_refs, config_ref, progress)
-            .map_err(convert_error)
+        run_create_with_optional_progress(
+            &output_path,
+            &sources_refs,
+            config_ref,
+            progress,
+            ProgressDispatch::Deferred,
+        )
+        .map_err(|err| Error::from(*err))
     })?;
 
     Ok(CreationReport::from(report))
@@ -528,20 +588,50 @@ pub fn create_archive_with_progress_sync(
 
 /// Runs `create_archive_with_progress` routing to the JS callback when
 /// present or to [`exarch_core::NoopProgress`] when absent.
+///
+/// A core creation failure and a JS callback throw can occur in the same run;
+/// both are carried out of here so neither is silently dropped, mirroring
+/// [`run_extract_with_optional_progress`]. Under
+/// [`ProgressDispatch::Deferred`] no throw is ever observable here — the
+/// callback runs only after the caller has returned.
 fn run_create_with_optional_progress(
     output_path: &str,
     sources: &[&str],
     config: &exarch_core::creation::CreationConfig,
     progress: Option<ThreadsafeFunction<(String, i64, i64, i64)>>,
-) -> exarch_core::Result<exarch_core::creation::CreationReport> {
+    dispatch: ProgressDispatch,
+) -> std::result::Result<exarch_core::creation::CreationReport, Box<ProgressCallbackError>> {
     progress.map_or_else(
         || {
             let mut noop = exarch_core::NoopProgress;
             exarch_core::create_archive_with_progress(output_path, sources, config, &mut noop)
+                .map_err(|source| {
+                    Box::new(ProgressCallbackError::Core {
+                        source,
+                        callback: None,
+                    })
+                })
         },
         |tsfn| {
-            let mut callback = NodeProgressAdapter::new(tsfn);
-            exarch_core::create_archive_with_progress(output_path, sources, config, &mut callback)
+            let mut callback = NodeProgressAdapter::new(tsfn, dispatch);
+            let result = exarch_core::create_archive_with_progress(
+                output_path,
+                sources,
+                config,
+                &mut callback,
+            );
+            match (result, callback.into_callback_error()) {
+                (Ok(report), None) => Ok(report),
+                (Ok(report), Some(source)) => {
+                    Err(Box::new(ProgressCallbackError::CreationCallback {
+                        source,
+                        report,
+                    }))
+                }
+                (Err(source), callback) => {
+                    Err(Box::new(ProgressCallbackError::Core { source, callback }))
+                }
+            }
         },
     )
 }
@@ -863,10 +953,10 @@ pub async fn extract_archive_with_progress(
     Ok(ExtractionReport::from(report))
 }
 
-/// Error from running an extraction with a JS progress callback: either the
-/// core extraction operation failed, or the JS callback itself threw.
+/// Error from running an extraction or a creation with a JS progress callback:
+/// either the core operation failed, or the JS callback itself threw.
 enum ProgressCallbackError {
-    /// The core extraction failed. `callback` carries a JS progress callback
+    /// The core operation failed. `callback` carries a JS progress callback
     /// throw observed during the same run, if any.
     Core {
         source: exarch_core::ArchiveError,
@@ -876,9 +966,16 @@ enum ProgressCallbackError {
     /// carries the already-converted napi error captured by
     /// [`NodeProgressAdapter`] (see issue #465) plus the report describing
     /// what was written to disk.
-    Callback {
+    ExtractionCallback {
         source: Error,
         report: exarch_core::ExtractionReport,
+    },
+    /// The JS progress callback threw while the creation itself succeeded;
+    /// the creation counterpart of [`Self::ExtractionCallback`], carrying the
+    /// report describing the archive that was written.
+    CreationCallback {
+        source: Error,
+        report: exarch_core::creation::CreationReport,
     },
 }
 
@@ -890,7 +987,7 @@ enum ProgressCallbackError {
 ///   throwing callback cannot mask a security violation from callers that match
 ///   on that prefix. A concurrent callback throw is flagged by a fixed marker
 ///   in the message and attached as `cause`.
-/// - A callback throw over a successful extraction is prefixed with
+/// - A callback throw over a successful extraction or creation is prefixed with
 ///   `PROGRESS_CALLBACK_ERROR` and carries the report fields, so callers can
 ///   still tell what was written to disk before deciding how to clean up.
 ///
@@ -902,7 +999,6 @@ enum ProgressCallbackError {
 /// would let it spoof the machine-readable fields.
 impl From<ProgressCallbackError> for Error {
     fn from(err: ProgressCallbackError) -> Self {
-        use std::fmt::Write;
         match err {
             ProgressCallbackError::Core { source, callback } => {
                 let mut converted = convert_error(source);
@@ -918,23 +1014,52 @@ impl From<ProgressCallbackError> for Error {
                 }
                 converted
             }
-            ProgressCallbackError::Callback { source, report } => {
-                let mut reason = String::with_capacity(128);
-                reason.push_str(
-                    "PROGRESS_CALLBACK_ERROR: progress callback threw after successful extraction",
-                );
-                // Writing to a String never fails
-                let _ = write!(
-                    &mut reason,
-                    " | filesExtracted={}, bytesWritten={}",
-                    report.files_extracted, report.bytes_written
-                );
-                let mut converted = Self::new(Status::GenericFailure, reason);
-                converted.set_cause(source);
-                converted
+            ProgressCallbackError::ExtractionCallback { source, report } => {
+                callback_throw_over_success(
+                    "extraction",
+                    format_args!(
+                        "filesExtracted={}, bytesWritten={}",
+                        report.files_extracted, report.bytes_written
+                    ),
+                    source,
+                )
+            }
+            ProgressCallbackError::CreationCallback { source, report } => {
+                callback_throw_over_success(
+                    "creation",
+                    format_args!(
+                        "filesAdded={}, bytesWritten={}",
+                        report.files_added, report.bytes_written
+                    ),
+                    source,
+                )
             }
         }
     }
+}
+
+/// Builds the rejection for a progress callback that threw over an otherwise
+/// successful operation: a fixed `PROGRESS_CALLBACK_ERROR` prefix, the report
+/// fields describing what was written, and the JS throw attached as `cause`.
+///
+/// `fields` must be built solely from report counters — the throw's own text
+/// and stack never enter the message (see the [`From`] impl above).
+fn callback_throw_over_success(
+    operation: &str,
+    fields: std::fmt::Arguments<'_>,
+    source: Error,
+) -> Error {
+    use std::fmt::Write;
+
+    let mut reason = String::with_capacity(128);
+    // Writing to a String never fails
+    let _ = write!(
+        &mut reason,
+        "PROGRESS_CALLBACK_ERROR: progress callback threw after successful {operation} | {fields}"
+    );
+    let mut converted = Error::new(Status::GenericFailure, reason);
+    converted.set_cause(source);
+    converted
 }
 
 /// Runs `extract_archive_with_options_and_progress` routing to the JS callback
@@ -968,7 +1093,7 @@ fn run_extract_with_optional_progress(
             })
         },
         |tsfn| {
-            let mut callback = NodeProgressAdapter::new(tsfn);
+            let mut callback = NodeProgressAdapter::new(tsfn, ProgressDispatch::Awaited);
             let result = exarch_core::extract_archive_with_options_and_progress(
                 archive_path,
                 output_dir,
@@ -979,7 +1104,10 @@ fn run_extract_with_optional_progress(
             match (result, callback.into_callback_error()) {
                 (Ok(report), None) => Ok(report),
                 (Ok(report), Some(source)) => {
-                    Err(Box::new(ProgressCallbackError::Callback { source, report }))
+                    Err(Box::new(ProgressCallbackError::ExtractionCallback {
+                        source,
+                        report,
+                    }))
                 }
                 (Err(source), callback) => {
                     Err(Box::new(ProgressCallbackError::Core { source, callback }))
@@ -1007,15 +1135,32 @@ fn run_extract_with_optional_progress(
 /// invoking a callback already known to be broken.
 struct NodeProgressAdapter {
     tsfn: ThreadsafeFunction<(String, i64, i64, i64)>,
+    dispatch: ProgressDispatch,
     current_entry_bytes: i64,
     total: usize,
     callback_error: Option<Error>,
 }
 
+/// How a progress dispatch reaches the JavaScript thread, which decides whether
+/// a callback throw can be reported through the operation's own result.
+#[derive(Clone, Copy)]
+enum ProgressDispatch {
+    /// The operation runs on a worker thread while the JavaScript event loop
+    /// keeps turning, so each dispatch can be awaited and a throw captured into
+    /// `callback_error` before the operation returns.
+    Awaited,
+    /// The operation runs on the JavaScript thread itself (a `*Sync` entry
+    /// point), so the event loop cannot turn until it returns and awaiting a
+    /// dispatch would deadlock. Calls are queued and delivered afterwards,
+    /// which also means a throw cannot be routed back into the return value.
+    Deferred,
+}
+
 impl NodeProgressAdapter {
-    fn new(tsfn: ThreadsafeFunction<(String, i64, i64, i64)>) -> Self {
+    fn new(tsfn: ThreadsafeFunction<(String, i64, i64, i64)>, dispatch: ProgressDispatch) -> Self {
         Self {
             tsfn,
+            dispatch,
             current_entry_bytes: 0,
             total: 0,
             callback_error: None,
@@ -1040,14 +1185,26 @@ impl exarch_core::ProgressCallback for NodeProgressAdapter {
         let total_i64 = i64::try_from(total).unwrap_or(i64::MAX);
         let current_i64 = i64::try_from(current).unwrap_or(i64::MAX);
         let value = Ok((path_str, total_i64, current_i64, self.current_entry_bytes));
-        // `call_async_catch` clears and captures a JS throw into `Err` rather
-        // than routing it through `napi_fatal_exception`. `block_on` is sound
-        // here because `on_entry_start` runs only on a `spawn_blocking`
-        // worker thread, never inside an async task-polling context.
-        if let Err(err) =
-            tokio::runtime::Handle::current().block_on(self.tsfn.call_async_catch(value))
-        {
-            self.callback_error = Some(err);
+        match self.dispatch {
+            // `call_async_catch` clears and captures a JS throw into `Err`
+            // rather than routing it through `napi_fatal_exception`. `block_on`
+            // is sound here because an `Awaited` adapter runs only on a
+            // `spawn_blocking` worker thread, never inside an async
+            // task-polling context and never on the JS thread.
+            ProgressDispatch::Awaited => {
+                if let Err(err) =
+                    tokio::runtime::Handle::current().block_on(self.tsfn.call_async_catch(value))
+                {
+                    self.callback_error = Some(err);
+                }
+            }
+            // No runtime is entered on the JS thread and the event loop is
+            // blocked, so the dispatch is queued unawaited. A throw surfaces as
+            // an ordinary Node.js `uncaughtException` on the delivering turn.
+            ProgressDispatch::Deferred => {
+                self.tsfn
+                    .call(value, ThreadsafeFunctionCallMode::NonBlocking);
+            }
         }
     }
 

--- a/crates/exarch-node/src/lib.rs
+++ b/crates/exarch-node/src/lib.rs
@@ -810,7 +810,8 @@ pub fn verify_archive_sync(
 /// around from this crate.
 ///
 /// Always throw an `Error` instance (or any non-primitive) from a progress
-/// callback to get the documented rejection behavior.
+/// callback to get the documented rejection behavior. Tracked upstream in
+/// <https://github.com/bug-ops/exarch/issues/473>.
 ///
 /// # Examples
 ///

--- a/crates/exarch-node/src/lib.rs
+++ b/crates/exarch-node/src/lib.rs
@@ -45,7 +45,6 @@
 
 use napi::bindgen_prelude::*;
 use napi::threadsafe_function::ThreadsafeFunction;
-use napi::threadsafe_function::ThreadsafeFunctionCallMode;
 use napi_derive::napi;
 
 mod config;
@@ -775,6 +774,44 @@ pub fn verify_archive_sync(
 /// prefixed with error codes for discrimination in JavaScript. See
 /// `extractArchive` for the full list of error codes.
 ///
+/// If `progress` throws, the returned promise rejects instead of crashing the
+/// process (see issue #465). Extraction has already run to completion (or
+/// failure) by the time the rejection is observed — a throwing callback cannot
+/// abort the extraction early, since the progress callback contract has no
+/// cancellation signal. The rejection therefore reports both signals:
+///
+/// - Extraction succeeded: the message is prefixed with
+///   `PROGRESS_CALLBACK_ERROR` and carries `filesExtracted=N, bytesWritten=M`,
+///   so the caller can still see what was written to disk.
+/// - Extraction also failed: the core error stays primary and keeps its
+///   error-code prefix, with a fixed ` | progressCallbackError: see cause`
+///   marker appended. A throwing callback can never mask a security error such
+///   as `SYMLINK_ESCAPE`.
+///
+/// In both cases the original JS exception is available as the `cause`
+/// property of the rejection value. The throw's own text and stack are never
+/// copied into the message — read `cause` for the callback's error detail
+/// rather than parsing it out of `message`.
+///
+/// ## Known limitation: primitive throws still crash the process
+///
+/// The catchable-rejection behavior above only holds when the callback throws a
+/// non-primitive value (`Error` and subclasses, plain objects, arrays, `null`,
+/// `undefined`, `Symbol`). Throwing a bare string, number, or boolean —
+/// `throw 'oops'` — still aborts the host process uncatchably with
+/// `Call JavaScript callback failed in threadsafe function`, and the promise
+/// never settles.
+///
+/// This is an upstream defect in napi-rs 3.12.0: the dispatcher behind
+/// `call_async_catch` overwrites its own status with the result of
+/// `napi_create_reference()`, which reports `napi_invalid_arg` for a primitive
+/// exception value, and that status is then escalated to a fatal exception even
+/// though the error was already delivered to the channel. It cannot be worked
+/// around from this crate.
+///
+/// Always throw an `Error` instance (or any non-primitive) from a progress
+/// callback to get the documented rejection behavior.
+///
 /// # Examples
 ///
 /// ```javascript
@@ -815,7 +852,7 @@ pub async fn extract_archive_with_progress(
                 &options_owned,
                 progress,
             )
-            .map_err(convert_error)
+            .map_err(|err| Error::from(*err))
         })
     })
     .await
@@ -825,15 +862,93 @@ pub async fn extract_archive_with_progress(
     Ok(ExtractionReport::from(report))
 }
 
+/// Error from running an extraction with a JS progress callback: either the
+/// core extraction operation failed, or the JS callback itself threw.
+enum ProgressCallbackError {
+    /// The core extraction failed. `callback` carries a JS progress callback
+    /// throw observed during the same run, if any.
+    Core {
+        source: exarch_core::ArchiveError,
+        callback: Option<Error>,
+    },
+    /// The JS progress callback threw while the extraction itself succeeded;
+    /// carries the already-converted napi error captured by
+    /// [`NodeProgressAdapter`] (see issue #465) plus the report describing
+    /// what was written to disk.
+    Callback {
+        source: Error,
+        report: exarch_core::ExtractionReport,
+    },
+}
+
+/// Projects a [`ProgressCallbackError`] onto the single napi error the promise
+/// rejects with, without discarding either signal:
+///
+/// - A core failure stays primary and keeps its error-code prefix
+///   (`SYMLINK_ESCAPE`, `QUOTA_EXCEEDED`, …) at the start of the message, so a
+///   throwing callback cannot mask a security violation from callers that match
+///   on that prefix. A concurrent callback throw is flagged by a fixed marker
+///   in the message and attached as `cause`.
+/// - A callback throw over a successful extraction is prefixed with
+///   `PROGRESS_CALLBACK_ERROR` and carries the report fields, so callers can
+///   still tell what was written to disk before deciding how to clean up.
+///
+/// In both cases the original JS exception is preserved as the `cause`
+/// property of the rejection, retaining its class and stack. Its text is never
+/// stringified into the message: the stack embeds an absolute host path (which
+/// #453 redacts everywhere else in release builds), and the throw content is
+/// attacker-influenced whenever the callback echoes archive entry data, which
+/// would let it spoof the machine-readable fields.
+impl From<ProgressCallbackError> for Error {
+    fn from(err: ProgressCallbackError) -> Self {
+        use std::fmt::Write;
+        match err {
+            ProgressCallbackError::Core { source, callback } => {
+                let mut converted = convert_error(source);
+                if let Some(cb) = callback {
+                    // Fixed marker only: the throw's own text carries a host
+                    // path in its stack and is attacker-influenced when the
+                    // callback echoes archive entry data, so it must not reach
+                    // the parseable message. `cause` carries it losslessly.
+                    converted
+                        .reason
+                        .push_str(" | progressCallbackError: see cause");
+                    converted.set_cause(cb);
+                }
+                converted
+            }
+            ProgressCallbackError::Callback { source, report } => {
+                let mut reason = String::with_capacity(128);
+                reason.push_str(
+                    "PROGRESS_CALLBACK_ERROR: progress callback threw after successful extraction",
+                );
+                // Writing to a String never fails
+                let _ = write!(
+                    &mut reason,
+                    " | filesExtracted={}, bytesWritten={}",
+                    report.files_extracted, report.bytes_written
+                );
+                let mut converted = Self::new(Status::GenericFailure, reason);
+                converted.set_cause(source);
+                converted
+            }
+        }
+    }
+}
+
 /// Runs `extract_archive_with_options_and_progress` routing to the JS callback
 /// when present or to [`exarch_core::NoopProgress`] when absent.
+///
+/// A core extraction failure and a JS callback throw can occur in the same
+/// run; both are carried out of here so neither is silently dropped (see the
+/// `From<ProgressCallbackError>` impl for how they merge into one rejection).
 fn run_extract_with_optional_progress(
     archive_path: &str,
     output_dir: &str,
     config: &exarch_core::SecurityConfig,
     options: &exarch_core::ExtractionOptions,
     progress: Option<ThreadsafeFunction<(String, i64, i64, i64)>>,
-) -> exarch_core::Result<exarch_core::ExtractionReport> {
+) -> std::result::Result<exarch_core::ExtractionReport, Box<ProgressCallbackError>> {
     progress.map_or_else(
         || {
             let mut noop = exarch_core::NoopProgress;
@@ -844,16 +959,31 @@ fn run_extract_with_optional_progress(
                 options,
                 &mut noop,
             )
+            .map_err(|source| {
+                Box::new(ProgressCallbackError::Core {
+                    source,
+                    callback: None,
+                })
+            })
         },
         |tsfn| {
             let mut callback = NodeProgressAdapter::new(tsfn);
-            exarch_core::extract_archive_with_options_and_progress(
+            let result = exarch_core::extract_archive_with_options_and_progress(
                 archive_path,
                 output_dir,
                 config,
                 options,
                 &mut callback,
-            )
+            );
+            match (result, callback.into_callback_error()) {
+                (Ok(report), None) => Ok(report),
+                (Ok(report), Some(source)) => {
+                    Err(Box::new(ProgressCallbackError::Callback { source, report }))
+                }
+                (Err(source), callback) => {
+                    Err(Box::new(ProgressCallbackError::Core { source, callback }))
+                }
+            }
         },
     )
 }
@@ -866,10 +996,19 @@ fn run_extract_with_optional_progress(
 /// `current_entry_bytes` to `0` immediately before doing so. `on_bytes_written`
 /// does accumulate per-chunk writes (during creation; extraction also emits
 /// these events for some formats), but never triggers a dispatch of its own.
+///
+/// If the JavaScript callback throws, the exception is captured into
+/// `callback_error` instead of being routed through `napi_fatal_exception`
+/// (which would otherwise crash the host process uncatchably, see issue
+/// #465). Once a throw has been captured, further dispatches are skipped:
+/// the [`exarch_core::ProgressCallback`] contract has no cancellation signal,
+/// so extraction/creation keeps running, but there is no value in repeatedly
+/// invoking a callback already known to be broken.
 struct NodeProgressAdapter {
     tsfn: ThreadsafeFunction<(String, i64, i64, i64)>,
     current_entry_bytes: i64,
     total: usize,
+    callback_error: Option<Error>,
 }
 
 impl NodeProgressAdapter {
@@ -878,21 +1017,37 @@ impl NodeProgressAdapter {
             tsfn,
             current_entry_bytes: 0,
             total: 0,
+            callback_error: None,
         }
+    }
+
+    /// Consumes the adapter, returning the error captured from a throwing JS
+    /// progress callback, if one occurred.
+    fn into_callback_error(self) -> Option<Error> {
+        self.callback_error
     }
 }
 
 impl exarch_core::ProgressCallback for NodeProgressAdapter {
     fn on_entry_start(&mut self, path: &std::path::Path, total: usize, current: usize) {
+        if self.callback_error.is_some() {
+            return;
+        }
         self.current_entry_bytes = 0;
         self.total = total;
         let path_str = path.to_string_lossy().into_owned();
         let total_i64 = i64::try_from(total).unwrap_or(i64::MAX);
         let current_i64 = i64::try_from(current).unwrap_or(i64::MAX);
-        self.tsfn.call(
-            Ok((path_str, total_i64, current_i64, self.current_entry_bytes)),
-            ThreadsafeFunctionCallMode::NonBlocking,
-        );
+        let value = Ok((path_str, total_i64, current_i64, self.current_entry_bytes));
+        // `call_async_catch` clears and captures a JS throw into `Err` rather
+        // than routing it through `napi_fatal_exception`. `block_on` is sound
+        // here because `on_entry_start` runs only on a `spawn_blocking`
+        // worker thread, never inside an async task-polling context.
+        if let Err(err) =
+            tokio::runtime::Handle::current().block_on(self.tsfn.call_async_catch(value))
+        {
+            self.callback_error = Some(err);
+        }
     }
 
     fn on_bytes_written(&mut self, bytes: u64) {

--- a/crates/exarch-node/tests/create-progress.test.js
+++ b/crates/exarch-node/tests/create-progress.test.js
@@ -1,0 +1,277 @@
+/**
+ * Tests for createArchiveWithProgress / createArchiveWithProgressSync,
+ * covering the #465 regression on the creation path: a throwing progress
+ * callback must neither crash the process nor silently discard the result of
+ * the creation that already ran.
+ *
+ * The create-side progress API landed in #469, after #465 was originally
+ * scoped to extraction only.
+ */
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { spawnSync } = require('node:child_process');
+const { createArchiveWithProgress, createArchiveWithProgressSync } = require('../index.js');
+
+const INDEX_JS = JSON.stringify(path.join(__dirname, '..', 'index.js'));
+
+// The unreadable-file fixture below relies on chmod actually denying reads,
+// which is not true on Windows and not true for root.
+const canDenyReads =
+  process.platform !== 'win32' && typeof process.getuid === 'function' && process.getuid() !== 0;
+
+function createTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'exarch-create-progress-test-'));
+}
+
+describe('createArchiveWithProgress', () => {
+  let tempDir;
+  let sourceDir;
+  let outputPath;
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+    sourceDir = path.join(tempDir, 'source');
+    fs.mkdirSync(sourceDir);
+    fs.writeFileSync(path.join(sourceDir, 'hello.txt'), 'Hello, World!');
+    fs.writeFileSync(path.join(sourceDir, 'world.txt'), 'Another file');
+    outputPath = path.join(tempDir, 'output.tar.gz');
+  });
+
+  afterEach(() => {
+    if (tempDir && fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  // Regression test for #465 on the creation path: a throwing progress
+  // callback must reject the promise instead of crashing the process.
+  it('rejects the promise instead of throwing when the callback throws', async () => {
+    await assert.rejects(
+      () =>
+        createArchiveWithProgress(outputPath, [sourceDir], null, () => {
+          throw new Error('boom from progress callback');
+        }),
+      (err) => {
+        assert.strictEqual(err.cause.message, 'boom from progress callback');
+        return true;
+      },
+    );
+  });
+
+  // Regression test for #465 on the creation path: before this fix the
+  // captured callback error was dropped on the floor and the promise resolved
+  // with the report, giving the caller no indication their callback threw.
+  it('preserves the creation report when the callback throws', async () => {
+    await assert.rejects(
+      () =>
+        createArchiveWithProgress(outputPath, [sourceDir], null, () => {
+          throw new Error('boom from progress callback');
+        }),
+      (err) => {
+        assert.ok(
+          err.message.startsWith('PROGRESS_CALLBACK_ERROR:'),
+          `expected PROGRESS_CALLBACK_ERROR prefix, got: ${err.message}`,
+        );
+        assert.match(err.message, /filesAdded=2/);
+        assert.match(err.message, /bytesWritten=\d+/);
+        // The throw's own text and stack must stay out of the parseable
+        // message — `cause` is the only channel for the callback's detail.
+        assert.ok(!err.message.includes('boom from progress callback'));
+        assert.strictEqual(err.cause.message, 'boom from progress callback');
+        return true;
+      },
+    );
+    // The archive really was written, which is why the report must survive.
+    assert.ok(fs.existsSync(outputPath));
+  });
+
+  // A throwing progress callback must not mask a core error: callers grep the
+  // error-code prefix, so the core error stays primary.
+  it(
+    'surfaces the core error when the callback also throws',
+    { skip: canDenyReads ? false : 'requires chmod-enforced read denial' },
+    async () => {
+      // hello.txt is added first and fires the callback (which throws), then
+      // the unreadable file fails the creation itself.
+      const unreadable = path.join(sourceDir, 'zz-unreadable.txt');
+      fs.writeFileSync(unreadable, 'secret');
+      fs.chmodSync(unreadable, 0o000);
+
+      await assert.rejects(
+        () =>
+          createArchiveWithProgress(outputPath, [sourceDir], null, () => {
+            throw new Error('boom from progress callback');
+          }),
+        (err) => {
+          assert.ok(
+            err.message.startsWith('IO_ERROR:'),
+            `core error code must stay primary, got: ${err.message}`,
+          );
+          assert.ok(err.message.endsWith(' | progressCallbackError: see cause'));
+          assert.ok(!err.message.includes('boom from progress callback'));
+          assert.strictEqual(err.cause.message, 'boom from progress callback');
+          return true;
+        },
+      );
+    },
+  );
+
+  // Run in a child process so a crash (uncaughtException, non-zero exit) can
+  // be distinguished from a clean rejection without taking down this test run.
+  it('does not crash the host process when the callback throws (child process)', () => {
+    const script = `
+      const exarch = require(${INDEX_JS});
+      exarch.createArchiveWithProgress(
+        ${JSON.stringify(outputPath)},
+        [${JSON.stringify(sourceDir)}],
+        null,
+        () => { throw new Error('boom from progress callback'); },
+      ).then(
+        () => { console.log('UNEXPECTED_RESOLVE'); process.exit(2); },
+        (err) => { console.log('REJECTED:' + err.cause.message); },
+      );
+    `;
+
+    const result = spawnSync(process.execPath, ['-e', script], { encoding: 'utf8' });
+
+    assert.strictEqual(
+      result.status,
+      0,
+      `expected clean exit, got status=${result.status}, stderr=${result.stderr}`,
+    );
+    assert.ok(
+      result.stdout.includes('REJECTED:boom from progress callback'),
+      `expected rejection to be observed, got stdout=${result.stdout}`,
+    );
+    assert.ok(
+      !result.stderr.includes('Uncaught'),
+      `expected no uncaught exception, got stderr=${result.stderr}`,
+    );
+  });
+
+  // KNOWN LIMITATION (not a passing "this works" test), shared with
+  // extractArchiveWithProgress: both await the dispatch via `call_async_catch`,
+  // whose napi-rs 3.12.0 defect turns a thrown primitive into an uncatchable
+  // process abort. See the long-form explanation in extract-progress.test.js
+  // and https://github.com/bug-ops/exarch/issues/473.
+  //
+  // This test pins the CURRENT behavior. A napi-rs upgrade that fixes the bug
+  // will make it fail — that is the intended signal: flip the assertions to
+  // match the clean-rejection case above and drop the caveat from the
+  // createArchiveWithProgress docs.
+  it('KNOWN LIMITATION: crashes the host process when the callback throws a primitive (child process)', () => {
+    const script = `
+      const exarch = require(${INDEX_JS});
+      exarch.createArchiveWithProgress(
+        ${JSON.stringify(outputPath)},
+        [${JSON.stringify(sourceDir)}],
+        null,
+        () => { throw 'oops'; },
+      ).then(
+        () => { console.log('UNEXPECTED_RESOLVE'); },
+        () => { console.log('UNEXPECTED_REJECT'); },
+      );
+    `;
+
+    const result = spawnSync(process.execPath, ['-e', script], { encoding: 'utf8' });
+
+    assert.notStrictEqual(
+      result.status,
+      0,
+      'primitive throws are expected to still crash the process; if this now ' +
+        'exits cleanly, the upstream napi-rs bug is fixed — update this test ' +
+        'and the createArchiveWithProgress docs',
+    );
+    assert.match(result.stderr, /Call JavaScript callback failed/);
+    // The promise never settles, so neither handler runs.
+    assert.strictEqual(result.stdout.trim(), '');
+  });
+});
+
+describe('createArchiveWithProgressSync', () => {
+  let tempDir;
+  let sourceDir;
+  let outputPath;
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+    sourceDir = path.join(tempDir, 'source');
+    fs.mkdirSync(sourceDir);
+    fs.writeFileSync(path.join(sourceDir, 'hello.txt'), 'Hello, World!');
+    outputPath = path.join(tempDir, 'output.tar.gz');
+  });
+
+  afterEach(() => {
+    if (tempDir && fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  // Every queued call is delivered only after this function has returned, so
+  // there is no result left to merge a callback throw into. The throw takes
+  // the ordinary deferred-callback route instead: an uncaughtException, which
+  // the caller can observe — unlike the async variant, it is NOT reported as
+  // a PROGRESS_CALLBACK_ERROR rejection.
+  const syncThrowScript = (thrown) => `
+    const exarch = require(${INDEX_JS});
+    process.on('uncaughtException', (err) => {
+      console.log('UNCAUGHT:' + (err && err.message ? err.message : String(err)));
+      process.exit(0);
+    });
+    const report = exarch.createArchiveWithProgressSync(
+      ${JSON.stringify(outputPath)},
+      [${JSON.stringify(sourceDir)}],
+      null,
+      () => { throw ${thrown}; },
+    );
+    console.log('RETURNED:' + report.filesAdded);
+  `;
+
+  it('returns the report and reports a throwing callback as an uncaughtException (child process)', () => {
+    const result = spawnSync(
+      process.execPath,
+      ['-e', syncThrowScript("new Error('boom from progress callback')")],
+      { encoding: 'utf8' },
+    );
+
+    assert.strictEqual(
+      result.status,
+      0,
+      `expected clean exit, got status=${result.status}, stderr=${result.stderr}`,
+    );
+    // The report is returned normally: the callback had not run yet.
+    assert.match(result.stdout, /RETURNED:1/);
+    assert.ok(
+      result.stdout.includes('UNCAUGHT:boom from progress callback'),
+      `expected the throw to surface as uncaughtException, got stdout=${result.stdout}`,
+    );
+  });
+
+  // The primitive-throw crash that afflicts the async variants does NOT apply
+  // here: the sync path cannot await its dispatch (the blocked event loop is
+  // the only thing that can deliver it), so it never enters the napi-rs
+  // `call_async_catch` code path that mishandles primitive exception values.
+  it('reports a thrown primitive as an uncaughtException too, without crashing (child process)', () => {
+    const result = spawnSync(process.execPath, ['-e', syncThrowScript("'oops'")], {
+      encoding: 'utf8',
+    });
+
+    assert.strictEqual(
+      result.status,
+      0,
+      `expected clean exit, got status=${result.status}, stderr=${result.stderr}`,
+    );
+    assert.match(result.stdout, /RETURNED:1/);
+    assert.ok(
+      result.stdout.includes('UNCAUGHT:oops'),
+      `expected the primitive throw to surface as uncaughtException, got stdout=${result.stdout}`,
+    );
+    assert.ok(
+      !result.stderr.includes('Call JavaScript callback failed'),
+      `sync dispatch must not hit the call_async_catch primitive bug, got stderr=${result.stderr}`,
+    );
+  });
+});

--- a/crates/exarch-node/tests/create-progress.test.js
+++ b/crates/exarch-node/tests/create-progress.test.js
@@ -13,7 +13,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
 const { spawnSync } = require('node:child_process');
-const { createArchiveWithProgress, createArchiveWithProgressSync } = require('../index.js');
+const { createArchiveWithProgress } = require('../index.js');
 
 const INDEX_JS = JSON.stringify(path.join(__dirname, '..', 'index.js'));
 
@@ -57,7 +57,7 @@ describe('createArchiveWithProgress', () => {
       (err) => {
         assert.strictEqual(err.cause.message, 'boom from progress callback');
         return true;
-      },
+      }
     );
   });
 
@@ -73,7 +73,7 @@ describe('createArchiveWithProgress', () => {
       (err) => {
         assert.ok(
           err.message.startsWith('PROGRESS_CALLBACK_ERROR:'),
-          `expected PROGRESS_CALLBACK_ERROR prefix, got: ${err.message}`,
+          `expected PROGRESS_CALLBACK_ERROR prefix, got: ${err.message}`
         );
         assert.match(err.message, /filesAdded=2/);
         assert.match(err.message, /bytesWritten=\d+/);
@@ -82,7 +82,7 @@ describe('createArchiveWithProgress', () => {
         assert.ok(!err.message.includes('boom from progress callback'));
         assert.strictEqual(err.cause.message, 'boom from progress callback');
         return true;
-      },
+      }
     );
     // The archive really was written, which is why the report must survive.
     assert.ok(fs.existsSync(outputPath));
@@ -90,34 +90,32 @@ describe('createArchiveWithProgress', () => {
 
   // A throwing progress callback must not mask a core error: callers grep the
   // error-code prefix, so the core error stays primary.
-  it(
-    'surfaces the core error when the callback also throws',
-    { skip: canDenyReads ? false : 'requires chmod-enforced read denial' },
-    async () => {
-      // hello.txt is added first and fires the callback (which throws), then
-      // the unreadable file fails the creation itself.
-      const unreadable = path.join(sourceDir, 'zz-unreadable.txt');
-      fs.writeFileSync(unreadable, 'secret');
-      fs.chmodSync(unreadable, 0o000);
+  it('surfaces the core error when the callback also throws', {
+    skip: canDenyReads ? false : 'requires chmod-enforced read denial',
+  }, async () => {
+    // hello.txt is added first and fires the callback (which throws), then
+    // the unreadable file fails the creation itself.
+    const unreadable = path.join(sourceDir, 'zz-unreadable.txt');
+    fs.writeFileSync(unreadable, 'secret');
+    fs.chmodSync(unreadable, 0o000);
 
-      await assert.rejects(
-        () =>
-          createArchiveWithProgress(outputPath, [sourceDir], null, () => {
-            throw new Error('boom from progress callback');
-          }),
-        (err) => {
-          assert.ok(
-            err.message.startsWith('IO_ERROR:'),
-            `core error code must stay primary, got: ${err.message}`,
-          );
-          assert.ok(err.message.endsWith(' | progressCallbackError: see cause'));
-          assert.ok(!err.message.includes('boom from progress callback'));
-          assert.strictEqual(err.cause.message, 'boom from progress callback');
-          return true;
-        },
-      );
-    },
-  );
+    await assert.rejects(
+      () =>
+        createArchiveWithProgress(outputPath, [sourceDir], null, () => {
+          throw new Error('boom from progress callback');
+        }),
+      (err) => {
+        assert.ok(
+          err.message.startsWith('IO_ERROR:'),
+          `core error code must stay primary, got: ${err.message}`
+        );
+        assert.ok(err.message.endsWith(' | progressCallbackError: see cause'));
+        assert.ok(!err.message.includes('boom from progress callback'));
+        assert.strictEqual(err.cause.message, 'boom from progress callback');
+        return true;
+      }
+    );
+  });
 
   // Run in a child process so a crash (uncaughtException, non-zero exit) can
   // be distinguished from a clean rejection without taking down this test run.
@@ -140,15 +138,15 @@ describe('createArchiveWithProgress', () => {
     assert.strictEqual(
       result.status,
       0,
-      `expected clean exit, got status=${result.status}, stderr=${result.stderr}`,
+      `expected clean exit, got status=${result.status}, stderr=${result.stderr}`
     );
     assert.ok(
       result.stdout.includes('REJECTED:boom from progress callback'),
-      `expected rejection to be observed, got stdout=${result.stdout}`,
+      `expected rejection to be observed, got stdout=${result.stdout}`
     );
     assert.ok(
       !result.stderr.includes('Uncaught'),
-      `expected no uncaught exception, got stderr=${result.stderr}`,
+      `expected no uncaught exception, got stderr=${result.stderr}`
     );
   });
 
@@ -183,7 +181,7 @@ describe('createArchiveWithProgress', () => {
       0,
       'primitive throws are expected to still crash the process; if this now ' +
         'exits cleanly, the upstream napi-rs bug is fixed — update this test ' +
-        'and the createArchiveWithProgress docs',
+        'and the createArchiveWithProgress docs'
     );
     assert.match(result.stderr, /Call JavaScript callback failed/);
     // The promise never settles, so neither handler runs.
@@ -234,19 +232,19 @@ describe('createArchiveWithProgressSync', () => {
     const result = spawnSync(
       process.execPath,
       ['-e', syncThrowScript("new Error('boom from progress callback')")],
-      { encoding: 'utf8' },
+      { encoding: 'utf8' }
     );
 
     assert.strictEqual(
       result.status,
       0,
-      `expected clean exit, got status=${result.status}, stderr=${result.stderr}`,
+      `expected clean exit, got status=${result.status}, stderr=${result.stderr}`
     );
     // The report is returned normally: the callback had not run yet.
     assert.match(result.stdout, /RETURNED:1/);
     assert.ok(
       result.stdout.includes('UNCAUGHT:boom from progress callback'),
-      `expected the throw to surface as uncaughtException, got stdout=${result.stdout}`,
+      `expected the throw to surface as uncaughtException, got stdout=${result.stdout}`
     );
   });
 
@@ -262,16 +260,16 @@ describe('createArchiveWithProgressSync', () => {
     assert.strictEqual(
       result.status,
       0,
-      `expected clean exit, got status=${result.status}, stderr=${result.stderr}`,
+      `expected clean exit, got status=${result.status}, stderr=${result.stderr}`
     );
     assert.match(result.stdout, /RETURNED:1/);
     assert.ok(
       result.stdout.includes('UNCAUGHT:oops'),
-      `expected the primitive throw to surface as uncaughtException, got stdout=${result.stdout}`,
+      `expected the primitive throw to surface as uncaughtException, got stdout=${result.stdout}`
     );
     assert.ok(
       !result.stderr.includes('Call JavaScript callback failed'),
-      `sync dispatch must not hit the call_async_catch primitive bug, got stderr=${result.stderr}`,
+      `sync dispatch must not hit the call_async_catch primitive bug, got stderr=${result.stderr}`
     );
   });
 });

--- a/crates/exarch-node/tests/error-redaction.test.js
+++ b/crates/exarch-node/tests/error-redaction.test.js
@@ -1,0 +1,99 @@
+/**
+ * End-to-end regression test for issue #464.
+ *
+ * Release builds redact `ArchiveError::Io` messages down to their
+ * `std::io::ErrorKind` description, which collapses every `io::Error::other`
+ * call site to the useless string "other error". Those call sites now wrap
+ * their detail in `exarch_core::IoContext` so the actionable, path-free
+ * context survives redaction while the dynamic detail does not.
+ *
+ * The redaction itself is unit-tested in `exarch-core`'s `error::redaction`
+ * module, where it now lives; those tests are gated on `debug_assertions`, so
+ * CI's debug `cargo nextest` run only covers the debug branch. This file is
+ * where the release-mode behaviour is asserted against the compiled binding.
+ */
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { createArchiveSync } = require('../index.js');
+
+// `IoContext::context` for the walkdir failure in `creation::walker`.
+const WALK_CONTEXT = 'directory walk failed';
+
+/**
+ * Reports whether the compiled binding redacts host paths.
+ *
+ * Redaction is gated on `#[cfg(not(debug_assertions))]`, so it is active under
+ * `npm run build` but not under `npm run build:debug`. Probed through the
+ * public API via `SourceNotFound`, whose path is reduced to a bare filename
+ * only when redaction is on.
+ */
+function redactionActive(tempDir) {
+  let message = null;
+  try {
+    createArchiveSync(path.join(tempDir, 'probe.tar.gz'), [
+      path.join(tempDir, 'probe-dir', 'missing.tar.gz'),
+    ]);
+  } catch (err) {
+    message = err.message;
+  }
+  assert.ok(message !== null, 'expected createArchiveSync to reject a missing source');
+  return !message.includes('probe-dir');
+}
+
+describe('IoContext error redaction', () => {
+  let tempDir;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'exarch-redaction-test-'));
+  });
+
+  afterEach(() => {
+    if (tempDir && fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps the walk-failure context without leaking the source path or OS detail', (t) => {
+    if (process.platform === 'win32') {
+      return t.skip('POSIX permission bits do not gate directory reads');
+    }
+
+    const source = path.join(tempDir, 'confidential-source');
+    fs.mkdirSync(source);
+    fs.writeFileSync(path.join(source, 'payload.txt'), 'data');
+    fs.chmodSync(source, 0o000);
+
+    try {
+      fs.readdirSync(source);
+      return t.skip('mode 000 does not block reads for this user (running as root?)');
+    } catch {
+      // Expected: the directory is genuinely unreadable.
+    }
+
+    let message = null;
+    try {
+      createArchiveSync(path.join(tempDir, 'out.tar.gz'), [source]);
+    } catch (err) {
+      message = err.message;
+    } finally {
+      fs.chmodSync(source, 0o755);
+    }
+
+    assert.ok(message !== null, 'expected createArchiveSync to fail on an unreadable source');
+    assert.ok(message.includes(WALK_CONTEXT), `lost IoContext context, got: ${message}`);
+
+    if (redactionActive(tempDir)) {
+      assert.ok(
+        !message.includes('confidential-source'),
+        `host path leaked in release build, got: ${message}`
+      );
+      assert.ok(
+        !message.includes('Permission denied'),
+        `raw OS detail leaked in release build, got: ${message}`
+      );
+    }
+  });
+});

--- a/crates/exarch-node/tests/extract-progress.test.js
+++ b/crates/exarch-node/tests/extract-progress.test.js
@@ -9,11 +9,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
 const { spawnSync } = require('node:child_process');
-const {
-  extractArchiveWithProgress,
-  createArchiveSync,
-  SecurityConfig,
-} = require('../index.js');
+const { extractArchiveWithProgress, createArchiveSync, SecurityConfig } = require('../index.js');
 
 function createTempDir() {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'exarch-progress-test-'));
@@ -55,7 +51,7 @@ describe('extractArchiveWithProgress', () => {
       null,
       (err, arg) => {
         calls.push([err, arg]);
-      },
+      }
     );
 
     assert.strictEqual(report.filesExtracted, 2);
@@ -83,7 +79,7 @@ describe('extractArchiveWithProgress', () => {
       (err) => {
         assert.strictEqual(err.cause.message, 'boom from progress callback');
         return true;
-      },
+      }
     );
   });
 
@@ -99,7 +95,7 @@ describe('extractArchiveWithProgress', () => {
       (err) => {
         assert.ok(
           err.message.startsWith('PROGRESS_CALLBACK_ERROR:'),
-          `expected PROGRESS_CALLBACK_ERROR prefix, got: ${err.message}`,
+          `expected PROGRESS_CALLBACK_ERROR prefix, got: ${err.message}`
         );
         assert.match(err.message, /filesExtracted=2/);
         assert.match(err.message, /bytesWritten=\d+/);
@@ -108,7 +104,7 @@ describe('extractArchiveWithProgress', () => {
         assert.ok(!err.message.includes('boom from progress callback'));
         assert.strictEqual(err.cause.message, 'boom from progress callback');
         return true;
-      },
+      }
     );
     assert.ok(fs.existsSync(path.join(outputDir, 'hello.txt')));
   });
@@ -128,14 +124,14 @@ describe('extractArchiveWithProgress', () => {
       (err) => {
         assert.ok(
           err.message.startsWith('QUOTA_EXCEEDED:'),
-          `core error code must stay primary, got: ${err.message}`,
+          `core error code must stay primary, got: ${err.message}`
         );
         assert.match(err.message, /file count/);
         assert.ok(err.message.endsWith(' | progressCallbackError: see cause'));
         assert.ok(!err.message.includes('boom from progress callback'));
         assert.strictEqual(err.cause.message, 'boom from progress callback');
         return true;
-      },
+      }
     );
   });
 
@@ -164,15 +160,15 @@ describe('extractArchiveWithProgress', () => {
     assert.strictEqual(
       result.status,
       0,
-      `expected clean exit, got status=${result.status}, stderr=${result.stderr}`,
+      `expected clean exit, got status=${result.status}, stderr=${result.stderr}`
     );
     assert.ok(
       result.stdout.includes('REJECTED:boom from progress callback'),
-      `expected rejection to be observed, got stdout=${result.stdout}`,
+      `expected rejection to be observed, got stdout=${result.stdout}`
     );
     assert.ok(
       !result.stderr.includes('Uncaught'),
-      `expected no uncaught exception, got stderr=${result.stderr}`,
+      `expected no uncaught exception, got stderr=${result.stderr}`
     );
   });
 
@@ -217,7 +213,7 @@ describe('extractArchiveWithProgress', () => {
       0,
       'primitive throws are expected to still crash the process; if this now ' +
         'exits cleanly, the upstream napi-rs bug is fixed — update this test ' +
-        'and the extractArchiveWithProgress docs',
+        'and the extractArchiveWithProgress docs'
     );
     assert.match(result.stderr, /Call JavaScript callback failed/);
     // The promise never settles, so neither handler runs.

--- a/crates/exarch-node/tests/extract-progress.test.js
+++ b/crates/exarch-node/tests/extract-progress.test.js
@@ -1,0 +1,225 @@
+/**
+ * Tests for extractArchiveWithProgress, including the #465 regression:
+ * a throwing progress callback must reject the returned promise instead of
+ * crashing the process via an uncatchable `uncaughtException`.
+ */
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { spawnSync } = require('node:child_process');
+const {
+  extractArchiveWithProgress,
+  createArchiveSync,
+  SecurityConfig,
+} = require('../index.js');
+
+function createTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'exarch-progress-test-'));
+}
+
+function createValidArchive(archivePath, tempDir) {
+  const sourceDir = path.join(tempDir, 'source');
+  fs.mkdirSync(sourceDir);
+  fs.writeFileSync(path.join(sourceDir, 'hello.txt'), 'Hello, World!');
+  fs.writeFileSync(path.join(sourceDir, 'world.txt'), 'Another file');
+  createArchiveSync(archivePath, [sourceDir]);
+}
+
+describe('extractArchiveWithProgress', () => {
+  let tempDir;
+  let archivePath;
+  let outputDir;
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+    archivePath = path.join(tempDir, 'test.tar.gz');
+    outputDir = path.join(tempDir, 'output');
+    fs.mkdirSync(outputDir);
+    createValidArchive(archivePath, tempDir);
+  });
+
+  afterEach(() => {
+    if (tempDir && fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('reports progress for each entry and resolves with the report', async () => {
+    const calls = [];
+    const report = await extractArchiveWithProgress(
+      archivePath,
+      outputDir,
+      null,
+      null,
+      (err, arg) => {
+        calls.push([err, arg]);
+      },
+    );
+
+    assert.strictEqual(report.filesExtracted, 2);
+    assert.strictEqual(calls.length, 2);
+    for (const [err, [entryPath, , , bytesWritten]] of calls) {
+      assert.strictEqual(err, null);
+      assert.ok(typeof entryPath === 'string' && entryPath.length > 0);
+      assert.strictEqual(bytesWritten, 0);
+    }
+  });
+
+  it('extracts successfully when no progress callback is passed', async () => {
+    const report = await extractArchiveWithProgress(archivePath, outputDir);
+    assert.strictEqual(report.filesExtracted, 2);
+  });
+
+  // Regression test for #465: a throwing progress callback must reject the
+  // promise instead of crashing the process uncatchably.
+  it('rejects the promise instead of throwing when the callback throws', async () => {
+    await assert.rejects(
+      () =>
+        extractArchiveWithProgress(archivePath, outputDir, null, null, () => {
+          throw new Error('boom from progress callback');
+        }),
+      (err) => {
+        assert.strictEqual(err.cause.message, 'boom from progress callback');
+        return true;
+      },
+    );
+  });
+
+  // Regression test for the #465 follow-up: when the callback throws but
+  // extraction succeeded, the report must not be silently discarded — files
+  // really were written to disk and the caller may need to clean them up.
+  it('preserves the extraction report when the callback throws', async () => {
+    await assert.rejects(
+      () =>
+        extractArchiveWithProgress(archivePath, outputDir, null, null, () => {
+          throw new Error('boom from progress callback');
+        }),
+      (err) => {
+        assert.ok(
+          err.message.startsWith('PROGRESS_CALLBACK_ERROR:'),
+          `expected PROGRESS_CALLBACK_ERROR prefix, got: ${err.message}`,
+        );
+        assert.match(err.message, /filesExtracted=2/);
+        assert.match(err.message, /bytesWritten=\d+/);
+        // The throw's own text and stack must stay out of the parseable
+        // message — `cause` is the only channel for the callback's detail.
+        assert.ok(!err.message.includes('boom from progress callback'));
+        assert.strictEqual(err.cause.message, 'boom from progress callback');
+        return true;
+      },
+    );
+    assert.ok(fs.existsSync(path.join(outputDir, 'hello.txt')));
+  });
+
+  // Regression test for the #465 follow-up: a throwing progress callback must
+  // not mask a core error. Callers grep the error-code prefix to detect
+  // security violations, so the core error stays primary and the callback
+  // throw is reported alongside it.
+  it('surfaces the core error when the callback also throws', async () => {
+    const config = new SecurityConfig().setMaxFileCount(1);
+
+    await assert.rejects(
+      () =>
+        extractArchiveWithProgress(archivePath, outputDir, config, null, () => {
+          throw new Error('boom from progress callback');
+        }),
+      (err) => {
+        assert.ok(
+          err.message.startsWith('QUOTA_EXCEEDED:'),
+          `core error code must stay primary, got: ${err.message}`,
+        );
+        assert.match(err.message, /file count/);
+        assert.ok(err.message.endsWith(' | progressCallbackError: see cause'));
+        assert.ok(!err.message.includes('boom from progress callback'));
+        assert.strictEqual(err.cause.message, 'boom from progress callback');
+        return true;
+      },
+    );
+  });
+
+  // Regression test for #465, pinning the actual process-level behavior: run
+  // in a child process so a crash (uncaughtException, non-zero exit) can be
+  // distinguished from a clean rejection without taking down this test run.
+  it('does not crash the host process when the callback throws (child process)', () => {
+    const script = `
+      const exarch = require(${JSON.stringify(path.join(__dirname, '..', 'index.js'))});
+      exarch.extractArchiveWithProgress(
+        ${JSON.stringify(archivePath)},
+        ${JSON.stringify(outputDir)},
+        null,
+        null,
+        () => { throw new Error('boom from progress callback'); },
+      ).then(
+        () => { console.log('UNEXPECTED_RESOLVE'); process.exit(2); },
+        (err) => { console.log('REJECTED:' + err.cause.message); },
+      );
+    `;
+
+    const result = spawnSync(process.execPath, ['-e', script], {
+      encoding: 'utf8',
+    });
+
+    assert.strictEqual(
+      result.status,
+      0,
+      `expected clean exit, got status=${result.status}, stderr=${result.stderr}`,
+    );
+    assert.ok(
+      result.stdout.includes('REJECTED:boom from progress callback'),
+      `expected rejection to be observed, got stdout=${result.stdout}`,
+    );
+    assert.ok(
+      !result.stderr.includes('Uncaught'),
+      `expected no uncaught exception, got stderr=${result.stderr}`,
+    );
+  });
+
+  // KNOWN LIMITATION (not a passing "this works" test): throwing a primitive
+  // (string/number/boolean) from the progress callback still crashes the host
+  // process uncatchably, so #465 is only fixed for non-primitive throws.
+  //
+  // Upstream bug in napi-rs 3.12.0 (threadsafe_function.rs:864): the dispatcher
+  // in `call_async_catch` overwrites its status with the result of
+  // `napi_create_reference()`, which returns `napi_invalid_arg` for a primitive
+  // exception value (a weak ref to a primitive is not possible). It correctly
+  // falls back to `maybe_ref: None` and still delivers `Err` to the channel,
+  // but the non-ok status then reaches `napi_fatal_exception`. The wasm branch
+  // of the same function already resets `status = napi_ok`.
+  //
+  // This test pins the CURRENT behavior. A napi-rs upgrade that fixes the bug
+  // will make it fail — that is the intended signal: flip the assertions to
+  // match the clean-rejection case above and drop the caveat from the
+  // `extractArchiveWithProgress` docs.
+  it('KNOWN LIMITATION: crashes the host process when the callback throws a primitive (child process)', () => {
+    const script = `
+      const exarch = require(${JSON.stringify(path.join(__dirname, '..', 'index.js'))});
+      exarch.extractArchiveWithProgress(
+        ${JSON.stringify(archivePath)},
+        ${JSON.stringify(outputDir)},
+        null,
+        null,
+        () => { throw 'oops'; },
+      ).then(
+        () => { console.log('UNEXPECTED_RESOLVE'); },
+        () => { console.log('UNEXPECTED_REJECT'); },
+      );
+    `;
+
+    const result = spawnSync(process.execPath, ['-e', script], {
+      encoding: 'utf8',
+    });
+
+    assert.notStrictEqual(
+      result.status,
+      0,
+      'primitive throws are expected to still crash the process; if this now ' +
+        'exits cleanly, the upstream napi-rs bug is fixed — update this test ' +
+        'and the extractArchiveWithProgress docs',
+    );
+    assert.match(result.stderr, /Call JavaScript callback failed/);
+    // The promise never settles, so neither handler runs.
+    assert.strictEqual(result.stdout.trim(), '');
+  });
+});

--- a/crates/exarch-node/tests/extract-progress.test.js
+++ b/crates/exarch-node/tests/extract-progress.test.js
@@ -191,7 +191,8 @@ describe('extractArchiveWithProgress', () => {
   // This test pins the CURRENT behavior. A napi-rs upgrade that fixes the bug
   // will make it fail — that is the intended signal: flip the assertions to
   // match the clean-rejection case above and drop the caveat from the
-  // `extractArchiveWithProgress` docs.
+  // `extractArchiveWithProgress` docs. Tracked in
+  // https://github.com/bug-ops/exarch/issues/473.
   it('KNOWN LIMITATION: crashes the host process when the callback throws a primitive (child process)', () => {
     const script = `
       const exarch = require(${JSON.stringify(path.join(__dirname, '..', 'index.js'))});

--- a/crates/exarch-python/src/error.rs
+++ b/crates/exarch-python/src/error.rs
@@ -508,9 +508,7 @@ mod tests {
             CoreError::SymlinkEscape {
                 path: nested.clone(),
             },
-            CoreError::HardlinkEscape {
-                path: nested.clone(),
-            },
+            CoreError::HardlinkEscape { path: nested },
         ];
         for err in variants {
             let err_str = convert_error(err).to_string();

--- a/crates/exarch-python/tests/test_error_redaction.py
+++ b/crates/exarch-python/tests/test_error_redaction.py
@@ -1,0 +1,68 @@
+"""End-to-end regression test for issue #464.
+
+Release builds redact `ArchiveError::Io` messages down to their
+`std::io::ErrorKind` description, which collapses every `io::Error::other`
+call site to the useless string "other error". Those call sites now wrap
+their detail in `exarch_core::IoContext` so the actionable, path-free context
+survives redaction while the dynamic detail does not.
+
+The redaction itself is unit-tested in `exarch-core`'s `error::redaction`
+module, where it now lives; those tests are gated on `debug_assertions`, so
+CI's debug `cargo nextest` run only covers the debug branch. This module is
+where the release-mode behaviour is asserted against the compiled extension.
+"""
+
+import os
+import sys
+
+import pytest
+
+import exarch
+
+# `IoContext::context` for the walkdir failure in `creation::walker`.
+WALK_CONTEXT = "directory walk failed"
+
+
+def _redaction_active(temp_dir):
+    """Report whether the compiled extension redacts host paths.
+
+    Redaction is gated on `#[cfg(not(debug_assertions))]`, so it is active in
+    the release wheels CI tests but not in a local `maturin develop` debug
+    build. Probed through the public API via `SourceNotFound`, whose path is
+    reduced to a bare filename only when redaction is on.
+    """
+    missing = temp_dir / "probe-dir" / "missing.tar.gz"
+    with pytest.raises(OSError) as excinfo:
+        exarch.create_archive(str(temp_dir / "probe.tar.gz"), [str(missing)])
+    return "probe-dir" not in str(excinfo.value)
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="POSIX permission bits do not gate directory reads"
+)
+def test_directory_walk_failure_keeps_context_without_leaking_detail(temp_dir):
+    source = temp_dir / "confidential-source"
+    source.mkdir()
+    (source / "payload.txt").write_text("data")
+    os.chmod(source, 0o000)
+
+    if os.access(source, os.R_OK):
+        os.chmod(source, 0o755)
+        pytest.skip("mode 000 does not block reads for this user (running as root?)")
+
+    try:
+        with pytest.raises(OSError) as excinfo:
+            exarch.create_archive(str(temp_dir / "out.tar.gz"), [str(source)])
+    finally:
+        os.chmod(source, 0o755)
+
+    message = str(excinfo.value)
+    assert WALK_CONTEXT in message, f"lost IoContext context, got: {message!r}"
+
+    if _redaction_active(temp_dir):
+        assert "confidential-source" not in message, (
+            f"host path leaked in release build, got: {message!r}"
+        )
+        assert "Permission denied" not in message, (
+            f"raw OS detail leaked in release build, got: {message!r}"
+        )


### PR DESCRIPTION
## Summary

- `extractArchiveWithProgress`'s progress callback used to crash the Node process uncatchably (`napi_fatal_exception`) when it threw, even inside `try`/`catch`. It now rejects the returned promise instead. When core extraction also fails, the core error's security-relevant prefix (`SYMLINK_ESCAPE`, `QUOTA_EXCEEDED`, ...) stays primary and unmaskable; when extraction succeeds despite the throw, the `ExtractionReport` (filesExtracted/bytesWritten) is preserved rather than discarded. The original JS exception is attached as the rejection's `cause` (never copied into `.message`, since the stack embeds a host path and the throw content can be attacker-influenced). Throwing a bare primitive (string/number/boolean) remains a documented, test-pinned limitation of the underlying napi-rs 3.12.0 `call_async_catch` implementation - tracked in #473.
- Extended the same fix to `createArchiveWithProgress`/`createArchiveWithProgressSync` (landed on `main` via #469 after #465 was originally scoped). Fixed a regression exposed only by rebasing onto that commit: `createArchiveWithProgressSync` panicked (`there is no reactor running`) because the adapter unconditionally called `Handle::current().block_on`, which has no runtime to enter on the sync entry point's calling thread. The adapter now dispatches via `Awaited` (async entry points, `spawn_blocking` worker - `block_on(call_async_catch)`) or `Deferred` (the `*Sync` entry point - plain `ThreadsafeFunction::call`, since napi-rs's catchable semantics require the `WithCallback` variant `call_async_catch` uses). The primitive-throw caveat above applies only to the async variants; the sync variant's throw was never covered by #465 in the first place and surfaces as an ordinary `uncaughtException`.
- Several `exarch-core` call sites built `io::Error::other(...)` errors that collapsed to the generic `"other error"` string in release builds after #453's redaction fix, losing all diagnostic value. Added `exarch_core::IoContext`, pairing a static, non-path-bearing context string with the dynamic detail. Rebasing onto #475 (which hoisted path redaction into a shared `exarch_core::error::redaction` module, closing #462/#463) meant porting this logic into that single shared location instead of two binding-local copies - simpler than before, and the regression test now lives in a crate CI actually runs against, rather than a per-binding unit test that only type-checked.

Closes #465
Closes #464

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` (1113/1113)
- [x] `cargo test --doc --workspace --all-features` (excluding exarch-python, pre-existing macOS PyO3 link limitation)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace`
- [x] `npm run build && npm test` in `crates/exarch-node` (111/111, covers extract + create paths, both async and sync entry points, callback-throws-and-core-succeeds, callback-throws-and-core-fails, and the known-limitation pin for primitive throws on async variants)
- [x] `maturin develop --features abi3 && pytest tests/ -v` in `crates/exarch-python` (46 passed, 1 pre-existing unrelated skip)
- [x] Empirically verified release-mode IoContext redaction end-to-end through the compiled bindings, not just type-checked
- [x] Branch rebased onto latest `main` (through #479) with two conflict-resolution passes (#469's create-side API, #475's redaction hoist); full suite re-verified green after each