### PR TITLE
fix(core,python,node)!: hoist path redaction into exarch-core and fix over-redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING: `ArchiveError::to_ffi_message` no longer takes a `sanitize_paths: bool` parameter
+  (#463)**: the parameter's runtime toggle no longer maps onto anything real once the redaction
+  policy became profile-gated (`cfg(debug_assertions)`) rather than caller-selected — see the
+  `#463`/`#462` entry under `### Fixed` for why the policy changed. `to_ffi_message()` now takes
+  no arguments and always applies the shared policy from the new `error::redaction` module via
+  `ArchiveError::redacted_path()`. The method had zero callers anywhere in the workspace, so this
+  has no runtime effect on `exarch-python`/`exarch-node`, but any direct Rust API consumer calling
+  `to_ffi_message(sanitize_paths)` must drop the argument.
 - **BREAKING: `SecurityConfig::validate()` now rejects malformed `allowed_extensions`/
   `banned_path_components` entries (#449)**: a new `validate_config_entry` helper in
   `exarch-core::security::boundary` (re-exported as `exarch_core::validate_config_entry`,
@@ -168,6 +176,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`sanitize_path_for_error`/`sanitize_io_error_for_error` duplicated verbatim across bindings
+  (plus a third, unused copy in `exarch-core` itself), and over-redacted attacker-authored paths
+  (#463, #462)**: the profile-gated redaction helpers added by #453 were byte-identical,
+  independently-maintained copies in `crates/exarch-python/src/error.rs` and
+  `crates/exarch-node/src/error.rs`, with no shared source or cross-binding test; a third,
+  never-called copy of the same policy also lived in `ArchiveError::to_ffi_message` and carried
+  the same bugs. Hoisted the two binding-local helpers into a new `exarch-core` module,
+  `error::redaction` (re-exported as `exarch_core::sanitize_path_for_error`,
+  `exarch_core::format_entry_path_for_error`, and `exarch_core::sanitize_io_error_for_error`) —
+  both bindings' `convert_error` bind the path per match arm and call the correct algorithm
+  directly (preserving the compiler's exhaustiveness guarantee that a new `ArchiveError` variant
+  forces every call site to handle it explicitly), and `ArchiveError::to_ffi_message` (previously
+  the buggy third copy, see `### Changed` for its resulting signature break) calls the same two
+  algorithms via a new `ArchiveError::redacted_path()` helper. Only the two redaction algorithms
+  are single-sourced this way — the variant-to-algorithm mapping itself is still applied
+  independently in three places (`redacted_path()`, and each binding's `convert_error`), guarded
+  by tests in each. While hoisting, fixed over-redaction: `PathTraversal`, `SymlinkEscape`, and
+  `HardlinkEscape` carry an archive-relative path the attacker authored inside the archive entry,
+  not a host filesystem path (see `exarch-core/src/types/safe_path.rs` and `safe_symlink.rs`), so
+  redacting them to filename-only in release builds hid nothing from the attacker while destroying
+  the defender's ability to identify the offending entry in redacted logs. These three variants —
+  and `InvalidPermissions`, which carries the same kind of archive-relative entry path (see
+  `inspection::verify`) — now keep the full path in both debug and release builds.
+  `SourceNotFound`, `SourceNotAccessible`, `OutputExists`, `UnknownFormat`, and `Io` are unaffected
+  and remain redacted to filename-only (or `ErrorKind` description, for `Io`) in release builds,
+  since those genuinely carry host-derived paths. **Behavior change**: release-build error
+  messages for `PathTraversal`, `SymlinkEscape`, `HardlinkEscape`, and `InvalidPermissions` now
+  include the full archive entry path where they
+  previously showed only the filename.
 - **`exarch-python` error messages leaked full absolute paths in release builds, and both
   bindings leaked host paths embedded in `CoreError::Io` messages (#453)**:
   `crates/exarch-python/src/error.rs` called `path.display()` directly and unconditionally for

--- a/crates/exarch-core/src/error/messages.rs
+++ b/crates/exarch-core/src/error/messages.rs
@@ -3,8 +3,7 @@
 //! Provides consistent error messages across Python and Node.js bindings
 //! while allowing platform-specific customization.
 
-use std::path::Path;
-
+use super::redaction::sanitize_io_error_for_error;
 use super::types::ArchiveError;
 
 /// Error message for FFI consumption.
@@ -26,11 +25,11 @@ pub struct FfiErrorMessage {
 impl ArchiveError {
     /// Formats error for FFI consumption.
     ///
-    /// # Arguments
-    ///
-    /// * `sanitize_paths` - If true, only show filename (not full path) for
-    ///   security. Should be `false` in development, `true` in production
-    ///   Node.js builds.
+    /// Path and I/O-error text is redacted per the shared policy in
+    /// [`super::redaction`] — see [`Self::redacted_path`] and
+    /// [`sanitize_io_error_for_error`] — so this always applies the same
+    /// policy `exarch-python` and `exarch-node` apply directly; there is no
+    /// separate `sanitize_paths` toggle to keep in sync with theirs.
     ///
     /// # Examples
     ///
@@ -39,41 +38,36 @@ impl ArchiveError {
     /// use std::path::PathBuf;
     ///
     /// let error = ArchiveError::PathTraversal {
-    ///     path: PathBuf::from("/etc/passwd"),
+    ///     path: PathBuf::from("../../etc/passwd"),
     /// };
     ///
-    /// let msg = error.to_ffi_message(true);
+    /// let msg = error.to_ffi_message();
     /// assert_eq!(msg.code, "PATH_TRAVERSAL");
-    /// assert!(msg.description.contains("passwd")); // Only filename shown
+    /// // Archive-relative, attacker-authored path: never redacted (#462).
+    /// assert!(msg.description.contains("../../etc/passwd"));
     /// ```
     #[must_use]
     #[allow(clippy::too_many_lines)]
-    pub fn to_ffi_message(&self, sanitize_paths: bool) -> FfiErrorMessage {
+    pub fn to_ffi_message(&self) -> FfiErrorMessage {
+        let path = self
+            .redacted_path()
+            .unwrap_or_else(|| "<unknown>".to_string());
         match self {
-            Self::PathTraversal { path } => FfiErrorMessage {
+            Self::PathTraversal { .. } => FfiErrorMessage {
                 code: "PATH_TRAVERSAL",
-                description: format!(
-                    "path traversal detected: {}",
-                    format_path(path, sanitize_paths)
-                ),
+                description: format!("path traversal detected: {path}"),
                 context: None,
             },
 
-            Self::SymlinkEscape { path } => FfiErrorMessage {
+            Self::SymlinkEscape { .. } => FfiErrorMessage {
                 code: "SYMLINK_ESCAPE",
-                description: format!(
-                    "symlink target outside extraction directory: {}",
-                    format_path(path, sanitize_paths)
-                ),
+                description: format!("symlink target outside extraction directory: {path}"),
                 context: None,
             },
 
-            Self::HardlinkEscape { path } => FfiErrorMessage {
+            Self::HardlinkEscape { .. } => FfiErrorMessage {
                 code: "HARDLINK_ESCAPE",
-                description: format!(
-                    "hardlink target outside extraction directory: {}",
-                    format_path(path, sanitize_paths)
-                ),
+                description: format!("hardlink target outside extraction directory: {path}"),
                 context: None,
             },
 
@@ -109,43 +103,31 @@ impl ArchiveError {
 
             Self::Io(io_err) => FfiErrorMessage {
                 code: "IO_ERROR",
-                description: io_err.to_string(),
+                description: sanitize_io_error_for_error(io_err),
                 context: Some(io_err.kind().to_string()),
             },
 
-            Self::InvalidPermissions { path, mode } => FfiErrorMessage {
+            Self::InvalidPermissions { mode, .. } => FfiErrorMessage {
                 code: "INVALID_PERMISSIONS",
-                description: format!(
-                    "invalid permissions for {}: {mode:#o}",
-                    format_path(path, sanitize_paths)
-                ),
+                description: format!("invalid permissions for {path}: {mode:#o}"),
                 context: None,
             },
 
-            Self::SourceNotFound { path } => FfiErrorMessage {
+            Self::SourceNotFound { .. } => FfiErrorMessage {
                 code: "SOURCE_NOT_FOUND",
-                description: format!(
-                    "source path not found: {}",
-                    format_path(path, sanitize_paths)
-                ),
+                description: format!("source path not found: {path}"),
                 context: None,
             },
 
-            Self::SourceNotAccessible { path } => FfiErrorMessage {
+            Self::SourceNotAccessible { .. } => FfiErrorMessage {
                 code: "SOURCE_NOT_ACCESSIBLE",
-                description: format!(
-                    "source path is not accessible: {}",
-                    format_path(path, sanitize_paths)
-                ),
+                description: format!("source path is not accessible: {path}"),
                 context: None,
             },
 
-            Self::OutputExists { path } => FfiErrorMessage {
+            Self::OutputExists { .. } => FfiErrorMessage {
                 code: "OUTPUT_EXISTS",
-                description: format!(
-                    "output file already exists: {}",
-                    format_path(path, sanitize_paths)
-                ),
+                description: format!("output file already exists: {path}"),
                 context: None,
             },
 
@@ -155,12 +137,9 @@ impl ArchiveError {
                 context: None,
             },
 
-            Self::UnknownFormat { path } => FfiErrorMessage {
+            Self::UnknownFormat { .. } => FfiErrorMessage {
                 code: "UNKNOWN_FORMAT",
-                description: format!(
-                    "cannot determine archive format from: {}",
-                    format_path(path, sanitize_paths)
-                ),
+                description: format!("cannot determine archive format from: {path}"),
                 context: None,
             },
 
@@ -170,7 +149,7 @@ impl ArchiveError {
                 context: None,
             },
 
-            Self::PartialExtraction { source, .. } => source.to_ffi_message(sanitize_paths),
+            Self::PartialExtraction { source, .. } => source.to_ffi_message(),
         }
     }
 
@@ -200,40 +179,49 @@ impl ArchiveError {
     }
 }
 
-/// Formats a path for error messages.
-///
-/// If `sanitize` is true, only returns the filename (for production).
-/// If `sanitize` is false, returns the full path (for development).
-fn format_path(path: &Path, sanitize: bool) -> String {
-    if sanitize {
-        path.file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("<unknown>")
-            .to_string()
-    } else {
-        path.display().to_string()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::path::PathBuf;
 
+    /// Regression test for #462: `PathTraversal` carries an
+    /// archive-relative, attacker-authored path and must never be redacted,
+    /// unlike a genuinely host-derived path variant (see the test below).
     #[test]
-    fn test_path_sanitization() {
+    fn test_attacker_path_never_redacted() {
         let error = ArchiveError::PathTraversal {
-            path: PathBuf::from("/etc/passwd"),
+            path: PathBuf::from("../../etc/passwd"),
         };
+        let msg = error.to_ffi_message();
+        assert!(msg.description.contains("../../etc/passwd"));
+    }
 
-        // Development: full path
-        let msg = error.to_ffi_message(false);
-        assert!(msg.description.contains("/etc/passwd"));
+    /// Regression test for #453: `SourceNotFound` carries a host filesystem
+    /// path; in release builds it must be redacted to filename-only. This
+    /// only exercises the release-build branch — the debug-build behavior
+    /// is covered directly in `super::redaction`.
+    #[test]
+    #[cfg(not(debug_assertions))]
+    fn test_host_path_redacted_in_release() {
+        let error = ArchiveError::SourceNotFound {
+            path: PathBuf::from("/srv/secret/app/x.txt"),
+        };
+        let msg = error.to_ffi_message();
+        assert!(msg.description.contains("x.txt"));
+        assert!(!msg.description.contains("/srv/secret"));
+    }
 
-        // Production: filename only
-        let msg = error.to_ffi_message(true);
-        assert!(msg.description.contains("passwd"));
-        assert!(!msg.description.contains("/etc/"));
+    /// Regression test for #453: `Io` messages must not leak a host path
+    /// embedded in the free-form message text in release builds.
+    #[test]
+    #[cfg(not(debug_assertions))]
+    fn test_io_error_redacted_in_release() {
+        let error = ArchiveError::Io(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "directory is not writable: /srv/secret/app/private-output",
+        ));
+        let msg = error.to_ffi_message();
+        assert!(!msg.description.contains("/srv/secret"));
     }
 
     #[test]
@@ -263,7 +251,7 @@ mod tests {
 
         for (error, expected_code) in test_cases {
             assert_eq!(error.error_code(), expected_code);
-            assert_eq!(error.to_ffi_message(false).code, expected_code);
+            assert_eq!(error.to_ffi_message().code, expected_code);
         }
     }
 
@@ -323,7 +311,7 @@ mod tests {
             let code = error.error_code();
             assert!(!code.is_empty(), "Error code should not be empty");
 
-            let msg = error.to_ffi_message(false);
+            let msg = error.to_ffi_message();
             assert_eq!(msg.code, code);
             assert!(!msg.description.is_empty());
         }

--- a/crates/exarch-core/src/error/mod.rs
+++ b/crates/exarch-core/src/error/mod.rs
@@ -1,6 +1,7 @@
 //! Error types for archive operations.
 
 pub mod messages;
+pub mod redaction;
 pub mod types;
 
 pub use messages::FfiErrorMessage;

--- a/crates/exarch-core/src/error/redaction.rs
+++ b/crates/exarch-core/src/error/redaction.rs
@@ -1,0 +1,380 @@
+//! Shared path and I/O-error redaction algorithms for FFI-facing error
+//! messages.
+//!
+//! `exarch-python` and `exarch-node` both render [`ArchiveError`] into
+//! host-language exceptions and must decide, per error variant, how much
+//! path information to expose. Getting this wrong in either direction is a
+//! problem: leaking a host filesystem path can disclose internal directory
+//! structure to a user reading a release-build error message (see #453),
+//! while over-redacting an archive-relative path that the *attacker*
+//! already authored (e.g. a `PathTraversal` entry) destroys the defender's
+//! ability to identify which archive entry triggered the violation without
+//! actually hiding anything (see #462).
+//!
+//! This module owns the two redaction algorithms — [`sanitize_path_for_error`]
+//! for genuinely host-derived paths and [`format_entry_path_for_error`] for
+//! archive-relative, attacker-authored paths — plus
+//! [`sanitize_io_error_for_error`] for I/O error messages (see #463). Both
+//! bindings call these algorithms directly, per variant, in their own
+//! `convert_error`; [`ArchiveError::to_ffi_message`] uses them via
+//! [`ArchiveError::redacted_path`]. The mapping from variant to algorithm is
+//! therefore still applied independently in three places — here (via
+//! `redacted_path`), in `exarch-python::convert_error`, and in
+//! `exarch-node::convert_error` — only the two algorithms themselves are
+//! single-sourced.
+
+use std::path::Path;
+
+use super::types::ArchiveError;
+
+/// Formats a host-derived filesystem path for inclusion in an FFI error
+/// message.
+///
+/// In debug builds, returns the full path for detailed diagnostics. In
+/// release builds, returns only the filename to avoid leaking internal
+/// directory structures to potential attackers.
+///
+/// Use this for variants whose path was derived from the host filesystem
+/// (e.g. [`ArchiveError::SourceNotFound`]), not for archive-relative,
+/// attacker-authored paths — see [`format_entry_path_for_error`] for those.
+///
+/// # Examples
+///
+/// ```
+/// use exarch_core::sanitize_path_for_error;
+/// use std::path::Path;
+///
+/// // Debug builds keep the full path; release builds keep only the
+/// // filename — either way the filename itself is always present.
+/// let redacted = sanitize_path_for_error(Path::new("/srv/secret/app/x.txt"));
+/// assert!(redacted.ends_with("x.txt"));
+/// ```
+#[cfg(debug_assertions)]
+#[must_use]
+pub fn sanitize_path_for_error(path: &Path) -> String {
+    path.display().to_string()
+}
+
+/// Formats a host-derived filesystem path for inclusion in an FFI error
+/// message.
+///
+/// In debug builds, returns the full path for detailed diagnostics. In
+/// release builds, returns only the filename to avoid leaking internal
+/// directory structures to potential attackers.
+///
+/// Use this for variants whose path was derived from the host filesystem
+/// (e.g. [`ArchiveError::SourceNotFound`]), not for archive-relative,
+/// attacker-authored paths — see [`format_entry_path_for_error`] for those.
+///
+/// # Examples
+///
+/// ```
+/// use exarch_core::sanitize_path_for_error;
+/// use std::path::Path;
+///
+/// // Debug builds keep the full path; release builds keep only the
+/// // filename — either way the filename itself is always present.
+/// let redacted = sanitize_path_for_error(Path::new("/srv/secret/app/x.txt"));
+/// assert!(redacted.ends_with("x.txt"));
+/// ```
+#[cfg(not(debug_assertions))]
+#[must_use]
+pub fn sanitize_path_for_error(path: &Path) -> String {
+    path.file_name().map_or_else(
+        || "<unknown>".to_string(),
+        |n| n.to_string_lossy().into_owned(),
+    )
+}
+
+/// Formats an archive-relative, attacker-authored path for inclusion in an
+/// FFI error message.
+///
+/// Unlike [`sanitize_path_for_error`], this never redacts: it always
+/// returns the full path, in both debug and release builds. It exists for
+/// variants like [`ArchiveError::PathTraversal`],
+/// [`ArchiveError::SymlinkEscape`], and [`ArchiveError::HardlinkEscape`], whose
+/// `path` is an entry path the attacker crafted inside the archive, not a host
+/// filesystem path — see #462. The attacker already knows the path they
+/// authored, so redacting it discloses nothing to them while destroying the
+/// defender's ability to identify the offending entry in a redacted
+/// release-build log.
+///
+/// # Examples
+///
+/// ```
+/// use exarch_core::format_entry_path_for_error;
+/// use std::path::Path;
+///
+/// let path = Path::new("../../etc/passwd");
+/// assert_eq!(
+///     format_entry_path_for_error(path),
+///     path.display().to_string()
+/// );
+/// ```
+#[must_use]
+pub fn format_entry_path_for_error(path: &Path) -> String {
+    path.display().to_string()
+}
+
+/// Sanitizes I/O error messages for FFI error reporting.
+///
+/// In debug builds, returns the full `Display` output (which may embed a
+/// host path, e.g. from `DestDir`'s validation messages). In release
+/// builds, returns only the [`std::io::ErrorKind`] description, since the
+/// free-form message text has no structured path field to redact.
+///
+/// # Examples
+///
+/// ```
+/// use exarch_core::sanitize_io_error_for_error;
+///
+/// let err = std::io::Error::new(std::io::ErrorKind::NotFound, "file not found");
+/// let msg = sanitize_io_error_for_error(&err);
+/// assert!(!msg.is_empty());
+/// ```
+#[cfg(debug_assertions)]
+#[must_use]
+pub fn sanitize_io_error_for_error(e: &std::io::Error) -> String {
+    e.to_string()
+}
+
+/// Sanitizes I/O error messages for FFI error reporting.
+///
+/// In debug builds, returns the full `Display` output (which may embed a
+/// host path, e.g. from `DestDir`'s validation messages). In release
+/// builds, returns only the [`std::io::ErrorKind`] description, since the
+/// free-form message text has no structured path field to redact.
+///
+/// # Examples
+///
+/// ```
+/// use exarch_core::sanitize_io_error_for_error;
+///
+/// let err = std::io::Error::new(std::io::ErrorKind::NotFound, "file not found");
+/// let msg = sanitize_io_error_for_error(&err);
+/// assert!(!msg.is_empty());
+/// ```
+#[cfg(not(debug_assertions))]
+#[must_use]
+pub fn sanitize_io_error_for_error(e: &std::io::Error) -> String {
+    e.kind().to_string()
+}
+
+impl ArchiveError {
+    /// Formats this error's path field for an FFI-facing error message,
+    /// applying the shared redaction policy, or returns `None` if this
+    /// variant carries no path.
+    ///
+    /// Maps each [`ArchiveError`] variant to the correct redaction
+    /// algorithm — [`format_entry_path_for_error`] (never redacted) for
+    /// archive-relative, attacker-authored paths, or
+    /// [`sanitize_path_for_error`] (redacted to filename-only in release
+    /// builds) for genuinely host-derived paths (see #462). Used by
+    /// [`Self::to_ffi_message`]. `exarch-python` and `exarch-node` apply
+    /// this same variant-to-algorithm mapping independently in their own
+    /// `convert_error` — calling [`format_entry_path_for_error`] and
+    /// [`sanitize_path_for_error`] directly, per match arm, rather than
+    /// through this method — so the mapping itself is duplicated across
+    /// core, python, and node; only the two algorithms are single-sourced
+    /// (see #463). `test_never_redacted_variants_keep_full_path` and
+    /// `test_host_path_variants_follow_profile_policy` below guard this
+    /// method's mapping; the bindings' own tests guard theirs.
+    ///
+    /// [`Self::InvalidPermissions`] carries an archive entry path (see
+    /// `check_permissions` in `inspection::verify`), not a host path, so it
+    /// is grouped with the never-redacted variants for the same reason as
+    /// `PathTraversal`/`SymlinkEscape`/`HardlinkEscape`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use exarch_core::ArchiveError;
+    /// use std::path::PathBuf;
+    ///
+    /// let err = ArchiveError::PathTraversal {
+    ///     path: PathBuf::from("../../etc/passwd"),
+    /// };
+    /// assert_eq!(err.redacted_path().as_deref(), Some("../../etc/passwd"));
+    ///
+    /// let err = ArchiveError::InvalidCompressionLevel { level: 0 };
+    /// assert_eq!(err.redacted_path(), None);
+    /// ```
+    #[must_use]
+    pub fn redacted_path(&self) -> Option<String> {
+        match self {
+            Self::PathTraversal { path }
+            | Self::SymlinkEscape { path }
+            | Self::HardlinkEscape { path }
+            | Self::InvalidPermissions { path, .. } => Some(format_entry_path_for_error(path)),
+
+            Self::SourceNotFound { path }
+            | Self::SourceNotAccessible { path }
+            | Self::OutputExists { path }
+            | Self::UnknownFormat { path } => Some(sanitize_path_for_error(path)),
+
+            Self::PartialExtraction { source, .. } => source.redacted_path(),
+
+            Self::Io(_)
+            | Self::InvalidArchive(_)
+            | Self::ZipBomb { .. }
+            | Self::QuotaExceeded { .. }
+            | Self::SecurityViolation { .. }
+            | Self::InvalidCompressionLevel { .. }
+            | Self::InvalidConfiguration { .. } => None,
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::ExtractionReport;
+    use std::path::PathBuf;
+
+    #[test]
+    #[cfg(debug_assertions)]
+    fn test_sanitize_path_for_error_keeps_full_path_in_debug() {
+        let path = PathBuf::from("/srv/secret/app/x.txt");
+        assert_eq!(sanitize_path_for_error(&path), "/srv/secret/app/x.txt");
+    }
+
+    #[test]
+    #[cfg(not(debug_assertions))]
+    fn test_sanitize_path_for_error_strips_directory_in_release() {
+        let path = PathBuf::from("/srv/secret/app/x.txt");
+        assert_eq!(sanitize_path_for_error(&path), "x.txt");
+    }
+
+    #[test]
+    fn test_format_entry_path_for_error_never_redacts() {
+        let path = PathBuf::from("../../etc/passwd");
+        assert_eq!(format_entry_path_for_error(&path), "../../etc/passwd");
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    fn test_sanitize_io_error_for_error_keeps_message_in_debug() {
+        let err = std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "directory is not writable: /srv/secret/app/private-output",
+        );
+        assert_eq!(
+            sanitize_io_error_for_error(&err),
+            "directory is not writable: /srv/secret/app/private-output"
+        );
+    }
+
+    #[test]
+    #[cfg(not(debug_assertions))]
+    fn test_sanitize_io_error_for_error_redacts_message_in_release() {
+        let err = std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "directory is not writable: /srv/secret/app/private-output",
+        );
+        let msg = sanitize_io_error_for_error(&err);
+        assert!(!msg.contains("/srv/secret/app"));
+        assert!(msg.contains("permission denied"));
+    }
+
+    /// Regression test for #462: every `ArchiveError` variant carrying an
+    /// archive-relative, attacker-authored path must keep the full path in
+    /// `redacted_path`, in both debug and release builds.
+    #[test]
+    fn test_never_redacted_variants_keep_full_path() {
+        let attacker_path = PathBuf::from("../../etc/passwd");
+        let never_redacted = [
+            ArchiveError::PathTraversal {
+                path: attacker_path.clone(),
+            },
+            ArchiveError::SymlinkEscape {
+                path: attacker_path.clone(),
+            },
+            ArchiveError::HardlinkEscape {
+                path: attacker_path.clone(),
+            },
+            ArchiveError::InvalidPermissions {
+                path: attacker_path,
+                mode: 0o777,
+            },
+        ];
+
+        for err in never_redacted {
+            assert_eq!(
+                err.redacted_path().as_deref(),
+                Some("../../etc/passwd"),
+                "expected full path to survive redaction for {err:?}"
+            );
+        }
+    }
+
+    /// Regression test for #453/#462: every `ArchiveError` variant carrying
+    /// a genuinely host-derived path is redacted to filename-only in
+    /// release builds (and kept in full in debug builds).
+    #[test]
+    fn test_host_path_variants_follow_profile_policy() {
+        let host_path = PathBuf::from("/srv/secret/app/x.txt");
+        let host_derived = [
+            ArchiveError::SourceNotFound {
+                path: host_path.clone(),
+            },
+            ArchiveError::SourceNotAccessible {
+                path: host_path.clone(),
+            },
+            ArchiveError::OutputExists {
+                path: host_path.clone(),
+            },
+            ArchiveError::UnknownFormat { path: host_path },
+        ];
+
+        for err in host_derived {
+            let redacted = err.redacted_path().expect("variant carries a path");
+            assert!(
+                redacted.ends_with("x.txt"),
+                "expected filename to survive redaction for {err:?}, got {redacted:?}"
+            );
+            #[cfg(not(debug_assertions))]
+            assert!(
+                !redacted.contains("/srv/secret"),
+                "expected host directory to be redacted for {err:?}, got {redacted:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_variants_without_path_return_none() {
+        let no_path = [
+            ArchiveError::ZipBomb {
+                compressed: 100,
+                uncompressed: 100_000,
+                ratio: 1000.0,
+            },
+            ArchiveError::InvalidArchive("bad header".to_string()),
+            ArchiveError::SecurityViolation {
+                reason: "test".to_string(),
+            },
+            ArchiveError::InvalidCompressionLevel { level: 0 },
+            ArchiveError::InvalidConfiguration {
+                reason: "test".to_string(),
+            },
+            ArchiveError::Io(std::io::Error::other("test")),
+        ];
+
+        for err in no_path {
+            assert_eq!(err.redacted_path(), None, "expected no path for {err:?}");
+        }
+    }
+
+    /// Regression test for #251/#210: `PartialExtraction` must delegate to
+    /// its `source`'s redaction policy rather than exposing a path itself.
+    #[test]
+    fn test_partial_extraction_delegates_to_source() {
+        let err = ArchiveError::PartialExtraction {
+            source: Box::new(ArchiveError::PathTraversal {
+                path: PathBuf::from("../../etc/passwd"),
+            }),
+            report: ExtractionReport::new(),
+        };
+        assert_eq!(err.redacted_path().as_deref(), Some("../../etc/passwd"));
+    }
+}

--- a/crates/exarch-core/src/lib.rs
+++ b/crates/exarch-core/src/lib.rs
@@ -53,6 +53,15 @@ pub use error::ArchiveError;
 pub use error::FfiErrorMessage;
 pub use error::QuotaResource;
 pub use error::Result;
+/// Formats an archive-relative, attacker-authored path for an FFI error
+/// message without redaction. Shared by `exarch-python` and `exarch-node`.
+pub use error::redaction::format_entry_path_for_error;
+/// Sanitizes a `std::io::Error` message for an FFI error message. Shared by
+/// `exarch-python` and `exarch-node`.
+pub use error::redaction::sanitize_io_error_for_error;
+/// Redacts a host-derived filesystem path for an FFI error message in
+/// release builds. Shared by `exarch-python` and `exarch-node`.
+pub use error::redaction::sanitize_path_for_error;
 pub use report::ExtractionReport;
 pub use report::NoopProgress;
 pub use report::ProgressCallback;

--- a/crates/exarch-node/src/error.rs
+++ b/crates/exarch-node/src/error.rs
@@ -2,42 +2,10 @@
 
 use exarch_core::ArchiveError as CoreError;
 use exarch_core::QuotaResource as CoreQuotaResource;
+use exarch_core::format_entry_path_for_error;
+use exarch_core::sanitize_io_error_for_error;
+use exarch_core::sanitize_path_for_error;
 use napi::bindgen_prelude::*;
-use std::path::Path;
-
-/// Sanitizes path information for error messages.
-///
-/// In debug builds, returns the full path for detailed diagnostics.
-/// In release builds, returns only the filename to avoid leaking internal
-/// directory structures to potential attackers.
-#[cfg(debug_assertions)]
-fn sanitize_path_for_error(path: &Path) -> String {
-    path.display().to_string()
-}
-
-#[cfg(not(debug_assertions))]
-fn sanitize_path_for_error(path: &Path) -> String {
-    path.file_name().map_or_else(
-        || "<unknown>".to_string(),
-        |n| n.to_string_lossy().into_owned(),
-    )
-}
-
-/// Sanitizes I/O error messages for error reporting.
-///
-/// In debug builds, returns the full `Display` output (which may embed a
-/// host path, e.g. from `DestDir`'s validation messages). In release builds,
-/// returns only the [`std::io::ErrorKind`] description, since the free-form
-/// message text has no structured path field to redact.
-#[cfg(debug_assertions)]
-fn sanitize_io_error_for_error(e: &std::io::Error) -> String {
-    e.to_string()
-}
-
-#[cfg(not(debug_assertions))]
-fn sanitize_io_error_for_error(e: &std::io::Error) -> String {
-    e.kind().to_string()
-}
 
 /// Converts Rust extraction errors to JavaScript exceptions.
 ///
@@ -60,21 +28,21 @@ pub fn convert_error(err: CoreError) -> Error {
     use std::fmt::Write;
     match err {
         CoreError::PathTraversal { path } => {
-            let path_str = sanitize_path_for_error(&path);
+            let path_str = format_entry_path_for_error(&path);
             let mut msg = String::with_capacity(50 + path_str.len());
             msg.push_str("PATH_TRAVERSAL: path traversal detected: ");
             msg.push_str(&path_str);
             Error::new(Status::GenericFailure, msg)
         }
         CoreError::SymlinkEscape { path } => {
-            let path_str = sanitize_path_for_error(&path);
+            let path_str = format_entry_path_for_error(&path);
             let mut msg = String::with_capacity(70 + path_str.len());
             msg.push_str("SYMLINK_ESCAPE: symlink target outside extraction directory: ");
             msg.push_str(&path_str);
             Error::new(Status::GenericFailure, msg)
         }
         CoreError::HardlinkEscape { path } => {
-            let path_str = sanitize_path_for_error(&path);
+            let path_str = format_entry_path_for_error(&path);
             let mut msg = String::with_capacity(70 + path_str.len());
             msg.push_str("HARDLINK_ESCAPE: hardlink target outside extraction directory: ");
             msg.push_str(&path_str);
@@ -94,7 +62,7 @@ pub fn convert_error(err: CoreError) -> Error {
             Error::new(Status::GenericFailure, msg)
         }
         CoreError::InvalidPermissions { path, mode } => {
-            let path_str = sanitize_path_for_error(&path);
+            let path_str = format_entry_path_for_error(&path);
             let mut msg = String::with_capacity(60 + path_str.len());
             // Writing to a String never fails
             let _ = write!(
@@ -218,10 +186,10 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
-    /// Asserts the full attacker-supplied path is present, which only holds
-    /// under `debug_assertions` (see `sanitize_path_for_error`).
+    /// Asserts the full attacker-supplied path is present in both debug and
+    /// release builds — `PathTraversal` carries an archive-relative,
+    /// attacker-authored path and is never redacted (see #462).
     #[test]
-    #[cfg(debug_assertions)]
     fn test_path_traversal_conversion() {
         let err = CoreError::PathTraversal {
             path: PathBuf::from("../etc/passwd"),
@@ -233,10 +201,10 @@ mod tests {
         assert!(err_str.contains("../etc/passwd"));
     }
 
-    /// Asserts the full path is present, which only holds under
-    /// `debug_assertions` (see `sanitize_path_for_error`).
+    /// Asserts the full path is present in both debug and release builds —
+    /// `SymlinkEscape` carries an archive-relative, attacker-authored path
+    /// and is never redacted (see #462).
     #[test]
-    #[cfg(debug_assertions)]
     fn test_symlink_escape_conversion() {
         let err = CoreError::SymlinkEscape {
             path: PathBuf::from("/etc/passwd"),
@@ -248,10 +216,10 @@ mod tests {
         assert!(err_str.contains("/etc/passwd"));
     }
 
-    /// Asserts the full path is present, which only holds under
-    /// `debug_assertions` (see `sanitize_path_for_error`).
+    /// Asserts the full path is present in both debug and release builds —
+    /// `HardlinkEscape` carries an archive-relative, attacker-authored path
+    /// and is never redacted (see #462).
     #[test]
-    #[cfg(debug_assertions)]
     fn test_hardlink_escape_conversion() {
         let err = CoreError::HardlinkEscape {
             path: PathBuf::from("/etc/shadow"),
@@ -390,14 +358,49 @@ mod tests {
         assert!(err_str.contains("file not found"));
     }
 
-    /// Regression test for #453 follow-up: in release builds,
-    /// `sanitize_path_for_error` must strip the path down to the filename,
-    /// not leak the full host path.
+    /// Regression test for #453 follow-up: in release builds, a
+    /// host-derived path variant must be reduced to the filename, not leak
+    /// the full host path. The redaction primitives themselves are tested
+    /// directly in `exarch_core::error::redaction`; this exercises the
+    /// binding's end-to-end `convert_error` path.
     #[test]
     #[cfg(not(debug_assertions))]
-    fn test_sanitize_path_for_error_strips_directory_in_release() {
-        let path = PathBuf::from("/srv/secret/app/x.txt");
-        assert_eq!(sanitize_path_for_error(&path), "x.txt");
+    fn test_source_not_found_strips_directory_in_release() {
+        let err = CoreError::SourceNotFound {
+            path: PathBuf::from("/srv/secret/app/x.txt"),
+        };
+        let napi_err = convert_error(err);
+        let err_str = napi_err.to_string();
+        assert!(err_str.contains("x.txt"), "got: {err_str}");
+        assert!(!err_str.contains("/srv/secret"), "got: {err_str}");
+    }
+
+    /// Regression test for #462: `PathTraversal`, `SymlinkEscape`, and
+    /// `HardlinkEscape` carry archive-relative, attacker-authored paths and
+    /// must keep the full path even in release builds, unlike genuinely
+    /// host-derived path variants (see the test above).
+    #[test]
+    #[cfg(not(debug_assertions))]
+    fn test_attacker_path_variants_not_redacted_in_release() {
+        let nested = PathBuf::from("nested/dir/../../etc/passwd");
+        let variants = [
+            CoreError::PathTraversal {
+                path: nested.clone(),
+            },
+            CoreError::SymlinkEscape {
+                path: nested.clone(),
+            },
+            CoreError::HardlinkEscape {
+                path: nested.clone(),
+            },
+        ];
+        for err in variants {
+            let err_str = convert_error(err).to_string();
+            assert!(
+                err_str.contains("nested/dir/../../etc/passwd"),
+                "expected full archive-relative path to survive redaction, got: {err_str}"
+            );
+        }
     }
 
     /// Regression test for #453 follow-up: `CoreError::Io` carries free-form
@@ -546,5 +549,42 @@ mod tests {
 
         let napi_err = convert_error(err);
         assert_partial_node_report(&napi_err, "SECURITY_VIOLATION", 2, 512);
+    }
+
+    /// Regression test for #463: `convert_error` binds `path` per match arm
+    /// and calls the redaction algorithm directly (S2 fix) rather than
+    /// going through `ArchiveError::redacted_path()`, so nothing at compile
+    /// time keeps the two mappings in sync. Cross-checks every path-carrying
+    /// variant's `convert_error` output against `redacted_path()` so the two
+    /// independently-maintained mappings (this file's and core's) cannot
+    /// silently drift apart.
+    #[test]
+    fn test_convert_error_paths_agree_with_redacted_path_dispatcher() {
+        let path = PathBuf::from("some/example/path.txt");
+        let variants: Vec<CoreError> = vec![
+            CoreError::PathTraversal { path: path.clone() },
+            CoreError::SymlinkEscape { path: path.clone() },
+            CoreError::HardlinkEscape { path: path.clone() },
+            CoreError::InvalidPermissions {
+                path: path.clone(),
+                mode: 0o644,
+            },
+            CoreError::SourceNotFound { path: path.clone() },
+            CoreError::SourceNotAccessible { path: path.clone() },
+            CoreError::OutputExists { path: path.clone() },
+            CoreError::UnknownFormat { path },
+        ];
+
+        for err in variants {
+            let expected = err
+                .redacted_path()
+                .expect("variant is known to carry a path");
+            let err_str = convert_error(err).to_string();
+            assert!(
+                err_str.contains(&expected),
+                "convert_error output does not agree with ArchiveError::redacted_path(): \
+                 expected {expected:?} in {err_str:?}"
+            );
+        }
     }
 }

--- a/crates/exarch-python/src/error.rs
+++ b/crates/exarch-python/src/error.rs
@@ -2,46 +2,14 @@
 
 use exarch_core::ArchiveError as CoreError;
 use exarch_core::QuotaResource as CoreQuotaResource;
+use exarch_core::format_entry_path_for_error;
+use exarch_core::sanitize_io_error_for_error;
+use exarch_core::sanitize_path_for_error;
 use pyo3::create_exception;
 use pyo3::exceptions::PyException;
 use pyo3::exceptions::PyIOError;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
-use std::path::Path;
-
-/// Sanitizes path information for error messages.
-///
-/// In debug builds, returns the full path for detailed diagnostics.
-/// In release builds, returns only the filename to avoid leaking internal
-/// directory structures to potential attackers.
-#[cfg(debug_assertions)]
-fn sanitize_path_for_error(path: &Path) -> String {
-    path.display().to_string()
-}
-
-#[cfg(not(debug_assertions))]
-fn sanitize_path_for_error(path: &Path) -> String {
-    path.file_name().map_or_else(
-        || "<unknown>".to_string(),
-        |n| n.to_string_lossy().into_owned(),
-    )
-}
-
-/// Sanitizes I/O error messages for error reporting.
-///
-/// In debug builds, returns the full `Display` output (which may embed a
-/// host path, e.g. from `DestDir`'s validation messages). In release builds,
-/// returns only the [`std::io::ErrorKind`] description, since the free-form
-/// message text has no structured path field to redact.
-#[cfg(debug_assertions)]
-fn sanitize_io_error_for_error(e: &std::io::Error) -> String {
-    e.to_string()
-}
-
-#[cfg(not(debug_assertions))]
-fn sanitize_io_error_for_error(e: &std::io::Error) -> String {
-    e.kind().to_string()
-}
 
 // Base exception for all extraction errors
 create_exception!(exarch, ArchiveError, PyException);
@@ -71,17 +39,17 @@ create_exception!(exarch, InvalidArchiveError, ArchiveError);
 pub fn convert_error(err: CoreError) -> PyErr {
     match err {
         CoreError::PathTraversal { path } => {
-            let path_str = sanitize_path_for_error(&path);
+            let path_str = format_entry_path_for_error(&path);
             PathTraversalError::new_err(format!("path traversal detected: {path_str}"))
         }
         CoreError::SymlinkEscape { path } => {
-            let path_str = sanitize_path_for_error(&path);
+            let path_str = format_entry_path_for_error(&path);
             SymlinkEscapeError::new_err(format!(
                 "symlink target outside extraction directory: {path_str}"
             ))
         }
         CoreError::HardlinkEscape { path } => {
-            let path_str = sanitize_path_for_error(&path);
+            let path_str = format_entry_path_for_error(&path);
             HardlinkEscapeError::new_err(format!(
                 "hardlink target outside extraction directory: {path_str}"
             ))
@@ -94,7 +62,7 @@ pub fn convert_error(err: CoreError) -> PyErr {
             "potential zip bomb: compressed={compressed} bytes, uncompressed={uncompressed} bytes (ratio: {ratio:.2})"
         )),
         CoreError::InvalidPermissions { path, mode } => {
-            let path_str = sanitize_path_for_error(&path);
+            let path_str = format_entry_path_for_error(&path);
             InvalidPermissionsError::new_err(format!(
                 "invalid permissions for {path_str}: {mode:#o}"
             ))
@@ -218,10 +186,10 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
-    /// Asserts the full attacker-supplied path is present, which only holds
-    /// under `debug_assertions` (see `sanitize_path_for_error`).
+    /// Asserts the full attacker-supplied path is present in both debug and
+    /// release builds — `PathTraversal` carries an archive-relative,
+    /// attacker-authored path and is never redacted (see #462).
     #[test]
-    #[cfg(debug_assertions)]
     fn test_path_traversal_conversion() {
         let err = CoreError::PathTraversal {
             path: PathBuf::from("../etc/passwd"),
@@ -240,10 +208,10 @@ mod tests {
         );
     }
 
-    /// Asserts the full path is present, which only holds under
-    /// `debug_assertions` (see `sanitize_path_for_error`).
+    /// Asserts the full path is present in both debug and release builds —
+    /// `SymlinkEscape` carries an archive-relative, attacker-authored path
+    /// and is never redacted (see #462).
     #[test]
-    #[cfg(debug_assertions)]
     fn test_symlink_escape_conversion() {
         let err = CoreError::SymlinkEscape {
             path: PathBuf::from("/etc/passwd"),
@@ -262,10 +230,10 @@ mod tests {
         );
     }
 
-    /// Asserts the full path is present, which only holds under
-    /// `debug_assertions` (see `sanitize_path_for_error`).
+    /// Asserts the full path is present in both debug and release builds —
+    /// `HardlinkEscape` carries an archive-relative, attacker-authored path
+    /// and is never redacted (see #462).
     #[test]
-    #[cfg(debug_assertions)]
     fn test_hardlink_escape_conversion() {
         let err = CoreError::HardlinkEscape {
             path: PathBuf::from("/etc/shadow"),
@@ -500,14 +468,58 @@ mod tests {
         );
     }
 
-    /// Regression test for #453 follow-up: in release builds,
-    /// `sanitize_path_for_error` must strip the path down to the filename,
-    /// not leak the full host path.
+    /// Regression test for #453 follow-up: in release builds, a
+    /// host-derived path variant must be reduced to the filename, not leak
+    /// the full host path. The redaction primitives themselves are tested
+    /// directly in `exarch_core::error::redaction`; this exercises the
+    /// binding's end-to-end `convert_error` path.
     #[test]
     #[cfg(not(debug_assertions))]
-    fn test_sanitize_path_for_error_strips_directory_in_release() {
-        let path = PathBuf::from("/srv/secret/app/x.txt");
-        assert_eq!(sanitize_path_for_error(&path), "x.txt");
+    fn test_source_not_found_strips_directory_in_release() {
+        let err = CoreError::SourceNotFound {
+            path: PathBuf::from("/srv/secret/app/x.txt"),
+        };
+        let py_err = convert_error(err);
+        let err_str = py_err.to_string();
+        assert!(
+            err_str.contains("x.txt"),
+            "Expected filename in error message, got: {}",
+            err_str
+        );
+        assert!(
+            !err_str.contains("/srv/secret"),
+            "Expected host directory to be redacted, got: {}",
+            err_str
+        );
+    }
+
+    /// Regression test for #462: `PathTraversal`, `SymlinkEscape`, and
+    /// `HardlinkEscape` carry archive-relative, attacker-authored paths and
+    /// must keep the full path even in release builds, unlike genuinely
+    /// host-derived path variants (see the test above).
+    #[test]
+    #[cfg(not(debug_assertions))]
+    fn test_attacker_path_variants_not_redacted_in_release() {
+        let nested = PathBuf::from("nested/dir/../../etc/passwd");
+        let variants = [
+            CoreError::PathTraversal {
+                path: nested.clone(),
+            },
+            CoreError::SymlinkEscape {
+                path: nested.clone(),
+            },
+            CoreError::HardlinkEscape {
+                path: nested.clone(),
+            },
+        ];
+        for err in variants {
+            let err_str = convert_error(err).to_string();
+            assert!(
+                err_str.contains("nested/dir/../../etc/passwd"),
+                "Expected full archive-relative path to survive redaction, got: {}",
+                err_str
+            );
+        }
     }
 
     /// Regression test for #453 follow-up: `CoreError::Io` carries free-form
@@ -750,5 +762,42 @@ mod tests {
 
         let py_err = convert_error(err);
         assert_partial_extraction_report::<SecurityViolationError>(&py_err, 2, 512);
+    }
+
+    /// Regression test for #463: `convert_error` binds `path` per match arm
+    /// and calls the redaction algorithm directly (S2 fix) rather than
+    /// going through `ArchiveError::redacted_path()`, so nothing at compile
+    /// time keeps the two mappings in sync. Cross-checks every path-carrying
+    /// variant's `convert_error` output against `redacted_path()` so the two
+    /// independently-maintained mappings (this file's and core's) cannot
+    /// silently drift apart.
+    #[test]
+    fn test_convert_error_paths_agree_with_redacted_path_dispatcher() {
+        let path = PathBuf::from("some/example/path.txt");
+        let variants: Vec<CoreError> = vec![
+            CoreError::PathTraversal { path: path.clone() },
+            CoreError::SymlinkEscape { path: path.clone() },
+            CoreError::HardlinkEscape { path: path.clone() },
+            CoreError::InvalidPermissions {
+                path: path.clone(),
+                mode: 0o644,
+            },
+            CoreError::SourceNotFound { path: path.clone() },
+            CoreError::SourceNotAccessible { path: path.clone() },
+            CoreError::OutputExists { path: path.clone() },
+            CoreError::UnknownFormat { path },
+        ];
+
+        for err in variants {
+            let expected = err
+                .redacted_path()
+                .expect("variant is known to carry a path");
+            let err_str = convert_error(err).to_string();
+            assert!(
+                err_str.contains(&expected),
+                "convert_error output does not agree with ArchiveError::redacted_path(): \
+                 expected {expected:?} in {err_str:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Hoists `sanitize_path_for_error`/`sanitize_io_error_for_error` — previously byte-identical, independently-maintained copies in `crates/exarch-python/src/error.rs` and `crates/exarch-node/src/error.rs`, plus a third, unused copy embedded in `ArchiveError::to_ffi_message` — into a single shared `exarch-core::error::redaction` module. Both bindings and `to_ffi_message` now call the same algorithms; a new `ArchiveError::redacted_path()` helper backs `to_ffi_message`.
- Fixes over-redaction: `PathTraversal`, `SymlinkEscape`, `HardlinkEscape`, and `InvalidPermissions` carry archive-relative, attacker-authored paths, not host paths — redacting them to filename-only in release builds hid nothing from the attacker while destroying the defender's ability to identify the offending entry in production logs. These four variants now retain the full path in both debug and release builds. `SourceNotFound`/`SourceNotAccessible`/`OutputExists`/`UnknownFormat`/`Io` are unaffected and remain redacted in release builds.
- Adds a cross-check test in both bindings asserting `convert_error`'s per-arm output agrees with `ArchiveError::redacted_path()` for every path-carrying variant, guarding against the two independently-applied variant-to-algorithm mappings silently drifting apart.

**BREAKING**: `ArchiveError::to_ffi_message` no longer takes a `sanitize_paths: bool` parameter. It had zero callers in the workspace, so this has no runtime effect on `exarch-python`/`exarch-node`, but direct Rust API consumers must drop the argument.

Closes #463
Closes #462

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` (1109 passed)
- [x] `cargo test --doc -p exarch-core --all-features` (115 passed)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace`
- [x] Release-profile redaction tests exercised manually (`cargo test --release`) for core and node, since standard debug-mode nextest doesn't hit the `cfg(not(debug_assertions))` arms and CI currently excludes both binding crates from nextest (tracked as a follow-up, see below)
- [x] `cargo deny check` / `cargo audit` clean, no new dependencies