### PR TITLE
perf(core): fix TempDir cleanup timing in ZIP extraction benchmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -274,6 +274,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   confirmation on CI hardware rather than local benchmarks (which showed >20% same-commit swings
   during this investigation).
 
+- **`many_small_files`/`file_count_scaling` benchmarks were timing `TempDir` cleanup as part of
+  extraction cost (#446)**: `benchmark_many_small_files` and `benchmark_file_count_scaling` in
+  `crates/exarch-core/benches/extraction.rs` timed `TempDir::drop()` (recursive deletion of every
+  extracted file) inside criterion's `b.iter()`, alongside the `ZipArchive::extract()` call being
+  measured — `sample` profiling attributed ~87% of the `many_small_files/10000` wall time to this
+  cleanup, not to extraction. Switched both benchmarks to `b.iter_custom`, excluding only
+  `TempDir::new()`/`drop()` from the timed window. dhat heap-allocation profiling showed
+  byte-identical allocations across the regression window, and re-measurement on the corrected
+  harness shows no residual regression vs. the ci-076 baseline: the originally reported +15.8% was
+  inflated by this harness bug on top of the real regression already addressed above by #470's
+  syscall reduction. This dev machine's benchmark noise floor (40-80% run-to-run variance under
+  shared load, observed during this investigation) still exceeds the project's 10% regression
+  threshold, and no CI workflow currently runs `cargo bench` (`bench-build` only compiles
+  benchmarks) — the "confirmation on CI hardware" noted above is not currently achievable and
+  should be read as aspirational pending a dedicated benchmark-running job, not a completed step.
+
 ### Security
 
 - **Dangling symlink at the extraction destination bypassed the duplicate-check and allowed

--- a/crates/exarch-core/benches/extraction.rs
+++ b/crates/exarch-core/benches/extraction.rs
@@ -33,6 +33,8 @@ use exarch_core::formats::traits::ArchiveFormat;
 use std::io::Cursor;
 use std::io::Write;
 use std::path::PathBuf;
+use std::time::Duration;
+use std::time::Instant;
 use tempfile::TempDir;
 use zip::write::SimpleFileOptions;
 use zip::write::ZipWriter;
@@ -237,18 +239,27 @@ fn benchmark_many_small_files(c: &mut Criterion) {
             BenchmarkId::from_parameter(file_count),
             &zip_data,
             |b, data| {
-                b.iter(|| {
-                    let temp = TempDir::new().unwrap();
-                    let cursor = Cursor::new(data.clone());
-                    let mut archive = ZipArchive::new(cursor).unwrap();
-                    archive
-                        .extract(
-                            temp.path(),
-                            &SecurityConfig::default().validate().unwrap(),
-                            &ExtractionOptions::default(),
-                            &mut exarch_core::NoopProgress,
-                        )
-                        .unwrap();
+                b.iter_custom(|iters| {
+                    let mut total = Duration::ZERO;
+                    for _ in 0..iters {
+                        let temp = TempDir::new().unwrap();
+
+                        let start = Instant::now();
+                        let cursor = Cursor::new(data.clone());
+                        let mut archive = ZipArchive::new(cursor).unwrap();
+                        archive
+                            .extract(
+                                temp.path(),
+                                &SecurityConfig::default().validate().unwrap(),
+                                &ExtractionOptions::default(),
+                                &mut exarch_core::NoopProgress,
+                            )
+                            .unwrap();
+                        total += start.elapsed();
+
+                        drop(temp);
+                    }
+                    total
                 });
             },
         );
@@ -490,18 +501,27 @@ fn benchmark_file_count_scaling(c: &mut Criterion) {
         group.throughput(Throughput::Elements(count_u64));
         group.bench_with_input(BenchmarkId::new("files", count), &zip_data, |b, data| {
             let config = SecurityConfig::default().validate().unwrap();
-            b.iter(|| {
-                let temp = TempDir::new().unwrap();
-                let cursor = Cursor::new(data.clone());
-                let mut archive = ZipArchive::new(cursor).unwrap();
-                archive
-                    .extract(
-                        temp.path(),
-                        &config,
-                        &ExtractionOptions::default(),
-                        &mut exarch_core::NoopProgress,
-                    )
-                    .unwrap();
+            b.iter_custom(|iters| {
+                let mut total = Duration::ZERO;
+                for _ in 0..iters {
+                    let temp = TempDir::new().unwrap();
+
+                    let start = Instant::now();
+                    let cursor = Cursor::new(data.clone());
+                    let mut archive = ZipArchive::new(cursor).unwrap();
+                    archive
+                        .extract(
+                            temp.path(),
+                            &config,
+                            &ExtractionOptions::default(),
+                            &mut exarch_core::NoopProgress,
+                        )
+                        .unwrap();
+                    total += start.elapsed();
+
+                    drop(temp);
+                }
+                total
             });
         });
     }


### PR DESCRIPTION
## Summary

- `benchmark_many_small_files` and `benchmark_file_count_scaling` in `crates/exarch-core/benches/extraction.rs` timed `TempDir::drop()` (recursive deletion of every extracted file) inside criterion's `b.iter()`, alongside the `ZipArchive::extract()` call being measured. Profiling with `sample` attributed ~87% of the `many_small_files/10000` wall time to this cleanup, not to extraction.
- Switched both benchmarks to `b.iter_custom`, excluding only `TempDir::new()`/`drop()` from the timed window. `data.clone()`, `ZipArchive::new()` (central-directory parse, including the `is_password_protected` scan), and config validation all stay inside the timed region, matching what the original `b.iter()` closure measured, so historical comparability is preserved modulo just the cleanup bug.
- dhat heap-allocation profiling showed byte-identical allocations across the regression window, and re-measurement on the corrected harness shows no residual regression vs. the ci-076 baseline.

## Root cause and framing

The +15.8% figure reported in #446 was inflated by this harness bug. The underlying regression at the commit #446 originally measured was plausibly real and was independently fixed by #470 (a separate, already-merged PR that folded a duplicate-existence `exists()` stat into the file-creation `open()` call via `O_EXCL`/`create_new`, a genuine syscall reduction recorded as -8.9%/-8.3% via a paired same-session `criterion --save-baseline` A/B in `benchmarks.md`). This PR fixes the harness on its own merits — it was measuring the wrong thing regardless of whether a regression is currently present.

This dev machine's benchmark noise floor (40-80% run-to-run variance observed under shared load during this investigation) still exceeds the project's 10% regression-detection threshold, and no CI workflow currently runs `cargo bench` (`bench-build` only compiles benchmarks). So this PR does not claim to have "confirmed" the regression is fully resolved on trustworthy hardware — only that the harness itself is now measuring the right thing, and that no regression is visible once the cleanup-timing bug is removed.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` (1109/1109 passed)
- [x] `cargo test --doc -p exarch-core -p exarch-cli --all-features` (115/115 passed; `exarch-python` doc-test excluded due to a pre-existing local Python-linking issue unrelated to this diff)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace` (clean; pre-existing private-item-link warnings unrelated to this diff)
- [x] `cargo bench -p exarch-core --bench extraction -- many_small_files file_count_scaling` re-run on the corrected harness

Closes #446