### PR TITLE
ci: run release-profile and binding-crate tests; fix: 7z dangling-symlink duplicate check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,38 @@ jobs:
       - name: Run doctests
         run: cargo test --doc --workspace --all-features --exclude exarch-python --exclude exarch-node
 
+  # Release-profile tests for exarch-core: exercises cfg(not(debug_assertions))
+  # tests (e.g. release-only redaction/security assertions) that the debug-mode
+  # `test` job above never runs (see #476).
+  test-release:
+    name: Test (release profile)
+    needs: [changes, format]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    if: |
+      needs.changes.outputs.rust == 'true' ||
+      github.ref == 'refs/heads/main' ||
+      github.ref == 'refs/heads/develop'
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "test-release"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Install nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+
+      - name: Run release-profile tests (exarch-core)
+        run: cargo nextest run -p exarch-core --release --all-features --no-fail-fast
+
   # Test Python bindings with coverage
   test-python:
     name: Test Python ${{ matrix.python-version }}
@@ -259,6 +291,9 @@ jobs:
         run: |
           cd crates/exarch-python
           uv pip install --system maturin "ruff==0.16.0" mypy pytest pytest-cov
+
+      - name: Run Rust unit tests (exarch-python)
+        run: cargo test -p exarch-python --lib --no-default-features
 
       - name: Format check with ruff
         run: |
@@ -345,6 +380,9 @@ jobs:
         run: |
           cd crates/exarch-node
           npm install
+
+      - name: Run Rust unit tests (exarch-node)
+        run: cargo test -p exarch-node --lib
 
       - name: Format check with Biome
         run: |
@@ -470,7 +508,7 @@ jobs:
   # All checks passed
   ci-success:
     name: CI Success
-    needs: [format, clippy, documentation, security, test, test-python, test-node, msrv, bench-build]
+    needs: [format, clippy, documentation, security, test, test-release, test-python, test-node, msrv, bench-build]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -483,6 +521,7 @@ jobs:
             "${{ needs.documentation.result }}"
             "${{ needs.security.result }}"
             "${{ needs.test.result }}"
+            "${{ needs.test-release.result }}"
             "${{ needs.test-python.result }}"
             "${{ needs.test-node.result }}"
             "${{ needs.msrv.result }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,6 +176,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`exarch-core`: 7z `skip_duplicates` check missed a dangling symlink at the destination path
+  (#468)**: `dest_path.exists()` follows symlinks and returns `false` for a dangling symlink, so a
+  pre-existing dangling symlink occupying an entry's destination silently passed the duplicate
+  check instead of being detected. With `skip_duplicates = true` the entry is now correctly skipped
+  rather than silently replacing the symlink; with `skip_duplicates = false`, this check's own
+  destination is still replaced via `rename` rather than followed, so this specific check is not a
+  symlink-escape vector (unlike TAR/ZIP, which hard-fail via `O_NOFOLLOW` here — that cross-format
+  divergence is tracked separately in #477). This is unrelated to the temp-file creation step
+  earlier in the same write path, which is a separate, open symlink-escape vector tracked as #471.
+  Replaced the check with `dest_path.symlink_metadata().is_ok()`, matching the same simplification
+  applied to `formats::common::create_symlink`'s equivalent duplicate check.
 - **`sanitize_path_for_error`/`sanitize_io_error_for_error` duplicated verbatim across bindings
   (plus a third, unused copy in `exarch-core` itself), and over-redacted attacker-authored paths
   (#463, #462)**: the profile-gated redaction helpers added by #453 were byte-identical,

--- a/crates/exarch-core/src/formats/common.rs
+++ b/crates/exarch-core/src/formats/common.rs
@@ -729,7 +729,7 @@ pub fn create_symlink(
         // Create parent directories using cache
         dir_cache.ensure_parent_dir(&link_path)?;
 
-        if link_path.exists() || link_path.symlink_metadata().is_ok() {
+        if link_path.symlink_metadata().is_ok() {
             if skip_duplicates {
                 report.files_skipped += 1;
                 report.warnings.push(format!(

--- a/crates/exarch-core/src/formats/sevenz.rs
+++ b/crates/exarch-core/src/formats/sevenz.rs
@@ -388,7 +388,7 @@ impl<R: Read + Seek> SevenZArchive<R> {
             ValidatedEntryType::File(permit) => {
                 dir_cache.ensure_parent_dir(&dest_path)?;
 
-                if dest_path.exists() {
+                if dest_path.symlink_metadata().is_ok() {
                     if skip_duplicates {
                         report.files_skipped += 1;
                         report.warnings.push(format!(
@@ -1710,5 +1710,88 @@ mod tests {
             "callback re-validation must independently reject a traversal entry via its own \
              validate_entry call, got: {result:?}"
         );
+    }
+
+    /// Issue #468: `Path::exists()` follows symlinks and returns `false` for
+    /// a dangling symlink, so the old `dest_path.exists()` check silently
+    /// missed a pre-existing dangling symlink occupying the entry's
+    /// destination path. With `skip_duplicates` true, the entry must be
+    /// detected as a duplicate and skipped, leaving the dangling symlink in
+    /// place instead of being silently replaced.
+    #[test]
+    #[cfg(unix)]
+    fn test_skip_duplicates_detects_dangling_symlink_at_destination() {
+        let data = make_sevenz_archive(&[("target.txt", b"payload")]);
+        let mut archive = SevenZArchive::new(Cursor::new(data)).unwrap();
+
+        let temp = TempDir::new().unwrap();
+        let link_path = temp.path().join("target.txt");
+        std::os::unix::fs::symlink(temp.path().join("does-not-exist"), &link_path).unwrap();
+        assert!(
+            !link_path.exists(),
+            "sanity check: dangling symlink must be invisible to exists()"
+        );
+
+        let config = SecurityConfig::default().validate().expect("valid config");
+        let report = archive
+            .extract(
+                temp.path(),
+                &config,
+                &ExtractionOptions::default(), // skip_duplicates = true
+                &mut crate::NoopProgress,
+            )
+            .unwrap();
+
+        assert_eq!(
+            report.files_skipped, 1,
+            "entry must be skipped as a duplicate of the dangling symlink"
+        );
+        assert_eq!(report.files_extracted, 0);
+        let metadata = std::fs::symlink_metadata(&link_path).unwrap();
+        assert!(
+            metadata.file_type().is_symlink(),
+            "dangling symlink must survive untouched, not be replaced by extracted content"
+        );
+    }
+
+    /// Characterization test, not a regression test for #468: this
+    /// `skip_duplicates = false` path passes identically on the pre-fix
+    /// code too, since `dest_path.exists()` is `false` for a dangling
+    /// symlink either way — the `if` block (and its `is_dir()`/
+    /// `remove_file` duplicate-removal logic) is never entered pre-fix.
+    /// The write still succeeds pre-fix because `write_file_with_permit`'s
+    /// temp-file + `rename` replaces whatever sits at `dest_path`, symlink
+    /// or not, without following it. It documents that this behavior is
+    /// unaffected by the #468 fix — 7z silently replaces a pre-existing
+    /// symlink here, unlike TAR/ZIP which hard-fail via `O_NOFOLLOW`/
+    /// `ELOOP` in `create_file_with_mode`. That cross-format divergence is
+    /// tracked separately in #477.
+    #[test]
+    #[cfg(unix)]
+    fn test_duplicate_replaces_dangling_symlink_when_not_skipping() {
+        let data = make_sevenz_archive(&[("target.txt", b"payload")]);
+        let mut archive = SevenZArchive::new(Cursor::new(data)).unwrap();
+
+        let temp = TempDir::new().unwrap();
+        let link_path = temp.path().join("target.txt");
+        std::os::unix::fs::symlink(temp.path().join("does-not-exist"), &link_path).unwrap();
+
+        let config = SecurityConfig::default().validate().expect("valid config");
+        let options = ExtractionOptions {
+            skip_duplicates: false,
+            ..ExtractionOptions::default()
+        };
+        let report = archive
+            .extract(temp.path(), &config, &options, &mut crate::NoopProgress)
+            .unwrap();
+
+        assert_eq!(report.files_extracted, 1);
+        assert_eq!(report.files_skipped, 0);
+        let metadata = std::fs::symlink_metadata(&link_path).unwrap();
+        assert!(
+            !metadata.file_type().is_symlink(),
+            "dangling symlink must be replaced by the extracted file"
+        );
+        assert_eq!(std::fs::read(&link_path).unwrap(), b"payload");
     }
 }

--- a/crates/exarch-python/Cargo.toml
+++ b/crates/exarch-python/Cargo.toml
@@ -19,10 +19,17 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 exarch-core.workspace = true
-pyo3 = { workspace = true, features = ["extension-module"] }
+pyo3.workspace = true
 
 [features]
-default = []
+# Enabled by default so plain `cargo build`/`maturin develop` behave as
+# before. Disable it (`--no-default-features`) to run `cargo test --lib`:
+# extension-module tells pyo3 to expect the host process (the Python
+# interpreter) to provide libpython symbols at dlopen time, which a
+# standalone test binary cannot satisfy — see PyO3's user guide section on
+# testing extension modules.
+default = ["extension-module"]
+extension-module = ["pyo3/extension-module"]
 abi3 = ["pyo3/abi3-py39"]
 # Exposes `_trigger_panic_for_testing()`, a deliberate-panic hook used by the
 # #395 regression test to verify the catch_unwind -> PyRuntimeError

--- a/crates/exarch-python/src/report.rs
+++ b/crates/exarch-python/src/report.rs
@@ -898,8 +898,9 @@ mod tests {
 
         assert_eq!(
             py_issue.severity(),
-            "Critical",
-            "severity should be Critical"
+            "CRITICAL",
+            "severity() forwards IssueSeverity's Display impl, which renders upper-case \
+             (matches exarch-cli and exarch-node's own convention)"
         );
         assert_eq!(
             py_issue.message(),
@@ -913,8 +914,9 @@ mod tests {
         );
         assert_eq!(
             py_issue.category(),
-            "PathTraversal",
-            "category should be PathTraversal"
+            "Path Traversal",
+            "category() forwards IssueCategory's Display impl (matches exarch-cli's JSON output \
+             and exarch-node's own convention)"
         );
         assert!(py_issue.context().is_some(), "context should be Some");
     }


### PR DESCRIPTION
## Summary

Two independent, unrelated fixes bundled into one PR per triage grouping decision.

- **CI (#476)**: the nextest job only ran in debug mode and excluded `exarch-python`/`exarch-node`, so every `cfg(not(debug_assertions))` test (including release-only redaction/security assertions from #453/#461/#475) and every Rust unit test inside the binding crates never ran automatically. Adds a `test-release` job for `exarch-core`, and `cargo test --lib` steps to the existing node/python jobs.
- **Bug fix (#468)**: 7z's `skip_duplicates` check used `Path::exists()`, which follows symlinks and returns `false` for a pre-existing dangling symlink at an entry's destination, silently letting it be replaced instead of detected as a duplicate. Fixed to `symlink_metadata()` (lstat).

## Necessary supporting changes

Enabling `exarch-python`'s lib tests in CI required gating pyo3's `extension-module` feature behind a default-on crate feature (a standalone test binary has no libpython to satisfy its dlopen-time symbol resolution) — this also surfaced a pre-existing test bug (wrong-case string literal assertions) that was invisible until the crate's test binary could link for the first time. Both fixed; without them the new CI job would have been red from day one.

## Explicitly out of scope (filed as separate follow-ups during review)

- #471 (P0, already open): a real symlink-write-escape in 7z's temp-file creation step — different root cause, not touched here.
- #467 (P0, already open): TAR hardlink path symlink escape — different format handler.
- #477 (P2, filed this cycle): 7z's `skip_duplicates=false` silently replaces a pre-existing symlink where TAR/ZIP hard-fail via `O_NOFOLLOW` — documented, not fixed here.
- #478 (P3, filed this cycle): 7z reserves quota before the `skip_duplicates` check, so skipped entries burn quota — pre-existing pattern, worsened but not introduced by this fix.

Closes #476
Closes #468

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` (1111 pass)
- [x] `cargo test --doc --workspace --all-features`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace`
- [x] `cargo test -p exarch-python --lib --no-default-features` (70/70)
- [x] `cargo test -p exarch-node --lib` (140/140)
- [x] `fy lint .github/workflows/ci.yml` (0 errors)
- [x] New regression + characterization tests for the sevenz dangling-symlink fix
- [x] Independent adversarial critique (2 rounds) and security audit passes, both approved