### PR TITLE
fix(core): close symlink write-through in 7z temp-files and TAR hardlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -362,6 +362,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **A pre-planted symlink at a predictable/checked destination path bypassed a `Path::exists()`-style
+  duplicate check, and the subsequent non-exclusive write followed it outside the extraction root
+  (#471, #467)**: two more instances of the vulnerability class fixed for TAR/ZIP's normal-file
+  write path in #459 below, found in the two write paths that fix did not cover. In 7z's
+  `write_file_with_permit` (`formats/sevenz.rs`), the temp-file-then-rename write path derived its
+  temp file name from the process PID and a per-process monotonic counter — predictable — and opened
+  it with a plain `File::create`, which follows an existing symlink (dangling or not) instead of
+  refusing it; fixed by opening with `OpenOptions::create_new`, retrying with a fresh counter value
+  on `AlreadyExists` up to `MAX_TEMP_FILE_CREATE_ATTEMPTS` (8) times. In TAR's `create_hardlink`
+  (`formats/tar.rs`), `Path::exists()` returns `false` for a dangling symlink at the hardlink's
+  destination, so a pre-planted one bypassed the duplicate-detection check entirely, and the
+  subsequent `std::fs::copy` followed it; fixed by opening the destination with
+  `OpenOptions::create_new` first — folding the duplicate check into the `open()` call itself — then
+  copying the hardlink target's content into the already-open handle via a new
+  `common::copy_file_content_with_permit`, which replaces the now-removed path-based
+  `common::copy_file_with_permit`. Both fixes share a new `common::TempFileGuard` RAII cleanup type
+  (hoisted out of `formats/sevenz.rs`, previously private to that module) so a fallible step between
+  file creation and the operation's success point does not leave a partial artifact behind on the
+  error path. Both preconditions require an attacker-writable destination directory, not a malicious
+  archive alone. `create_hardlink`'s *read* side had a narrower version of the same class: hardlink
+  targets are validated for containment in a first pass (`HardlinkTracker::validate_hardlink`,
+  resolving on-disk symlinks as of that point in time) but the two-pass design defers actually
+  reading the target to a later, second pass with nothing re-validating it in between — a plain
+  path-based `File::open`/`std::fs::metadata` in that second pass would silently follow whatever
+  ended up at the target path by then, which an attacker with write access to the destination could
+  swap out after the first pass validated it (TOCTOU, not an unconditional read: a symlink present
+  *before* the first pass runs is already rejected there, per #116). The same path-based `stat`
+  also left quota sizing vulnerable to the same swap, independent of the read TOCTOU (bypassing
+  #426's per-hardlink accounting). Both are closed by a new `common::open_no_follow`, which opens
+  the target exactly once with `O_NOFOLLOW` (Unix), so any symlink present by the second pass
+  fails the open instead of being followed; `copy_file_content_with_permit` now takes that
+  already-open handle instead of a path, and the quota reservation is sized from the same handle's
+  `fstat` rather than a separate `stat` call. A symlink at the target is not automatically treated
+  as an attack, since it is a legitimate archive shape for a hardlink's target to be a symlink
+  created earlier in the same extraction (already first-pass-validated): on `open_no_follow`
+  returning `ELOOP`, `create_hardlink` re-runs the first pass's own `resolve_through_symlinks`
+  containment check against the current on-disk state and, if it still resolves inside the
+  destination, opens the resolved path instead of failing outright.
 - **Dangling symlink at the extraction destination bypassed the duplicate-check and allowed
   writing outside the destination root (#459, pre-existing, TAR and ZIP)**: the duplicate-existence
   check used `Path::exists()`, which follows symlinks and returns `false` for a dangling one. A

--- a/crates/exarch-core/src/formats/common.rs
+++ b/crates/exarch-core/src/formats/common.rs
@@ -9,6 +9,11 @@
 //! - [`extract_file_with_permit`]: Generic file extraction with buffered I/O
 //! - [`create_directory`]: Directory creation (idempotent)
 //! - [`create_symlink`]: Symbolic link creation (Unix only)
+//! - [`open_no_follow`]: Read-only open that refuses to follow a symlink
+//! - [`is_filesystem_loop_error`]: Detects the `ELOOP` error `open_no_follow`
+//!   produces
+//! - [`copy_file_content_with_permit`]: Hardlink content copy between
+//!   already-open source/destination handles
 //! - [`check_extension_allowed`]: Extension allowlist filtering
 
 use rustc_hash::FxHashSet;
@@ -437,7 +442,7 @@ pub fn check_extension_allowed(
 /// component is a symlink on any branch.
 #[inline]
 #[cfg(unix)]
-fn create_file_with_mode(
+pub fn create_file_with_mode(
     path: &Path,
     mode: Option<u32>,
     create_new: bool,
@@ -499,7 +504,7 @@ fn create_file_with_mode(
 /// exists.
 #[inline]
 #[cfg(not(unix))]
-fn create_file_with_mode(
+pub fn create_file_with_mode(
     path: &Path,
     _mode: Option<u32>,
     create_new: bool,
@@ -757,18 +762,150 @@ pub fn create_symlink(
     }
 }
 
-/// Copies a hardlink target's bytes to a new inode, consuming the
-/// [`QuotaPermit`] that authorized the copy.
+/// Opens `path` for reading, refusing to follow a symlink at its final path
+/// component.
+///
+/// # Security - Hardlink-Target TOCTOU Rejection (issue #467)
+///
+/// A hardlink's target is validated for containment in an earlier pass
+/// (`HardlinkTracker::validate_hardlink`, resolving on-disk symlinks as of
+/// that point in time) but nothing re-validates it by the time a later pass
+/// actually reads it — a plain `File::open` at that point would silently
+/// follow whatever is at the target path *then*, which given an
+/// attacker-writable destination directory may no longer be what the
+/// earlier pass validated. On Unix, this is closed with `O_NOFOLLOW`: the
+/// open fails instead of following a symlink planted or swapped in at the
+/// target path since. Callers should reserve quota and copy from the
+/// returned handle rather than re-opening `path`, to avoid a TOCTOU window
+/// between a path-based size check and a separate path-based read. A symlink
+/// at `path` is not automatically an attack, though — see
+/// [`resolve_through_symlinks`](crate::types::safe_symlink::resolve_through_symlinks)
+/// for the re-validation callers should perform on `ErrorKind::FilesystemLoop`
+/// before treating it as one.
+///
+/// This mitigation is Unix-only: non-Unix platforms have no `O_NOFOLLOW`
+/// equivalent wired up here, so the TOCTOU window this closes on Unix
+/// remains open on those platforms.
+///
+/// # Errors
+///
+/// Returns an I/O error if `path` does not exist, is a symlink (Unix only,
+/// via `ELOOP`), or otherwise cannot be opened for reading.
+pub fn open_no_follow(path: &Path) -> std::io::Result<File> {
+    let mut opts = std::fs::OpenOptions::new();
+    opts.read(true);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.custom_flags(libc::O_NOFOLLOW);
+    }
+
+    opts.open(path)
+}
+
+/// Returns `true` if `error` is the "too many levels of symbolic links"
+/// error (`ELOOP` on Unix) that [`open_no_follow`] produces when its final
+/// path component is a symlink.
+///
+/// `std::io::ErrorKind::FilesystemLoop` exists for exactly this case but is
+/// not yet stable (`io_error_more`, rust-lang/rust#86442 as of this crate's
+/// MSRV), so this compares the raw OS error code directly on Unix. Always
+/// `false` on non-Unix, since [`open_no_follow`] has no `O_NOFOLLOW`
+/// equivalent there and cannot produce this specific error.
+#[must_use]
+pub fn is_filesystem_loop_error(error: &std::io::Error) -> bool {
+    #[cfg(unix)]
+    {
+        error.raw_os_error() == Some(libc::ELOOP)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = error;
+        false
+    }
+}
+
+/// Copies a hardlink target's bytes from an already-open source handle into
+/// an already-open destination handle, consuming the [`QuotaPermit`] that
+/// authorized the copy.
 ///
 /// Taking `permit` by value ensures a reservation can be spent at most once:
 /// `QuotaPermit` is neither `Clone` nor `Copy`, so the caller cannot retain
 /// it to pass to a second copy.
 ///
+/// # Security - Symlink Rejection and Quota TOCTOU (issue #467)
+///
+/// Unlike `std::fs::copy(from, to)`, both `from` and `to` are already-open
+/// [`File`] handles rather than paths. Callers obtain `to` via
+/// `OpenOptions::create_new` (refusing to create through a pre-existing
+/// destination path, symlink or not) and `from` via [`open_no_follow`]
+/// (refusing to follow a symlink at the source path), and reserve quota from
+/// `from`'s already-open `fstat`, not a separate path-based `stat`. Passing
+/// paths instead would both re-expose the symlink-follow read this function
+/// exists to prevent, and reopen a TOCTOU window where the reserved size and
+/// the actually-copied bytes come from two different filesystem objects.
+///
+/// On Unix, `from`'s permission bits are copied to `to` afterward, matching
+/// `std::fs::copy`'s behavior. `from`'s permissions were already sanitized
+/// when the target file was extracted as a regular file (setuid/setgid
+/// stripped), so re-applying them to the brand-new `to` here does not
+/// reintroduce anything unsanitized.
+///
 /// # Errors
 ///
-/// Returns an I/O error if the copy fails.
-pub fn copy_file_with_permit(from: &Path, to: &Path, _permit: QuotaPermit) -> std::io::Result<u64> {
-    std::fs::copy(from, to)
+/// Returns an I/O error if the copy or (on Unix) applying permissions fails.
+pub fn copy_file_content_with_permit(
+    mut from: File,
+    mut to: File,
+    _permit: QuotaPermit,
+) -> std::io::Result<u64> {
+    let bytes_copied = std::io::copy(&mut from, &mut to)?;
+
+    #[cfg(unix)]
+    {
+        let permissions = from.metadata()?.permissions();
+        to.set_permissions(permissions)?;
+    }
+
+    Ok(bytes_copied)
+}
+
+/// RAII guard that removes a file at `path` when dropped, unless [`persist`]
+/// was called first.
+///
+/// Shared between TAR's hardlink-content copy and 7z's temp-file-then-rename
+/// write path so a fallible step between file creation and the operation's
+/// success point (quota reservation, the copy itself) does not leave a
+/// partial artifact behind on the error path.
+///
+/// [`persist`]: TempFileGuard::persist
+pub struct TempFileGuard {
+    path: PathBuf,
+    should_cleanup: bool,
+}
+
+impl TempFileGuard {
+    /// Creates a new guard that will remove `path` on drop.
+    pub fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            should_cleanup: true,
+        }
+    }
+
+    /// Marks the file as successfully processed, preventing cleanup on drop.
+    pub fn persist(mut self) {
+        self.should_cleanup = false;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if self.should_cleanup {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/exarch-core/src/formats/sevenz.rs
+++ b/crates/exarch-core/src/formats/sevenz.rs
@@ -106,6 +106,16 @@ use sevenz_rust2::Password;
 // Atomic counter for generating unique temporary file names
 static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
+/// Maximum number of attempts to create a uniquely-named temp file before
+/// giving up.
+///
+/// Bounds retry cost if an attacker has pre-planted symlinks at several
+/// predicted `.{name}.exarch-tmp-{pid}-{counter}` paths (issue #471); a
+/// genuine collision from concurrent extraction into the same directory
+/// resolves on the first or second attempt since `TEMP_COUNTER` is
+/// monotonically increasing per process.
+const MAX_TEMP_FILE_CREATE_ATTEMPTS: u32 = 8;
+
 use crate::ArchiveError;
 use crate::ExtractionOptions;
 use crate::ExtractionReport;
@@ -123,36 +133,6 @@ use crate::types::EntryType;
 
 use super::common;
 use super::traits::ArchiveFormat;
-
-/// RAII guard for temporary files.
-/// Ensures temp files are cleaned up on error.
-struct TempFileGuard {
-    path: PathBuf,
-    should_cleanup: bool,
-}
-
-impl TempFileGuard {
-    fn new(path: PathBuf) -> Self {
-        Self {
-            path,
-            should_cleanup: true,
-        }
-    }
-
-    /// Mark the temp file as successfully processed.
-    /// Prevents cleanup on drop.
-    fn persist(mut self) {
-        self.should_cleanup = false;
-    }
-}
-
-impl Drop for TempFileGuard {
-    fn drop(&mut self) {
-        if self.should_cleanup {
-            let _ = std::fs::remove_file(&self.path);
-        }
-    }
-}
 
 /// Cached entry metadata from initial archive read.
 /// Avoids re-parsing archive during extraction.
@@ -297,34 +277,98 @@ impl<R: Read + Seek> SevenZArchive<R> {
 /// consuming the [`QuotaPermit`] that authorized the write.
 ///
 /// Taking `permit` by value mirrors the guarantee
-/// [`common::copy_file_with_permit`] gives TAR's hardlink path, and the
-/// guarantee [`common::extract_file_with_permit`] gives TAR/ZIP's normal-file
-/// path (issue #445): `QuotaPermit` is neither `Clone` nor `Copy`, so a
-/// caller cannot retain it to authorize a second write, and this function
-/// cannot be called at all without moving a genuine permit out of the
-/// validated entry.
+/// [`common::copy_file_content_with_permit`] gives TAR's hardlink path, and
+/// the guarantee [`common::extract_file_with_permit`] gives TAR/ZIP's
+/// normal-file path (issue #445): `QuotaPermit` is neither `Clone` nor
+/// `Copy`, so a caller cannot retain it to authorize a second write, and this
+/// function cannot be called at all without moving a genuine permit out of
+/// the validated entry.
+///
+/// # Security - Symlink-at-Destination Rejection (issue #471)
+///
+/// The temp file name is predictable from the process PID and a per-process
+/// monotonic counter, so a pre-planted symlink (dangling or not) at a
+/// predicted temp path used to be silently followed by `File::create`,
+/// writing archive content outside the extraction root. The temp file is
+/// now opened via `common::create_file_with_mode` (mode `None`, since 7z
+/// never exposes a Unix mode to sanitize) with `create_new = true`, reusing
+/// the same `O_EXCL`+`O_NOFOLLOW` (Unix) discipline as the normal-file write
+/// path (issue #459) for consistency, though `create_new`'s `O_EXCL` alone
+/// already refuses any pre-existing path instead of following it. On
+/// collision (`ErrorKind::AlreadyExists`), a fresh counter value is drawn
+/// and creation is retried up to [`MAX_TEMP_FILE_CREATE_ATTEMPTS`] times.
 ///
 /// # Errors
 ///
-/// Returns an error if temp file creation, the copy, or the rename fails.
+/// Returns an error if a unique temp file cannot be created within
+/// [`MAX_TEMP_FILE_CREATE_ATTEMPTS`] attempts, or if the copy or rename
+/// fails.
 fn write_file_with_permit(
     reader: &mut dyn Read,
     dest_path: &Path,
-    _permit: QuotaPermit,
+    permit: QuotaPermit,
 ) -> std::result::Result<u64, sevenz_rust2::Error> {
-    let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
     let pid = id();
     let original_name = dest_path
         .file_name()
         .map_or_else(|| "file".to_string(), |n| n.to_string_lossy().to_string());
-    let temp_name = format!(".{original_name}.exarch-tmp-{pid}-{counter}");
-    let temp_path = dest_path.with_file_name(&temp_name);
 
-    let temp_guard = TempFileGuard::new(temp_path.clone());
-    let bytes_written = {
-        let mut temp_file = std::fs::File::create(&temp_path)?;
-        std::io::copy(reader, &mut temp_file)?
-    };
+    write_file_with_permit_using(reader, dest_path, permit, || {
+        let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let temp_name = format!(".{original_name}.exarch-tmp-{pid}-{counter}");
+        dest_path.with_file_name(&temp_name)
+    })
+}
+
+/// Implementation behind [`write_file_with_permit`], parameterized over the
+/// candidate temp-path generator.
+///
+/// Tests inject a private, non-shared generator here instead of calling
+/// [`write_file_with_permit`] directly, so that predicting which paths a
+/// test run will attempt never depends on the process-global
+/// [`TEMP_COUNTER`] — a global shared with every other test in the same
+/// binary that also happens to write a 7z file, and therefore not something
+/// a single test can safely predict under `cargo test`'s default
+/// multi-threaded execution (only nextest's one-test-per-process model would
+/// make that safe).
+///
+/// # Errors
+///
+/// Returns an error if a unique temp file cannot be created within
+/// [`MAX_TEMP_FILE_CREATE_ATTEMPTS`] attempts, or if the copy or rename
+/// fails.
+fn write_file_with_permit_using(
+    reader: &mut dyn Read,
+    dest_path: &Path,
+    _permit: QuotaPermit,
+    mut next_candidate_path: impl FnMut() -> PathBuf,
+) -> std::result::Result<u64, sevenz_rust2::Error> {
+    let mut created: Option<(PathBuf, std::fs::File)> = None;
+    for _ in 0..MAX_TEMP_FILE_CREATE_ATTEMPTS {
+        let candidate_path = next_candidate_path();
+
+        match common::create_file_with_mode(&candidate_path, None, true) {
+            Ok(file) => {
+                created = Some((candidate_path, file));
+                break;
+            }
+            Err(e) if e.kind() == ErrorKind::AlreadyExists => {}
+            Err(e) => return Err(e.into()),
+        }
+    }
+
+    let (temp_path, mut temp_file) = created.ok_or_else(|| {
+        std::io::Error::new(
+            ErrorKind::AlreadyExists,
+            format!(
+                "failed to create a unique temp file for {} after {MAX_TEMP_FILE_CREATE_ATTEMPTS} attempts",
+                dest_path.display()
+            ),
+        )
+    })?;
+
+    let temp_guard = common::TempFileGuard::new(temp_path.clone());
+    let bytes_written = std::io::copy(reader, &mut temp_file)?;
     std::fs::rename(&temp_path, dest_path)?;
     temp_guard.persist();
 
@@ -878,6 +922,123 @@ mod tests {
         let data = load_fixture("simple.7z");
         assert!(!data.is_empty());
         assert_eq!(&data[0..6], &SEVENZ_MAGIC);
+    }
+
+    /// Reserves a throwaway [`QuotaPermit`] for use in tests that call
+    /// `write_file_with_permit` directly, bypassing the normal validation
+    /// pipeline that would otherwise produce one.
+    fn test_permit() -> QuotaPermit {
+        let config = SecurityConfig::default().validate().expect("valid config");
+        crate::security::quota::QuotaTracker::new()
+            .reserve(0, &config)
+            .expect("reservation should succeed")
+    }
+
+    /// Regression test for issue #471: `write_file_with_permit`'s temp file
+    /// name is predictable from the process PID and a per-process monotonic
+    /// counter (`.{name}.exarch-tmp-{pid}-{counter}`). A dangling symlink
+    /// pre-planted at one of the next few predicted counter values used to
+    /// be silently followed by a non-exclusive `File::create`, writing
+    /// archive content through it and outside the extraction root. The fix
+    /// retries with a fresh counter value on `AlreadyExists` instead of
+    /// falling through to a non-exclusive open.
+    ///
+    /// Exercises [`write_file_with_permit_using`] directly with a private,
+    /// test-local candidate generator instead of calling
+    /// [`write_file_with_permit`] (which draws from the process-global
+    /// [`TEMP_COUNTER`]): predicting exactly which paths a call will attempt
+    /// is only safe if nothing else in the process can advance that counter
+    /// concurrently, which does not hold under `cargo test`'s default
+    /// multi-threaded execution (sibling tests write 7z files too). A
+    /// private generator has no shared state to race on, so this test is
+    /// deterministic under both `cargo test` and nextest (see #471 review).
+    #[test]
+    #[cfg(unix)]
+    fn test_write_file_with_permit_skips_planted_symlinks() {
+        let temp = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let dest_path = temp.path().join("real-output.txt");
+
+        // Plant dangling symlinks at every candidate path the generator
+        // below will produce, except the last available attempt, so the fix
+        // must retry past all of them.
+        let mut victims = Vec::new();
+        for offset in 0..(MAX_TEMP_FILE_CREATE_ATTEMPTS - 1) {
+            let planted_path = temp.path().join(format!(".candidate-{offset}.tmp"));
+            let victim_path = outside.path().join(format!("victim-{offset}.txt"));
+            std::os::unix::fs::symlink(&victim_path, &planted_path).unwrap();
+            victims.push((planted_path, victim_path));
+        }
+
+        let mut next_candidate = 0u32;
+        let temp_dir_path = temp.path().to_path_buf();
+        let mut reader = Cursor::new(b"legit content".to_vec());
+        let bytes_written =
+            write_file_with_permit_using(&mut reader, &dest_path, test_permit(), || {
+                let path = temp_dir_path.join(format!(".candidate-{next_candidate}.tmp"));
+                next_candidate += 1;
+                path
+            })
+            .expect("should retry past every planted symlink and succeed");
+
+        assert_eq!(bytes_written, 13);
+        assert_eq!(std::fs::read(&dest_path).unwrap(), b"legit content");
+        // The generator must have been driven past every planted symlink to
+        // reach a free candidate — otherwise this test would pass vacuously
+        // without ever exercising the retry-on-AlreadyExists path.
+        assert_eq!(next_candidate, MAX_TEMP_FILE_CREATE_ATTEMPTS);
+
+        for (planted_path, victim_path) in &victims {
+            assert!(
+                !victim_path.exists(),
+                "write followed a planted symlink outside the extraction root"
+            );
+            let metadata = std::fs::symlink_metadata(planted_path).unwrap();
+            assert!(
+                metadata.file_type().is_symlink(),
+                "planted symlink should be left untouched, not consumed or replaced"
+            );
+        }
+    }
+
+    /// Companion to [`test_write_file_with_permit_skips_planted_symlinks`]:
+    /// when every attempt's candidate path is blocked by a planted symlink,
+    /// `write_file_with_permit_using` must give up with an error instead of
+    /// looping forever or falling back to a non-exclusive open. Uses the
+    /// same private-generator approach for the same determinism reason.
+    #[test]
+    #[cfg(unix)]
+    fn test_write_file_with_permit_gives_up_after_max_attempts() {
+        let temp = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let dest_path = temp.path().join("real-output.txt");
+
+        let mut victims = Vec::new();
+        for offset in 0..MAX_TEMP_FILE_CREATE_ATTEMPTS {
+            let planted_path = temp.path().join(format!(".candidate-{offset}.tmp"));
+            let victim_path = outside.path().join(format!("victim-{offset}.txt"));
+            std::os::unix::fs::symlink(&victim_path, &planted_path).unwrap();
+            victims.push(victim_path);
+        }
+
+        let mut next_candidate = 0u32;
+        let temp_dir_path = temp.path().to_path_buf();
+        let mut reader = Cursor::new(b"legit content".to_vec());
+        let result = write_file_with_permit_using(&mut reader, &dest_path, test_permit(), || {
+            let path = temp_dir_path.join(format!(".candidate-{next_candidate}.tmp"));
+            next_candidate += 1;
+            path
+        });
+
+        assert!(
+            result.is_err(),
+            "expected exhaustion error, got: {result:?}"
+        );
+        assert_eq!(next_candidate, MAX_TEMP_FILE_CREATE_ATTEMPTS);
+        assert!(!dest_path.exists());
+        for victim_path in &victims {
+            assert!(!victim_path.exists());
+        }
     }
 
     #[test]

--- a/crates/exarch-core/src/formats/sevenz.rs
+++ b/crates/exarch-core/src/formats/sevenz.rs
@@ -927,6 +927,7 @@ mod tests {
     /// Reserves a throwaway [`QuotaPermit`] for use in tests that call
     /// `write_file_with_permit` directly, bypassing the normal validation
     /// pipeline that would otherwise produce one.
+    #[cfg(unix)]
     fn test_permit() -> QuotaPermit {
         let config = SecurityConfig::default().validate().expect("valid config");
         crate::security::quota::QuotaTracker::new()

--- a/crates/exarch-core/src/formats/tar.rs
+++ b/crates/exarch-core/src/formats/tar.rs
@@ -866,6 +866,7 @@ mod tests {
     use std::assert_matches;
     use std::io::Cursor;
     use std::io::Write;
+    #[cfg(unix)]
     use std::path::PathBuf;
     use tempfile::TempDir;
 

--- a/crates/exarch-core/src/formats/tar.rs
+++ b/crates/exarch-core/src/formats/tar.rs
@@ -129,6 +129,7 @@ use crate::security::validator::ValidatedEntryType;
 use crate::types::DestDir;
 use crate::types::EntryType;
 use crate::types::SafePath;
+use crate::types::safe_symlink::resolve_through_symlinks;
 
 use super::common;
 use super::tar_metadata_limit::budget_violation;
@@ -303,10 +304,66 @@ impl<R: Read> TarArchive<R> {
 
     /// Creates a hardlink in the second pass by copying content.
     ///
-    /// Uses `fs::copy` instead of `fs::hard_link` to avoid shared-inode
+    /// Uses a content copy instead of `fs::hard_link` to avoid shared-inode
     /// corruption: a real OS hardlink would allow a subsequent write to
     /// `link_path` to silently overwrite `target_path` (GHSA-2367-c296-3mp2
     /// variant, issue #130).
+    ///
+    /// # Security - Symlink-at-Destination Rejection (issue #467)
+    ///
+    /// `Path::exists()` returns `false` for a dangling symlink, so a
+    /// pre-planted symlink at `link_path` used to bypass the old
+    /// existence-based duplicate check, and the subsequent `fs::copy`
+    /// followed it, writing archive content outside the extraction root.
+    /// The destination is now opened via `common::create_file_with_mode`
+    /// (mode `None`, since permissions are copied from the target's bytes
+    /// afterward, not set at creation) with `create_new = true`, which
+    /// atomically fails with `ErrorKind::AlreadyExists` for any pre-existing
+    /// path at `link_path` — symlink (dangling or not), regular file, or
+    /// directory — folding the duplicate check into the `open()` call
+    /// itself instead of a separate, bypassable `exists()` probe. This
+    /// reuses the same `O_EXCL`+`O_NOFOLLOW` (Unix) discipline as the
+    /// normal-file write path (issue #459) for consistency, though
+    /// `create_new`'s `O_EXCL` alone already refuses any pre-existing path.
+    ///
+    /// # Security - Target Read TOCTOU and Quota TOCTOU (issue #467)
+    ///
+    /// Hardlinks are validated in two passes: `EntryValidator::validate_entry`
+    /// (via `HardlinkTracker::validate_hardlink`) resolves `target` through
+    /// any on-disk symlinks and checks containment in pass one, but this
+    /// function — pass two — runs later, after every entry in the archive has
+    /// been validated and every non-hardlink entry extracted. Nothing
+    /// re-validates `target_path` in between. A plain path-based `File::open`
+    /// (or `std::fs::metadata`, as this function used to do to size the quota
+    /// reservation) would silently follow whatever is at `target_path` by the
+    /// time pass two runs — which, given an attacker-writable destination
+    /// directory, may not be what pass one validated at all (the target
+    /// swapped for a symlink escaping `dest` in between the two passes).
+    /// Separately, sizing the quota reservation from a path-based `stat` and
+    /// then copying from a *different*, separately-opened handle left its own
+    /// TOCTOU window: swapping `target_path` between the two operations could
+    /// charge the quota for N bytes while actually copying an unbounded
+    /// amount.
+    ///
+    /// Both are narrowed the same way: [`common::open_no_follow`] opens
+    /// `target_path` once, refusing to follow a symlink (Unix, via
+    /// `O_NOFOLLOW`) rather than a separate `stat`-then-`open`; the quota
+    /// reservation is sized from that same open handle's `fstat`, and the
+    /// copy reads from that same handle — never re-touching the path
+    /// afterward. A symlink at `target_path` is not automatically rejected,
+    /// though: it is a legitimate, common archive shape for a hardlink's
+    /// target to itself be a symlink created earlier in the *same*
+    /// extraction (already pass-one-validated). On `ErrorKind::FilesystemLoop`
+    /// from `open_no_follow`, [`resolve_through_symlinks`] re-runs the exact
+    /// containment check pass one already trusts, against the *current*
+    /// on-disk state; if it still resolves inside `dest`, the resolved
+    /// (symlink-free, since `canonicalize` dereferences fully) path is opened
+    /// instead. This narrows the TOCTOU window from "the entire gap between
+    /// pass one and pass two" down to "between this re-check and the open" —
+    /// consistent with the check-then-act discipline the rest of the pipeline
+    /// already accepts elsewhere (e.g. `DirCache`'s documented TOCTOU). If the
+    /// re-resolution instead lands outside `dest`, that is a genuine escape
+    /// attempt and is reported as such, not as a raw OS errno.
     fn create_hardlink(info: &HardlinkInfo, ctx: &mut ExtractionContext<'_, '_>) -> Result<()> {
         let link_path = ctx.dest.join(&info.link_path);
         let target_path = ctx.dest.join(&info.target_path);
@@ -321,41 +378,73 @@ impl<R: Read> TarArchive<R> {
         // Create parent directories using cache
         ctx.dir_cache.ensure_parent_dir(&link_path)?;
 
-        if link_path.exists() {
-            if ctx.skip_duplicates {
-                ctx.report.files_skipped =
-                    ctx.report
-                        .files_skipped
-                        .checked_add(1)
-                        .ok_or(ArchiveError::QuotaExceeded {
+        let link_file = match common::create_file_with_mode(&link_path, None, true) {
+            Ok(file) => file,
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                if ctx.skip_duplicates {
+                    ctx.report.files_skipped = ctx.report.files_skipped.checked_add(1).ok_or(
+                        ArchiveError::QuotaExceeded {
                             resource: crate::QuotaResource::IntegerOverflow,
-                        })?;
-                ctx.report.warnings.push(format!(
-                    "skipped duplicate hardlink: {}",
+                        },
+                    )?;
+                    ctx.report.warnings.push(format!(
+                        "skipped duplicate hardlink: {}",
+                        info.link_path.as_path().display()
+                    ));
+                    return Ok(());
+                }
+                return Err(ArchiveError::InvalidArchive(format!(
+                    "duplicate entry: {}",
                     info.link_path.as_path().display()
-                ));
-                return Ok(());
+                )));
             }
-            return Err(ArchiveError::InvalidArchive(format!(
-                "duplicate entry: {}",
-                info.link_path.as_path().display()
-            )));
-        }
+            Err(e) => return Err(ArchiveError::Io(e)),
+        };
+        let cleanup_guard = common::TempFileGuard::new(link_path);
+
+        // Opened once, refusing to follow a symlink at `target_path`; the
+        // quota reservation below and the copy further down both operate on
+        // this same handle instead of re-touching the path (issue #467).
+        let target_file = match common::open_no_follow(&target_path) {
+            Ok(file) => file,
+            Err(e) if common::is_filesystem_loop_error(&e) => {
+                // `target_path`'s final component is a symlink. Re-run pass
+                // one's own containment check against the current on-disk
+                // state; a symlink created by an earlier entry in this same
+                // extraction resolves safely inside `dest` and is opened at
+                // its resolved (symlink-free) location, while a genuine
+                // escape attempt is rejected as HardlinkEscape rather than
+                // surfacing as a raw ELOOP.
+                let resolved = resolve_through_symlinks(
+                    ctx.dest.as_path(),
+                    info.target_path.as_path(),
+                    ctx.dest.as_path(),
+                    info.link_path.as_path(),
+                )
+                .map_err(|_| ArchiveError::HardlinkEscape {
+                    path: info.link_path.as_path().to_path_buf(),
+                })?;
+                common::open_no_follow(&resolved)?
+            }
+            Err(e) => return Err(ArchiveError::Io(e)),
+        };
 
         // Every hardlink copies the target's real bytes to a new inode, so it
         // must be charged against the same quota tracker as regular files
         // (issue #426): otherwise N hardlinks to one small file extract N
         // full copies with no size or count enforcement. Reserved after the
-        // duplicate-skip check above (mirroring `extract_file_generic`) so a
+        // duplicate-check above (mirroring `extract_file_generic`) so a
         // `skip_duplicates=true` archive is not spuriously charged for an
         // entry that is ultimately never copied. The permit is consumed by
         // value below, so this reservation cannot be spent twice.
-        let target_size = std::fs::metadata(&target_path)?.len();
+        let target_size = target_file.metadata()?.len();
         let permit = ctx.validator.reserve_hardlink(target_size)?;
 
-        // Copy content to a new independent inode. Any subsequent write to
-        // `link_path` cannot corrupt `target_path` because they are separate files.
-        let bytes_copied = common::copy_file_with_permit(&target_path, &link_path, permit)?;
+        // Copy content between the two handles opened above. Any subsequent
+        // write to `link_path` cannot corrupt `target_path` because they are
+        // separate files.
+        let bytes_copied = common::copy_file_content_with_permit(target_file, link_file, permit)?;
+        cleanup_guard.persist();
 
         ctx.report.files_extracted =
             ctx.report
@@ -777,6 +866,7 @@ mod tests {
     use std::assert_matches;
     use std::io::Cursor;
     use std::io::Write;
+    use std::path::PathBuf;
     use tempfile::TempDir;
 
     #[test]
@@ -1915,6 +2005,314 @@ mod tests {
             }
             _ => panic!("Expected InvalidArchive error for missing hardlink target"),
         }
+    }
+
+    /// Builds a TAR with a regular file entry (`target.txt`) followed by a
+    /// hardlink entry (`hardlink.txt`) pointing at it.
+    #[cfg(unix)]
+    fn create_hardlink_tar(target_content: &[u8]) -> Vec<u8> {
+        let mut builder = tar::Builder::new(Vec::new());
+
+        let mut file_header = tar::Header::new_gnu();
+        file_header.set_entry_type(tar::EntryType::Regular);
+        file_header.set_size(target_content.len() as u64);
+        file_header.set_mode(0o644);
+        file_header.set_cksum();
+        builder
+            .append_data(&mut file_header, "target.txt", target_content)
+            .unwrap();
+
+        let mut link_header = tar::Header::new_gnu();
+        link_header.set_entry_type(tar::EntryType::Link);
+        link_header.set_link_name("target.txt").unwrap();
+        link_header.set_size(0);
+        link_header.set_cksum();
+        builder
+            .append_data(&mut link_header, "hardlink.txt", &[] as &[u8])
+            .unwrap();
+
+        builder.into_inner().unwrap()
+    }
+
+    /// Regression test for issue #467: a dangling symlink pre-planted at the
+    /// hardlink's destination path used to bypass the old `Path::exists()`
+    /// duplicate check (which returns `false` for a dangling symlink) and a
+    /// subsequent `fs::copy` followed it, writing archive content outside
+    /// the extraction root. With `skip_duplicates=true` (the default), the
+    /// pre-existing path at `hardlink.txt` must now be treated as a
+    /// duplicate and skipped instead of being written through.
+    #[test]
+    #[cfg(unix)]
+    fn test_hardlink_dangling_symlink_at_destination_skipped() {
+        let temp = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let victim_path = outside.path().join("victim.txt");
+
+        // Pre-plant a dangling symlink at the hardlink's destination path,
+        // pointing outside the extraction root at a file that does not exist.
+        let link_dest = temp.path().join("hardlink.txt");
+        std::os::unix::fs::symlink(&victim_path, &link_dest).unwrap();
+        assert!(!victim_path.exists());
+
+        let tar_data = create_hardlink_tar(b"pwned!");
+        let mut archive = TarArchive::new(Cursor::new(tar_data));
+
+        let mut config = SecurityConfig::default();
+        config.allowed.hardlinks = true;
+        let config = config.validate().expect("valid config");
+
+        let report = archive
+            .extract(
+                temp.path(),
+                &config,
+                &ExtractionOptions::default(), // skip_duplicates = true
+                &mut crate::NoopProgress,
+            )
+            .expect("extraction should succeed by skipping the duplicate");
+
+        assert_eq!(report.files_skipped, 1);
+        assert!(
+            !victim_path.exists(),
+            "hardlink write followed the pre-planted symlink outside the extraction root"
+        );
+
+        // The pre-planted symlink itself must be left untouched, not followed
+        // or replaced.
+        let link_metadata = std::fs::symlink_metadata(&link_dest).unwrap();
+        assert!(link_metadata.file_type().is_symlink());
+    }
+
+    /// Companion to [`test_hardlink_dangling_symlink_at_destination_skipped`]
+    /// with `skip_duplicates=false`: the pre-planted symlink must still be
+    /// rejected as a duplicate-entry error rather than followed.
+    #[test]
+    #[cfg(unix)]
+    fn test_hardlink_dangling_symlink_at_destination_errors_when_skip_disabled() {
+        let temp = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let victim_path = outside.path().join("victim.txt");
+
+        let link_dest = temp.path().join("hardlink.txt");
+        std::os::unix::fs::symlink(&victim_path, &link_dest).unwrap();
+
+        let tar_data = create_hardlink_tar(b"pwned!");
+        let mut archive = TarArchive::new(Cursor::new(tar_data));
+
+        let mut config = SecurityConfig::default();
+        config.allowed.hardlinks = true;
+        let config = config.validate().expect("valid config");
+        let options = ExtractionOptions {
+            atomic: false,
+            skip_duplicates: false,
+        };
+
+        let result = archive.extract(temp.path(), &config, &options, &mut crate::NoopProgress);
+
+        assert!(!victim_path.exists());
+        // The regular `target.txt` entry extracts successfully before the
+        // hardlink entry fails, so the error arrives wrapped in
+        // PartialExtraction; unwrap one level to check the source.
+        match result {
+            Err(ArchiveError::PartialExtraction { source, .. }) => match *source {
+                ArchiveError::InvalidArchive(msg) => assert!(msg.contains("duplicate entry")),
+                other => panic!("Expected InvalidArchive duplicate-entry error, got: {other:?}"),
+            },
+            Err(ArchiveError::InvalidArchive(msg)) => {
+                assert!(msg.contains("duplicate entry"));
+            }
+            other => panic!("Expected InvalidArchive duplicate-entry error, got: {other:?}"),
+        }
+
+        let link_metadata = std::fs::symlink_metadata(&link_dest).unwrap();
+        assert!(link_metadata.file_type().is_symlink());
+    }
+
+    /// Regression test for issue #467's pass-1-to-pass-2 TOCTOU: a hardlink
+    /// target that is safe when `EntryValidator::validate_entry`
+    /// (`HardlinkTracker::validate_hardlink`) runs in pass one, but gets
+    /// swapped for a symlink escaping `dest` before `create_hardlink` (pass
+    /// two) actually reads it, must not have its escape-target content
+    /// copied into the destination.
+    ///
+    /// Calls `create_hardlink` directly with a hand-built `HardlinkInfo`
+    /// instead of going through `TarArchive::extract`, since the two passes
+    /// run back-to-back within a single `extract()` call with no way for a
+    /// test to inject a filesystem change in between. This is deliberate: a
+    /// plain pre-planted symlink present *before* pass one runs is already
+    /// rejected by pass one's own `resolve_through_symlinks` check
+    /// (`HardlinkTracker::validate_hardlink`, issue #116) and never reaches
+    /// `create_hardlink` at all — asserting against that scenario would
+    /// pass identically on the pre-#467-fix code and prove nothing about
+    /// this change. Simulating the race directly is the only way to
+    /// exercise `open_no_follow`'s `ErrorKind::FilesystemLoop` retry path
+    /// and its `resolve_through_symlinks` re-validation.
+    #[test]
+    #[cfg(unix)]
+    fn test_hardlink_target_swapped_for_escaping_symlink_between_passes() {
+        let temp = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let sentinel_path = outside.path().join("sentinel.txt");
+        std::fs::write(&sentinel_path, b"top secret").unwrap();
+
+        let dest = DestDir::new_or_create(temp.path().to_path_buf()).unwrap();
+        let mut config = SecurityConfig::default();
+        config.allowed.hardlinks = true;
+        let config = config.validate().expect("valid config");
+
+        // Simulates: pass one validated "target.txt" as a safe relative
+        // target (it did not exist yet, or was something innocuous) and
+        // recorded this `HardlinkInfo` for pass two. Between the two passes,
+        // an attacker with write access to `dest` swaps in a symlink
+        // escaping the destination — exactly the window pass one's
+        // point-in-time check cannot see across.
+        let info = HardlinkInfo {
+            link_path: SafePath::new_unchecked(PathBuf::from("loot.txt")),
+            target_path: SafePath::new_unchecked(PathBuf::from("target.txt")),
+        };
+        std::os::unix::fs::symlink(&sentinel_path, dest.as_path().join("target.txt")).unwrap();
+
+        let mut validator = EntryValidator::new(&config, &dest);
+        let mut report = ExtractionReport::new();
+        let mut copy_buffer = CopyBuffer::new();
+        let mut dir_cache = common::DirCache::new();
+        let mut progress = crate::NoopProgress;
+        let mut ctx = ExtractionContext {
+            validator: &mut validator,
+            dest: &dest,
+            report: &mut report,
+            copy_buffer: &mut copy_buffer,
+            dir_cache: &mut dir_cache,
+            skip_duplicates: true,
+            config: &config,
+            progress: &mut progress,
+        };
+
+        let result = TarArchive::<Cursor<Vec<u8>>>::create_hardlink(&info, &mut ctx);
+
+        assert_matches!(
+            result,
+            Err(ArchiveError::HardlinkEscape { .. }),
+            "expected the pass-1-to-pass-2 target swap to be rejected as a hardlink escape, got: {result:?}"
+        );
+        assert!(
+            !temp.path().join("loot.txt").exists(),
+            "sentinel content must not have been copied into the destination, and TempFileGuard \
+             must have removed the exclusively-opened link file on this error path"
+        );
+    }
+
+    /// Regression test for issue #467's `TempFileGuard` cleanup path: when
+    /// the quota reservation fails *after* the hardlink's exclusive-open
+    /// destination file was already created, no stray zero-byte file must
+    /// be left behind at `link_path`.
+    #[test]
+    #[cfg(unix)]
+    fn test_hardlink_quota_failure_leaves_no_stray_link_file() {
+        let temp = TempDir::new().unwrap();
+
+        let tar_data = create_hardlink_tar(&[b'A'; 100]);
+        let mut archive = TarArchive::new(Cursor::new(tar_data));
+
+        let mut config = SecurityConfig::default();
+        config.allowed.hardlinks = true;
+        // Enough room for target.txt (100 bytes) but not for the hardlink's
+        // own independent 100-byte copy on top of it.
+        config.max_total_size = 150;
+        let config = config.validate().expect("valid config");
+
+        let result = archive.extract(
+            temp.path(),
+            &config,
+            &ExtractionOptions::default(),
+            &mut crate::NoopProgress,
+        );
+
+        assert!(result.is_err(), "expected quota exceeded, got: {result:?}");
+        assert!(
+            temp.path().join("target.txt").exists(),
+            "target.txt should have been extracted before the hardlink's quota failure"
+        );
+        assert!(
+            !temp.path().join("hardlink.txt").exists(),
+            "TempFileGuard must remove the empty hardlink destination file left by the failed \
+             quota reservation"
+        );
+    }
+
+    /// Regression test for issue #467's
+    /// `open_no_follow`/`ErrorKind::FilesystemLoop` re-resolution path: a
+    /// hardlink whose target is itself a symlink pointing *inside* `dest`
+    /// (a legitimate, common archive shape — two links sharing an inode,
+    /// where the second is stored as a `Symlink` entry rather than a second
+    /// `Link` entry) must still extract correctly, not hard-fail with a raw
+    /// `ELOOP`.
+    ///
+    /// Archive order matters here: `real.txt` (regular) then `loot.txt`
+    /// (hardlink -> `target.txt`) then `target.txt` (symlink -> `real.txt`)
+    /// means `target.txt` does not exist on disk yet when `loot.txt`'s
+    /// hardlink entry is validated in pass one, so pass one cannot resolve
+    /// the symlink itself — deferring to pass two's `create_hardlink`, which
+    /// by then finds `target.txt` on disk as the symlink created earlier in
+    /// the same pass-one loop. This is the exact ordering the regression was
+    /// reproduced with.
+    #[test]
+    #[cfg(unix)]
+    fn test_hardlink_target_is_legitimate_symlink_created_earlier_in_extraction() {
+        let temp = TempDir::new().unwrap();
+
+        let mut builder = tar::Builder::new(Vec::new());
+
+        let mut file_header = tar::Header::new_gnu();
+        file_header.set_entry_type(tar::EntryType::Regular);
+        file_header.set_size(5);
+        file_header.set_mode(0o644);
+        file_header.set_cksum();
+        builder
+            .append_data(&mut file_header, "real.txt", b"hello" as &[u8])
+            .unwrap();
+
+        let mut link_header = tar::Header::new_gnu();
+        link_header.set_entry_type(tar::EntryType::Link);
+        link_header.set_link_name("target.txt").unwrap();
+        link_header.set_size(0);
+        link_header.set_cksum();
+        builder
+            .append_data(&mut link_header, "loot.txt", &[] as &[u8])
+            .unwrap();
+
+        let mut symlink_header = tar::Header::new_gnu();
+        symlink_header.set_entry_type(tar::EntryType::Symlink);
+        symlink_header.set_link_name("real.txt").unwrap();
+        symlink_header.set_size(0);
+        symlink_header.set_cksum();
+        builder
+            .append_data(&mut symlink_header, "target.txt", &[] as &[u8])
+            .unwrap();
+
+        let tar_data = builder.into_inner().unwrap();
+        let mut archive = TarArchive::new(Cursor::new(tar_data));
+
+        let mut config = SecurityConfig::default();
+        config.allowed.hardlinks = true;
+        config.allowed.symlinks = true;
+        let config = config.validate().expect("valid config");
+
+        let report = archive
+            .extract(
+                temp.path(),
+                &config,
+                &ExtractionOptions::default(),
+                &mut crate::NoopProgress,
+            )
+            .expect("legitimate hardlink-to-in-dest-symlink shape must extract successfully");
+
+        assert_eq!(report.files_extracted, 2, "real.txt and loot.txt");
+        assert_eq!(report.symlinks_created, 1, "target.txt");
+        assert_eq!(
+            std::fs::read(temp.path().join("loot.txt")).unwrap(),
+            b"hello",
+            "loot.txt must contain real.txt's content, resolved through target.txt's symlink"
+        );
     }
 
     // OPT-H001: Test SmallVec stack allocation for hardlinks

--- a/crates/exarch-core/src/security/validator.rs
+++ b/crates/exarch-core/src/security/validator.rs
@@ -83,8 +83,8 @@ impl ValidatedEntry {
     /// — `QuotaPermit` is neither `Clone` nor `Copy` by design, so ownership
     /// can only be obtained by consuming the `ValidatedEntry` that holds it.
     /// Write paths that need to thread the permit by value into a helper
-    /// (mirroring `formats::common::copy_file_with_permit`'s guarantee) call
-    /// this instead of `entry_type()`.
+    /// (mirroring `formats::common::copy_file_content_with_permit`'s guarantee)
+    /// call this instead of `entry_type()`.
     #[inline]
     #[must_use]
     pub(crate) fn into_parts(self) -> (SafePath, ValidatedEntryType, Option<u32>) {

--- a/crates/exarch-core/tests/security/hardlink_quota_bypass.rs
+++ b/crates/exarch-core/tests/security/hardlink_quota_bypass.rs
@@ -11,7 +11,7 @@
 //! The fix adds `EntryValidator::reserve_hardlink`, which charges each
 //! hardlink's on-disk target size against the *same* `QuotaTracker` instance
 //! used for regular files, called after the parent-dir/duplicate checks and
-//! before `common::copy_file_with_permit` runs.
+//! before `common::copy_file_content_with_permit` runs.
 
 #![allow(clippy::unwrap_used, clippy::cast_possible_truncation)]
 


### PR DESCRIPTION
## Summary

- 7z's `write_file_with_permit` derived a predictable temp file name (PID + per-process counter) and opened it with a plain `File::create`, following any symlink planted at that path instead of refusing it. Fixed by opening with `OpenOptions::create_new`, retrying with a fresh counter on `AlreadyExists` (bounded by `MAX_TEMP_FILE_CREATE_ATTEMPTS`).
- TAR's `create_hardlink` used `Path::exists()` to detect duplicates at the link destination, which is `false` for a dangling symlink, then wrote through it via `std::fs::copy`. Fixed by folding the duplicate check into an exclusive `create_new` open, copying into the already-open handle via a new `copy_file_content_with_permit` (replacing the removed path-based `copy_file_with_permit`).
- The hardlink's *read* side had a narrower TOCTOU: targets are validated for containment in a first pass, but the two-pass design defers reading them to a second pass with nothing re-checked in between, so an attacker could swap the target after validation. Closed with a new `open_no_follow`, opening the target once with `O_NOFOLLOW` so a second-pass symlink swap fails the open instead of being followed. A legitimate hardlink-to-symlink-in-dest (a real archive shape) still works via a `resolve_through_symlinks` re-check on `ELOOP`. The same open also fixes a quota-sizing TOCTOU, since reservation is now sized from the open handle's `fstat` instead of a separate path-based `stat`.

Both write-side preconditions require an attacker-writable destination directory, not a malicious archive alone. This branch was rebased onto `main` after PR #470 (the #459/#445 fix for TAR/ZIP's normal-file write path) landed concurrently, so it builds on that same `create_new`/`O_NOFOLLOW` discipline rather than duplicating it.

## Test plan

- [x] Regression tests for #471: dangling/planted symlink at the predicted 7z temp-file path is refused, not followed
- [x] Regression tests for #467 write side: dangling symlink at hardlink destination is refused under both `skip_duplicates` settings
- [x] Regression tests for #467 read-side TOCTOU: target swapped for an escaping symlink between passes is rejected (`HardlinkEscape`); a legitimate hardlink-to-symlink created earlier in the same extraction still succeeds
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` (1109/1109)
- [x] `cargo test -p exarch-core --all-features` (plain, multi-threaded — this is where a test-flakiness bug from the shared temp-counter surfaced and was fixed)
- [x] `cargo test --doc --workspace --all-features`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace`

Closes #471
Closes #467