### PR TITLE
fix(node): close primitive-throw crash in progress callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,20 +260,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   redacts everywhere else in release builds) and the throw content is attacker-influenced whenever
   the callback echoes archive entry data — read `cause` for the callback's detail rather than
   parsing it out of `message`.
-  Known limitation, now documented on both `*WithProgress` functions and pinned by child-process
-  tests: this only covers non-primitive throws. Throwing a bare string, number, or boolean
-  (`throw 'oops'`) still crashes the process and leaves the promise unsettled, due to an upstream
-  napi-rs 3.12.0 defect where `call_async_catch`'s dispatcher escalates the `napi_invalid_arg`
-  from `napi_create_reference()` on a primitive exception value into a fatal exception. Throw an
-  `Error` instance (or any non-primitive) from a progress callback to get the documented
-  rejection behavior. Tracked upstream in #473.
+  At the time this landed, throwing a bare primitive (string, number, boolean) from the callback
+  was a known, documented limitation that still crashed the process on both `*WithProgress`
+  functions; see the following entry for the fix.
   `createArchiveWithProgressSync` cannot use the awaiting dispatch at all: it runs on the JS
   thread, so no tokio runtime is entered (`Handle::current()` panicked) and awaiting a call that
   only the blocked event loop can deliver would deadlock. It now dispatches unawaited and is
   documented accordingly — every call arrives after the function has already returned its
   `CreationReport`, so a throw cannot be merged into the result and instead surfaces as an
   ordinary `uncaughtException`, observable via `process.on('uncaughtException', …)`. Because that
-  path never enters `call_async_catch`, the primitive-throw crash above does not apply to it.
+  path never enters `call_async_catch`, the primitive-throw crash above never applied to it —
+  string, number, and boolean throws already reached `uncaughtException` intact, exactly like an
+  `Error` throw, so it needed no fix and is unaffected by the following entry.
+
+- **`exarch-node`: throwing a bare primitive from a progress callback still crashed the process
+  (#473, follow-up to #465)**: #465's fix above only covered `Error`/object throws on
+  `extractArchiveWithProgress` and `createArchiveWithProgress` — a callback throwing `'oops'`,
+  `42`, or `true` still crashed the process uncatchably, because the `napi_invalid_arg` status
+  that `call_async_catch`'s dispatcher gets back from `napi_create_reference()` on a primitive
+  exception value is escalated to `napi_fatal_exception` regardless of the exception having
+  already been delivered correctly to the Rust side — an upstream napi-rs 3.12.0 defect that
+  cannot be fixed from this crate. Both functions now wrap the user-supplied `progress` callback
+  in a small JavaScript shim (built via `Env::run_script`, applied inside a shared
+  `ProgressCallback::from_napi_value` impl before the `ThreadsafeFunction` is constructed) that
+  catches any synchronous throw and, unless the thrown value is already an object or function
+  `napi_create_reference()` can reference, re-throws a new `Error` carrying the original value as
+  `cause` — so napi-rs's dispatcher never observes a primitive crossing the callback boundary in
+  the first place. A non-function `progress` argument is now also rejected immediately via a
+  `ValueType` check, instead of running the whole operation to completion first. Does not cover an
+  `async` progress callback whose returned `Promise` rejects with a primitive — a `try`/`catch`
+  only observes synchronous throws — nor `createArchiveWithProgressSync`, which was never affected
+  by this class of bug (see the preceding entry).
 
 - **`exarch-python` error messages leaked full absolute paths in release builds, and both
   bindings leaked host paths embedded in `CoreError::Io` messages (#453)**:

--- a/crates/exarch-node/index.d.ts
+++ b/crates/exarch-node/index.d.ts
@@ -479,15 +479,17 @@ export declare function createArchiveSync(outputPath: string, sources: Array<str
  * copied into the message — read `cause` for the callback's error detail
  * rather than parsing it out of `message`.
  *
- * ## Known limitation: primitive throws still crash the process
- *
- * Identical to `extractArchiveWithProgress`: the catchable-rejection behavior
- * holds only for non-primitive throws. `throw 'oops'` from the callback still
- * aborts the host process uncatchably with `Call JavaScript callback failed in
- * threadsafe function`, and the promise never settles. Both functions dispatch
- * through the same `call_async_catch` path, so they share the upstream
- * napi-rs 3.12.0 defect described there. Always throw an `Error` instance.
- * Tracked in <https://github.com/bug-ops/exarch/issues/473>.
+ * This holds regardless of what the callback *synchronously throws*,
+ * including a bare primitive (`throw 'oops'`, `throw 42`, `throw true`):
+ * `progress` is wrapped in a small JavaScript shim before it is ever handed
+ * to napi-rs's threadsafe function dispatcher (see issue #473; identical
+ * mechanism to `extractArchiveWithProgress`, which shares more detail on
+ * why this is necessary). This does **not** cover an `async` progress
+ * callback whose returned `Promise` rejects with a primitive — a
+ * `try`/`catch` only observes synchronous throws — nor
+ * `createArchiveWithProgressSync`'s deferred dispatch, which never enters
+ * the affected code path to begin with (see its own doc comment). Keep
+ * `progress` synchronous.
  *
  * # Examples
  *
@@ -762,25 +764,30 @@ export declare function extractArchiveSync(archivePath: string, outputDir: strin
  * copied into the message — read `cause` for the callback's error detail
  * rather than parsing it out of `message`.
  *
- * ## Known limitation: primitive throws still crash the process
+ * This holds regardless of what the callback *synchronously throws*,
+ * including a bare primitive (`throw 'oops'`, `throw 42`, `throw true`):
+ * `progress` is wrapped in a small JavaScript shim before it is ever handed
+ * to napi-rs's threadsafe function dispatcher (see issue #473). The shim's
+ * `try`/`catch` catches any synchronous throw and, unless the thrown value
+ * is already an object or function `napi_create_reference()` can reference,
+ * re-throws a new `Error` carrying the original value as `cause`. napi-rs
+ * 3.12.0's `call_async_catch` dispatcher crashes the host process
+ * uncatchably when the JS value it observes crossing the callback boundary
+ * is a primitive — `napi_create_reference()` cannot create a weak reference
+ * to one, and the resulting non-ok status is escalated to
+ * `napi_fatal_exception` regardless of the exception having already been
+ * delivered to the channel — so the shim guarantees napi-rs never observes
+ * a primitive throw in the first place, rather than relying on a fix inside
+ * the upstream dispatcher.
  *
- * The catchable-rejection behavior above only holds when the callback throws a
- * non-primitive value (`Error` and subclasses, plain objects, arrays, `null`,
- * `undefined`, `Symbol`). Throwing a bare string, number, or boolean —
- * `throw 'oops'` — still aborts the host process uncatchably with
- * `Call JavaScript callback failed in threadsafe function`, and the promise
- * never settles.
- *
- * This is an upstream defect in napi-rs 3.12.0: the dispatcher behind
- * `call_async_catch` overwrites its own status with the result of
- * `napi_create_reference()`, which reports `napi_invalid_arg` for a primitive
- * exception value, and that status is then escalated to a fatal exception even
- * though the error was already delivered to the channel. It cannot be worked
- * around from this crate.
- *
- * Always throw an `Error` instance (or any non-primitive) from a progress
- * callback to get the documented rejection behavior. Tracked upstream in
- * <https://github.com/bug-ops/exarch/issues/473>.
+ * This does **not** cover an `async` progress callback whose returned
+ * `Promise` rejects with a primitive: a `try`/`catch` only observes
+ * synchronous throws, so a rejected `Promise` passes through the shim as an
+ * ordinary (fulfilled, from the shim's point of view) return value, napi-rs
+ * never awaits it, and Node terminates the process with
+ * `ERR_UNHANDLED_REJECTION` once the rejection goes unhandled — a
+ * pre-existing gap (present since before #465) that this fix does not
+ * address. Keep `progress` synchronous.
  *
  * # Examples
  *

--- a/crates/exarch-node/src/lib.rs
+++ b/crates/exarch-node/src/lib.rs
@@ -374,6 +374,111 @@ pub fn create_archive_sync(
     Ok(CreationReport::from(report))
 }
 
+/// JavaScript source for a factory that wraps a progress callback so any
+/// primitive value it throws is normalized to a proper `Error` before
+/// napi-rs's threadsafe function dispatcher ever observes it (see issue
+/// #473).
+///
+/// `napi_create_reference()` cannot create a weak reference to a thrown
+/// primitive (string/number/boolean/`undefined`/`BigInt`/`null`); napi-rs
+/// 3.12.0's `call_async_catch` dispatcher (`threadsafe_function.rs`) still
+/// escalates that failure to `napi_fatal_exception`, crashing the host
+/// process, even though the error was already delivered correctly to the
+/// Rust side. Catching the throw in real JavaScript, ahead of that
+/// dispatcher, sidesteps the defect entirely: napi-rs never sees a primitive
+/// cross the callback boundary.
+///
+/// The guard only rewraps values `napi_create_reference()` actually can't
+/// reference — any object or function (plain objects, custom `Error`
+/// subclasses, cross-realm `Error`s, arrays) passes through unchanged, so the
+/// original thrown value stays directly under the rejection's `cause` rather
+/// than being demoted to `cause.cause`.
+///
+/// A thrown `Symbol` is stringified before being attached as `cause`, rather
+/// than attached as-is like every other primitive: napi-rs's own
+/// `extract_error_cause` (used when the *rejection* value's `.cause` is later
+/// read back out) coerces `.cause` to a string via `napi_coerce_to_string`,
+/// which throws `TypeError: Cannot convert a Symbol value to a string` for a
+/// raw `Symbol` — reproducing this fix's own target crash one layer further
+/// in, uncatchably under `--force-node-api-uncaught-exceptions-policy=true`.
+const WRAP_PROGRESS_CALLBACK_JS: &str = r#"(callback) => function progressCallbackWrapper(err, arg) {
+  try {
+    return callback(err, arg);
+  } catch (thrown) {
+    if (thrown !== null && (typeof thrown === "object" || typeof thrown === "function")) {
+      throw thrown;
+    }
+    const wrapped = new Error("progress callback threw a non-object value: " + String(thrown));
+    wrapped.cause = typeof thrown === "symbol" ? String(thrown) : thrown;
+    throw wrapped;
+  }
+}"#;
+
+/// Argument type for a progress callback that wraps the JS value with
+/// `WRAP_PROGRESS_CALLBACK_JS` before building the [`ThreadsafeFunction`].
+///
+/// Shared by `createArchiveWithProgress` and `extractArchiveWithProgress` —
+/// the two entry points that dispatch through `ProgressDispatch::Awaited`
+/// (`call_async_catch`) and therefore share the primitive-throw crash this
+/// type exists to prevent. `createArchiveWithProgressSync` dispatches
+/// through `ProgressDispatch::Deferred` (plain `ThreadsafeFunction::call`)
+/// instead, which never enters the buggy code path in the first place — see
+/// its own doc comment — so it takes a raw `ThreadsafeFunction` unchanged.
+///
+/// The wrapping must happen inside [`FromNapiValue::from_napi_value`] rather
+/// than in the body of an `async fn` like `extract_archive_with_progress`:
+/// `Env` and `Function` wrap raw, thread-affine JS engine pointers and are
+/// not `Send`, so neither can be a parameter of that `async fn` — its future
+/// is later driven by `tokio::task::spawn_blocking`, which requires `Send`.
+/// Argument extraction, by contrast, always runs synchronously on the JS
+/// thread before the future is constructed, which is exactly where
+/// `Env`/`Function` access is valid.
+pub struct ProgressCallback(ThreadsafeFunction<(String, i64, i64, i64)>);
+
+impl TypeName for ProgressCallback {
+    fn type_name() -> &'static str {
+        "Function"
+    }
+
+    fn value_type() -> ValueType {
+        ValueType::Function
+    }
+}
+
+impl ValidateNapiValue for ProgressCallback {}
+
+impl FromNapiValue for ProgressCallback {
+    // SAFETY: `from_napi_value` is unsafe only because the trait contract
+    // requires `env`/`napi_val` to be a valid, currently-active napi
+    // environment and value, which is guaranteed here: napi-rs's generated
+    // argument-extraction code calls this exclusively from inside the JS
+    // callback that receives the corresponding `#[napi]` function's raw
+    // arguments, on the JS thread, before either pointer can be invalidated.
+    #[allow(unsafe_code)]
+    unsafe fn from_napi_value(env: sys::napi_env, napi_val: sys::napi_value) -> Result<Self> {
+        // `Function::from_napi_value` wraps any value with zero type
+        // checking, unlike `ThreadsafeFunction::from_napi_value` (which fails
+        // fast via `napi_create_reference`). Without this check, a
+        // non-function `progress` argument would run the whole operation to
+        // completion and only fail when the shim's `callback(...)` call
+        // throws `TypeError: callback is not a function` — surfaced as a
+        // misleading post-hoc `PROGRESS_CALLBACK_ERROR` instead of an
+        // upfront rejection.
+        assert_type_of!(env, napi_val, ValueType::Function)?;
+        // SAFETY: same guarantee as above — `env`/`napi_val` come from the
+        // trait caller and are valid for the duration of this call.
+        let callback = unsafe { Function::<Unknown, Unknown>::from_napi_value(env, napi_val)? };
+        let factory: Function<'_, Unknown<'_>, Function<'_, Unknown<'_>, Unknown<'_>>> =
+            Env::from_raw(env).run_script(WRAP_PROGRESS_CALLBACK_JS)?;
+        let wrapped = factory.call(callback.to_unknown())?;
+        let tsfn = wrapped
+            .build_threadsafe_function::<(String, i64, i64, i64)>()
+            .callee_handled::<true>()
+            .build_callback(|ctx| Ok(ctx.value))?;
+        Ok(Self(tsfn))
+    }
+}
+
 /// Create an archive from source files and directories with a progress
 /// callback (async).
 ///
@@ -427,15 +532,17 @@ pub fn create_archive_sync(
 /// copied into the message — read `cause` for the callback's error detail
 /// rather than parsing it out of `message`.
 ///
-/// ## Known limitation: primitive throws still crash the process
-///
-/// Identical to `extractArchiveWithProgress`: the catchable-rejection behavior
-/// holds only for non-primitive throws. `throw 'oops'` from the callback still
-/// aborts the host process uncatchably with `Call JavaScript callback failed in
-/// threadsafe function`, and the promise never settles. Both functions dispatch
-/// through the same `call_async_catch` path, so they share the upstream
-/// napi-rs 3.12.0 defect described there. Always throw an `Error` instance.
-/// Tracked in <https://github.com/bug-ops/exarch/issues/473>.
+/// This holds regardless of what the callback *synchronously throws*,
+/// including a bare primitive (`throw 'oops'`, `throw 42`, `throw true`):
+/// `progress` is wrapped in a small JavaScript shim before it is ever handed
+/// to napi-rs's threadsafe function dispatcher (see issue #473; identical
+/// mechanism to `extractArchiveWithProgress`, which shares more detail on
+/// why this is necessary). This does **not** cover an `async` progress
+/// callback whose returned `Promise` rejects with a primitive — a
+/// `try`/`catch` only observes synchronous throws — nor
+/// `createArchiveWithProgressSync`'s deferred dispatch, which never enters
+/// the affected code path to begin with (see its own doc comment). Keep
+/// `progress` synchronous.
 ///
 /// # Examples
 ///
@@ -456,7 +563,10 @@ pub async fn create_archive_with_progress(
     output_path: String,
     sources: Vec<String>,
     config: Option<&CreationConfig>,
-    progress: Option<ThreadsafeFunction<(String, i64, i64, i64)>>,
+    #[napi(
+        ts_arg_type = "(((err: Error | null, arg: [string, number, number, number]) => any)) | undefined | null"
+    )]
+    progress: Option<ProgressCallback>,
 ) -> Result<CreationReport> {
     validate_path(&output_path)?;
     for source in &sources {
@@ -465,6 +575,7 @@ pub async fn create_archive_with_progress(
 
     let config_owned: exarch_core::creation::CreationConfig =
         config.map(|c| c.as_core().clone()).unwrap_or_default();
+    let progress = progress.map(|ProgressCallback(tsfn)| tsfn);
 
     let report = tokio::task::spawn_blocking(move || {
         catch_panic_as_js_err("archive creation with progress", || {
@@ -883,25 +994,30 @@ pub fn verify_archive_sync(
 /// copied into the message — read `cause` for the callback's error detail
 /// rather than parsing it out of `message`.
 ///
-/// ## Known limitation: primitive throws still crash the process
+/// This holds regardless of what the callback *synchronously throws*,
+/// including a bare primitive (`throw 'oops'`, `throw 42`, `throw true`):
+/// `progress` is wrapped in a small JavaScript shim before it is ever handed
+/// to napi-rs's threadsafe function dispatcher (see issue #473). The shim's
+/// `try`/`catch` catches any synchronous throw and, unless the thrown value
+/// is already an object or function `napi_create_reference()` can reference,
+/// re-throws a new `Error` carrying the original value as `cause`. napi-rs
+/// 3.12.0's `call_async_catch` dispatcher crashes the host process
+/// uncatchably when the JS value it observes crossing the callback boundary
+/// is a primitive — `napi_create_reference()` cannot create a weak reference
+/// to one, and the resulting non-ok status is escalated to
+/// `napi_fatal_exception` regardless of the exception having already been
+/// delivered to the channel — so the shim guarantees napi-rs never observes
+/// a primitive throw in the first place, rather than relying on a fix inside
+/// the upstream dispatcher.
 ///
-/// The catchable-rejection behavior above only holds when the callback throws a
-/// non-primitive value (`Error` and subclasses, plain objects, arrays, `null`,
-/// `undefined`, `Symbol`). Throwing a bare string, number, or boolean —
-/// `throw 'oops'` — still aborts the host process uncatchably with
-/// `Call JavaScript callback failed in threadsafe function`, and the promise
-/// never settles.
-///
-/// This is an upstream defect in napi-rs 3.12.0: the dispatcher behind
-/// `call_async_catch` overwrites its own status with the result of
-/// `napi_create_reference()`, which reports `napi_invalid_arg` for a primitive
-/// exception value, and that status is then escalated to a fatal exception even
-/// though the error was already delivered to the channel. It cannot be worked
-/// around from this crate.
-///
-/// Always throw an `Error` instance (or any non-primitive) from a progress
-/// callback to get the documented rejection behavior. Tracked upstream in
-/// <https://github.com/bug-ops/exarch/issues/473>.
+/// This does **not** cover an `async` progress callback whose returned
+/// `Promise` rejects with a primitive: a `try`/`catch` only observes
+/// synchronous throws, so a rejected `Promise` passes through the shim as an
+/// ordinary (fulfilled, from the shim's point of view) return value, napi-rs
+/// never awaits it, and Node terminates the process with
+/// `ERR_UNHANDLED_REJECTION` once the rejection goes unhandled — a
+/// pre-existing gap (present since before #465) that this fix does not
+/// address. Keep `progress` synchronous.
 ///
 /// # Examples
 ///
@@ -924,7 +1040,10 @@ pub async fn extract_archive_with_progress(
     output_dir: String,
     config: Option<&SecurityConfig>,
     options: Option<&ExtractionOptions>,
-    progress: Option<ThreadsafeFunction<(String, i64, i64, i64)>>,
+    #[napi(
+        ts_arg_type = "(((err: Error | null, arg: [string, number, number, number]) => any)) | undefined | null"
+    )]
+    progress: Option<ProgressCallback>,
 ) -> Result<ExtractionReport> {
     validate_path(&archive_path)?;
     validate_path(&output_dir)?;
@@ -933,6 +1052,7 @@ pub async fn extract_archive_with_progress(
         config.map(|c| c.as_core().clone()).unwrap_or_default();
     let options_owned: exarch_core::ExtractionOptions =
         options.map(|o| o.as_core().clone()).unwrap_or_default();
+    let progress = progress.map(|ProgressCallback(tsfn)| tsfn);
 
     let report = tokio::task::spawn_blocking(move || {
         catch_panic_as_js_err("archive extraction with progress", || {

--- a/crates/exarch-node/tests/create-progress.test.js
+++ b/crates/exarch-node/tests/create-progress.test.js
@@ -150,42 +150,137 @@ describe('createArchiveWithProgress', () => {
     );
   });
 
-  // KNOWN LIMITATION (not a passing "this works" test), shared with
-  // extractArchiveWithProgress: both await the dispatch via `call_async_catch`,
-  // whose napi-rs 3.12.0 defect turns a thrown primitive into an uncatchable
-  // process abort. See the long-form explanation in extract-progress.test.js
-  // and https://github.com/bug-ops/exarch/issues/473.
-  //
-  // This test pins the CURRENT behavior. A napi-rs upgrade that fixes the bug
-  // will make it fail — that is the intended signal: flip the assertions to
-  // match the clean-rejection case above and drop the caveat from the
-  // createArchiveWithProgress docs.
-  it('KNOWN LIMITATION: crashes the host process when the callback throws a primitive (child process)', () => {
-    const script = `
-      const exarch = require(${INDEX_JS});
-      exarch.createArchiveWithProgress(
-        ${JSON.stringify(outputPath)},
-        [${JSON.stringify(sourceDir)}],
-        null,
-        () => { throw 'oops'; },
-      ).then(
-        () => { console.log('UNEXPECTED_RESOLVE'); },
-        () => { console.log('UNEXPECTED_REJECT'); },
+  // Regression test for #473, shared mechanism with extractArchiveWithProgress:
+  // throwing a bare primitive (string/number/boolean) from the progress
+  // callback must also reject the promise instead of crashing the process
+  // uncatchably. Run in a child process so a crash (uncaughtException,
+  // non-zero exit) can be distinguished from a clean rejection without
+  // taking down this test run. See extract-progress.test.js for the
+  // long-form explanation of the fix.
+  for (const [label, thrown, thrownRepr] of [
+    ['string', "'oops'", 'oops'],
+    ['number', '42', '42'],
+    ['boolean', 'true', 'true'],
+  ]) {
+    it(`rejects the promise instead of crashing when the callback throws a ${label} (child process)`, () => {
+      const script = `
+        const exarch = require(${INDEX_JS});
+        exarch.createArchiveWithProgress(
+          ${JSON.stringify(outputPath)},
+          [${JSON.stringify(sourceDir)}],
+          null,
+          () => { throw ${thrown}; },
+        ).then(
+          () => { console.log('UNEXPECTED_RESOLVE'); process.exit(2); },
+          (err) => { console.log('REJECTED:' + err.cause.message + ':' + err.cause.cause); },
+        );
+      `;
+
+      const result = spawnSync(process.execPath, ['-e', script], { encoding: 'utf8' });
+
+      assert.strictEqual(
+        result.status,
+        0,
+        `expected clean exit, got status=${result.status}, stderr=${result.stderr}`
       );
-    `;
+      assert.ok(
+        result.stdout.includes(
+          `REJECTED:progress callback threw a non-object value: ${thrownRepr}:${thrownRepr}`
+        ),
+        `expected rejection to be observed, got stdout=${result.stdout}`
+      );
+      assert.ok(
+        !result.stderr.includes('Uncaught') &&
+          !result.stderr.includes('Call JavaScript callback failed'),
+        `expected no crash/uncaught exception, got stderr=${result.stderr}`
+      );
+    });
+  }
 
-    const result = spawnSync(process.execPath, ['-e', script], { encoding: 'utf8' });
-
-    assert.notStrictEqual(
-      result.status,
-      0,
-      'primitive throws are expected to still crash the process; if this now ' +
-        'exits cleanly, the upstream napi-rs bug is fixed — update this test ' +
-        'and the createArchiveWithProgress docs'
+  // Regression test for #473, in-process: a callback throwing a primitive no
+  // longer crashes the host, so this can be asserted directly like the
+  // `Error`-throw case above instead of needing a child process.
+  it('preserves the creation report when the callback throws a primitive', async () => {
+    await assert.rejects(
+      () =>
+        createArchiveWithProgress(outputPath, [sourceDir], null, () => {
+          throw 'oops';
+        }),
+      (err) => {
+        assert.ok(
+          err.message.startsWith('PROGRESS_CALLBACK_ERROR:'),
+          `expected PROGRESS_CALLBACK_ERROR prefix, got: ${err.message}`
+        );
+        assert.match(err.message, /filesAdded=2/);
+        assert.strictEqual(
+          err.cause.message,
+          'progress callback threw a non-object value: oops'
+        );
+        assert.strictEqual(err.cause.cause, 'oops');
+        return true;
+      }
     );
-    assert.match(result.stderr, /Call JavaScript callback failed/);
-    // The promise never settles, so neither handler runs.
-    assert.strictEqual(result.stdout.trim(), '');
+    assert.ok(fs.existsSync(outputPath));
+  });
+
+  // Regression test for the #473 review: a non-function `progress` argument
+  // must fail fast (before touching the archive), not run the whole
+  // creation and only fail when the shim's `callback(...)` call throws
+  // `TypeError: callback is not a function`. Argument extraction happens
+  // synchronously before the returned promise is even constructed, so the
+  // invalid argument throws synchronously rather than rejecting.
+  it('throws synchronously when progress is not a function, without creating', () => {
+    assert.throws(
+      () => createArchiveWithProgress(outputPath, [sourceDir], null, 42),
+      (err) => {
+        assert.match(err.message, /Function/);
+        return true;
+      }
+    );
+    assert.ok(!fs.existsSync(outputPath));
+  });
+
+  // Regression test for the #473 review: the shim must only rewrap values
+  // `napi_create_reference()` genuinely cannot reference (primitives). A
+  // plain object throw (or any non-Error object) must stay directly under
+  // `cause`, not get demoted to `cause.cause` behind a synthesized wrapper.
+  it('preserves a plain-object throw directly under cause, not cause.cause', async () => {
+    await assert.rejects(
+      () =>
+        createArchiveWithProgress(outputPath, [sourceDir], null, () => {
+          throw { code: 'CUSTOM', detail: 'stuff' };
+        }),
+      (err) => {
+        assert.deepStrictEqual(err.cause, { code: 'CUSTOM', detail: 'stuff' });
+        return true;
+      }
+    );
+  });
+
+  // Regression test for the #473 re-critique: a thrown `Symbol` is a
+  // primitive the shim's guard correctly rewraps (`typeof` is `"symbol"`,
+  // not `"object"`/`"function"`), but assigning it to `wrapped.cause` as-is
+  // relocates the crash rather than fixing it — napi-rs's own
+  // `extract_error_cause` later coerces `.cause` to a string via
+  // `napi_coerce_to_string`, which throws for a raw `Symbol` and, under
+  // `--force-node-api-uncaught-exceptions-policy=true`, reproduces the exact
+  // uncatchable crash this fix targets. The shim stringifies a `Symbol`
+  // before attaching it as `cause` to avoid that.
+  it('preserves a thrown Symbol as its string form under cause, without crashing', async () => {
+    await assert.rejects(
+      () =>
+        createArchiveWithProgress(outputPath, [sourceDir], null, () => {
+          throw Symbol('boom');
+        }),
+      (err) => {
+        assert.strictEqual(
+          err.cause.message,
+          'progress callback threw a non-object value: Symbol(boom)'
+        );
+        assert.strictEqual(err.cause.cause, 'Symbol(boom)');
+        return true;
+      }
+    );
   });
 });
 

--- a/crates/exarch-node/tests/create-progress.test.js
+++ b/crates/exarch-node/tests/create-progress.test.js
@@ -212,10 +212,7 @@ describe('createArchiveWithProgress', () => {
           `expected PROGRESS_CALLBACK_ERROR prefix, got: ${err.message}`
         );
         assert.match(err.message, /filesAdded=2/);
-        assert.strictEqual(
-          err.cause.message,
-          'progress callback threw a non-object value: oops'
-        );
+        assert.strictEqual(err.cause.message, 'progress callback threw a non-object value: oops');
         assert.strictEqual(err.cause.cause, 'oops');
         return true;
       }

--- a/crates/exarch-node/tests/extract-progress.test.js
+++ b/crates/exarch-node/tests/extract-progress.test.js
@@ -172,51 +172,147 @@ describe('extractArchiveWithProgress', () => {
     );
   });
 
-  // KNOWN LIMITATION (not a passing "this works" test): throwing a primitive
-  // (string/number/boolean) from the progress callback still crashes the host
-  // process uncatchably, so #465 is only fixed for non-primitive throws.
+  // Regression test for #473: throwing a bare primitive (string/number/
+  // boolean) from the progress callback must also reject the promise
+  // instead of crashing the process uncatchably. Run in a child process so a
+  // crash (uncaughtException, non-zero exit) can be distinguished from a
+  // clean rejection without taking down this test run.
   //
-  // Upstream bug in napi-rs 3.12.0 (threadsafe_function.rs:864): the dispatcher
-  // in `call_async_catch` overwrites its status with the result of
-  // `napi_create_reference()`, which returns `napi_invalid_arg` for a primitive
-  // exception value (a weak ref to a primitive is not possible). It correctly
-  // falls back to `maybe_ref: None` and still delivers `Err` to the channel,
-  // but the non-ok status then reaches `napi_fatal_exception`. The wasm branch
-  // of the same function already resets `status = napi_ok`.
-  //
-  // This test pins the CURRENT behavior. A napi-rs upgrade that fixes the bug
-  // will make it fail — that is the intended signal: flip the assertions to
-  // match the clean-rejection case above and drop the caveat from the
-  // `extractArchiveWithProgress` docs. Tracked in
-  // https://github.com/bug-ops/exarch/issues/473.
-  it('KNOWN LIMITATION: crashes the host process when the callback throws a primitive (child process)', () => {
-    const script = `
-      const exarch = require(${JSON.stringify(path.join(__dirname, '..', 'index.js'))});
-      exarch.extractArchiveWithProgress(
-        ${JSON.stringify(archivePath)},
-        ${JSON.stringify(outputDir)},
-        null,
-        null,
-        () => { throw 'oops'; },
-      ).then(
-        () => { console.log('UNEXPECTED_RESOLVE'); },
-        () => { console.log('UNEXPECTED_REJECT'); },
+  // Fixed by wrapping the callback in a small JS shim (see
+  // `WRAP_PROGRESS_CALLBACK_JS` in lib.rs) before it is ever handed to
+  // napi-rs's threadsafe function dispatcher: the shim catches any
+  // synchronous throw and, unless the thrown value is already an object or
+  // function, re-throws a new `Error` carrying the original value as
+  // `cause`. This sidesteps a napi-rs 3.12.0 upstream defect where
+  // `call_async_catch` crashes the process when the JS value crossing the
+  // callback boundary is a primitive (`napi_create_reference()` cannot
+  // create a weak reference to one).
+  for (const [label, thrown, thrownRepr] of [
+    ['string', "'oops'", 'oops'],
+    ['number', '42', '42'],
+    ['boolean', 'true', 'true'],
+  ]) {
+    it(`rejects the promise instead of crashing when the callback throws a ${label} (child process)`, () => {
+      const script = `
+        const exarch = require(${JSON.stringify(path.join(__dirname, '..', 'index.js'))});
+        exarch.extractArchiveWithProgress(
+          ${JSON.stringify(archivePath)},
+          ${JSON.stringify(outputDir)},
+          null,
+          null,
+          () => { throw ${thrown}; },
+        ).then(
+          () => { console.log('UNEXPECTED_RESOLVE'); process.exit(2); },
+          (err) => { console.log('REJECTED:' + err.cause.message + ':' + err.cause.cause); },
+        );
+      `;
+
+      const result = spawnSync(process.execPath, ['-e', script], {
+        encoding: 'utf8',
+      });
+
+      assert.strictEqual(
+        result.status,
+        0,
+        `expected clean exit, got status=${result.status}, stderr=${result.stderr}`
       );
-    `;
-
-    const result = spawnSync(process.execPath, ['-e', script], {
-      encoding: 'utf8',
+      assert.ok(
+        result.stdout.includes(
+          `REJECTED:progress callback threw a non-object value: ${thrownRepr}:${thrownRepr}`
+        ),
+        `expected rejection to be observed, got stdout=${result.stdout}`
+      );
+      assert.ok(
+        !result.stderr.includes('Uncaught') &&
+          !result.stderr.includes('Call JavaScript callback failed'),
+        `expected no crash/uncaught exception, got stderr=${result.stderr}`
+      );
     });
+  }
 
-    assert.notStrictEqual(
-      result.status,
-      0,
-      'primitive throws are expected to still crash the process; if this now ' +
-        'exits cleanly, the upstream napi-rs bug is fixed — update this test ' +
-        'and the extractArchiveWithProgress docs'
+  // Regression test for #473, in-process: a callback throwing a primitive no
+  // longer crashes the host, so this can be asserted directly like the
+  // `Error`-throw case above instead of needing a child process.
+  it('preserves the extraction report when the callback throws a primitive', async () => {
+    await assert.rejects(
+      () =>
+        extractArchiveWithProgress(archivePath, outputDir, null, null, () => {
+          throw 'oops';
+        }),
+      (err) => {
+        assert.ok(
+          err.message.startsWith('PROGRESS_CALLBACK_ERROR:'),
+          `expected PROGRESS_CALLBACK_ERROR prefix, got: ${err.message}`
+        );
+        assert.match(err.message, /filesExtracted=2/);
+        assert.strictEqual(
+          err.cause.message,
+          'progress callback threw a non-object value: oops'
+        );
+        assert.strictEqual(err.cause.cause, 'oops');
+        return true;
+      }
     );
-    assert.match(result.stderr, /Call JavaScript callback failed/);
-    // The promise never settles, so neither handler runs.
-    assert.strictEqual(result.stdout.trim(), '');
+    assert.ok(fs.existsSync(path.join(outputDir, 'hello.txt')));
+  });
+
+  // Regression test for the #473 review: a non-function `progress` argument
+  // must fail fast (before touching the archive), not run the whole
+  // extraction and only fail when the shim's `callback(...)` call throws
+  // `TypeError: callback is not a function`. Argument extraction happens
+  // synchronously before the returned promise is even constructed, so the
+  // invalid argument throws synchronously rather than rejecting.
+  it('throws synchronously when progress is not a function, without extracting', () => {
+    assert.throws(
+      () => extractArchiveWithProgress(archivePath, outputDir, null, null, 42),
+      (err) => {
+        assert.match(err.message, /Function/);
+        return true;
+      }
+    );
+    assert.strictEqual(fs.readdirSync(outputDir).length, 0);
+  });
+
+  // Regression test for the #473 review: the shim must only rewrap values
+  // `napi_create_reference()` genuinely cannot reference (primitives). A
+  // plain object throw (or any non-Error object) must stay directly under
+  // `cause`, not get demoted to `cause.cause` behind a synthesized wrapper.
+  it('preserves a plain-object throw directly under cause, not cause.cause', async () => {
+    await assert.rejects(
+      () =>
+        extractArchiveWithProgress(archivePath, outputDir, null, null, () => {
+          throw { code: 'CUSTOM', detail: 'stuff' };
+        }),
+      (err) => {
+        assert.deepStrictEqual(err.cause, { code: 'CUSTOM', detail: 'stuff' });
+        return true;
+      }
+    );
+  });
+
+  // Regression test for the #473 re-critique: a thrown `Symbol` is a
+  // primitive the shim's guard correctly rewraps (`typeof` is `"symbol"`,
+  // not `"object"`/`"function"`), but assigning it to `wrapped.cause` as-is
+  // relocates the crash rather than fixing it — napi-rs's own
+  // `extract_error_cause` later coerces `.cause` to a string via
+  // `napi_coerce_to_string`, which throws for a raw `Symbol` and, under
+  // `--force-node-api-uncaught-exceptions-policy=true`, reproduces the exact
+  // uncatchable crash this fix targets. The shim stringifies a `Symbol`
+  // before attaching it as `cause` to avoid that.
+  it('preserves a thrown Symbol as its string form under cause, without crashing', async () => {
+    await assert.rejects(
+      () =>
+        extractArchiveWithProgress(archivePath, outputDir, null, null, () => {
+          throw Symbol('boom');
+        }),
+      (err) => {
+        assert.strictEqual(
+          err.cause.message,
+          'progress callback threw a non-object value: Symbol(boom)'
+        );
+        assert.strictEqual(err.cause.cause, 'Symbol(boom)');
+        return true;
+      }
+    );
   });
 });

--- a/crates/exarch-node/tests/extract-progress.test.js
+++ b/crates/exarch-node/tests/extract-progress.test.js
@@ -245,10 +245,7 @@ describe('extractArchiveWithProgress', () => {
           `expected PROGRESS_CALLBACK_ERROR prefix, got: ${err.message}`
         );
         assert.match(err.message, /filesExtracted=2/);
-        assert.strictEqual(
-          err.cause.message,
-          'progress callback threw a non-object value: oops'
-        );
+        assert.strictEqual(err.cause.message, 'progress callback threw a non-object value: oops');
         assert.strictEqual(err.cause.cause, 'oops');
         return true;
       }


### PR DESCRIPTION
## Summary
- `extractArchiveWithProgress` and `createArchiveWithProgress` crashed the process uncatchably when the progress callback threw a bare primitive (string, number, boolean, or Symbol) — an upstream napi-rs 3.12.0 defect in `call_async_catch`'s dispatcher (`napi_create_reference` fails on primitive exception values, and the failure status is escalated to `napi_fatal_exception` regardless of the exception already having been delivered correctly).
- Fixed by wrapping the user-supplied `progress` callback in a JS shim (injected via `Env::run_script` inside a `ProgressCallback` newtype's `FromNapiValue` impl) that normalizes any synchronous throw into a proper `Error` — preserving the original value under `.cause` — before it ever reaches napi-rs's dispatcher. A non-function `progress` argument now also fails fast via a `ValueType` check instead of running the whole operation first.
- `createArchiveWithProgressSync` is unaffected by this bug class: it dispatches via a plain, non-catching `ThreadsafeFunction::call` and never enters `call_async_catch`, so primitive and `Error` throws already behaved identically there (verified empirically) — left untouched.
- Known, documented, non-blocking gap: an `async` progress callback whose returned Promise *rejects* (rather than throwing synchronously) still isn't caught by this shim and can still crash the process; this is called out explicitly in the doc comments and CHANGELOG.

## Test plan
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` (1115/1115)
- [x] `cargo test --doc -p exarch-node -p exarch-core --all-features` (117/117)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace`
- [x] `npm test` in `crates/exarch-node` (123/123), including new primitive/Symbol/non-function/plain-object regression tests for both `extractArchiveWithProgress` and `createArchiveWithProgress`
- [x] Verified the Symbol-cause fix under `node --force-node-api-uncaught-exceptions-policy=true`

Closes #473