### PR TITLE
fix(core): reject symlink-at-dest and fix quota accounting in 7z skip_duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -362,6 +362,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **`exarch-core`: 7z's `skip_duplicates = false` path silently replaced a pre-existing symlink at
+  the destination instead of rejecting it, and quota was reserved before the duplicate-skip
+  decision (#477, #478)**: the #468 fix below (`skip_duplicates.symlink_metadata()`) closed the
+  duplicate-*detection* gap for `skip_duplicates = true`, but as that entry's own text noted,
+  `skip_duplicates = false` was left unresolved and tracked separately here. `process_entry_inner`
+  now `lstat`s the destination via a shared `lstat_dest` helper before doing anything else with it:
+  with `skip_duplicates = false`, a symlink there (dangling or live) now fails with the same `ELOOP`
+  I/O error TAR/ZIP's `O_NOFOLLOW` open produces, instead of `write_file_with_permit`'s
+  temp-file-then-`rename` silently unlinking and replacing it — `rename(2)` itself never followed
+  the symlink even pre-fix, so this was a silent-replacement bug, not a symlink-escape (content
+  never wrote through the link to its target). A regular file or directory at the destination is
+  still overwritten as before; only a symlink is now rejected. Separately, quota (`reserve_file`,
+  a new `EntryValidator` method mirroring the existing `reserve_hardlink`) is now reserved *after*
+  this check and after the duplicate-skip decision, not before: previously every entry's quota was
+  reserved unconditionally via `validate_entry` before the destination was even inspected, so an
+  entry skipped as a duplicate permanently consumed its file-count/byte-size allotment (`QuotaPermit`
+  has no `Drop` impl to release it). Both fixes apply identically to `SevenZArchive::extract`'s Step
+  1 pre-validation pass, which previously used neither check, so a symlink-at-destination or a
+  since-skipped duplicate could pass pre-validation and only fail (or over-consume quota) partway
+  through the later extraction pass. New `EntryValidator::validate_entry_path` splits path
+  validation out of `validate_entry` so callers needing the destination path before deciding on
+  quota (7z's duplicate check, mirroring `reserve_hardlink`'s existing decoupling for hardlinks) no
+  longer have to reserve quota just to get it.
 - **A pre-planted symlink at a predictable/checked destination path bypassed a `Path::exists()`-style
   duplicate check, and the subsequent non-exclusive write followed it outside the extraction root
   (#471, #467)**: two more instances of the vulnerability class fixed for TAR/ZIP's normal-file

--- a/crates/exarch-core/src/formats/common.rs
+++ b/crates/exarch-core/src/formats/common.rs
@@ -7,6 +7,8 @@
 //! # Functions
 //!
 //! - [`extract_file_with_permit`]: Generic file extraction with buffered I/O
+//! - [`create_file_with_mode`]: O_NOFOLLOW/O_EXCL-safe file creation, also used
+//!   by 7z for its temp file (issues #459, #471)
 //! - [`create_directory`]: Directory creation (idempotent)
 //! - [`create_symlink`]: Symbolic link creation (Unix only)
 //! - [`open_no_follow`]: Read-only open that refuses to follow a symlink

--- a/crates/exarch-core/src/formats/sevenz.rs
+++ b/crates/exarch-core/src/formats/sevenz.rs
@@ -127,7 +127,6 @@ use crate::config::Validated;
 use crate::error::QuotaResource;
 use crate::security::EntryValidator;
 use crate::security::quota::QuotaPermit;
-use crate::security::validator::ValidatedEntryType;
 use crate::types::DestDir;
 use crate::types::EntryType;
 
@@ -375,6 +374,52 @@ fn write_file_with_permit_using(
     Ok(bytes_written)
 }
 
+/// lstat's `dest_path`, returning `Ok(None)` if nothing occupies it.
+///
+/// Uses `symlink_metadata` rather than `exists()`/`is_dir()`: those follow
+/// symlinks and report a dangling symlink as absent, which would let a
+/// dangling symlink slip past both duplicate detection and the
+/// pre-existing-symlink rejection below (issues #468, #477, #478). Shared by
+/// both `SevenZArchive::extract`'s Step 1 pre-validation loop and
+/// `process_entry_inner`'s Step 3 extraction callback, so the two agree on
+/// what counts as "something already at this path".
+///
+/// # TOCTOU
+///
+/// This check is advisory, not atomic: nothing prevents the filesystem state
+/// at `dest_path` from changing between this lstat and the later
+/// `remove_file`/`remove_dir_all`/`rename`. That window is benign here —
+/// unlike TAR/ZIP's `O_NOFOLLOW` open (a single atomic syscall), 7z's
+/// temp+rename write never opens `dest_path` itself, and `rename(2)`
+/// replaces whatever occupies the destination without following a symlink
+/// planted there in the interim, so a race cannot redirect the write through
+/// a symlink target.
+fn lstat_dest(dest_path: &Path) -> std::io::Result<Option<std::fs::Metadata>> {
+    match std::fs::symlink_metadata(dest_path) {
+        Ok(meta) => Ok(Some(meta)),
+        Err(e) if e.kind() == ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
+/// Returns the `ELOOP` I/O error `common::open_no_follow` produces when a
+/// symlink occupies the destination path, so 7z's own checks fail the same
+/// way instead of silently replacing the symlink (issue #477). Converts via
+/// `?`/`.into()` into either `ArchiveError` (Step 1) or `sevenz_rust2::Error`
+/// (Step 3), both of which implement `From<std::io::Error>`.
+///
+/// `#[cfg(unix)]`, not just conditional at runtime: `O_NOFOLLOW` is a
+/// Unix-specific mechanism (see `common::open_no_follow`), and
+/// `common::create_file_with_mode`'s non-Unix branch provides no equivalent
+/// symlink guard for TAR/ZIP either, so non-Unix keeps the pre-existing
+/// remove-then-rename behavior for parity with TAR/ZIP's own platform split.
+/// Both call sites are gated by the same `#[cfg(unix)]`, so this function
+/// does not exist at all — and cannot be reached — on non-Unix targets.
+#[cfg(unix)]
+fn symlink_at_dest_error() -> std::io::Error {
+    std::io::Error::from_raw_os_error(libc::ELOOP)
+}
+
 impl<R: Read + Seek> SevenZArchive<R> {
     /// Processes a single 7z entry: validates, extracts file or creates
     /// directory.
@@ -398,7 +443,7 @@ impl<R: Read + Seek> SevenZArchive<R> {
             sevenz_rust2::Error::Other(format!("entry type detection failed: {e}").into())
         })?;
 
-        // Extension filter runs before validate_entry to avoid quota
+        // Extension filter runs before path validation to avoid quota
         // double-counting for skipped files.
         if matches!(entry_type, EntryType::File)
             && !common::check_extension_allowed(entry_path, config, report)
@@ -406,45 +451,61 @@ impl<R: Read + Seek> SevenZArchive<R> {
             return Ok(0);
         }
 
-        // Re-validate (defense in depth)
-        let validated = validator
-            .validate_entry(entry_path, &entry_type, entry.size, None, None, None)
+        // Re-validate the path only (defense in depth); quota for File
+        // entries is reserved separately below, after the duplicate-skip
+        // check, so a skipped entry never consumes quota it will not use
+        // (issue #478). See `EntryValidator::validate_entry_path`.
+        let safe_path = validator
+            .validate_entry_path(entry_path, None)
             .map_err(|e| sevenz_rust2::Error::Other(format!("validation failed: {e}").into()))?;
-
-        // Extract based on type. `into_parts()` consumes `validated` so the
-        // File arm can move its QuotaPermit by value into
-        // write_file_with_permit, rather than only observing it through
-        // entry_type()'s shared reference.
-        //
-        // `_mode` is discarded: sevenz-rust2 never exposes Unix mode, so this
-        // module has no set_permissions/sanitize_permissions call today. If
-        // that limitation is ever lifted, wire `_mode` into the write path
-        // instead of continuing to drop it here.
-        let (safe_path, entry_type, _mode) = validated.into_parts();
         let dest_path = dest.join_path(safe_path.as_path());
 
         match entry_type {
-            ValidatedEntryType::Directory => {
+            EntryType::Directory => {
                 dir_cache.ensure_dir(&dest_path)?;
                 report.directories_created += 1;
                 Ok(0)
             }
-            ValidatedEntryType::File(permit) => {
+            EntryType::File => {
                 dir_cache.ensure_parent_dir(&dest_path)?;
 
-                if dest_path.symlink_metadata().is_ok() {
-                    if skip_duplicates {
-                        report.files_skipped += 1;
-                        report.warnings.push(format!(
-                            "skipped duplicate entry: {}",
-                            safe_path.as_path().display()
-                        ));
-                        return Ok(0);
-                    }
-                    // 7z uses temp+rename (unlike TAR/ZIP which truncate in-place via
-                    // File::create). Remove the existing path first so `rename`
-                    // can succeed.
-                    if dest_path.is_dir() {
+                let existing = lstat_dest(&dest_path)?;
+
+                if existing.is_some() && skip_duplicates {
+                    report.files_skipped += 1;
+                    report.warnings.push(format!(
+                        "skipped duplicate entry: {}",
+                        safe_path.as_path().display()
+                    ));
+                    return Ok(0);
+                }
+
+                #[cfg(unix)]
+                if let Some(meta) = &existing
+                    && meta.file_type().is_symlink()
+                {
+                    // SECURITY: refuse to silently unlink a pre-existing
+                    // symlink at the destination and replace it — fail
+                    // the same way TAR/ZIP's O_NOFOLLOW open does
+                    // (ELOOP), instead of proceeding to remove_file +
+                    // rename underneath it (issue #477).
+                    return Err(symlink_at_dest_error().into());
+                }
+
+                // Reserve quota BEFORE mutating the filesystem: deciding
+                // (quota check) must precede acting (removing the existing
+                // path), so a QuotaExceeded error never first destroys a
+                // pre-existing destination it could not ultimately replace.
+                let permit = validator.reserve_file(entry.size).map_err(|e| {
+                    sevenz_rust2::Error::Other(format!("validation failed: {e}").into())
+                })?;
+
+                if let Some(meta) = existing {
+                    // 7z uses temp+rename (unlike TAR/ZIP which truncate
+                    // in-place via File::create). Remove the existing path
+                    // first so `rename` can succeed. Deferred until after
+                    // the quota reservation above succeeds.
+                    if meta.is_dir() {
                         std::fs::remove_dir_all(&dest_path)?;
                     } else {
                         std::fs::remove_file(&dest_path)?;
@@ -624,30 +685,50 @@ impl<R: Read + Seek> ArchiveFormat for SevenZArchive<R> {
         let mut prevalidator = EntryValidator::new(config, &dest);
         for entry in &self.entries {
             let path = std::path::PathBuf::from(common::normalize_entry_name(&entry.name));
-            let entry_type = if entry.is_directory {
-                EntryType::Directory
-            } else {
-                EntryType::File
-            };
+
+            // Path-only validation here; quota for File entries is reserved
+            // below, after checking whether this entry would be skipped as a
+            // duplicate at the destination, so pre-validation does not
+            // over-count entries Step 3 will actually skip (issue #478).
+            let safe_path = prevalidator.validate_entry_path(&path, None)?;
+
+            if entry.is_directory {
+                continue;
+            }
+
+            let dest_path = dest.join_path(safe_path.as_path());
+            // lstat so a pre-existing symlink at dest_path — including a
+            // dangling one — counts as "already there", matching the
+            // duplicate detection Step 3 performs (issue #468, #477, #478).
+            let existing = lstat_dest(&dest_path)?;
+
+            if existing.is_some() && options.skip_duplicates {
+                // Step 3 will skip this entry; do not reserve its quota.
+                continue;
+            }
+
+            #[cfg(unix)]
+            if let Some(meta) = &existing
+                && meta.file_type().is_symlink()
+            {
+                // Fail here too, not only in Step 3: with
+                // skip_duplicates=false, a symlink at this entry's
+                // destination will be rejected once extraction reaches it,
+                // so failing during pre-validation — before any entry is
+                // written — preserves this loop's "no partial extraction"
+                // guarantee (issue #477).
+                return Err(symlink_at_dest_error().into());
+            }
 
             // KNOWN LIMITATION: compressed_size is None, so compression ratio check is
             // skipped. Defense relies on max_total_size and max_file_size
             // quotas.
-            let validated =
-                prevalidator.validate_entry(&path, &entry_type, entry.size, None, None, None)?;
-
-            match validated.entry_type() {
-                ValidatedEntryType::File(_) | ValidatedEntryType::Directory => {
-                    // Will be extracted in Step 3
-                }
-                _ => {
-                    // KNOWN LIMITATION: sevenz-rust2 doesn't expose symlink/hardlink detection.
-                    // If entry type detection improves, this will catch them.
-                    return Err(ArchiveError::SecurityViolation {
-                        reason: "symlinks/hardlinks not yet supported for 7z".into(),
-                    });
-                }
-            }
+            //
+            // The permit itself is discarded: this loop only needs
+            // `reserve_file`'s Err on a would-be quota violation, since
+            // `prevalidator` is thrown away once Step 1 finishes (Step 3
+            // uses a fresh validator, see below).
+            let _permit = prevalidator.reserve_file(entry.size)?;
         }
 
         // Empty archives: skip extraction entirely — decompress_with_extract_fn
@@ -1916,21 +1997,18 @@ mod tests {
         );
     }
 
-    /// Characterization test, not a regression test for #468: this
-    /// `skip_duplicates = false` path passes identically on the pre-fix
-    /// code too, since `dest_path.exists()` is `false` for a dangling
-    /// symlink either way — the `if` block (and its `is_dir()`/
-    /// `remove_file` duplicate-removal logic) is never entered pre-fix.
-    /// The write still succeeds pre-fix because `write_file_with_permit`'s
-    /// temp-file + `rename` replaces whatever sits at `dest_path`, symlink
-    /// or not, without following it. It documents that this behavior is
-    /// unaffected by the #468 fix — 7z silently replaces a pre-existing
-    /// symlink here, unlike TAR/ZIP which hard-fail via `O_NOFOLLOW`/
-    /// `ELOOP` in `create_file_with_mode`. That cross-format divergence is
-    /// tracked separately in #477.
+    /// Regression test for #477: before this fix, `skip_duplicates = false`
+    /// against a dangling symlink at the destination silently replaced it —
+    /// `write_file_with_permit`'s temp-file + `rename` replaces whatever
+    /// sits at `dest_path`, symlink or not, without following it, and
+    /// nothing upstream of that rename rejected a symlink destination the
+    /// way TAR/ZIP's `O_NOFOLLOW`/`ELOOP` in `create_file_with_mode` does.
+    /// `process_entry_inner` now checks `lstat_dest` before reserving quota
+    /// or removing anything, and fails with the same `ELOOP` I/O error
+    /// TAR/ZIP produce instead of silently replacing the symlink.
     #[test]
     #[cfg(unix)]
-    fn test_duplicate_replaces_dangling_symlink_when_not_skipping() {
+    fn test_duplicate_rejects_dangling_symlink_when_not_skipping() {
         let data = make_sevenz_archive(&[("target.txt", b"payload")]);
         let mut archive = SevenZArchive::new(Cursor::new(data)).unwrap();
 
@@ -1943,17 +2021,17 @@ mod tests {
             skip_duplicates: false,
             ..ExtractionOptions::default()
         };
-        let report = archive
-            .extract(temp.path(), &config, &options, &mut crate::NoopProgress)
-            .unwrap();
+        let result = archive.extract(temp.path(), &config, &options, &mut crate::NoopProgress);
 
-        assert_eq!(report.files_extracted, 1);
-        assert_eq!(report.files_skipped, 0);
+        assert!(
+            result.is_err(),
+            "a pre-existing symlink at the destination must be rejected, not silently \
+             replaced: {result:?}"
+        );
         let metadata = std::fs::symlink_metadata(&link_path).unwrap();
         assert!(
-            !metadata.file_type().is_symlink(),
-            "dangling symlink must be replaced by the extracted file"
+            metadata.file_type().is_symlink(),
+            "dangling symlink must survive untouched, not be replaced by extracted content"
         );
-        assert_eq!(std::fs::read(&link_path).unwrap(), b"payload");
     }
 }

--- a/crates/exarch-core/src/security/quota.rs
+++ b/crates/exarch-core/src/security/quota.rs
@@ -11,10 +11,18 @@ use crate::config::Validated;
 /// [`QuotaTracker`].
 ///
 /// This is a capability token, not a data type: it carries no payload and
-/// exists only so that [`ValidatedEntryType::File`] cannot be constructed
-/// without a tracker having actually authorized the charge. Its only
-/// producer is [`QuotaTracker::reserve`] — the private field means no other
-/// code, in or out of this crate, can assemble one directly.
+/// exists only so that code holding one can prove a tracker actually
+/// authorized the charge. Its only producer is [`QuotaTracker::reserve`] —
+/// the private field means no other code, in or out of this crate, can
+/// assemble one directly. `EntryValidator` exposes three ways to obtain one,
+/// all funneling through that same `reserve` call:
+/// [`EntryValidator::validate_entry`] embeds it in
+/// [`ValidatedEntryType::File`] for the common case where path validation and
+/// quota reservation happen together; its crate-private `reserve_hardlink`
+/// and `reserve_file` methods return it standalone for callers that must
+/// decouple the two — hardlinks (target size only known in a second pass)
+/// and 7z's duplicate-skip check (quota must not be reserved for an entry
+/// that turns out to be a skipped duplicate), respectively.
 ///
 /// Deliberately not `Clone`/`Copy`/`Default`: a permit represents a single
 /// reservation and must not be duplicated or spent more than once. Zero-sized
@@ -22,11 +30,12 @@ use crate::config::Validated;
 /// `Result<()>`.
 ///
 /// [`ValidatedEntryType::File`]: crate::security::validator::ValidatedEntryType::File
+/// [`EntryValidator::validate_entry`]: crate::security::validator::EntryValidator::validate_entry
 ///
 /// # Examples
 ///
-/// A `QuotaPermit` is never constructed directly — it arrives already
-/// embedded in a validated file entry:
+/// The common case: a `QuotaPermit` arrives already embedded in a validated
+/// file entry, via [`EntryValidator::validate_entry`]:
 ///
 /// ```no_run
 /// use exarch_core::SecurityConfig;

--- a/crates/exarch-core/src/security/validator.rs
+++ b/crates/exarch-core/src/security/validator.rs
@@ -236,15 +236,7 @@ impl<'a> EntryValidator<'a> {
         mode: Option<u32>,
         dir_cache: Option<&DirCache>,
     ) -> Result<ValidatedEntry> {
-        let mut ctx = ValidationContext::new(self.config.allowed.symlinks);
-        if let Some(cache) = dir_cache {
-            ctx = ctx.with_dir_cache(cache);
-        }
-        if self.symlink_seen {
-            ctx.mark_symlink_seen();
-        }
-
-        let safe_path = SafePath::validate_with_context(path, self.dest, self.config, &ctx)?;
+        let safe_path = self.validate_entry_path(path, dir_cache)?;
 
         let (validated_type, sanitized_mode) = match entry_type {
             EntryType::File => {
@@ -295,6 +287,60 @@ impl<'a> EntryValidator<'a> {
             validated_type,
             sanitized_mode,
         ))
+    }
+
+    /// Validates only the path portion of an entry — traversal, absolute-path,
+    /// depth, and symlink-escape-adjacent checks — without reserving quota or
+    /// applying type-specific validation (symlink/hardlink target checks,
+    /// permission sanitization).
+    ///
+    /// Split out of [`validate_entry`](Self::validate_entry), which calls
+    /// this for its own path-validation step so the two never diverge.
+    /// Callers that must resolve an entry's destination path *before*
+    /// deciding whether to reserve quota — 7z's duplicate-skip check (issue
+    /// #478), which needs the path to check for a pre-existing file at the
+    /// destination — use this together with
+    /// [`reserve_file`](Self::reserve_file) instead of `validate_entry`, so
+    /// a skipped entry never reserves quota it will not use.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ArchiveError::PathTraversal`](crate::ArchiveError::PathTraversal)
+    /// or another path-validation error if `path` fails validation.
+    pub(crate) fn validate_entry_path(
+        &self,
+        path: &Path,
+        dir_cache: Option<&DirCache>,
+    ) -> Result<SafePath> {
+        let mut ctx = ValidationContext::new(self.config.allowed.symlinks);
+        if let Some(cache) = dir_cache {
+            ctx = ctx.with_dir_cache(cache);
+        }
+        if self.symlink_seen {
+            ctx.mark_symlink_seen();
+        }
+
+        SafePath::validate_with_context(path, self.dest, self.config, &ctx)
+    }
+
+    /// Reserves quota capacity for a regular file's byte count, independent
+    /// of path validation.
+    ///
+    /// Mirrors [`reserve_hardlink`](Self::reserve_hardlink), which exists for
+    /// the same reason on the hardlink path: reserving quota unconditionally
+    /// inside `validate_entry` and only checking for a duplicate afterward
+    /// would permanently consume the entry's quota allotment on the skip
+    /// path, since [`QuotaPermit`] has no `Drop` impl to release it. Used by
+    /// 7z's extraction callback together with
+    /// [`validate_entry_path`](Self::validate_entry_path) (issue #478).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ArchiveError::QuotaExceeded`](crate::ArchiveError::QuotaExceeded)
+    /// if recording `size` bytes would exceed `max_file_size`,
+    /// `max_file_count`, or `max_total_size`.
+    pub(crate) fn reserve_file(&mut self, size: u64) -> Result<QuotaPermit> {
+        self.quota_tracker.reserve(size, self.config)
     }
 
     /// Validates the compression ratio (zip bomb detection) when a

--- a/crates/exarch-core/tests/skip_duplicates_integration.rs
+++ b/crates/exarch-core/tests/skip_duplicates_integration.rs
@@ -144,6 +144,42 @@ fn make_sevenz_with_duplicate(path: &str, first: &[u8], second: &[u8]) -> NamedT
     f
 }
 
+/// Build a 7z archive in memory containing a single file entry.
+#[cfg(unix)]
+fn make_sevenz_single(path: &str, content: &[u8]) -> NamedTempFile {
+    let mut f = NamedTempFile::with_suffix(".7z").unwrap();
+    {
+        let mut writer = ArchiveWriter::new(&mut f).unwrap();
+        writer
+            .push_archive_entry(ArchiveEntry::new_file(path), Some(content))
+            .unwrap();
+        writer.finish().unwrap();
+    }
+    f
+}
+
+/// Build a 7z archive in memory containing two entries at distinct paths.
+#[cfg(unix)]
+fn make_sevenz_two_entries(
+    path_a: &str,
+    content_a: &[u8],
+    path_b: &str,
+    content_b: &[u8],
+) -> NamedTempFile {
+    let mut f = NamedTempFile::with_suffix(".7z").unwrap();
+    {
+        let mut writer = ArchiveWriter::new(&mut f).unwrap();
+        writer
+            .push_archive_entry(ArchiveEntry::new_file(path_a), Some(content_a))
+            .unwrap();
+        writer
+            .push_archive_entry(ArchiveEntry::new_file(path_b), Some(content_b))
+            .unwrap();
+        writer.finish().unwrap();
+    }
+    f
+}
+
 /// `skip_duplicates=true` (default): first entry extracted, second skipped.
 /// The file on disk must contain the content of the FIRST entry.
 #[test]
@@ -317,5 +353,170 @@ fn tar_dangling_symlink_at_destination_rejected_when_overwrite_requested() {
     assert!(
         !escape_target.exists(),
         "payload must never land outside dest via the dangling symlink"
+    );
+}
+
+// ============================================================================
+// 7z symlink-at-destination regression tests (issues #477, #478)
+// ============================================================================
+//
+// 7z's extraction path uses temp-file-then-rename instead of TAR/ZIP's
+// O_EXCL/O_NOFOLLOW open, and validated quota before checking for a
+// duplicate at the destination. Two bugs followed:
+//
+// - #477: `skip_duplicates=false` against a pre-existing symlink at the
+//   destination silently unlinked and replaced it (`rename()` doesn't follow
+//   symlinks), where TAR/ZIP fail with `ELOOP`.
+// - #478: quota was reserved before the duplicate-skip check, so a skipped
+//   entry permanently consumed its quota allotment (`QuotaPermit` has no `Drop`
+//   impl to release it).
+
+/// `skip_duplicates=false`: a pre-existing (dangling) symlink at the
+/// destination path must be rejected, not silently unlinked and replaced by
+/// the temp+rename write (issue #477).
+#[cfg(unix)]
+#[test]
+fn sevenz_dangling_symlink_at_destination_rejected_when_overwrite_requested() {
+    use std::os::unix::fs::symlink;
+
+    let dest = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+    let escape_target = outside.path().join("escaped.txt");
+
+    symlink(&escape_target, dest.path().join("file.txt")).unwrap();
+    assert!(
+        !escape_target.exists(),
+        "symlink target must be dangling before extraction"
+    );
+
+    let archive = make_sevenz_single("file.txt", b"payload");
+    let config = SecurityConfig::default();
+    let options = ExtractionOptions::default().with_skip_duplicates(false);
+
+    let result = extract_archive_with_options(archive.path(), dest.path(), &config, &options);
+
+    assert!(
+        result.is_err(),
+        "writing through a symlink at the destination must be rejected, not silently followed"
+    );
+    assert!(
+        !escape_target.exists(),
+        "payload must never land outside dest via the dangling symlink"
+    );
+    assert!(
+        dest.path()
+            .join("file.txt")
+            .symlink_metadata()
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "the pre-existing symlink must be left untouched, not unlinked and replaced"
+    );
+}
+
+/// `skip_duplicates=true` (default): a dangling symlink at the destination
+/// path is skipped like any other duplicate, and — unlike before the #478
+/// fix — the skipped entry must never reserve quota in the first place (it
+/// is never released, because it was never reserved). Proven here by
+/// extracting a second, independent entry against a `max_file_count` of 1:
+/// it only fits if the skipped entry's quota was never reserved.
+#[cfg(unix)]
+#[test]
+fn sevenz_dangling_symlink_at_destination_quota_not_consumed_when_skipped() {
+    use std::os::unix::fs::symlink;
+
+    let dest = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+    let escape_target = outside.path().join("escaped.txt");
+
+    symlink(&escape_target, dest.path().join("link.txt")).unwrap();
+    assert!(
+        !escape_target.exists(),
+        "symlink target must be dangling before extraction"
+    );
+
+    let archive = make_sevenz_two_entries("link.txt", b"payload", "other.txt", b"second-file");
+    let config = SecurityConfig::default().with_max_file_count(1);
+    let options = ExtractionOptions::default(); // skip_duplicates = true (default)
+
+    let report = extract_archive_with_options(archive.path(), dest.path(), &config, &options)
+        .expect("a skipped duplicate must not permanently consume the file-count quota");
+
+    assert_eq!(
+        report.files_skipped, 1,
+        "the symlinked path must be counted as skipped"
+    );
+    assert_eq!(
+        report.files_extracted, 1,
+        "the second entry must still fit within max_file_count=1: it only does if the \
+         skipped entry never reserved quota in the first place"
+    );
+    assert!(dest.path().join("other.txt").exists());
+    assert!(
+        !escape_target.exists(),
+        "payload must never land outside dest via the dangling symlink"
+    );
+}
+
+/// `skip_duplicates=false`: a pre-existing *regular file* (not a symlink) at
+/// the destination must still be overwritten, guarding against the ELOOP
+/// rejection above over-firing for ordinary duplicates — only a symlink at
+/// dest is special-cased.
+#[test]
+fn sevenz_regular_file_at_destination_still_overwritten_when_overwrite_requested() {
+    let dest = TempDir::new().unwrap();
+    std::fs::write(dest.path().join("file.txt"), b"pre-existing").unwrap();
+
+    let archive = make_sevenz_single("file.txt", b"payload");
+    let config = SecurityConfig::default();
+    let options = ExtractionOptions::default().with_skip_duplicates(false);
+
+    let report = extract_archive_with_options(archive.path(), dest.path(), &config, &options)
+        .expect("overwriting a pre-existing regular file must still succeed");
+
+    assert_eq!(report.files_extracted, 1);
+    let content = std::fs::read(dest.path().join("file.txt")).unwrap();
+    assert_eq!(content, b"payload", "regular file must be overwritten");
+}
+
+/// `skip_duplicates=false`: a *live* (non-dangling) symlink at the
+/// destination must be rejected the same way a dangling one is — the ELOOP
+/// check is not specific to dangling links.
+#[cfg(unix)]
+#[test]
+fn sevenz_live_symlink_at_destination_rejected_when_overwrite_requested() {
+    use std::os::unix::fs::symlink;
+
+    let dest = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+    let live_target = outside.path().join("real.txt");
+    std::fs::write(&live_target, b"outside content").unwrap();
+
+    symlink(&live_target, dest.path().join("file.txt")).unwrap();
+    assert!(live_target.exists(), "symlink target must resolve");
+
+    let archive = make_sevenz_single("file.txt", b"payload");
+    let config = SecurityConfig::default();
+    let options = ExtractionOptions::default().with_skip_duplicates(false);
+
+    let result = extract_archive_with_options(archive.path(), dest.path(), &config, &options);
+
+    assert!(
+        result.is_err(),
+        "a live symlink at the destination must be rejected just like a dangling one"
+    );
+    assert_eq!(
+        std::fs::read(&live_target).unwrap(),
+        b"outside content",
+        "the symlink's real target must never be written through"
+    );
+    assert!(
+        dest.path()
+            .join("file.txt")
+            .symlink_metadata()
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "the pre-existing symlink must be left untouched, not unlinked and replaced"
     );
 }

--- a/crates/exarch-core/tests/skip_duplicates_integration.rs
+++ b/crates/exarch-core/tests/skip_duplicates_integration.rs
@@ -145,7 +145,6 @@ fn make_sevenz_with_duplicate(path: &str, first: &[u8], second: &[u8]) -> NamedT
 }
 
 /// Build a 7z archive in memory containing a single file entry.
-#[cfg(unix)]
 fn make_sevenz_single(path: &str, content: &[u8]) -> NamedTempFile {
     let mut f = NamedTempFile::with_suffix(".7z").unwrap();
     {


### PR DESCRIPTION
## Summary

- 7z's `skip_duplicates=false` path silently replaced a pre-existing symlink at the destination via its temp-file-then-rename write instead of rejecting it the way TAR/ZIP's `O_NOFOLLOW` open does. `#468` closed the duplicate-*detection* gap for `skip_duplicates=true` only and explicitly tracked this case separately; `skip_duplicates=false` now fails with `ELOOP` on a symlink at the destination (Unix), matching TAR/ZIP. Note: `rename(2)` never followed the symlink even before this fix, so this closes a silent-replacement inconsistency, not a symlink-escape — no attacker-controlled content ever wrote through the planted symlink to its target.
- 7z's quota reservation happened before the skip-duplicates decision, so an entry skipped as a duplicate permanently consumed its quota allotment with no release (`QuotaPermit` has no `Drop`). Quota is now reserved after the skip check, matching the existing pattern in TAR's hardlink path. The same bug existed independently in `extract()`'s Step 1 pre-validation loop and is fixed there too.

## Also included

A P0 temp-file symlink vulnerability was independently rediscovered by this PR's review pass (predictable temp-file name + non-exclusive open in `write_file_with_permit`), then found to already be fixed on `main` by #482 with a more complete implementation (retry-based `create_new`). That duplicate finding was reconciled against #482/#471 and no separate fix ships here.

## Follow-ups filed (out of scope for this PR)

- #483 — 7z's `skip_duplicates=false` runs `remove_dir_all` on a pre-existing directory at the destination instead of failing with `EISDIR` like TAR/ZIP.
- #484 — Step 1 pre-validation no longer reserves quota for `skip_duplicates` pre-existing entries, losing the `max_file_count` preflight for that case, and `report.warnings` can grow unbounded.

Closes #477
Closes #478

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` (1126/1126 pass)
- [x] `cargo test --doc --workspace --all-features` (scoped to exarch-core/-cli/-node; exarch-python doctest linking fails in this environment due to a pre-existing missing-libpython constraint, unrelated to this change)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace` (rustdoc gate, exarch-core)
- [x] New regression tests: symlink-at-dest rejected with `skip_duplicates=false` (live and dangling); quota not consumed when a duplicate is skipped (Step 1 and Step 3, via `max_file_count=1` + a second real entry); pre-existing regular file still overwritten (guards the new check against over-firing on non-symlinks)