### PR TITLE
fix(core): cap duplicate-skip warnings in tar/zip and reject drive-relative symlink targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `hasattr(e, "files_extracted")` idiom), so the marker is what tells the two apart; if the
   operation also failed, the core error stays primary (a raising callback can never mask a
   security error) with the callback's exception chained onto it via `__cause__`.
+- **`exarch-core`: `SafeSymlink::validate` did not explicitly reject Windows drive/UNC prefix or
+  root-relative components in a symlink target, relying only on `is_absolute()` (#491)**: a
+  drive-relative target like `C:foo` (no backslash after the colon, `Prefix` without `RootDir`) and
+  a root-relative target like `\evil` (`RootDir` without `Prefix`) are both not `is_absolute()` per
+  Rust's definition, which requires both components together, yet each still resolves relative to
+  the current directory/drive — a GHSA-9ppj-qmqm-q256-class bypass. `SafeHardlink::validate`
+  (`security/hardlink.rs`, tag `H-SEC-2`) and `SafePath::validate` already carry this explicit
+  `Component::Prefix(_) | Component::RootDir` rejection; `SafeSymlink::validate` only carried it as
+  an unstated side effect of `PathBuf::push`'s Windows prefix-without-root replacement behavior in
+  `resolve_through_symlinks`. Added the same explicit guard so the rejection is deliberate rather
+  than incidental.
+- **`exarch-core`: TAR and ZIP `skip_duplicates = true` pushed one unbounded warning `String` per
+  pre-existing-duplicate entry, symlink, or (TAR-only) hardlink (#490)**: `report.warnings` grew by
+  one entry per skipped duplicate, proportional to archive size with no cap — the same class of
+  issue already fixed for 7z in #484/#487. `common::extract_file_with_permit` and
+  `common::create_symlink` (shared by both formats) and TAR's own inline hardlink duplicate-skip
+  path in `create_hardlink` now accumulate counters instead, and each format's `extract()` pushes at
+  most two aggregated warnings once extraction completes (one for file/symlink duplicates, plus one
+  for hardlink duplicates on TAR, since ZIP has no hardlink entry type). `report.files_skipped`'s
+  count is unaffected.
 - **`exarch-core`: 7z `skip_duplicates = false` deleted a pre-existing destination directory tree
   instead of failing like TAR/ZIP's `EISDIR` (#483)**: when a 7z file entry's destination path was
   occupied by a pre-existing directory, extraction called `remove_dir_all` on it and wrote a fresh
@@ -209,7 +229,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   proportional to archive size with no cap. Replaced with a single aggregated warning
   (`"skipped N entries as pre-existing duplicates"`) emitted once extraction completes, if any
   entries were skipped this way. `report.files_skipped`'s count is unaffected. TAR/ZIP's equivalent
-  per-entry duplicate-skip warning is unchanged.
+  per-entry duplicate-skip warning was fixed the same way in #490.
 - **`exarch-core`: 7z `skip_duplicates` check missed a dangling symlink at the destination path
   (#468)**: `dest_path.exists()` follows symlinks and returns `false` for a dangling symlink, so a
   pre-existing dangling symlink occupying an entry's destination silently passed the duplicate

--- a/crates/exarch-core/src/formats/common.rs
+++ b/crates/exarch-core/src/formats/common.rs
@@ -334,6 +334,45 @@ pub fn normalize_entry_name(name: &str) -> String {
     }
 }
 
+/// Appends a single aggregated warning for `count` skipped duplicate
+/// entries, choosing `noun_singular`/`noun_plural` based on `count`.
+///
+/// Shared by the TAR and ZIP extractors so a single warning is pushed once
+/// extraction completes instead of one warning per skipped duplicate,
+/// mirroring 7z's `duplicate_skips` accumulator
+/// (`SevenZArchive::extract_with_callback`, issues #484/#487/#490). A no-op
+/// when `count` is zero.
+///
+/// # Examples
+///
+/// ```ignore
+/// # use exarch_core::formats::common::push_duplicate_skip_warning;
+/// # use exarch_core::ExtractionReport;
+/// let mut report = ExtractionReport::new();
+/// push_duplicate_skip_warning(&mut report, 3, "entry", "entries");
+/// assert_eq!(
+///     report.warnings,
+///     vec!["skipped 3 entries as pre-existing duplicates".to_string()]
+/// );
+/// ```
+pub fn push_duplicate_skip_warning(
+    report: &mut ExtractionReport,
+    count: u64,
+    noun_singular: &str,
+    noun_plural: &str,
+) {
+    if count > 0 {
+        let noun = if count == 1 {
+            noun_singular
+        } else {
+            noun_plural
+        };
+        report
+            .warnings
+            .push(format!("skipped {count} {noun} as pre-existing duplicates"));
+    }
+}
+
 /// Returns `true` if `path`'s extension passes `config`'s allowlist.
 ///
 /// If the extension is not allowed, records the skip in `report`
@@ -567,6 +606,10 @@ pub fn create_file_with_mode(
 /// * `expected_size` - Expected file size (if known) for quota pre-check
 /// * `copy_buffer` - Reusable buffer for I/O operations
 /// * `dir_cache` - Directory cache to reduce redundant mkdir syscalls
+/// * `duplicate_skips` - Counter incremented (not pushed as a warning string)
+///   when a duplicate entry is skipped; the caller aggregates it into a single
+///   warning after extraction completes, mirroring 7z's `duplicate_skips`
+///   accumulator (issue #490)
 ///
 /// # Errors
 ///
@@ -588,6 +631,7 @@ pub fn extract_file_with_permit<R: Read>(
     copy_buffer: &mut CopyBuffer,
     dir_cache: &mut DirCache,
     skip_duplicates: bool,
+    duplicate_skips: &mut u64,
     progress: &mut dyn ProgressCallback,
 ) -> Result<()> {
     let output_path = dest.join(safe_path);
@@ -617,10 +661,7 @@ pub fn extract_file_with_permit<R: Read>(
         Ok(file) => file,
         Err(e) if skip_duplicates && e.kind() == std::io::ErrorKind::AlreadyExists => {
             report.files_skipped += 1;
-            report.warnings.push(format!(
-                "skipped duplicate entry: {}",
-                safe_path.as_path().display()
-            ));
+            *duplicate_skips = duplicate_skips.saturating_add(1);
             return Ok(());
         }
         Err(e) => return Err(e.into()),
@@ -710,6 +751,10 @@ pub fn create_directory(
 /// * `dest` - Destination directory
 /// * `report` - Extraction statistics (updated)
 /// * `dir_cache` - Directory cache to reduce redundant mkdir syscalls
+/// * `duplicate_skips` - Counter incremented (not pushed as a warning string)
+///   when a duplicate symlink is skipped; the caller aggregates it into a
+///   single warning after extraction completes, mirroring 7z's
+///   `duplicate_skips` accumulator (issue #490)
 ///
 /// # Errors
 ///
@@ -725,6 +770,7 @@ pub fn create_symlink(
     report: &mut ExtractionReport,
     dir_cache: &mut DirCache,
     skip_duplicates: bool,
+    duplicate_skips: &mut u64,
 ) -> Result<()> {
     #[cfg(unix)]
     {
@@ -739,10 +785,7 @@ pub fn create_symlink(
         if link_path.symlink_metadata().is_ok() {
             if skip_duplicates {
                 report.files_skipped += 1;
-                report.warnings.push(format!(
-                    "skipped duplicate symlink: {}",
-                    safe_symlink.link_path().display()
-                ));
+                *duplicate_skips = duplicate_skips.saturating_add(1);
                 return Ok(());
             }
             std::fs::remove_file(&link_path)?;
@@ -959,6 +1002,7 @@ mod tests {
             &mut copy_buffer,
             &mut dir_cache,
             true,
+            &mut 0u64,
             &mut NoopProgress,
         );
 
@@ -1356,6 +1400,7 @@ mod tests {
             &mut copy_buffer,
             &mut dir_cache,
             true,
+            &mut 0u64,
             &mut NoopProgress,
         )
         .expect("extraction should succeed");
@@ -1439,13 +1484,27 @@ mod tests {
         let mut dir_cache = DirCache::new();
 
         // First creation
-        create_symlink(&safe_symlink, &dest, &mut report, &mut dir_cache, false)
-            .expect("first create_symlink should succeed");
+        create_symlink(
+            &safe_symlink,
+            &dest,
+            &mut report,
+            &mut dir_cache,
+            false,
+            &mut 0u64,
+        )
+        .expect("first create_symlink should succeed");
         assert_eq!(report.symlinks_created, 1);
 
         // Second creation with skip_duplicates=false must overwrite without error
-        create_symlink(&safe_symlink, &dest, &mut report, &mut dir_cache, false)
-            .expect("second create_symlink should overwrite");
+        create_symlink(
+            &safe_symlink,
+            &dest,
+            &mut report,
+            &mut dir_cache,
+            false,
+            &mut 0u64,
+        )
+        .expect("second create_symlink should overwrite");
         assert_eq!(report.symlinks_created, 2);
         assert_eq!(report.files_skipped, 0);
         assert!(temp.path().join("link.txt").exists());

--- a/crates/exarch-core/src/formats/tar.rs
+++ b/crates/exarch-core/src/formats/tar.rs
@@ -264,6 +264,7 @@ impl<R: Read> TarArchive<R> {
                     ctx.report,
                     ctx.dir_cache,
                     ctx.skip_duplicates,
+                    ctx.duplicate_skips,
                 )?;
                 Ok(None)
             }
@@ -298,6 +299,7 @@ impl<R: Read> TarArchive<R> {
             ctx.copy_buffer,
             ctx.dir_cache,
             ctx.skip_duplicates,
+            ctx.duplicate_skips,
             ctx.progress,
         )
     }
@@ -387,10 +389,7 @@ impl<R: Read> TarArchive<R> {
                             resource: crate::QuotaResource::IntegerOverflow,
                         },
                     )?;
-                    ctx.report.warnings.push(format!(
-                        "skipped duplicate hardlink: {}",
-                        info.link_path.as_path().display()
-                    ));
+                    *ctx.hardlink_duplicate_skips = ctx.hardlink_duplicate_skips.saturating_add(1);
                     return Ok(());
                 }
                 return Err(ArchiveError::InvalidArchive(format!(
@@ -497,6 +496,16 @@ impl<R: Read> ArchiveFormat for TarArchive<R> {
 
         let mut current_entry: usize = 0;
 
+        // Aggregated once, at every exit point, into a single warning per
+        // counter instead of one warning per skipped entry — keeps
+        // `report.warnings`'s growth independent of how many duplicate
+        // entries an archive contains (issue #490). Hardlinks are counted
+        // separately since they are format-specific to TAR (ZIP has no
+        // hardlink entry type) and go through `create_hardlink` directly
+        // rather than `common::extract_file_with_permit`/`create_symlink`.
+        let mut duplicate_skips: u64 = 0;
+        let mut hardlink_duplicate_skips: u64 = 0;
+
         let reader = self.inner.take().ok_or_else(|| {
             ArchiveError::InvalidArchive("archive reader already consumed by list()".into())
         })?;
@@ -512,6 +521,8 @@ impl<R: Read> ArchiveFormat for TarArchive<R> {
             copy_buffer: &mut copy_buffer,
             dir_cache: &mut dir_cache,
             skip_duplicates,
+            duplicate_skips: &mut duplicate_skips,
+            hardlink_duplicate_skips: &mut hardlink_duplicate_skips,
             config,
             progress,
         };
@@ -521,6 +532,11 @@ impl<R: Read> ArchiveFormat for TarArchive<R> {
                 let raw = budget_violation(&e).unwrap_or_else(|| {
                     ArchiveError::InvalidArchive(format!("failed to read entry: {e}"))
                 });
+                push_duplicate_skip_warnings(
+                    ctx.report,
+                    *ctx.duplicate_skips,
+                    *ctx.hardlink_duplicate_skips,
+                );
                 ArchiveError::partial_or(std::mem::take(ctx.report), raw)
             })?;
 
@@ -548,6 +564,11 @@ impl<R: Read> ArchiveFormat for TarArchive<R> {
                     // the guard's usual bounded drain is pointless I/O, not a
                     // correctness requirement (see `TarEntryGuard::abandon`).
                     guard.abandon();
+                    push_duplicate_skip_warnings(
+                        ctx.report,
+                        *ctx.duplicate_skips,
+                        *ctx.hardlink_duplicate_skips,
+                    );
                     return Err(ArchiveError::partial_or(std::mem::take(ctx.report), e));
                 }
             }
@@ -556,10 +577,20 @@ impl<R: Read> ArchiveFormat for TarArchive<R> {
         // Two-pass extraction: create hardlinks after all target files exist
         for hardlink_info in &hardlinks {
             if let Err(e) = Self::create_hardlink(hardlink_info, &mut ctx) {
+                push_duplicate_skip_warnings(
+                    ctx.report,
+                    *ctx.duplicate_skips,
+                    *ctx.hardlink_duplicate_skips,
+                );
                 return Err(ArchiveError::partial_or(std::mem::take(ctx.report), e));
             }
         }
 
+        push_duplicate_skip_warnings(
+            ctx.report,
+            *ctx.duplicate_skips,
+            *ctx.hardlink_duplicate_skips,
+        );
         ctx.progress.on_complete();
         report.duration = start.elapsed();
 
@@ -624,8 +655,32 @@ struct ExtractionContext<'a, 'v> {
     copy_buffer: &'a mut CopyBuffer,
     dir_cache: &'a mut common::DirCache,
     skip_duplicates: bool,
+    /// Count of file/symlink entries skipped as pre-existing duplicates,
+    /// threaded through `common::extract_file_with_permit` and
+    /// `common::create_symlink`. Aggregated into a single warning by
+    /// [`push_duplicate_skip_warnings`] instead of one warning per entry
+    /// (issue #490).
+    duplicate_skips: &'a mut u64,
+    /// Count of hardlinks skipped as pre-existing duplicates in
+    /// [`TarArchive::create_hardlink`]. Tracked separately from
+    /// `duplicate_skips` because hardlinks are TAR-specific (ZIP has no
+    /// hardlink entry type) and are not routed through `common.rs`.
+    hardlink_duplicate_skips: &'a mut u64,
     config: &'v SecurityConfig<Validated>,
     progress: &'a mut dyn ProgressCallback,
+}
+
+/// Appends aggregated duplicate-skip warnings to `report`, one entry per
+/// non-zero counter, mirroring 7z's single end-of-extraction warning
+/// (`SevenZArchive::extract_with_callback`) instead of one warning per
+/// skipped entry (issue #490).
+fn push_duplicate_skip_warnings(
+    report: &mut ExtractionReport,
+    duplicate_skips: u64,
+    hardlink_duplicate_skips: u64,
+) {
+    common::push_duplicate_skip_warning(report, duplicate_skips, "entry", "entries");
+    common::push_duplicate_skip_warning(report, hardlink_duplicate_skips, "hardlink", "hardlinks");
 }
 
 #[allow(dead_code)] // Fields used only on Unix
@@ -2177,6 +2232,8 @@ mod tests {
         let mut copy_buffer = CopyBuffer::new();
         let mut dir_cache = common::DirCache::new();
         let mut progress = crate::NoopProgress;
+        let mut duplicate_skips = 0u64;
+        let mut hardlink_duplicate_skips = 0u64;
         let mut ctx = ExtractionContext {
             validator: &mut validator,
             dest: &dest,
@@ -2184,6 +2241,8 @@ mod tests {
             copy_buffer: &mut copy_buffer,
             dir_cache: &mut dir_cache,
             skip_duplicates: true,
+            duplicate_skips: &mut duplicate_skips,
+            hardlink_duplicate_skips: &mut hardlink_duplicate_skips,
             config: &config,
             progress: &mut progress,
         };
@@ -2620,7 +2679,7 @@ mod tests {
         assert_eq!(report.files_extracted, 1);
         assert_eq!(report.files_skipped, 1);
         assert_eq!(report.warnings.len(), 1);
-        assert!(report.warnings[0].contains("legit.txt"));
+        assert!(report.warnings[0].contains("pre-existing duplicates"));
 
         // File content is from the first entry
         let content = std::fs::read(temp.path().join("legit.txt")).unwrap();
@@ -2650,6 +2709,119 @@ mod tests {
         // File content is from the second (overwriting) entry
         let content = std::fs::read(temp.path().join("legit.txt")).unwrap();
         assert_eq!(content, b"second");
+    }
+
+    /// Regression test for issue #490: extracting an archive with many
+    /// pre-existing duplicate entries must push exactly one aggregated
+    /// warning onto `report.warnings`, not one `String` per skipped entry
+    /// (mirrors 7z's `test_skip_duplicates_aggregates_single_warning`, #484).
+    #[test]
+    fn test_skip_duplicates_aggregates_single_warning() {
+        const ENTRY_COUNT: usize = 30;
+        let names: Vec<String> = (0..ENTRY_COUNT).map(|i| format!("dup-{i}.txt")).collect();
+        let entries: Vec<(&str, &[u8])> = names
+            .iter()
+            .map(|n| (n.as_str(), b"payload".as_slice()))
+            .collect();
+        let tar_data = create_test_tar(entries);
+        let mut archive = TarArchive::new(Cursor::new(tar_data));
+
+        let temp = TempDir::new().unwrap();
+        for name in &names {
+            std::fs::write(temp.path().join(name), b"already here").unwrap();
+        }
+
+        let config = SecurityConfig::default().validate().expect("valid config");
+        let report = archive
+            .extract(
+                temp.path(),
+                &config,
+                &ExtractionOptions::default(), // skip_duplicates = true
+                &mut crate::NoopProgress,
+            )
+            .unwrap();
+
+        assert_eq!(report.files_skipped, ENTRY_COUNT);
+        assert_eq!(report.files_extracted, 0);
+        assert_eq!(
+            report.warnings.len(),
+            1,
+            "duplicate skips must be aggregated into a single warning, got: {:?}",
+            report.warnings
+        );
+        assert!(
+            report.warnings[0].contains(&ENTRY_COUNT.to_string()),
+            "aggregated warning must report the correct skipped count, got: {}",
+            report.warnings[0]
+        );
+    }
+
+    /// Companion to [`test_skip_duplicates_aggregates_single_warning`]: TAR's
+    /// hardlink duplicate-skip path (`create_hardlink`) is not routed
+    /// through `common.rs`, so it needs its own counter and must be verified
+    /// to aggregate separately (issue #490).
+    #[test]
+    #[cfg(unix)]
+    fn test_skip_duplicate_hardlinks_aggregates_single_warning() {
+        const LINK_COUNT: usize = 10;
+
+        let mut builder = tar::Builder::new(Vec::new());
+
+        let mut header = tar::Header::new_gnu();
+        header.set_size(5);
+        header.set_mode(0o644);
+        header.set_entry_type(tar::EntryType::Regular);
+        header.set_cksum();
+        builder
+            .append_data(&mut header, "target.txt", &b"data\n"[..])
+            .unwrap();
+
+        for i in 0..LINK_COUNT {
+            let mut header = tar::Header::new_gnu();
+            header.set_entry_type(tar::EntryType::Link);
+            header.set_link_name("target.txt").unwrap();
+            header.set_size(0);
+            header.set_cksum();
+            builder
+                .append_data(&mut header, format!("link{i}.txt"), &[] as &[u8])
+                .unwrap();
+        }
+
+        let tar_data = builder.into_inner().unwrap();
+        let mut archive = TarArchive::new(Cursor::new(tar_data));
+
+        let temp = TempDir::new().unwrap();
+        for i in 0..LINK_COUNT {
+            std::fs::write(temp.path().join(format!("link{i}.txt")), b"already here").unwrap();
+        }
+
+        let mut config = SecurityConfig::default();
+        config.allowed.hardlinks = true;
+        let config = config.validate().expect("valid config");
+
+        let report = archive
+            .extract(
+                temp.path(),
+                &config,
+                &ExtractionOptions::default(), // skip_duplicates = true
+                &mut crate::NoopProgress,
+            )
+            .unwrap();
+
+        assert_eq!(report.files_skipped, LINK_COUNT);
+        assert_eq!(report.files_extracted, 1, "only target.txt is extracted");
+        assert_eq!(
+            report.warnings.len(),
+            1,
+            "hardlink duplicate skips must be aggregated into a single warning, got: {:?}",
+            report.warnings
+        );
+        assert!(
+            report.warnings[0].contains(&LINK_COUNT.to_string())
+                && report.warnings[0].contains("hardlink"),
+            "aggregated warning must report the correct skipped hardlink count, got: {}",
+            report.warnings[0]
+        );
     }
 
     #[test]

--- a/crates/exarch-core/src/formats/zip.rs
+++ b/crates/exarch-core/src/formats/zip.rs
@@ -157,6 +157,12 @@ struct ZipExtractionContext<'a> {
     copy_buffer: &'a mut CopyBuffer,
     dir_cache: &'a mut common::DirCache,
     skip_duplicates: bool,
+    /// Count of file/symlink entries skipped as pre-existing duplicates,
+    /// threaded through `common::extract_file_with_permit` and
+    /// `common::create_symlink`. Aggregated into a single warning after
+    /// extraction completes instead of one warning per entry, mirroring
+    /// 7z's `duplicate_skips` accumulator (issue #490).
+    duplicate_skips: &'a mut u64,
     progress: &'a mut dyn ProgressCallback,
 }
 
@@ -378,6 +384,7 @@ impl<R: Read + Seek> ZipArchive<R> {
                     ctx.report,
                     ctx.dir_cache,
                     ctx.skip_duplicates,
+                    ctx.duplicate_skips,
                 )?;
             }
         } else {
@@ -438,6 +445,7 @@ impl<R: Read + Seek> ZipArchive<R> {
             ctx.copy_buffer,
             ctx.dir_cache,
             ctx.skip_duplicates,
+            ctx.duplicate_skips,
             ctx.progress,
         )
     }
@@ -465,6 +473,11 @@ impl<R: Read + Seek> ArchiveFormat for ZipArchive<R> {
         let mut copy_buffer = CopyBuffer::new();
 
         let mut dir_cache = common::DirCache::new();
+
+        // Aggregated into a single warning after extraction instead of one
+        // per skipped entry, mirroring 7z's `duplicate_skips` accumulator
+        // (issue #490).
+        let mut duplicate_skips: u64 = 0;
 
         let entry_count = self.inner.len();
 
@@ -495,6 +508,7 @@ impl<R: Read + Seek> ArchiveFormat for ZipArchive<R> {
                 copy_buffer: &mut copy_buffer,
                 dir_cache: &mut dir_cache,
                 skip_duplicates,
+                duplicate_skips: &mut duplicate_skips,
                 progress: guard.progress_mut(),
             };
 
@@ -502,11 +516,18 @@ impl<R: Read + Seek> ArchiveFormat for ZipArchive<R> {
 
             if let Err(e) = result {
                 drop(guard);
+                common::push_duplicate_skip_warning(
+                    &mut report,
+                    duplicate_skips,
+                    "entry",
+                    "entries",
+                );
                 return Err(ArchiveError::partial_or(std::mem::take(&mut report), e));
             }
             guard.complete();
         }
 
+        common::push_duplicate_skip_warning(&mut report, duplicate_skips, "entry", "entries");
         progress.on_complete();
         report.duration = start.elapsed();
 
@@ -1900,6 +1921,53 @@ mod tests {
         // ZIP extractor still succeeds without panicking on such archives.
         assert_eq!(report.files_extracted, 1);
         assert!(temp.path().join("legit.txt").exists());
+    }
+
+    /// Regression test for issue #490: extracting an archive whose entries
+    /// collide with many pre-existing files on disk must push exactly one
+    /// aggregated warning onto `report.warnings`, not one `String` per
+    /// skipped entry (mirrors 7z's
+    /// `test_skip_duplicates_aggregates_single_warning`, #484).
+    #[test]
+    fn test_skip_duplicates_aggregates_single_warning() {
+        const ENTRY_COUNT: usize = 30;
+        let names: Vec<String> = (0..ENTRY_COUNT).map(|i| format!("dup-{i}.txt")).collect();
+        let entries: Vec<(&str, &[u8])> = names
+            .iter()
+            .map(|n| (n.as_str(), b"payload".as_slice()))
+            .collect();
+        let zip_data = create_test_zip(entries);
+        let cursor = Cursor::new(zip_data);
+        let mut archive = ZipArchive::new(cursor).unwrap();
+
+        let temp = TempDir::new().unwrap();
+        for name in &names {
+            std::fs::write(temp.path().join(name), b"already here").unwrap();
+        }
+
+        let config = SecurityConfig::default().validate().expect("valid config");
+        let report = archive
+            .extract(
+                temp.path(),
+                &config,
+                &ExtractionOptions::default(), // skip_duplicates = true
+                &mut crate::NoopProgress,
+            )
+            .unwrap();
+
+        assert_eq!(report.files_skipped, ENTRY_COUNT);
+        assert_eq!(report.files_extracted, 0);
+        assert_eq!(
+            report.warnings.len(),
+            1,
+            "duplicate skips must be aggregated into a single warning, got: {:?}",
+            report.warnings
+        );
+        assert!(
+            report.warnings[0].contains(&ENTRY_COUNT.to_string()),
+            "aggregated warning must report the correct skipped count, got: {}",
+            report.warnings[0]
+        );
     }
 
     #[test]

--- a/crates/exarch-core/src/types/safe_symlink.rs
+++ b/crates/exarch-core/src/types/safe_symlink.rs
@@ -64,7 +64,9 @@ impl SafeSymlink {
     /// 1. Verify symlinks are allowed in the security configuration
     /// 2. Reject an empty target (points nowhere) or a target containing NUL
     ///    bytes
-    /// 3. Validate target is relative (reject absolute symlinks)
+    /// 3. Reject a target containing a `Prefix` or `RootDir` component (e.g.
+    ///    Windows `C:\` or `C:foo` drive-relative paths), then validate the
+    ///    target is relative (reject absolute symlinks)
     /// 4. Check target components against banned components and
     ///    `max_path_depth`
     /// 5. Verify the link's parent directory chain contains no symlinks (TOCTOU
@@ -78,7 +80,8 @@ impl SafeSymlink {
     /// Returns an error if:
     /// - Symlinks are not allowed by configuration
     /// - Target is empty or contains NUL bytes
-    /// - Target is an absolute path
+    /// - Target is an absolute path, or contains a Windows drive/UNC prefix
+    ///   component
     /// - Target contains a banned path component or exceeds `max_path_depth`
     /// - Resolved target escapes the destination directory
     ///
@@ -137,7 +140,28 @@ impl SafeSymlink {
             });
         }
 
-        // 2. Validate target is relative
+        // H-SEC-2: Reject Windows-specific absolute path components in the
+        // target before relying on `is_absolute()` below. On Windows, a
+        // drive-relative path like `C:foo` (no backslash after the colon) is
+        // not `is_absolute()` per Rust's definition (requires both a prefix
+        // AND a root), yet still resolves relative to the current directory
+        // on that drive — letting a malicious archive escape via a
+        // drive-relative symlink target. Mirrors the identical guard in
+        // `HardlinkTracker::validate_hardlink` (`security/hardlink.rs`) and
+        // `SafePath::validate` (issue #491, GHSA-9ppj-qmqm-q256 class).
+        for component in target.components() {
+            if matches!(
+                component,
+                std::path::Component::Prefix(_) | std::path::Component::RootDir
+            ) {
+                return Err(ArchiveError::SymlinkEscape {
+                    path: link.as_path().to_path_buf(),
+                });
+            }
+        }
+
+        // 2. Validate target is relative (redundant with the check above on
+        // Windows, but keeps this check for other absolute-path shapes).
         if target.is_absolute() {
             return Err(ArchiveError::SymlinkEscape {
                 path: link.as_path().to_path_buf(),
@@ -407,6 +431,140 @@ mod tests {
 
         let result = SafeSymlink::validate(&link, &target, &dest, &config);
         assert_matches!(result, Err(ArchiveError::SymlinkEscape { .. }));
+    }
+
+    /// Behavior test for issue #491 (GHSA-9ppj-qmqm-q256 class): a Windows
+    /// drive-relative target like `C:foo` (no backslash after the colon) is
+    /// NOT `is_absolute()` per Rust's definition, which requires both a
+    /// `Prefix` AND a `RootDir` component, yet still resolves relative to
+    /// the current directory on that drive.
+    ///
+    /// This test alone does NOT prove the new `Component::Prefix` guard is
+    /// what rejects it: pre-fix, `C:foo` was already rejected with the same
+    /// `SymlinkEscape` variant via `resolve_through_symlinks`'s `_ =>
+    /// current.push(component)` fallback arm, since Windows `PathBuf::push`
+    /// with a prefix-but-no-root component replaces `current` entirely
+    /// (`current` becomes `"C:"`), which then fails
+    /// `current.starts_with(dest)`. See
+    /// `test_safe_symlink_reject_drive_relative_target_with_banned_component_windows`
+    /// below for the discriminating regression test. `Component::Prefix` can
+    /// only be produced by the path parser on Windows, so this test is
+    /// `cfg(windows)`-gated (mirrors
+    /// `inspection::list::test_contains_traversal_prefix_gated_by_flag`).
+    #[test]
+    #[cfg(windows)]
+    fn test_safe_symlink_reject_drive_relative_target_windows_behavior() {
+        let (_temp, dest) = create_test_dest();
+        let config = create_config_with_symlinks();
+
+        let link = SafePath::validate(&PathBuf::from("link"), &dest, &config)
+            .expect("link path should be valid");
+        let target = PathBuf::from("C:foo");
+        assert!(
+            !target.is_absolute(),
+            "C:foo must not be is_absolute() per Rust's definition — this is the exact gap #491 closes"
+        );
+        assert!(
+            target
+                .components()
+                .any(|c| matches!(c, std::path::Component::Prefix(_))),
+            "C:foo must parse to a Prefix component on Windows"
+        );
+
+        let result = SafeSymlink::validate(&link, &target, &dest, &config);
+        assert_matches!(
+            result,
+            Err(ArchiveError::SymlinkEscape { .. }),
+            "drive-relative symlink target must be rejected, got: {result:?}"
+        );
+    }
+
+    /// Discriminating regression test for issue #491: unlike the plain
+    /// `C:foo` behavior test above, this target is chosen so pre-fix and
+    /// post-fix code paths disagree on the *error variant* returned, proving
+    /// the new `Component::Prefix` guard — not
+    /// `resolve_through_symlinks`'s unrelated fallback rejection — is what
+    /// fires.
+    ///
+    /// `C:.git\evil` is drive-relative (`Prefix` component, no `RootDir`,
+    /// same as `C:foo`) but its second component, `.git`, is also a default
+    /// `banned_path_components` entry (`SecurityConfig::default()`,
+    /// `config.rs:218`). Pre-fix, the old code's `Component::Normal`-only
+    /// scan (step 2.5) would reach `.git` first — since the pre-fix code had
+    /// no `Prefix` guard ahead of it — and reject with
+    /// `SecurityViolation("banned component")`, never reaching
+    /// `resolve_through_symlinks` at all. Post-fix, the new guard runs
+    /// first and rejects with `SymlinkEscape` before the banned-component
+    /// scan is ever reached. Reverting the new guard flips this test's
+    /// expected variant from `SymlinkEscape` to `SecurityViolation`, so it
+    /// fails closed if the guard regresses.
+    #[test]
+    #[cfg(windows)]
+    fn test_safe_symlink_reject_drive_relative_target_with_banned_component_windows() {
+        let (_temp, dest) = create_test_dest();
+        let config = create_config_with_symlinks();
+
+        let link = SafePath::validate(&PathBuf::from("link"), &dest, &config)
+            .expect("link path should be valid");
+        let target = PathBuf::from(r"C:.git\evil");
+        assert!(
+            !target.is_absolute(),
+            "C:.git\\evil must not be is_absolute() — drive-relative, no RootDir"
+        );
+
+        let result = SafeSymlink::validate(&link, &target, &dest, &config);
+        assert_matches!(
+            result,
+            Err(ArchiveError::SymlinkEscape { .. }),
+            "drive-relative target with a banned second component must be rejected by the new \
+             Prefix guard (SymlinkEscape), not fall through to the banned-component scan \
+             (SecurityViolation) — got: {result:?}"
+        );
+    }
+
+    /// Companion to the drive-relative regression test above, for the other
+    /// half of the `Component::Prefix(_) | Component::RootDir` guard: a
+    /// Windows root-relative target (`RootDir` with no `Prefix`, e.g.
+    /// `\evil`) resolves relative to the current drive and is also NOT
+    /// `is_absolute()` per Rust's definition (which requires both a prefix
+    /// AND a root). This is a second, previously-untested gap the #491 fix
+    /// closes, not just the drive-relative one.
+    ///
+    /// Uses the same banned-component discriminator as the drive-relative
+    /// case above: pre-fix, `.git` is reached by the old Normal-only scan
+    /// and rejected as `SecurityViolation`; post-fix, the new `RootDir` arm
+    /// fires first and rejects as `SymlinkEscape`.
+    #[test]
+    #[cfg(windows)]
+    fn test_safe_symlink_reject_root_relative_target_with_banned_component_windows() {
+        let (_temp, dest) = create_test_dest();
+        let config = create_config_with_symlinks();
+
+        let link = SafePath::validate(&PathBuf::from("link"), &dest, &config)
+            .expect("link path should be valid");
+        let target = PathBuf::from(r"\.git\evil");
+        assert!(
+            !target.is_absolute(),
+            r"\.git\evil must not be is_absolute() — RootDir without a Prefix"
+        );
+        assert!(
+            target
+                .components()
+                .any(|c| matches!(c, std::path::Component::RootDir))
+                && !target
+                    .components()
+                    .any(|c| matches!(c, std::path::Component::Prefix(_))),
+            r"\.git\evil must parse to RootDir without Prefix on Windows"
+        );
+
+        let result = SafeSymlink::validate(&link, &target, &dest, &config);
+        assert_matches!(
+            result,
+            Err(ArchiveError::SymlinkEscape { .. }),
+            "root-relative target with a banned second component must be rejected by the new \
+             RootDir guard (SymlinkEscape), not fall through to the banned-component scan \
+             (SecurityViolation) — got: {result:?}"
+        );
     }
 
     #[test]

--- a/crates/exarch-core/tests/skip_duplicates_integration.rs
+++ b/crates/exarch-core/tests/skip_duplicates_integration.rs
@@ -82,14 +82,13 @@ fn tar_skip_duplicates_true_keeps_first_entry() {
         report.files_skipped, 1,
         "second entry must be counted as skipped"
     );
+    // TAR aggregates all pre-existing-duplicate skips into a single warning
+    // without per-path text, to keep `report.warnings` bounded regardless of
+    // how many entries are skipped (see #490, mirroring 7z's #484).
     assert_eq!(
-        report.warnings.len(),
-        1,
-        "exactly one duplicate warning expected"
-    );
-    assert!(
-        report.warnings[0].contains("file.txt"),
-        "warning must identify the duplicate path"
+        report.warnings,
+        vec!["skipped 1 entry as pre-existing duplicates".to_string()],
+        "TAR now emits one aggregated duplicate-skip warning, not a per-path one"
     );
 
     let content = std::fs::read(dest.path().join("file.txt")).unwrap();
@@ -199,10 +198,10 @@ fn sevenz_skip_duplicates_true_keeps_first_entry() {
         report.files_skipped, 1,
         "second entry must be counted as skipped"
     );
-    // Unlike TAR/ZIP (which push one warning per skipped path, asserted above),
     // 7z aggregates all pre-existing-duplicate skips into a single warning
     // without per-path text, to keep `report.warnings` bounded regardless of
-    // how many entries are skipped (see #484).
+    // how many entries are skipped (see #484; TAR/ZIP do the same as of #490,
+    // asserted above).
     assert_eq!(
         report.warnings,
         vec!["skipped 1 entry as pre-existing duplicates".to_string()],


### PR DESCRIPTION
## Summary
- Aggregate tar/zip duplicate-skip warnings into a single summary message instead of one per skipped entry, mirroring the pattern already used by 7z (#484/#487), so `report.warnings` cannot grow unbounded on archives with many duplicate-named entries.
- Add an explicit `Component::Prefix(_) | Component::RootDir` rejection guard to `SafeSymlink::validate`, mirroring `HardlinkTracker::validate_hardlink`'s `H-SEC-2` guard, so symlink-target safety against Windows drive-relative paths (the GHSA-9ppj-qmqm-q256 class) is an explicit, tested check rather than relying on an unstated `PathBuf::push` side effect. Two new `#[cfg(windows)]` regression tests cover both the `Prefix`-without-`RootDir` and `RootDir`-without-`Prefix` shapes, using targets that flip the returned `ArchiveError` variant between pre-fix and post-fix code so the tests actually discriminate.

## Test plan
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` (1132 passed)
- [x] `cargo test --doc --workspace --all-features --exclude exarch-python --exclude exarch-node` (117 passed)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace`
- [x] `cargo deny check` / `cargo audit` (security review, no dependency changes)
- [ ] New Windows-gated regression tests for #491 type-check via cross-compilation but have not executed on Windows CI yet — verify on the `windows-latest` CI job

Closes #490
Closes #491