### PR TITLE
fix(core): cap unbounded per-entry disallowed-extension warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`exarch-core`: TAR, ZIP, and 7z pushed one unbounded, path-bearing warning `String` per entry
+  rejected by the extension allowlist (#495)**: `common::check_extension_allowed` (shared by all
+  three format handlers) pushed a `"skipped entry with disallowed extension: {path}"` warning
+  directly into `report.warnings` for every rejected entry, growing the report proportional to
+  archive size with no cap — the same class of issue already fixed for pre-existing-duplicate skips
+  in #484/#490. The function now increments a `disallowed_extension_skips` counter instead; each
+  format's `extract()` aggregates it into at most one `"skipped N entries with disallowed
+  extensions"` warning once extraction completes. `report.files_skipped`'s count is unaffected.
 - **`exarch-python`: a raising progress callback was silently swallowed during extraction/creation
   (#489)**: `PyProgressAdapter::on_entry_start` discarded both the return value and any Python
   exception from `self.callback.call1(...)` via `let _ = ...`, so a callback raising to signal an

--- a/crates/exarch-core/src/formats/common.rs
+++ b/crates/exarch-core/src/formats/common.rs
@@ -17,6 +17,8 @@
 //! - [`copy_file_content_with_permit`]: Hardlink content copy between
 //!   already-open source/destination handles
 //! - [`check_extension_allowed`]: Extension allowlist filtering
+//! - [`push_disallowed_extension_warning`]: Aggregated disallowed-extension
+//!   skip warning
 
 use rustc_hash::FxHashSet;
 use std::fs::File;
@@ -373,10 +375,42 @@ pub fn push_duplicate_skip_warning(
     }
 }
 
+/// Appends a single aggregated warning for `count` entries skipped due to a
+/// disallowed extension.
+///
+/// Mirrors [`push_duplicate_skip_warning`]'s aggregation pattern so
+/// `report.warnings` grows once per extraction instead of once per rejected
+/// entry (issue #495). A no-op when `count` is zero.
+///
+/// # Examples
+///
+/// ```ignore
+/// # use exarch_core::formats::common::push_disallowed_extension_warning;
+/// # use exarch_core::ExtractionReport;
+/// let mut report = ExtractionReport::new();
+/// push_disallowed_extension_warning(&mut report, 3);
+/// assert_eq!(
+///     report.warnings,
+///     vec!["skipped 3 entries with disallowed extensions".to_string()]
+/// );
+/// ```
+pub fn push_disallowed_extension_warning(report: &mut ExtractionReport, count: u64) {
+    if count > 0 {
+        let (noun, ext_noun) = if count == 1 {
+            ("entry", "extension")
+        } else {
+            ("entries", "extensions")
+        };
+        report
+            .warnings
+            .push(format!("skipped {count} {noun} with disallowed {ext_noun}"));
+    }
+}
+
 /// Returns `true` if `path`'s extension passes `config`'s allowlist.
 ///
-/// If the extension is not allowed, records the skip in `report`
-/// (increments `files_skipped`, pushes the standard warning) and returns
+/// If the extension is not allowed, records the skip (increments
+/// `report.files_skipped` and `disallowed_extension_skips`) and returns
 /// `false`. Shared by the TAR, ZIP, and 7z extractors, which all reject
 /// entries with disallowed extensions before further validation.
 ///
@@ -385,11 +419,21 @@ pub fn push_duplicate_skip_warning(
 /// exists because the pattern already drifted once for the FFI boundary
 /// path check in #406 — see #413).
 ///
+/// # Aggregated Warning (issue #495)
+///
+/// `path` is deliberately not recorded anywhere: earlier versions pushed one
+/// path-bearing warning string per rejected entry, which grew
+/// `report.warnings` without bound for archives with many disallowed
+/// entries. The caller instead increments `disallowed_extension_skips` and
+/// aggregates it into a single [`push_disallowed_extension_warning`] once
+/// extraction completes, mirroring the `duplicate_skips` pattern used by
+/// [`push_duplicate_skip_warning`].
+///
 /// # Examples
 ///
 /// ```ignore
 /// # use exarch_core::formats::common::check_extension_allowed;
-/// if !check_extension_allowed(&path, config, report) {
+/// if !check_extension_allowed(&path, config, report, &mut disallowed_extension_skips) {
 ///     return Ok(None);
 /// }
 /// ```
@@ -399,6 +443,7 @@ pub fn check_extension_allowed(
     path: &Path,
     config: &SecurityConfig<Validated>,
     report: &mut ExtractionReport,
+    disallowed_extension_skips: &mut u64,
 ) -> bool {
     let ext = path.extension().and_then(|e| e.to_str());
     if config.is_path_extension_allowed(ext) {
@@ -406,10 +451,7 @@ pub fn check_extension_allowed(
     }
 
     report.files_skipped += 1;
-    report.warnings.push(format!(
-        "skipped entry with disallowed extension: {}",
-        path.display()
-    ));
+    *disallowed_extension_skips = disallowed_extension_skips.saturating_add(1);
     false
 }
 
@@ -1510,31 +1552,30 @@ mod tests {
         assert!(temp.path().join("link.txt").exists());
     }
 
-    /// Pins the exact warning message text produced by
-    /// `check_extension_allowed`, so any future edit that changes the
-    /// wording (or re-inlines this pattern with different wording at a call
-    /// site) is caught immediately rather than drifting unnoticed, as
-    /// happened in #413.
+    /// Pins the aggregation behavior of `check_extension_allowed`: a rejected
+    /// entry increments `disallowed_extension_skips` instead of pushing a
+    /// per-entry warning, so `report.warnings`'s growth stays independent of
+    /// how many disallowed entries an archive contains (issue #495).
     #[test]
-    fn test_check_extension_allowed_warning_message_text() {
+    fn test_check_extension_allowed_increments_counter_not_warnings() {
         let config = SecurityConfig::default()
             .with_allowed_extensions(vec!["txt".to_string()])
             .validate()
             .expect("valid config");
         let mut report = ExtractionReport::default();
         let path = PathBuf::from("skip.exe");
+        let mut disallowed_extension_skips = 0u64;
 
-        let allowed = check_extension_allowed(&path, &config, &mut report);
+        let allowed =
+            check_extension_allowed(&path, &config, &mut report, &mut disallowed_extension_skips);
 
         assert!(!allowed, "disallowed extension must be rejected");
         assert_eq!(report.files_skipped, 1);
-        assert_eq!(
-            report.warnings,
-            vec!["skipped entry with disallowed extension: skip.exe".to_string()]
-        );
+        assert_eq!(disallowed_extension_skips, 1);
+        assert!(report.warnings.is_empty());
     }
 
-    /// Verifies the happy path leaves `report` untouched.
+    /// Verifies the happy path leaves `report` and the counter untouched.
     #[test]
     fn test_check_extension_allowed_allowed_extension() {
         let config = SecurityConfig::default()
@@ -1543,11 +1584,37 @@ mod tests {
             .expect("valid config");
         let mut report = ExtractionReport::default();
         let path = PathBuf::from("keep.txt");
+        let mut disallowed_extension_skips = 0u64;
 
-        let allowed = check_extension_allowed(&path, &config, &mut report);
+        let allowed =
+            check_extension_allowed(&path, &config, &mut report, &mut disallowed_extension_skips);
 
         assert!(allowed, "allowed extension must pass");
         assert_eq!(report.files_skipped, 0);
+        assert_eq!(disallowed_extension_skips, 0);
         assert!(report.warnings.is_empty());
+    }
+
+    /// Pins the exact aggregated warning message text produced by
+    /// `push_disallowed_extension_warning` for both singular and plural
+    /// counts, and confirms it is a no-op for a zero count.
+    #[test]
+    fn test_push_disallowed_extension_warning_text() {
+        let mut report = ExtractionReport::default();
+        push_disallowed_extension_warning(&mut report, 0);
+        assert!(report.warnings.is_empty(), "zero count must be a no-op");
+
+        push_disallowed_extension_warning(&mut report, 1);
+        assert_eq!(
+            report.warnings,
+            vec!["skipped 1 entry with disallowed extension".to_string()]
+        );
+
+        report.warnings.clear();
+        push_disallowed_extension_warning(&mut report, 3);
+        assert_eq!(
+            report.warnings,
+            vec!["skipped 3 entries with disallowed extensions".to_string()]
+        );
     }
 }

--- a/crates/exarch-core/src/formats/sevenz.rs
+++ b/crates/exarch-core/src/formats/sevenz.rs
@@ -517,6 +517,7 @@ impl<R: Read + Seek> SevenZArchive<R> {
         skip_duplicates: bool,
         config: &SecurityConfig<Validated>,
         duplicate_skips: &mut u64,
+        disallowed_extension_skips: &mut u64,
         pending_io_error: &mut Option<std::io::Error>,
     ) -> std::result::Result<u64, sevenz_rust2::Error> {
         let entry_type = SevenZEntryAdapter::to_entry_type(entry).map_err(|e| {
@@ -526,7 +527,12 @@ impl<R: Read + Seek> SevenZArchive<R> {
         // Extension filter runs before path validation to avoid quota
         // double-counting for skipped files.
         if matches!(entry_type, EntryType::File)
-            && !common::check_extension_allowed(entry_path, config, report)
+            && !common::check_extension_allowed(
+                entry_path,
+                config,
+                report,
+                disallowed_extension_skips,
+            )
         {
             return Ok(0);
         }
@@ -702,6 +708,11 @@ impl<R: Read + Seek> SevenZArchive<R> {
             /// keeping `report.warnings`'s growth independent of how many
             /// duplicate entries an archive contains.
             duplicate_skips: u64,
+            /// Count of file entries skipped by
+            /// `common::check_extension_allowed` because their
+            /// extension is not in the allowlist. Aggregated the
+            /// same way as `duplicate_skips` (issue #495).
+            disallowed_extension_skips: u64,
             /// Set when `process_entry_inner` needs its caller to construct
             /// `ArchiveError::Io` directly from a raw `io::Error`, bypassing
             /// the lossy `sevenz_rust2::Error` -> `ArchiveError` conversion
@@ -717,6 +728,7 @@ impl<R: Read + Seek> SevenZArchive<R> {
             progress,
             current_idx: 0,
             duplicate_skips: 0,
+            disallowed_extension_skips: 0,
             pending_io_error: None,
         };
 
@@ -748,6 +760,7 @@ impl<R: Read + Seek> SevenZArchive<R> {
                 skip_duplicates,
                 config,
                 &mut ctx.duplicate_skips,
+                &mut ctx.disallowed_extension_skips,
                 &mut ctx.pending_io_error,
             );
 
@@ -784,6 +797,7 @@ impl<R: Read + Seek> SevenZArchive<R> {
                 ctx.duplicate_skips
             ));
         }
+        common::push_disallowed_extension_warning(&mut accumulated, ctx.disallowed_extension_skips);
 
         let e = match result {
             Ok(()) => return Ok(accumulated),
@@ -1911,7 +1925,119 @@ mod tests {
                 .exists(),
             ".txt files must be extracted"
         );
-        assert!(report.warnings.iter().any(|w| w.contains("program.exe")));
+        assert_eq!(
+            report.warnings,
+            vec!["skipped 1 entry with disallowed extension".to_string()],
+            "the disallowed-extension skip must be aggregated into a single warning \
+             instead of a per-entry, path-bearing one (issue #495)"
+        );
+    }
+
+    /// Reproduces the actual #495 bug scenario end-to-end: many entries
+    /// rejected by the extension allowlist must aggregate into a single
+    /// warning instead of growing `report.warnings` proportional to archive
+    /// size (mirrors `test_skip_duplicates_aggregates_single_warning`, #490).
+    #[test]
+    fn test_disallowed_extension_aggregates_single_warning() {
+        const ENTRY_COUNT: usize = 30;
+        let names: Vec<String> = (0..ENTRY_COUNT).map(|i| format!("skip-{i}.exe")).collect();
+        let entries: Vec<(&str, &[u8])> = names
+            .iter()
+            .map(|n| (n.as_str(), b"payload".as_slice()))
+            .collect();
+        let data = make_sevenz_archive(&entries);
+        let dest = TempDir::new().unwrap();
+        let config = SecurityConfig::default()
+            .with_allowed_extensions(vec!["txt".to_string()])
+            .validate()
+            .expect("valid config");
+
+        let report = SevenZArchive::new(Cursor::new(data))
+            .unwrap()
+            .extract(
+                dest.path(),
+                &config,
+                &ExtractionOptions::default(),
+                &mut crate::NoopProgress,
+            )
+            .unwrap();
+
+        assert_eq!(report.files_skipped, ENTRY_COUNT);
+        assert_eq!(report.files_extracted, 0);
+        assert_eq!(
+            report.warnings,
+            vec![format!(
+                "skipped {ENTRY_COUNT} entries with disallowed extensions"
+            )],
+            "disallowed-extension skips must be aggregated into a single warning, got: {:?}",
+            report.warnings
+        );
+    }
+
+    /// Verifies duplicate-skip and disallowed-extension-skip counters
+    /// aggregate independently in the same extraction: an archive mixing
+    /// both skip reasons must produce exactly two warnings, one per reason,
+    /// each with the correct count (issue #495).
+    #[test]
+    fn test_duplicate_and_disallowed_extension_skips_aggregate_independently() {
+        const DUPLICATE_COUNT: usize = 5;
+        const DISALLOWED_COUNT: usize = 7;
+
+        let mut names: Vec<String> = (0..DUPLICATE_COUNT)
+            .map(|i| format!("dup-{i}.txt"))
+            .collect();
+        names.extend((0..DISALLOWED_COUNT).map(|i| format!("skip-{i}.exe")));
+        let entries: Vec<(&str, &[u8])> = names
+            .iter()
+            .map(|n| (n.as_str(), b"payload".as_slice()))
+            .collect();
+        let data = make_sevenz_archive(&entries);
+
+        let temp = TempDir::new().unwrap();
+        for name in names.iter().take(DUPLICATE_COUNT) {
+            std::fs::write(temp.path().join(name), b"already here").unwrap();
+        }
+
+        let config = SecurityConfig::default()
+            .with_allowed_extensions(vec!["txt".to_string()])
+            .validate()
+            .expect("valid config");
+
+        let report = SevenZArchive::new(Cursor::new(data))
+            .unwrap()
+            .extract(
+                temp.path(),
+                &config,
+                &ExtractionOptions::default(), // skip_duplicates = true
+                &mut crate::NoopProgress,
+            )
+            .unwrap();
+
+        assert_eq!(report.files_skipped, DUPLICATE_COUNT + DISALLOWED_COUNT);
+        assert_eq!(report.files_extracted, 0);
+        assert_eq!(
+            report.warnings.len(),
+            2,
+            "each skip reason must aggregate into its own single warning, got: {:?}",
+            report.warnings
+        );
+        assert!(
+            report
+                .warnings
+                .iter()
+                .any(|w| w.contains(&DUPLICATE_COUNT.to_string()) && w.contains("duplicate")),
+            "expected a duplicate-skip warning reporting {DUPLICATE_COUNT}, got: {:?}",
+            report.warnings
+        );
+        assert!(
+            report
+                .warnings
+                .iter()
+                .any(|w| w.contains(&DISALLOWED_COUNT.to_string())
+                    && w.contains("disallowed extension")),
+            "expected a disallowed-extension warning reporting {DISALLOWED_COUNT}, got: {:?}",
+            report.warnings
+        );
     }
 
     #[test]
@@ -2109,6 +2235,7 @@ mod tests {
         let mut dir_cache = common::DirCache::new();
         let mut report = ExtractionReport::new();
         let mut duplicate_skips = 0u64;
+        let mut disallowed_extension_skips = 0u64;
         let mut pending_io_error = None;
 
         let mut entry = sevenz_rust2::ArchiveEntry::new_file("../../evil.txt");
@@ -2127,6 +2254,7 @@ mod tests {
             false,
             &config,
             &mut duplicate_skips,
+            &mut disallowed_extension_skips,
             &mut pending_io_error,
         );
 

--- a/crates/exarch-core/src/formats/tar.rs
+++ b/crates/exarch-core/src/formats/tar.rs
@@ -228,7 +228,12 @@ impl<R: Read> TarArchive<R> {
         let mode = entry.header().mode().ok();
 
         if matches!(entry_type, EntryType::File)
-            && !common::check_extension_allowed(&path, ctx.config, ctx.report)
+            && !common::check_extension_allowed(
+                &path,
+                ctx.config,
+                ctx.report,
+                ctx.disallowed_extension_skips,
+            )
         {
             return Ok(None);
         }
@@ -505,6 +510,9 @@ impl<R: Read> ArchiveFormat for TarArchive<R> {
         // rather than `common::extract_file_with_permit`/`create_symlink`.
         let mut duplicate_skips: u64 = 0;
         let mut hardlink_duplicate_skips: u64 = 0;
+        // Same aggregation, for entries rejected by the extension allowlist
+        // (issue #495).
+        let mut disallowed_extension_skips: u64 = 0;
 
         let reader = self.inner.take().ok_or_else(|| {
             ArchiveError::InvalidArchive("archive reader already consumed by list()".into())
@@ -523,6 +531,7 @@ impl<R: Read> ArchiveFormat for TarArchive<R> {
             skip_duplicates,
             duplicate_skips: &mut duplicate_skips,
             hardlink_duplicate_skips: &mut hardlink_duplicate_skips,
+            disallowed_extension_skips: &mut disallowed_extension_skips,
             config,
             progress,
         };
@@ -536,6 +545,7 @@ impl<R: Read> ArchiveFormat for TarArchive<R> {
                     ctx.report,
                     *ctx.duplicate_skips,
                     *ctx.hardlink_duplicate_skips,
+                    *ctx.disallowed_extension_skips,
                 );
                 ArchiveError::partial_or(std::mem::take(ctx.report), raw)
             })?;
@@ -568,6 +578,7 @@ impl<R: Read> ArchiveFormat for TarArchive<R> {
                         ctx.report,
                         *ctx.duplicate_skips,
                         *ctx.hardlink_duplicate_skips,
+                        *ctx.disallowed_extension_skips,
                     );
                     return Err(ArchiveError::partial_or(std::mem::take(ctx.report), e));
                 }
@@ -581,6 +592,7 @@ impl<R: Read> ArchiveFormat for TarArchive<R> {
                     ctx.report,
                     *ctx.duplicate_skips,
                     *ctx.hardlink_duplicate_skips,
+                    *ctx.disallowed_extension_skips,
                 );
                 return Err(ArchiveError::partial_or(std::mem::take(ctx.report), e));
             }
@@ -590,6 +602,7 @@ impl<R: Read> ArchiveFormat for TarArchive<R> {
             ctx.report,
             *ctx.duplicate_skips,
             *ctx.hardlink_duplicate_skips,
+            *ctx.disallowed_extension_skips,
         );
         ctx.progress.on_complete();
         report.duration = start.elapsed();
@@ -666,21 +679,28 @@ struct ExtractionContext<'a, 'v> {
     /// `duplicate_skips` because hardlinks are TAR-specific (ZIP has no
     /// hardlink entry type) and are not routed through `common.rs`.
     hardlink_duplicate_skips: &'a mut u64,
+    /// Count of file entries skipped by `common::check_extension_allowed`
+    /// because their extension is not in the allowlist. Aggregated into a
+    /// single warning by [`push_duplicate_skip_warnings`] instead of one
+    /// warning per entry (issue #495).
+    disallowed_extension_skips: &'a mut u64,
     config: &'v SecurityConfig<Validated>,
     progress: &'a mut dyn ProgressCallback,
 }
 
-/// Appends aggregated duplicate-skip warnings to `report`, one entry per
-/// non-zero counter, mirroring 7z's single end-of-extraction warning
-/// (`SevenZArchive::extract_with_callback`) instead of one warning per
-/// skipped entry (issue #490).
+/// Appends aggregated duplicate-skip and disallowed-extension warnings to
+/// `report`, one entry per non-zero counter, mirroring 7z's single
+/// end-of-extraction warning (`SevenZArchive::extract_with_callback`)
+/// instead of one warning per skipped entry (issues #490, #495).
 fn push_duplicate_skip_warnings(
     report: &mut ExtractionReport,
     duplicate_skips: u64,
     hardlink_duplicate_skips: u64,
+    disallowed_extension_skips: u64,
 ) {
     common::push_duplicate_skip_warning(report, duplicate_skips, "entry", "entries");
     common::push_duplicate_skip_warning(report, hardlink_duplicate_skips, "hardlink", "hardlinks");
+    common::push_disallowed_extension_warning(report, disallowed_extension_skips);
 }
 
 #[allow(dead_code)] // Fields used only on Unix
@@ -2234,6 +2254,7 @@ mod tests {
         let mut progress = crate::NoopProgress;
         let mut duplicate_skips = 0u64;
         let mut hardlink_duplicate_skips = 0u64;
+        let mut disallowed_extension_skips = 0u64;
         let mut ctx = ExtractionContext {
             validator: &mut validator,
             dest: &dest,
@@ -2243,6 +2264,7 @@ mod tests {
             skip_duplicates: true,
             duplicate_skips: &mut duplicate_skips,
             hardlink_duplicate_skips: &mut hardlink_duplicate_skips,
+            disallowed_extension_skips: &mut disallowed_extension_skips,
             config: &config,
             progress: &mut progress,
         };
@@ -2970,7 +2992,117 @@ mod tests {
         assert_eq!(report.files_skipped, 1);
         assert!(dest.path().join("keep.txt").exists());
         assert!(!dest.path().join("skip.exe").exists());
-        assert!(report.warnings.iter().any(|w| w.contains("skip.exe")));
+        assert_eq!(
+            report.warnings,
+            vec!["skipped 1 entry with disallowed extension".to_string()],
+            "the disallowed-extension skip must be aggregated into a single warning \
+             instead of a per-entry, path-bearing one (issue #495)"
+        );
+    }
+
+    /// Reproduces the actual #495 bug scenario end-to-end: many entries
+    /// rejected by the extension allowlist must aggregate into a single
+    /// warning instead of growing `report.warnings` proportional to archive
+    /// size (mirrors `test_skip_duplicates_aggregates_single_warning`, #490).
+    #[test]
+    fn test_disallowed_extension_aggregates_single_warning() {
+        const ENTRY_COUNT: usize = 30;
+        let names: Vec<String> = (0..ENTRY_COUNT).map(|i| format!("skip-{i}.exe")).collect();
+        let entries: Vec<(&str, &[u8])> = names
+            .iter()
+            .map(|n| (n.as_str(), b"payload".as_slice()))
+            .collect();
+        let tar_data = create_test_tar(entries);
+        let dest = tempfile::tempdir().unwrap();
+        let config = SecurityConfig::default()
+            .with_allowed_extensions(vec!["txt".to_string()])
+            .validate()
+            .expect("valid config");
+
+        let report = TarArchive::new(Cursor::new(tar_data))
+            .extract(
+                dest.path(),
+                &config,
+                &ExtractionOptions::default(),
+                &mut NoopProgress,
+            )
+            .unwrap();
+
+        assert_eq!(report.files_skipped, ENTRY_COUNT);
+        assert_eq!(report.files_extracted, 0);
+        assert_eq!(
+            report.warnings,
+            vec![format!(
+                "skipped {ENTRY_COUNT} entries with disallowed extensions"
+            )],
+            "disallowed-extension skips must be aggregated into a single warning, got: {:?}",
+            report.warnings
+        );
+    }
+
+    /// Verifies duplicate-skip and disallowed-extension-skip counters
+    /// aggregate independently in the same extraction: an archive mixing
+    /// both skip reasons must produce exactly two warnings, one per reason,
+    /// each with the correct count (issue #495).
+    #[test]
+    fn test_duplicate_and_disallowed_extension_skips_aggregate_independently() {
+        const DUPLICATE_COUNT: usize = 5;
+        const DISALLOWED_COUNT: usize = 7;
+
+        let mut names: Vec<String> = (0..DUPLICATE_COUNT)
+            .map(|i| format!("dup-{i}.txt"))
+            .collect();
+        names.extend((0..DISALLOWED_COUNT).map(|i| format!("skip-{i}.exe")));
+        let entries: Vec<(&str, &[u8])> = names
+            .iter()
+            .map(|n| (n.as_str(), b"payload".as_slice()))
+            .collect();
+        let tar_data = create_test_tar(entries);
+
+        let temp = TempDir::new().unwrap();
+        for name in names.iter().take(DUPLICATE_COUNT) {
+            std::fs::write(temp.path().join(name), b"already here").unwrap();
+        }
+
+        let config = SecurityConfig::default()
+            .with_allowed_extensions(vec!["txt".to_string()])
+            .validate()
+            .expect("valid config");
+
+        let report = TarArchive::new(Cursor::new(tar_data))
+            .extract(
+                temp.path(),
+                &config,
+                &ExtractionOptions::default(), // skip_duplicates = true
+                &mut NoopProgress,
+            )
+            .unwrap();
+
+        assert_eq!(report.files_skipped, DUPLICATE_COUNT + DISALLOWED_COUNT);
+        assert_eq!(report.files_extracted, 0);
+        assert_eq!(
+            report.warnings.len(),
+            2,
+            "each skip reason must aggregate into its own single warning, got: {:?}",
+            report.warnings
+        );
+        assert!(
+            report
+                .warnings
+                .iter()
+                .any(|w| w.contains(&DUPLICATE_COUNT.to_string()) && w.contains("duplicate")),
+            "expected a duplicate-skip warning reporting {DUPLICATE_COUNT}, got: {:?}",
+            report.warnings
+        );
+        assert!(
+            report
+                .warnings
+                .iter()
+                .any(|w| w.contains(&DISALLOWED_COUNT.to_string())
+                    && w.contains("disallowed extension")),
+            "expected a disallowed-extension warning reporting {DISALLOWED_COUNT}, got: {:?}",
+            report.warnings
+        );
     }
 
     #[test]

--- a/crates/exarch-core/src/formats/zip.rs
+++ b/crates/exarch-core/src/formats/zip.rs
@@ -163,6 +163,11 @@ struct ZipExtractionContext<'a> {
     /// extraction completes instead of one warning per entry, mirroring
     /// 7z's `duplicate_skips` accumulator (issue #490).
     duplicate_skips: &'a mut u64,
+    /// Count of file entries skipped by `common::check_extension_allowed`
+    /// because their extension is not in the allowlist. Aggregated into a
+    /// single warning after extraction completes instead of one warning
+    /// per entry (issue #495).
+    disallowed_extension_skips: &'a mut u64,
     progress: &'a mut dyn ProgressCallback,
 }
 
@@ -388,7 +393,12 @@ impl<R: Read + Seek> ZipArchive<R> {
                 )?;
             }
         } else {
-            if !common::check_extension_allowed(&path, ctx.config, ctx.report) {
+            if !common::check_extension_allowed(
+                &path,
+                ctx.config,
+                ctx.report,
+                ctx.disallowed_extension_skips,
+            ) {
                 return Ok(());
             }
             // File: validate BEFORE writing (security invariant preserved),
@@ -479,6 +489,10 @@ impl<R: Read + Seek> ArchiveFormat for ZipArchive<R> {
         // (issue #490).
         let mut duplicate_skips: u64 = 0;
 
+        // Same aggregation, for entries rejected by the extension allowlist
+        // (issue #495).
+        let mut disallowed_extension_skips: u64 = 0;
+
         let entry_count = self.inner.len();
 
         for i in 0..entry_count {
@@ -509,6 +523,7 @@ impl<R: Read + Seek> ArchiveFormat for ZipArchive<R> {
                 dir_cache: &mut dir_cache,
                 skip_duplicates,
                 duplicate_skips: &mut duplicate_skips,
+                disallowed_extension_skips: &mut disallowed_extension_skips,
                 progress: guard.progress_mut(),
             };
 
@@ -522,12 +537,14 @@ impl<R: Read + Seek> ArchiveFormat for ZipArchive<R> {
                     "entry",
                     "entries",
                 );
+                common::push_disallowed_extension_warning(&mut report, disallowed_extension_skips);
                 return Err(ArchiveError::partial_or(std::mem::take(&mut report), e));
             }
             guard.complete();
         }
 
         common::push_duplicate_skip_warning(&mut report, duplicate_skips, "entry", "entries");
+        common::push_disallowed_extension_warning(&mut report, disallowed_extension_skips);
         progress.on_complete();
         report.duration = start.elapsed();
 
@@ -2104,7 +2121,121 @@ mod tests {
         assert_eq!(report.files_skipped, 1);
         assert!(dest.path().join("keep.txt").exists());
         assert!(!dest.path().join("skip.exe").exists());
-        assert!(report.warnings.iter().any(|w| w.contains("skip.exe")));
+        assert_eq!(
+            report.warnings,
+            vec!["skipped 1 entry with disallowed extension".to_string()],
+            "the disallowed-extension skip must be aggregated into a single warning \
+             instead of a per-entry, path-bearing one (issue #495)"
+        );
+    }
+
+    /// Reproduces the actual #495 bug scenario end-to-end: many entries
+    /// rejected by the extension allowlist must aggregate into a single
+    /// warning instead of growing `report.warnings` proportional to archive
+    /// size (mirrors `test_skip_duplicates_aggregates_single_warning`, #490).
+    #[test]
+    fn test_disallowed_extension_aggregates_single_warning() {
+        use crate::NoopProgress;
+        const ENTRY_COUNT: usize = 30;
+        let names: Vec<String> = (0..ENTRY_COUNT).map(|i| format!("skip-{i}.exe")).collect();
+        let entries: Vec<(&str, &[u8])> = names
+            .iter()
+            .map(|n| (n.as_str(), b"payload".as_slice()))
+            .collect();
+        let zip_data = create_test_zip(entries);
+        let dest = tempfile::tempdir().unwrap();
+        let config = SecurityConfig::default()
+            .with_allowed_extensions(vec!["txt".to_string()])
+            .validate()
+            .expect("valid config");
+
+        let report = ZipArchive::new(Cursor::new(zip_data))
+            .unwrap()
+            .extract(
+                dest.path(),
+                &config,
+                &ExtractionOptions::default(),
+                &mut NoopProgress,
+            )
+            .unwrap();
+
+        assert_eq!(report.files_skipped, ENTRY_COUNT);
+        assert_eq!(report.files_extracted, 0);
+        assert_eq!(
+            report.warnings,
+            vec![format!(
+                "skipped {ENTRY_COUNT} entries with disallowed extensions"
+            )],
+            "disallowed-extension skips must be aggregated into a single warning, got: {:?}",
+            report.warnings
+        );
+    }
+
+    /// Verifies duplicate-skip and disallowed-extension-skip counters
+    /// aggregate independently in the same extraction: an archive mixing
+    /// both skip reasons must produce exactly two warnings, one per reason,
+    /// each with the correct count (issue #495).
+    #[test]
+    fn test_duplicate_and_disallowed_extension_skips_aggregate_independently() {
+        use crate::NoopProgress;
+        const DUPLICATE_COUNT: usize = 5;
+        const DISALLOWED_COUNT: usize = 7;
+
+        let mut names: Vec<String> = (0..DUPLICATE_COUNT)
+            .map(|i| format!("dup-{i}.txt"))
+            .collect();
+        names.extend((0..DISALLOWED_COUNT).map(|i| format!("skip-{i}.exe")));
+        let entries: Vec<(&str, &[u8])> = names
+            .iter()
+            .map(|n| (n.as_str(), b"payload".as_slice()))
+            .collect();
+        let zip_data = create_test_zip(entries);
+
+        let temp = TempDir::new().unwrap();
+        for name in names.iter().take(DUPLICATE_COUNT) {
+            std::fs::write(temp.path().join(name), b"already here").unwrap();
+        }
+
+        let config = SecurityConfig::default()
+            .with_allowed_extensions(vec!["txt".to_string()])
+            .validate()
+            .expect("valid config");
+
+        let report = ZipArchive::new(Cursor::new(zip_data))
+            .unwrap()
+            .extract(
+                temp.path(),
+                &config,
+                &ExtractionOptions::default(), // skip_duplicates = true
+                &mut NoopProgress,
+            )
+            .unwrap();
+
+        assert_eq!(report.files_skipped, DUPLICATE_COUNT + DISALLOWED_COUNT);
+        assert_eq!(report.files_extracted, 0);
+        assert_eq!(
+            report.warnings.len(),
+            2,
+            "each skip reason must aggregate into its own single warning, got: {:?}",
+            report.warnings
+        );
+        assert!(
+            report
+                .warnings
+                .iter()
+                .any(|w| w.contains(&DUPLICATE_COUNT.to_string()) && w.contains("duplicate")),
+            "expected a duplicate-skip warning reporting {DUPLICATE_COUNT}, got: {:?}",
+            report.warnings
+        );
+        assert!(
+            report
+                .warnings
+                .iter()
+                .any(|w| w.contains(&DISALLOWED_COUNT.to_string())
+                    && w.contains("disallowed extension")),
+            "expected a disallowed-extension warning reporting {DISALLOWED_COUNT}, got: {:?}",
+            report.warnings
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `common::check_extension_allowed` (shared by TAR, ZIP, and 7z) pushed one path-bearing warning string into `report.warnings` per entry rejected by the extension allowlist, growing the report unbounded by archive size.
- Replaced with a `disallowed_extension_skips` counter, aggregated into a single `"skipped N entries with disallowed extensions"` warning per extraction, mirroring the `duplicate_skips` aggregation pattern introduced in #490.
- Threaded the counter through all flush points in TAR (4 exit points), ZIP (2 flush points), and 7z (1 flush point alongside the existing `duplicate_skips` block).
- Fixed 3 pre-existing per-format tests that asserted the old per-entry warning text; added 6 new regression tests (2 per format) covering many-entry aggregation and mixed duplicate + disallowed-extension scenarios.

## Test plan
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features --exclude exarch-python -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` (1139/1139)
- [x] `cargo test --doc --workspace --all-features` (117/117 for exarch-core; workspace-wide doc test hits a pre-existing, unrelated exarch-python/pyo3 linker issue)
- [x] Adversarial critique (verdict: minor, no blocking issues)
- [x] Code review (approved)

Closes #495