### PR TITLE
refactor(core): use shared push_duplicate_skip_warning in 7z extractor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`formats::sevenz::extract_archive` now builds its duplicate-skip warning via the shared
+  `common::push_duplicate_skip_warning` helper (#499)**, matching the TAR and ZIP handlers instead
+  of re-implementing the singular/plural aggregation inline. No behavior or message change.
 - **BREAKING: `ArchiveError::to_ffi_message` no longer takes a `sanitize_paths: bool` parameter
   (#463)**: the parameter's runtime toggle no longer maps onto anything real once the redaction
   policy became profile-gated (`cfg(debug_assertions)`) rather than caller-selected — see the

--- a/crates/exarch-core/src/formats/common.rs
+++ b/crates/exarch-core/src/formats/common.rs
@@ -339,11 +339,9 @@ pub fn normalize_entry_name(name: &str) -> String {
 /// Appends a single aggregated warning for `count` skipped duplicate
 /// entries, choosing `noun_singular`/`noun_plural` based on `count`.
 ///
-/// Shared by the TAR and ZIP extractors so a single warning is pushed once
-/// extraction completes instead of one warning per skipped duplicate,
-/// mirroring 7z's `duplicate_skips` accumulator
-/// (`SevenZArchive::extract_with_callback`, issues #484/#487/#490). A no-op
-/// when `count` is zero.
+/// Shared by the TAR, ZIP, and 7z extractors (#499) so a single warning is
+/// pushed once extraction completes instead of one warning per skipped
+/// duplicate. A no-op when `count` is zero.
 ///
 /// # Examples
 ///
@@ -1615,6 +1613,29 @@ mod tests {
         assert_eq!(
             report.warnings,
             vec!["skipped 3 entries with disallowed extensions".to_string()]
+        );
+    }
+
+    /// Pins the exact aggregated warning message text produced by
+    /// `push_duplicate_skip_warning` for both singular and plural counts,
+    /// and confirms it is a no-op for a zero count.
+    #[test]
+    fn test_push_duplicate_skip_warning_text() {
+        let mut report = ExtractionReport::default();
+        push_duplicate_skip_warning(&mut report, 0, "entry", "entries");
+        assert!(report.warnings.is_empty(), "zero count must be a no-op");
+
+        push_duplicate_skip_warning(&mut report, 1, "entry", "entries");
+        assert_eq!(
+            report.warnings,
+            vec!["skipped 1 entry as pre-existing duplicates".to_string()]
+        );
+
+        report.warnings.clear();
+        push_duplicate_skip_warning(&mut report, 3, "entry", "entries");
+        assert_eq!(
+            report.warnings,
+            vec!["skipped 3 entries as pre-existing duplicates".to_string()]
         );
     }
 }

--- a/crates/exarch-core/src/formats/sevenz.rs
+++ b/crates/exarch-core/src/formats/sevenz.rs
@@ -786,17 +786,12 @@ impl<R: Read + Seek> SevenZArchive<R> {
         let mut archive_reader = ArchiveReader::from_archive(archive, source, Password::empty());
         let result = archive_reader.for_each_entries(&mut extract_fn);
         let mut accumulated = ctx.report;
-        if ctx.duplicate_skips > 0 {
-            let noun = if ctx.duplicate_skips == 1 {
-                "entry"
-            } else {
-                "entries"
-            };
-            accumulated.warnings.push(format!(
-                "skipped {} {noun} as pre-existing duplicates",
-                ctx.duplicate_skips
-            ));
-        }
+        common::push_duplicate_skip_warning(
+            &mut accumulated,
+            ctx.duplicate_skips,
+            "entry",
+            "entries",
+        );
         common::push_disallowed_extension_warning(&mut accumulated, ctx.disallowed_extension_skips);
 
         let e = match result {


### PR DESCRIPTION
## Summary

- `formats/sevenz.rs` re-implemented the singular/plural duplicate-skip warning aggregation inline instead of calling `formats/common.rs::push_duplicate_skip_warning`, already used by the TAR and ZIP handlers for the same warning.
- Replaced the hand-rolled block with a call to the shared helper — pure call-site substitution, byte-identical output.
- Updated the helper's stale doc comment (was: "mirroring 7z's `duplicate_skips` accumulator", which became inaccurate once 7z started calling the helper directly).
- Added `test_push_duplicate_skip_warning_text`, pinning the exact singular/plural/no-op output, mirroring the existing sibling test for `push_disallowed_extension_warning`.

Closes #499

## Test plan

- [x] `cargo build -p exarch-core --all-features`
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` (1142/1142 passed)
- [x] `cargo test --doc --workspace --all-features` (117/117 in exarch-core)