### PR TITLE
fix(cli): surface extract warnings/files_skipped and cap conflict errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,6 +209,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`exarch-cli`: `extract`'s human and `--json` output never surfaced `ExtractionReport.warnings`
+  or `files_skipped` (#498)**: both fields are populated correctly by `exarch-core` and already
+  exposed by the Python and Node.js bindings, but `format_extraction_result` in `output/human.rs`
+  and `output/json.rs` only read `files_extracted`/`directories_created`/`symlinks_created`/
+  `bytes_written`/`duration`, silently dropping any warnings (e.g. capped disallowed-extension or
+  duplicate-skip summaries from #495/#497) and the skipped-file count. `format_extraction_result`
+  now prints a `Files skipped:` line and a `Warnings:` section (mirroring `create`'s existing
+  formatter), and the JSON `ExtractionOutput` struct gained `files_skipped`/`warnings` fields
+  (mirroring `CreationOutput`).
+- **`exarch-cli`: `extract`'s pre-flight destination-conflict error listed every conflicting path
+  with no cap (#500)**: the pre-flight check in `commands/extract.rs` (run before core extraction,
+  when `--force`/`--atomic` are absent) built an `anyhow::bail!` message listing one line per
+  pre-existing destination file: with `max_file_count` defaulting to 10000, extracting an archive
+  with many same-named entries over a populated destination could dump up to 10000 lines to
+  stderr — the same unbounded-output class already fixed for `exarch-core`'s warning aggregation
+  in #484/#490/#495/#497. `conflict_error_message` now sorts the conflicting paths before listing
+  at most 10 of them and collapsing the remainder into a single `... and N more` summary line —
+  sorting first keeps "first 10 shown" a deterministic, reproducible subset rather than whatever
+  order the archive manifest happened to yield.
 - **`exarch-core`: TAR, ZIP, and 7z pushed one unbounded, path-bearing warning `String` per entry
   rejected by the extension allowlist (#495)**: `common::check_extension_allowed` (shared by all
   three format handlers) pushed a `"skipped entry with disallowed extension: {path}"` warning

--- a/crates/exarch-cli/README.md
+++ b/crates/exarch-cli/README.md
@@ -276,8 +276,24 @@ Extraction complete
     "files_extracted": 1523,
     "directories_created": 87,
     "symlinks_created": 0,
-    "bytes_written": 44396032
+    "bytes_written": 44396032,
+    "files_skipped": 0,
+    "duration_ms": 842,
+    "warnings": []
   }
+}
+```
+
+`files_skipped` and `warnings` are populated whenever entries are skipped without failing the
+extraction — e.g. `--allowed-extensions` rejecting entries by extension, or pre-existing
+duplicate destination files skipped by default (unless `--force` is passed):
+
+```json
+{
+  "files_skipped": 2,
+  "warnings": [
+    "skipped 2 entries with disallowed extensions"
+  ]
 }
 ```
 

--- a/crates/exarch-cli/src/commands/extract.rs
+++ b/crates/exarch-cli/src/commands/extract.rs
@@ -44,6 +44,45 @@ fn parse_extensions(raw: &[String]) -> Vec<String> {
         .collect()
 }
 
+/// Maximum number of conflicting destination paths listed individually in
+/// the pre-flight conflict error before the remainder is collapsed into a
+/// single "... and N more" summary line.
+const MAX_LISTED_CONFLICTS: usize = 10;
+
+/// Builds the pre-flight destination-conflict error message for `conflicts`.
+///
+/// Caps the number of individually listed paths at [`MAX_LISTED_CONFLICTS`]
+/// so an archive with many same-named pre-existing files (up to
+/// `max_file_count`, 10000 by default) cannot flood stderr with one line per
+/// conflict. `conflicts` is sorted before truncation so "first N shown" is a
+/// deterministic, reproducible subset rather than whatever order the archive
+/// manifest happened to yield.
+fn conflict_error_message(conflicts: &[std::path::PathBuf]) -> String {
+    let count = conflicts.len();
+    let noun = if count == 1 { "file" } else { "files" };
+    let verb = if count == 1 { "exists" } else { "exist" };
+
+    let mut sorted: Vec<&std::path::PathBuf> = conflicts.iter().collect();
+    sorted.sort();
+
+    let list = sorted
+        .into_iter()
+        .take(MAX_LISTED_CONFLICTS)
+        .map(|p| format!("  {}", p.display()))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let remaining = count.saturating_sub(MAX_LISTED_CONFLICTS);
+    if remaining == 0 {
+        format!("{count} destination {noun} already {verb} (use --force to overwrite):\n{list}")
+    } else {
+        format!(
+            "{count} destination {noun} already {verb} (use --force to overwrite); \
+             first {MAX_LISTED_CONFLICTS} shown:\n{list}\n  ... and {remaining} more"
+        )
+    }
+}
+
 /// Drops empty entries from raw `--banned-component` values.
 ///
 /// `SecurityConfig::validate()` rejects empty entries, but an empty value is
@@ -128,12 +167,7 @@ pub fn execute(
             .collect();
 
         if !conflicts.is_empty() {
-            let list = conflicts
-                .iter()
-                .map(|p| format!("  {}", p.display()))
-                .collect::<Vec<_>>()
-                .join("\n");
-            anyhow::bail!("destination files already exist (use --force to overwrite):\n{list}");
+            anyhow::bail!(conflict_error_message(&conflicts));
         }
     }
 
@@ -241,5 +275,95 @@ mod tests {
     fn filter_banned_components_keeps_non_empty_entries() {
         let raw = vec![".git".to_string(), String::new(), ".ssh".to_string()];
         assert_eq!(filter_banned_components(&raw), vec![".git", ".ssh"]);
+    }
+
+    #[test]
+    fn conflict_error_message_singular() {
+        let conflicts = vec![std::path::PathBuf::from("a.txt")];
+        let msg = conflict_error_message(&conflicts);
+        assert!(msg.starts_with("1 destination file already exists"));
+        assert!(msg.contains("a.txt"));
+        assert!(!msg.contains("more"));
+    }
+
+    #[test]
+    fn conflict_error_message_under_cap_lists_all_without_truncation_note() {
+        let conflicts: Vec<_> = (0..5)
+            .map(|i| std::path::PathBuf::from(format!("f{i}.txt")))
+            .collect();
+        let msg = conflict_error_message(&conflicts);
+        assert!(msg.starts_with("5 destination files already exist"));
+        for i in 0..5 {
+            assert!(msg.contains(&format!("f{i}.txt")));
+        }
+        assert!(!msg.contains("more"));
+        assert!(!msg.contains("first"));
+    }
+
+    #[test]
+    fn conflict_error_message_at_cap_lists_all_without_truncation_note() {
+        let conflicts: Vec<_> = (0..MAX_LISTED_CONFLICTS)
+            .map(|i| std::path::PathBuf::from(format!("f{i}.txt")))
+            .collect();
+        let msg = conflict_error_message(&conflicts);
+        assert!(msg.starts_with("10 destination files already exist"));
+        for i in 0..MAX_LISTED_CONFLICTS {
+            assert!(msg.contains(&format!("f{i}.txt")));
+        }
+        assert!(!msg.contains("more"));
+        assert!(!msg.contains("first"));
+    }
+
+    #[test]
+    fn conflict_error_message_over_cap_truncates_and_summarizes() {
+        // Zero-padded so lexicographic (PathBuf::Ord) sort matches numeric
+        // order, and reverse-inserted to prove the shown subset is the
+        // sorted-first-10, not an insertion-order-first-10.
+        let conflicts: Vec<_> = (0..25)
+            .rev()
+            .map(|i| std::path::PathBuf::from(format!("f{i:02}.txt")))
+            .collect();
+        let msg = conflict_error_message(&conflicts);
+        assert!(msg.starts_with("25 destination files already exist"));
+        assert!(msg.contains("first 10 shown"));
+        for i in 0..10 {
+            assert!(msg.contains(&format!("f{i:02}.txt")));
+        }
+        for i in 10..25 {
+            assert!(!msg.contains(&format!("f{i:02}.txt")));
+        }
+        assert!(msg.contains("... and 15 more"));
+    }
+
+    #[test]
+    fn conflict_error_message_lists_shown_entries_in_sorted_order() {
+        let conflicts: Vec<_> = ["c.txt", "a.txt", "b.txt"]
+            .iter()
+            .map(std::path::PathBuf::from)
+            .collect();
+        let msg = conflict_error_message(&conflicts);
+        let find = |needle: &str| {
+            msg.find(needle)
+                .unwrap_or_else(|| panic!("{needle} missing from: {msg}"))
+        };
+        assert!(
+            find("a.txt") < find("b.txt") && find("b.txt") < find("c.txt"),
+            "shown paths must be listed in sorted order regardless of input order: {msg}"
+        );
+    }
+
+    #[test]
+    fn conflict_error_message_is_deterministic_across_input_permutations() {
+        let ascending: Vec<_> = (0..15)
+            .map(|i| std::path::PathBuf::from(format!("f{i:02}.txt")))
+            .collect();
+        let mut reversed = ascending.clone();
+        reversed.reverse();
+
+        assert_eq!(
+            conflict_error_message(&ascending),
+            conflict_error_message(&reversed),
+            "the message must not depend on the order conflicts were discovered in"
+        );
     }
 }

--- a/crates/exarch-cli/src/output/human.rs
+++ b/crates/exarch-cli/src/output/human.rs
@@ -134,6 +134,13 @@ impl<O: Write, E: Write> OutputFormatter for HumanFormatter<O, E> {
             format_args!("  Total size: {}", humanize_bytes(report.bytes_written)),
         );
 
+        if report.files_skipped > 0 {
+            emit_line(
+                &mut self.out,
+                format_args!("  Files skipped: {}", report.files_skipped),
+            );
+        }
+
         if self.verbose {
             emit_line(
                 &mut self.out,
@@ -143,6 +150,21 @@ impl<O: Write, E: Write> OutputFormatter for HumanFormatter<O, E> {
                 &mut self.out,
                 format_args!("  Duration: {:?}", report.duration),
             );
+        }
+
+        if report.has_warnings() {
+            emit_blank(&mut self.out);
+            if self.use_colors {
+                emit_line(
+                    &mut self.out,
+                    format_args!("{}", style("Warnings:").yellow().bold()),
+                );
+            } else {
+                emit_line(&mut self.out, format_args!("Warnings:"));
+            }
+            for warning in &report.warnings {
+                emit_line(&mut self.out, format_args!("  - {warning}"));
+            }
         }
 
         Ok(())
@@ -519,6 +541,31 @@ mod tests {
         assert!(text.contains("Directories: 1"));
         assert!(text.contains("Total size: 2.0 KB"));
         assert!(!text.contains("Symlinks:"));
+    }
+
+    #[test]
+    fn format_extraction_result_with_warnings_and_files_skipped() {
+        let mut f = formatter(false, false, false);
+        let mut report = sample_extraction_report();
+        report.files_skipped = 2;
+        report
+            .warnings
+            .push("skipped 2 entries with disallowed extensions".to_string());
+        f.format_extraction_result(&report).unwrap();
+        let text = out_text(&f);
+        assert!(text.contains("Files skipped: 2"));
+        assert!(text.contains("Warnings:"));
+        assert!(text.contains("skipped 2 entries with disallowed extensions"));
+    }
+
+    #[test]
+    fn format_extraction_result_no_warnings_section_when_empty() {
+        let mut f = formatter(false, false, false);
+        f.format_extraction_result(&sample_extraction_report())
+            .unwrap();
+        let text = out_text(&f);
+        assert!(!text.contains("Warnings:"));
+        assert!(!text.contains("Files skipped:"));
     }
 
     #[test]

--- a/crates/exarch-cli/src/output/json.rs
+++ b/crates/exarch-cli/src/output/json.rs
@@ -82,7 +82,9 @@ impl<W: Write> OutputFormatter for JsonFormatter<W> {
             directories_created: usize,
             symlinks_created: usize,
             bytes_written: u64,
+            files_skipped: usize,
             duration_ms: u128,
+            warnings: Vec<String>,
         }
 
         let data = ExtractionOutput {
@@ -90,7 +92,9 @@ impl<W: Write> OutputFormatter for JsonFormatter<W> {
             directories_created: report.directories_created,
             symlinks_created: report.symlinks_created,
             bytes_written: report.bytes_written,
+            files_skipped: report.files_skipped,
             duration_ms: report.duration.as_millis(),
+            warnings: report.warnings.clone(),
         };
 
         let output = JsonOutput::success("extract", data);
@@ -522,6 +526,27 @@ mod tests {
         assert_eq!(v["status"], "success");
         assert_eq!(v["data"]["files_extracted"], 3);
         assert_eq!(v["data"]["bytes_written"], 2048);
+    }
+
+    #[test]
+    fn format_extraction_result_includes_warnings_and_files_skipped() {
+        let mut f = JsonFormatter::with_writer(Vec::new());
+        let report = ExtractionReport {
+            files_extracted: 3,
+            directories_created: 1,
+            symlinks_created: 0,
+            bytes_written: 2048,
+            files_skipped: 2,
+            duration: std::time::Duration::from_secs(1),
+            warnings: vec!["skipped 2 entries with disallowed extensions".to_string()],
+        };
+        f.format_extraction_result(&report).unwrap();
+        let v = parsed(&f);
+        assert_eq!(v["data"]["files_skipped"], 2);
+        assert_eq!(
+            v["data"]["warnings"][0],
+            "skipped 2 entries with disallowed extensions"
+        );
     }
 
     #[test]

--- a/crates/exarch-cli/tests/cli_tests.rs
+++ b/crates/exarch-cli/tests/cli_tests.rs
@@ -1980,6 +1980,168 @@ fn test_extract_with_force_overwrites_conflicts() {
         .stdout(predicate::str::contains("Extraction complete"));
 }
 
+/// Regression test for #500: the pre-flight destination-conflict error must
+/// cap the number of individually listed paths rather than dumping one line
+/// per conflicting file.
+#[test]
+fn test_extract_without_force_caps_conflict_list_for_many_files() {
+    use flate2::Compression;
+    use flate2::write::GzEncoder;
+
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let archive_path = temp.path().join("many_files.tar.gz");
+
+    let file = std::fs::File::create(&archive_path).expect("create archive");
+    let gz = GzEncoder::new(file, Compression::default());
+    let mut builder = tar::Builder::new(gz);
+
+    for i in 0..15 {
+        let mut header = tar::Header::new_gnu();
+        header.set_size(4);
+        header.set_mode(0o644);
+        header
+            .set_path(format!("f{i}.txt"))
+            .expect("set entry path");
+        header.set_cksum();
+        builder
+            .append_data(&mut header, format!("f{i}.txt"), &b"data"[..])
+            .expect("append file entry");
+    }
+    builder
+        .into_inner()
+        .expect("finish tar")
+        .finish()
+        .expect("finish gzip");
+
+    let output_dir = temp.path().join("out");
+
+    // First extraction populates the output directory.
+    exarch_cmd()
+        .arg("extract")
+        .arg(&archive_path)
+        .arg(&output_dir)
+        .assert()
+        .success();
+
+    // Second extraction without --force must fail with a capped conflict list.
+    exarch_cmd()
+        .arg("extract")
+        .arg(&archive_path)
+        .arg(&output_dir)
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("15 destination files already exist")
+                .and(predicate::str::contains("first 10 shown"))
+                .and(predicate::str::contains("... and 5 more")),
+        );
+}
+
+/// Builds a tar.gz with `allowed` files matching `.txt` and `rejected` files
+/// matching `.exe`, so `--allowed-extensions txt` skips exactly `rejected`
+/// entries.
+fn make_mixed_extension_archive(path: &std::path::Path, allowed: usize, rejected: usize) {
+    use flate2::Compression;
+    use flate2::write::GzEncoder;
+
+    let file = std::fs::File::create(path).expect("create archive");
+    let gz = GzEncoder::new(file, Compression::default());
+    let mut builder = tar::Builder::new(gz);
+
+    for i in 0..allowed {
+        let mut header = tar::Header::new_gnu();
+        header.set_size(4);
+        header.set_mode(0o644);
+        header
+            .set_path(format!("keep{i}.txt"))
+            .expect("set entry path");
+        header.set_cksum();
+        builder
+            .append_data(&mut header, format!("keep{i}.txt"), &b"data"[..])
+            .expect("append file entry");
+    }
+    for i in 0..rejected {
+        let mut header = tar::Header::new_gnu();
+        header.set_size(4);
+        header.set_mode(0o644);
+        header
+            .set_path(format!("drop{i}.exe"))
+            .expect("set entry path");
+        header.set_cksum();
+        builder
+            .append_data(&mut header, format!("drop{i}.exe"), &b"data"[..])
+            .expect("append file entry");
+    }
+    builder
+        .into_inner()
+        .expect("finish tar")
+        .finish()
+        .expect("finish gzip");
+}
+
+/// Regression test for #498: entries skipped by `--allowed-extensions` (a
+/// real core→CLI round trip, not a synthetic report fed directly to the
+/// formatter) must be surfaced in human-readable stdout as `Files skipped:`
+/// plus a `Warnings:` section.
+#[test]
+fn test_extract_reports_files_skipped_and_warnings_for_disallowed_extensions() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let archive_path = temp.path().join("mixed.tar.gz");
+    make_mixed_extension_archive(&archive_path, 3, 2);
+
+    let output_dir = temp.path().join("out");
+
+    exarch_cmd()
+        .arg("extract")
+        .arg("--allowed-extensions")
+        .arg("txt")
+        .arg(&archive_path)
+        .arg(&output_dir)
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("Files skipped: 2")
+                .and(predicate::str::contains("Warnings:"))
+                .and(predicate::str::contains(
+                    "skipped 2 entries with disallowed extensions",
+                )),
+        );
+}
+
+/// Regression test for #498: same scenario as
+/// `test_extract_reports_files_skipped_and_warnings_for_disallowed_extensions`
+/// but for `--json`, verifying the `files_skipped`/`warnings` fields the
+/// Python and Node.js bindings already exposed are now present in the CLI's
+/// JSON payload too.
+#[test]
+fn test_extract_json_reports_files_skipped_and_warnings_for_disallowed_extensions() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let archive_path = temp.path().join("mixed.tar.gz");
+    make_mixed_extension_archive(&archive_path, 3, 2);
+
+    let output_dir = temp.path().join("out");
+
+    let output = exarch_cmd()
+        .arg("extract")
+        .arg("--allowed-extensions")
+        .arg("txt")
+        .arg("--json")
+        .arg(&archive_path)
+        .arg(&output_dir)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json: serde_json::Value = serde_json::from_slice(&output).expect("valid JSON output");
+    assert_eq!(json["data"]["files_skipped"], 2);
+    assert_eq!(
+        json["data"]["warnings"][0],
+        "skipped 2 entries with disallowed extensions"
+    );
+}
+
 // ============================================================================
 // symlink_target in JSON list output (#346)
 // ============================================================================

--- a/skills/exarch-cli/SKILL.md
+++ b/skills/exarch-cli/SKILL.md
@@ -272,7 +272,32 @@ Success (`extract`):
     "directories_created": 0,
     "symlinks_created": 0,
     "bytes_written": 6,
-    "duration_ms": 0
+    "files_skipped": 0,
+    "duration_ms": 0,
+    "warnings": []
+  }
+}
+```
+
+`files_skipped` and `warnings` are populated whenever entries are skipped without failing the
+extraction — e.g. `--allowed-extensions` rejecting entries by extension, or duplicate destination
+files skipped under `--skip-duplicates` semantics (the default when `--force` is absent).
+Verified live with a mixed-extension archive extracted via `--allowed-extensions txt`:
+
+```json
+{
+  "operation": "extract",
+  "status": "success",
+  "data": {
+    "files_extracted": 3,
+    "directories_created": 1,
+    "symlinks_created": 0,
+    "bytes_written": 18,
+    "files_skipped": 2,
+    "duration_ms": 0,
+    "warnings": [
+      "skipped 2 entries with disallowed extensions"
+    ]
   }
 }
 ```


### PR DESCRIPTION
## Summary
- `extract`'s human and `--json` output never surfaced `ExtractionReport.warnings` or `files_skipped`, even though `exarch-core` populates both and the Python/Node bindings already expose them. `format_extraction_result` now prints a `Files skipped:` line and a `Warnings:` section (mirroring `create`'s formatter), and the JSON `ExtractionOutput` struct gained `files_skipped`/`warnings` fields.
- The pre-flight destination-conflict check listed every conflicting path with no cap, risking up to `max_file_count` (10000 by default) lines dumped to stderr on a crafted archive extracted over a populated destination. `conflict_error_message` now sorts the conflicts and caps the listing at 10, collapsing the remainder into a single `... and N more` summary, matching the aggregation pattern already used for `exarch-core`'s warning caps.
- `skills/exarch-cli/SKILL.md` and `crates/exarch-cli/README.md` updated to document the new `--json` fields, verified against the built binary.

Closes #498
Closes #500

## Test plan
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` (1154 passed)
- [x] `cargo test --doc --workspace --all-features` (117 passed; exarch-python excluded — pre-existing local pyo3 link failure, unrelated to this change)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace`
- [x] New integration tests exercise the real core→CLI wiring for #498 (mixed-extension archive through `--allowed-extensions`, asserting `Files skipped:`/`Warnings:` in human output and `files_skipped`/`warnings` in `--json`)
- [x] New unit tests cover `conflict_error_message` sorting/capping at N=1/5/10/11/25
- [x] Live-verified `SKILL.md`/README `--json` examples against `./target/debug/exarch extract ... --json`