### PR TITLE
fix(core): use saturating_add for 7z duplicate_skips counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -239,6 +239,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   include `files_skipped` and `warnings` (the human path only when non-empty, mirroring the
   existing success-path convention), without changing the existing "WARNING: Extraction was
   stopped..." / "HINT: ..." wording.
+- **`exarch-core`: 7z's `duplicate_skips` counter used a plain `+= 1` instead of `saturating_add`,
+  the only non-saturating skip counter in the codebase (#502)**: every other skip-counter increment
+  — `disallowed_extension_skips` (`common.rs:452`), TAR/ZIP's shared `duplicate_skips`
+  (`common.rs:704`), and TAR's `hardlink_duplicate_skips` (`tar.rs:397`) — already used
+  `saturating_add` to avoid wrapping after `u64::MAX` skips; 7z's own counter
+  (`formats/sevenz.rs:575`) was the one site still using bare `+= 1`. Switched to
+  `duplicate_skips.saturating_add(1)`, matching the existing idiom exactly.
 - **`exarch-core`: TAR, ZIP, and 7z pushed one unbounded, path-bearing warning `String` per entry
   rejected by the extension allowlist (#495)**: `common::check_extension_allowed` (shared by all
   three format handlers) pushed a `"skipped entry with disallowed extension: {path}"` warning

--- a/crates/exarch-core/src/formats/sevenz.rs
+++ b/crates/exarch-core/src/formats/sevenz.rs
@@ -572,7 +572,7 @@ impl<R: Read + Seek> SevenZArchive<R> {
 
                 if existing.is_some() && skip_duplicates {
                     report.files_skipped += 1;
-                    *duplicate_skips += 1;
+                    *duplicate_skips = duplicate_skips.saturating_add(1);
                     return Ok(0);
                 }
 
@@ -2258,6 +2258,57 @@ mod tests {
             Err(sevenz_rust2::Error::Other(m)) if m.contains("validation failed"),
             "callback re-validation must independently reject a traversal entry via its own \
              validate_entry call, got: {result:?}"
+        );
+    }
+
+    /// Regression test for #502: `duplicate_skips` must saturate instead of
+    /// wrapping (or panicking, in debug builds) once it reaches `u64::MAX`,
+    /// mirroring the near-boundary pattern used by
+    /// `common.rs`'s `test_extract_file_with_permit_integer_overflow_check`
+    /// for `bytes_written`.
+    #[test]
+    fn test_process_entry_inner_duplicate_skips_saturates_at_max() {
+        let temp = TempDir::new().unwrap();
+        let dest = DestDir::new_or_create(temp.path().to_path_buf()).unwrap();
+        std::fs::write(temp.path().join("existing.txt"), b"already here").unwrap();
+
+        let config = SecurityConfig::default().validate().expect("valid config");
+        let mut validator = EntryValidator::new(&config, &dest);
+        let mut dir_cache = common::DirCache::new();
+        let mut report = ExtractionReport::new();
+        let mut duplicate_skips = u64::MAX;
+        let mut disallowed_extension_skips = 0u64;
+        let mut pending_io_error = None;
+
+        let mut entry = sevenz_rust2::ArchiveEntry::new_file("existing.txt");
+        entry.has_stream = true;
+        entry.size = 5;
+        let entry_path = std::path::PathBuf::from(common::normalize_entry_name(&entry.name));
+
+        let result = SevenZArchive::<Cursor<Vec<u8>>>::process_entry_inner(
+            &entry,
+            &mut std::io::empty(),
+            &entry_path,
+            &mut validator,
+            &dest,
+            &mut report,
+            &mut dir_cache,
+            true, // skip_duplicates
+            &config,
+            &mut duplicate_skips,
+            &mut disallowed_extension_skips,
+            &mut pending_io_error,
+        );
+
+        assert_matches!(
+            result,
+            Ok(0),
+            "duplicate skip must not error, got: {result:?}"
+        );
+        assert_eq!(
+            duplicate_skips,
+            u64::MAX,
+            "duplicate_skips must saturate at u64::MAX instead of wrapping or panicking"
         );
     }
 


### PR DESCRIPTION
## Summary

- `sevenz.rs` incremented the `duplicate_skips` counter with a plain `+= 1`, the only non-saturating skip-counter increment in the codebase.
- Every other equivalent counter (`disallowed_extension_skips`, TAR/ZIP's shared `duplicate_skips`, TAR's `hardlink_duplicate_skips`) already used `saturating_add` to avoid wrapping past `u64::MAX`.
- Changed to `duplicate_skips.saturating_add(1)`, matching the existing idiom exactly.
- Added a regression test that pre-seeds the counter at `u64::MAX` and asserts it stays saturated instead of wrapping.

Closes #502

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` (1143/1143 passed)
- [x] `cargo test --doc -p exarch-core --all-features` (117/117 passed; `exarch-python` doctest excluded — pre-existing pyo3 linker issue in this environment, reproduces identically on `main`, unrelated to this change)
- [x] CHANGELOG.md updated under `[Unreleased]` / `Fixed`