### PR TITLE
fix(cli): surface files_skipped/warnings in extract error-path output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,6 +228,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   at most 10 of them and collapsing the remainder into a single `... and N more` summary line —
   sorting first keeps "first 10 shown" a deterministic, reproducible subset rather than whatever
   order the archive manifest happened to yield.
+- **`exarch-cli`: `files_skipped`/`warnings` were dropped from the error-path JSON and human
+  output on a mid-archive extraction failure (#503)**: when extraction stopped partway through
+  (e.g. a symlink escape after some entries already extracted), the partial `ExtractionReport`
+  carried `files_skipped` and `warnings`, but neither `format_error`'s `JsonPartialReport`
+  (`output/json.rs`, `output/formatter.rs`) nor `PartialExtractionContext`'s `Display` impl
+  (`error.rs`, used for human-readable output) surfaced them — only `files_extracted`,
+  `directories_created`, `symlinks_created`, and `bytes_written` were reported, silently hiding
+  any disallowed-extension or duplicate skips that happened before the failure. Both paths now
+  include `files_skipped` and `warnings` (the human path only when non-empty, mirroring the
+  existing success-path convention), without changing the existing "WARNING: Extraction was
+  stopped..." / "HINT: ..." wording.
 - **`exarch-core`: TAR, ZIP, and 7z pushed one unbounded, path-bearing warning `String` per entry
   rejected by the extension allowlist (#495)**: `common::check_extension_allowed` (shared by all
   three format handlers) pushed a `"skipped entry with disallowed extension: {path}"` warning

--- a/crates/exarch-cli/src/error.rs
+++ b/crates/exarch-cli/src/error.rs
@@ -63,9 +63,21 @@ impl fmt::Display for PartialExtractionContext {
         write!(
             f,
             "WARNING: Extraction was stopped. {items} items ({} files, {} directories, {} symlinks) \
-             were written to disk before the error.\n\
-             HINT: Inspect or remove the output directory before re-running.",
+             were written to disk before the error.",
             r.files_extracted, r.directories_created, r.symlinks_created,
+        )?;
+        if r.files_skipped > 0 {
+            write!(f, "\nFiles skipped: {}", r.files_skipped)?;
+        }
+        if !r.warnings.is_empty() {
+            write!(f, "\nWarnings:")?;
+            for warning in &r.warnings {
+                write!(f, "\n  - {warning}")?;
+            }
+        }
+        write!(
+            f,
+            "\nHINT: Inspect or remove the output directory before re-running."
         )
     }
 }
@@ -428,5 +440,64 @@ mod tests {
             occurrences, 1,
             "inner error path should appear exactly once, got: {msg}"
         );
+    }
+
+    // Regression tests for issue #503: files_skipped/warnings must be shown in
+    // the partial-extraction Display output when present, and hidden when
+    // both are empty/zero (mirrors the #498-fix "shown when present" pattern).
+
+    #[test]
+    fn test_partial_display_shows_files_skipped_and_warnings_when_present() {
+        use exarch_core::ExtractionReport;
+        use std::time::Duration;
+
+        let inner = ArchiveError::HardlinkEscape {
+            path: PathBuf::from("hardlink_escape_path"),
+        };
+        let report = ExtractionReport {
+            files_extracted: 1,
+            directories_created: 0,
+            symlinks_created: 0,
+            bytes_written: 0,
+            duration: Duration::from_millis(0),
+            files_skipped: 2,
+            warnings: vec!["skipped a broken symlink".to_string()],
+        };
+        let err = ArchiveError::PartialExtraction {
+            source: Box::new(inner),
+            report,
+        };
+        let converted = convert_extraction_error(err, Path::new("archive.tar.gz"), false);
+        let msg = format!("{converted:#}");
+        assert!(msg.contains("Files skipped: 2"), "got: {msg}");
+        assert!(msg.contains("Warnings:"), "got: {msg}");
+        assert!(msg.contains("skipped a broken symlink"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_partial_display_hides_files_skipped_and_warnings_when_empty() {
+        use exarch_core::ExtractionReport;
+        use std::time::Duration;
+
+        let inner = ArchiveError::HardlinkEscape {
+            path: PathBuf::from("hardlink_escape_path"),
+        };
+        let report = ExtractionReport {
+            files_extracted: 1,
+            directories_created: 0,
+            symlinks_created: 0,
+            bytes_written: 0,
+            duration: Duration::from_millis(0),
+            files_skipped: 0,
+            warnings: vec![],
+        };
+        let err = ArchiveError::PartialExtraction {
+            source: Box::new(inner),
+            report,
+        };
+        let converted = convert_extraction_error(err, Path::new("archive.tar.gz"), false);
+        let msg = format!("{converted:#}");
+        assert!(!msg.contains("Files skipped"), "got: {msg}");
+        assert!(!msg.contains("Warnings:"), "got: {msg}");
     }
 }

--- a/crates/exarch-cli/src/output/formatter.rs
+++ b/crates/exarch-cli/src/output/formatter.rs
@@ -53,6 +53,8 @@ pub struct JsonPartialReport {
     pub directories_created: usize,
     pub symlinks_created: usize,
     pub bytes_written: u64,
+    pub files_skipped: usize,
+    pub warnings: Vec<String>,
 }
 
 /// Structured error object in JSON output

--- a/crates/exarch-cli/src/output/json.rs
+++ b/crates/exarch-cli/src/output/json.rs
@@ -159,6 +159,8 @@ impl<W: Write> OutputFormatter for JsonFormatter<W> {
                     directories_created: ctx.report.directories_created,
                     symlinks_created: ctx.report.symlinks_created,
                     bytes_written: ctx.report.bytes_written,
+                    files_skipped: ctx.report.files_skipped,
+                    warnings: ctx.report.warnings.clone(),
                 });
 
         let output = if let Some(pr) = partial_report {
@@ -583,6 +585,38 @@ mod tests {
         assert_eq!(v["operation"], "extract");
         assert_eq!(v["status"], "error");
         assert_eq!(v["error"]["kind"], "ZipBomb");
+    }
+
+    #[test]
+    fn format_error_writes_partial_report_with_skipped_and_warnings() {
+        use crate::error::convert_extraction_error;
+        use exarch_core::ExtractionReport;
+
+        let mut f = JsonFormatter::with_writer(Vec::new());
+        let inner = ArchiveError::HardlinkEscape {
+            path: PathBuf::from("escaped"),
+        };
+        let report = ExtractionReport {
+            files_extracted: 2,
+            directories_created: 1,
+            symlinks_created: 0,
+            bytes_written: 512,
+            duration: std::time::Duration::from_millis(0),
+            files_skipped: 3,
+            warnings: vec!["skipped disallowed extension".to_string()],
+        };
+        let err = ArchiveError::PartialExtraction {
+            source: Box::new(inner),
+            report,
+        };
+        let converted = convert_extraction_error(err, Path::new("archive.tar.gz"), false);
+        f.format_error("extract", &converted);
+        let v = parsed(&f);
+        assert_eq!(v["error"]["partial_report"]["files_skipped"], 3);
+        assert_eq!(
+            v["error"]["partial_report"]["warnings"][0],
+            "skipped disallowed extension"
+        );
     }
 
     fn sample_manifest() -> ArchiveManifest {

--- a/skills/exarch-cli/SKILL.md
+++ b/skills/exarch-cli/SKILL.md
@@ -246,11 +246,13 @@ For `verify`, branch on `data.status` (or the process exit code), not on top-lev
 
 For `extract`, when some files were already written before a mid-archive failure, `error` carries
 a structured `error.partial_report` object (`files_extracted`, `directories_created`,
-`symlinks_created`, `bytes_written`). Verified live against a two-entry archive where the first
-entry extracts and the second is a symlink rejected by the (default-off) `--allow-symlinks`
-check. The same progress counts also appear as free text inside `error.message` (prefixed
-`"WARNING: Extraction was stopped. ..."`) — prefer the structured `error.partial_report` field
-over parsing that text.
+`symlinks_created`, `bytes_written`, `files_skipped`, `warnings`). Verified live against a
+three-entry archive where the first entry extracts, the second is skipped for a disallowed
+extension (via `--allowed-extensions`), and the third is a symlink rejected by the (default-off)
+`--allow-symlinks` check. The same progress counts, skip count, and warnings also appear as free
+text inside `error.message` (prefixed `"WARNING: Extraction was stopped. ..."`, with optional
+`"Files skipped: N"` / `"Warnings:"` lines when non-empty) — prefer the structured
+`error.partial_report` field over parsing that text.
 
 Note: `extract` always lists the archive first (`list_archive()`, sharing `--max-file-count`,
 `--max-total-size`, and `--max-file-size` with the extraction config) to detect output
@@ -316,7 +318,8 @@ Error (`extract`, path traversal):
 ```
 
 Error (`extract`, mid-archive security failure with partial progress — note the structured
-`error.partial_report` field; the archive's first entry extracts, then a symlink entry is
+`error.partial_report` field, including `files_skipped`/`warnings`; the archive's first entry
+extracts, its second entry is skipped for a disallowed extension, then a symlink entry is
 rejected because `--allow-symlinks` was not passed):
 
 ```json
@@ -325,12 +328,16 @@ rejected because `--allow-symlinks` was not passed):
   "status": "error",
   "error": {
     "kind": "SecurityViolation",
-    "message": "WARNING: Extraction was stopped. 1 items (1 files, 0 directories, 0 symlinks) were written to disk before the error.\nHINT: Inspect or remove the output directory before re-running.: operation denied by security policy: symlinks not allowed",
+    "message": "WARNING: Extraction was stopped. 1 items (1 files, 0 directories, 0 symlinks) were written to disk before the error.\nFiles skipped: 1\nWarnings:\n  - skipped 1 entry with disallowed extension\nHINT: Inspect or remove the output directory before re-running.: operation denied by security policy: symlinks not allowed",
     "partial_report": {
       "files_extracted": 1,
       "directories_created": 0,
       "symlinks_created": 0,
-      "bytes_written": 4
+      "bytes_written": 5,
+      "files_skipped": 1,
+      "warnings": [
+        "skipped 1 entry with disallowed extension"
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary
- `JsonPartialReport` (`--json` error output) and `PartialExtractionContext`'s human-readable `Display` only carried `files_extracted`/`directories_created`/`symlinks_created`/`bytes_written` from the partial `ExtractionReport` on a mid-archive extraction failure, silently dropping any `files_skipped` count and `warnings` (disallowed-extension, duplicate-skip, etc.) that accumulated before the failure.
- Both the JSON `partial_report` and the human error message now surface `files_skipped`/`warnings`, mirroring the already-shipped success-path convention (PR #504): the human path shows the new lines only when non-empty, without altering the existing "WARNING: Extraction was stopped..." / "HINT: ..." wording.
- Updated `skills/exarch-cli/SKILL.md`'s documented `error.partial_report` schema and verified JSON example against a live `exarch extract --json` run.

## Follow-up filed
Adversarial review surfaced a related but out-of-scope gap one layer down: `exarch-core`'s `ArchiveError::partial_or` discards the partial report entirely (via `ExtractionReport::total_items()` excluding `files_skipped`) when every entry before the failure was *skipped* rather than written — so this CLI fix has nothing to render in that specific case. Filed as #505 (P2, core) rather than expanding this PR's scope.

Closes #503

## Test plan
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` (1157/1157 passed)
- [x] `cargo test --doc --workspace --all-features --exclude exarch-python --exclude exarch-node` (117 passed)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace`
- [x] New unit tests: `format_error_writes_partial_report_with_skipped_and_warnings` (json.rs), `test_partial_display_shows_files_skipped_and_warnings_when_present` / `test_partial_display_hides_files_skipped_and_warnings_when_empty` (error.rs)
- [x] SKILL.md JSON example manually re-verified against a live 3-entry tar (extract + disallowed-extension skip + symlink escape)