### PR TITLE
fix(core): surface skip-only partial extraction reports; harden ZIP error paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,6 +209,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`exarch-core`: hardened ZIP's `by_index()`/`name()` error paths inside `extract()`'s entry loop
+  to route through the same warning aggregation and `ArchiveError::partial_or` wrapping as other
+  failures in the loop**: `formats/zip.rs`'s extraction loop opened each entry via
+  `self.inner.by_index(i)?` and read its name via `zip_file.name()?`, both using a bare `?` that
+  returned the raw error immediately, bypassing the duplicate/disallowed-extension warning
+  aggregation and `ArchiveError::partial_or` wrapping used for `process_entry` failures a few lines
+  below. In practice this path is not reachable through the public API today: `ZipArchive::new()`
+  already scans every entry via `by_index()` during its password-protection check, so any entry
+  that would fail `by_index()`/`name()` is caught at open time, before `extract()`'s loop ever
+  runs — the gap would only matter if the underlying reader's data changed between that scan and
+  extraction, or in a future refactor that removes or narrows the open-time scan. Both failure
+  sites now aggregate the same warnings and route through `ArchiveError::partial_or` before
+  returning, via a shared `push_duplicate_skip_warnings` helper (mirroring TAR's existing helper of
+  the same name), giving ZIP the same structural handling as TAR and 7z as defense-in-depth, not as
+  a fix for a demonstrated user-facing bug.
+- **`exarch-core`: a mid-archive extraction failure where every entry processed beforehand was
+  skipped (not written) discarded the entire partial report, including its warnings (#505)**:
+  `ArchiveError::partial_or` only wrapped a failure into `PartialExtraction { report, .. }` when
+  `report.total_items()` (`files_extracted + directories_created + symlinks_created`) was nonzero.
+  An archive whose only processed entries before the failure were rejected — e.g. by
+  `--allowed-extensions` or as pre-existing duplicates — left `total_items()` at `0`, so
+  `partial_or` returned the original error unwrapped, silently dropping `report.warnings` and
+  `report.files_skipped` even though both were populated. `partial_or` now also treats a report as
+  worth surfacing when `files_skipped > 0` or `warnings` is non-empty, without changing
+  `total_items()` itself (it remains "items written to disk", matching its existing Python binding
+  semantics and tests).
 - **`exarch-cli`: `extract`'s human and `--json` output never surfaced `ExtractionReport.warnings`
   or `files_skipped` (#498)**: both fields are populated correctly by `exarch-core` and already
   exposed by the Python and Node.js bindings, but `format_extraction_result` in `output/human.rs`

--- a/crates/exarch-core/src/error/types.rs
+++ b/crates/exarch-core/src/error/types.rs
@@ -299,15 +299,20 @@ impl ArchiveError {
     }
 
     /// Wraps `err` in [`Self::PartialExtraction`] if `report` recorded any
-    /// processed items, otherwise returns `err` unchanged.
+    /// processed items, skipped files, or warnings, otherwise returns `err`
+    /// unchanged.
     ///
     /// Format handlers call this at every point where extraction can fail
     /// mid-archive, so callers can distinguish "nothing was written" from
     /// "extraction stopped partway through" without each handler
-    /// reimplementing the same check.
+    /// reimplementing the same check. A report is considered worth surfacing
+    /// even when [`ExtractionReport::total_items`] is zero, since an archive
+    /// where every entry before the failure was rejected (e.g. by an
+    /// extension allowlist) still accumulates `files_skipped` and
+    /// `warnings` that the caller should see.
     #[must_use]
     pub(crate) fn partial_or(report: crate::ExtractionReport, err: Self) -> Self {
-        if report.total_items() > 0 {
+        if report.total_items() > 0 || report.files_skipped > 0 || report.has_warnings() {
             Self::PartialExtraction {
                 source: Box::new(err),
                 report,
@@ -722,6 +727,40 @@ mod tests {
             result,
             ArchiveError::InvalidArchive(_),
             "expected the original error unwrapped when report is empty, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_partial_or_wraps_when_report_has_only_files_skipped() {
+        use crate::ExtractionReport;
+
+        let mut report = ExtractionReport::new();
+        report.files_skipped = 2;
+        let err = ArchiveError::InvalidArchive("bad entry".into());
+
+        let result = ArchiveError::partial_or(report, err);
+        assert_matches!(
+            result,
+            ArchiveError::PartialExtraction { .. },
+            "expected PartialExtraction when report has files_skipped > 0 but zero total_items \
+             and no warnings, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_partial_or_wraps_when_report_has_only_warnings() {
+        use crate::ExtractionReport;
+
+        let mut report = ExtractionReport::new();
+        report.add_warning("skipped disallowed extension".into());
+        let err = ArchiveError::InvalidArchive("bad entry".into());
+
+        let result = ArchiveError::partial_or(report, err);
+        assert_matches!(
+            result,
+            ArchiveError::PartialExtraction { .. },
+            "expected PartialExtraction when report has a warning but zero total_items and zero \
+             files_skipped, got: {result:?}"
         );
     }
 

--- a/crates/exarch-core/src/formats/zip.rs
+++ b/crates/exarch-core/src/formats/zip.rs
@@ -171,6 +171,20 @@ struct ZipExtractionContext<'a> {
     progress: &'a mut dyn ProgressCallback,
 }
 
+/// Appends aggregated duplicate-skip and disallowed-extension warnings to
+/// `report`, mirroring TAR's `push_duplicate_skip_warnings` (issues #490,
+/// #495). Called on every extraction exit path — including entry-open/name
+/// failures that occur before a [`ZipExtractionContext`] exists — so no
+/// early return can drop accumulated skip counts from the report.
+fn push_duplicate_skip_warnings(
+    report: &mut ExtractionReport,
+    duplicate_skips: u64,
+    disallowed_extension_skips: u64,
+) {
+    common::push_duplicate_skip_warning(report, duplicate_skips, "entry", "entries");
+    common::push_disallowed_extension_warning(report, disallowed_extension_skips);
+}
+
 /// ZIP archive handler with random-access extraction.
 ///
 /// Supports:
@@ -496,22 +510,37 @@ impl<R: Read + Seek> ArchiveFormat for ZipArchive<R> {
         let entry_count = self.inner.len();
 
         for i in 0..entry_count {
-            let zip_file = self.inner.by_index(i).map_err(|e| {
-                if e.to_string().contains("Password required to decrypt file") {
-                    return ArchiveError::SecurityViolation {
-                        reason: "archive is password-protected.\n  Password-protected ZIP archives are not supported. Decrypt the archive externally and try again.".into(),
+            let zip_file = match self.inner.by_index(i) {
+                Ok(f) => f,
+                Err(e) => {
+                    let err = if e.to_string().contains("Password required to decrypt file") {
+                        ArchiveError::SecurityViolation {
+                            reason: "archive is password-protected.\n  Password-protected ZIP archives are not supported. Decrypt the archive externally and try again.".into(),
+                        }
+                    } else {
+                        ArchiveError::InvalidArchive(format!("failed to open zip entry {i}: {e}"))
                     };
+                    push_duplicate_skip_warnings(
+                        &mut report,
+                        duplicate_skips,
+                        disallowed_extension_skips,
+                    );
+                    return Err(ArchiveError::partial_or(std::mem::take(&mut report), err));
                 }
-                ArchiveError::InvalidArchive(format!("failed to open zip entry {i}: {e}"))
-            })?;
-            let entry_path = PathBuf::from(
-                zip_file
-                    .name()
-                    .map_err(|e| {
-                        ArchiveError::InvalidArchive(format!("invalid entry name at {i}: {e}"))
-                    })?
-                    .as_ref(),
-            );
+            };
+            let entry_path = match zip_file.name() {
+                Ok(name) => PathBuf::from(name.as_ref()),
+                Err(e) => {
+                    let err =
+                        ArchiveError::InvalidArchive(format!("invalid entry name at {i}: {e}"));
+                    push_duplicate_skip_warnings(
+                        &mut report,
+                        duplicate_skips,
+                        disallowed_extension_skips,
+                    );
+                    return Err(ArchiveError::partial_or(std::mem::take(&mut report), err));
+                }
+            };
             progress.on_entry_start(&entry_path, entry_count, i.saturating_add(1));
             let mut guard = EntryCompleteGuard::new(progress, &entry_path);
 
@@ -531,20 +560,17 @@ impl<R: Read + Seek> ArchiveFormat for ZipArchive<R> {
 
             if let Err(e) = result {
                 drop(guard);
-                common::push_duplicate_skip_warning(
+                push_duplicate_skip_warnings(
                     &mut report,
                     duplicate_skips,
-                    "entry",
-                    "entries",
+                    disallowed_extension_skips,
                 );
-                common::push_disallowed_extension_warning(&mut report, disallowed_extension_skips);
                 return Err(ArchiveError::partial_or(std::mem::take(&mut report), e));
             }
             guard.complete();
         }
 
-        common::push_duplicate_skip_warning(&mut report, duplicate_skips, "entry", "entries");
-        common::push_disallowed_extension_warning(&mut report, disallowed_extension_skips);
+        push_duplicate_skip_warnings(&mut report, duplicate_skips, disallowed_extension_skips);
         progress.on_complete();
         report.duration = start.elapsed();
 
@@ -2236,6 +2262,76 @@ mod tests {
             "expected a disallowed-extension warning reporting {DISALLOWED_COUNT}, got: {:?}",
             report.warnings
         );
+    }
+
+    /// Regression for critic finding S1 (found during #505 review):
+    /// `by_index()` failing partway through the loop previously returned its
+    /// error via a bare `?`, bypassing the duplicate/disallowed-extension
+    /// warning aggregation and `ArchiveError::partial_or` wrapping used for
+    /// `process_entry` failures — silently discarding any skips/warnings
+    /// accumulated from earlier entries. `ZipArchive::new()`'s own
+    /// encryption pre-scan already calls `by_index()` on every entry, so a
+    /// corrupted local header would normally be caught there rather than in
+    /// `extract()`; this test bypasses that pre-scan by constructing
+    /// `ZipArchive` directly from an already-parsed `zip::ZipArchive`, to
+    /// exercise `extract()`'s own `by_index()` failure path in isolation.
+    #[test]
+    fn test_by_index_failure_preserves_prior_skip_warnings() {
+        use crate::NoopProgress;
+
+        let mut zip_data = create_test_zip(vec![("bad.exe", b"x"), ("good.txt", b"hello world")]);
+
+        // Corrupt the second entry's local file header signature so
+        // `by_index(1)` fails in `extract()` while the central directory
+        // (read by `zip::ZipArchive::new()`) remains intact.
+        let sig = b"PK\x03\x04";
+        let first = zip_data
+            .windows(4)
+            .position(|w| w == sig)
+            .expect("first local header signature");
+        let second = zip_data[first + 4..]
+            .windows(4)
+            .position(|w| w == sig)
+            .map(|p| p + first + 4)
+            .expect("second local header signature");
+        zip_data[second..second + 4].copy_from_slice(b"XXXX");
+
+        // Bypass `ZipArchive::new()`'s encryption pre-scan (which itself
+        // calls `by_index()` on every entry and would surface the
+        // corruption before `extract()` is ever reached) by constructing
+        // the wrapper directly around an already-open reader.
+        let inner = ZipReader::new(Cursor::new(zip_data)).expect("valid central directory");
+        let mut archive = ZipArchive { inner };
+
+        let config = SecurityConfig::default()
+            .with_allowed_extensions(vec!["txt".to_string()])
+            .validate()
+            .expect("valid config");
+        let temp = TempDir::new().unwrap();
+
+        let err = archive
+            .extract(
+                temp.path(),
+                &config,
+                &ExtractionOptions::default(),
+                &mut NoopProgress,
+            )
+            .unwrap_err();
+
+        match err {
+            ArchiveError::PartialExtraction { report, .. } => {
+                assert_eq!(
+                    report.files_skipped, 1,
+                    "the disallowed-extension skip of bad.exe before the by_index failure \
+                     must be preserved, got report: {report:?}"
+                );
+                assert!(
+                    report.has_warnings(),
+                    "the disallowed-extension warning must be preserved, got report: {report:?}"
+                );
+            }
+            other => panic!("expected PartialExtraction preserving the prior skip, got: {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/exarch-core/src/report.rs
+++ b/crates/exarch-core/src/report.rs
@@ -42,7 +42,15 @@ impl ExtractionReport {
         self.warnings.push(message);
     }
 
-    /// Returns total number of items processed.
+    /// Returns the total number of items actually written to disk
+    /// (`files_extracted + directories_created + symlinks_created`).
+    ///
+    /// This deliberately excludes [`files_skipped`](Self::files_skipped): a
+    /// report can carry meaningful progress — skipped entries, warnings —
+    /// while this is `0`. Callers deciding whether a report is worth
+    /// surfacing (e.g. `ArchiveError::partial_or`) must check
+    /// `files_skipped`/[`has_warnings`](Self::has_warnings) too, not rely on
+    /// this alone.
     #[must_use]
     pub fn total_items(&self) -> usize {
         self.files_extracted + self.directories_created + self.symlinks_created

--- a/crates/exarch-core/tests/security/mod.rs
+++ b/crates/exarch-core/tests/security/mod.rs
@@ -2,6 +2,7 @@
 
 mod cve_regression;
 mod hardlink_quota_bypass;
+mod partial_report_skip_and_fail;
 mod sevenz_traversal;
 mod symlink_target_validation;
 mod tar_budget_parity;

--- a/crates/exarch-core/tests/security/partial_report_skip_and_fail.rs
+++ b/crates/exarch-core/tests/security/partial_report_skip_and_fail.rs
@@ -1,0 +1,80 @@
+//! Regression test for issue #505: a skip-only `ExtractionReport` (zero
+//! `total_items()`, but nonzero `files_skipped`/warnings) was discarded by
+//! `ArchiveError::partial_or` on a later mid-archive failure, instead of
+//! surfacing as `PartialExtraction`. This exercises the exact repro shape
+//! through the public `extract_archive` API: a first entry skipped by the
+//! extension allowlist, followed by a second entry that fails validation.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use exarch_core::ArchiveError;
+use exarch_core::SecurityConfig;
+use exarch_core::extract_archive;
+use std::assert_matches;
+use tempfile::TempDir;
+
+/// Builds a TAR with a disallowed-extension entry (skipped by the extension
+/// allowlist before validation runs) followed by a symlink whose absolute
+/// target escapes the extraction directory (a hard validation failure).
+fn build_tar_skip_then_symlink_escape() -> Vec<u8> {
+    let mut builder = tar::Builder::new(Vec::new());
+
+    let mut h1 = tar::Header::new_gnu();
+    h1.set_size(3);
+    h1.set_mode(0o644);
+    h1.set_cksum();
+    builder
+        .append_data(&mut h1, "payload.bin", &b"abc"[..])
+        .unwrap();
+
+    let mut h2 = tar::Header::new_gnu();
+    h2.set_entry_type(tar::EntryType::Symlink);
+    h2.set_size(0);
+    h2.set_mode(0o644);
+    h2.set_link_name("/etc/evil").unwrap();
+    h2.set_cksum();
+    builder
+        .append_data(&mut h2, "escape_link", std::io::empty())
+        .unwrap();
+
+    builder.into_inner().unwrap()
+}
+
+#[test]
+fn skip_only_report_still_wraps_as_partial_extraction_on_later_failure() {
+    let data = build_tar_skip_then_symlink_escape();
+    let archive_dir = TempDir::new().expect("temp dir for archive");
+    let archive_path = archive_dir.path().join("skip_then_fail.tar");
+    std::fs::write(&archive_path, &data).expect("write tar to disk");
+
+    let dest = TempDir::new().expect("temp dir for extraction");
+    let config = SecurityConfig::default()
+        .with_allowed_extensions(vec!["txt".to_string()])
+        .with_allow_symlinks(true);
+
+    let result = extract_archive(&archive_path, dest.path(), &config);
+
+    match result {
+        Err(ArchiveError::PartialExtraction { source, report }) => {
+            assert_matches!(
+                *source,
+                ArchiveError::SymlinkEscape { .. },
+                "expected SymlinkEscape source, got: {source:?}"
+            );
+            assert_eq!(
+                report.files_skipped, 1,
+                "payload.bin must be counted as skipped for its disallowed extension"
+            );
+            assert_eq!(
+                report.total_items(),
+                0,
+                "no entry was ever written before the failure"
+            );
+            assert!(
+                report.has_warnings(),
+                "the extension-skip warning must survive on the wrapped report"
+            );
+        }
+        other => panic!("expected PartialExtraction wrapping the skip-only report, got: {other:?}"),
+    }
+}

--- a/crates/exarch-core/tests/security/tar_metadata_bomb.rs
+++ b/crates/exarch-core/tests/security/tar_metadata_bomb.rs
@@ -901,9 +901,12 @@ fn list_and_verify_accept_a_single_legitimate_entry_at_every_size_that_broke_c2(
 // crate-internal `BudgetedEntries` iterator directly; the tests below
 // exercise the same shapes through the public API these internals actually
 // serve, so wall-clock is the only externally observable "failed fast"
-// signal available here (the extension-filter skip path never populates a
-// `PartialExtraction` report to count against, since only `files_skipped`,
-// not `total_items()`, would be nonzero).
+// signal available here. (Since #505, a skip-only report — nonzero
+// `files_skipped` but zero `total_items()` — does populate `PartialExtraction`
+// on a later failure, but `assert_is_budget_violation` below deliberately
+// keys off `is_security_violation()`/`context()`, which delegate through
+// `PartialExtraction` either way, so it is agnostic to whether that wrapping
+// occurred.)
 
 /// Builds a multi-entry TAR of `n` GNU sparse entries, each named
 /// `spam{i}.bin`, each declaring a hole (`gap`) beyond its one physical


### PR DESCRIPTION
## Summary
- `ArchiveError::partial_or` only wrapped a mid-archive extraction failure as `PartialExtraction` when `ExtractionReport::total_items()` was nonzero. An archive where every entry processed before the failure was *skipped* (disallowed extension, duplicate) rather than written left `total_items()` at 0, so the entire partial report — including accumulated `warnings`/`files_skipped` — was silently discarded instead of surfacing to callers. `partial_or` now also treats a report as worth surfacing when `files_skipped > 0` or `warnings` is non-empty. `ExtractionReport::total_items()` itself is left unchanged (its "written to disk" meaning is relied on by existing `exarch-python` binding tests). This is the actual fix for #505.
- Additionally hardens ZIP's extraction loop, which independently routes two error paths (`by_index()` and `name()` failures) around `partial_or` via a bare `?`, discarding warnings accumulated by prior skipped entries. **Correction from an earlier revision of this PR**: this was initially described as closing a reachable bug ("ZIP bypass"), based on a live reproduction that turned out to be invalid — adversarial re-verification found the trigger (a password-protected/corrupted entry) is already caught by `ZipArchive::new()`'s open-time pre-scan (`is_password_protected`, which calls `by_index()` on every entry), before `extract()`'s loop ever runs. So this path is not reachable through the public API today; the change is defense-in-depth giving ZIP the same structural handling as TAR and 7z, in case the underlying reader's data changes between open-time scan and extraction, or a future refactor narrows that scan. Not a fix for a demonstrated user-facing bug.
- Added integration coverage exercising the `partial_or` fix through the public `extract_archive` API, plus a lower-level unit test constructing `ZipArchive` directly (bypassing the public `new()` entry point, since the failure path it exercises is otherwise unreachable) to cover the ZIP hardening, plus two unit tests isolating each new `partial_or` disjunct (`files_skipped`-only vs `warnings`-only).
- A related but distinct gap — the Python and Node.js bindings' `PartialExtraction` error conversion never surfaces `files_skipped`/`warnings` to callers — is out of scope here and tracked separately in #508.

Closes #505

## Test plan
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` (1162 passed)
- [x] `cargo test --doc --workspace --all-features` (exarch-python excluded — pre-existing local pyo3 link failure, unrelated to this change)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace`
- [x] New integration test (`crates/exarch-core/tests/security/partial_report_skip_and_fail.rs`) reproduces the issue's exact repro shape through `extract_archive`
- [x] Live-verified the issue's `--json` repro: `partial_report` now appears where it was previously silently dropped