### PR TITLE
fix(bindings): surface files_skipped/warnings on PartialExtraction in Python and Node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -272,6 +272,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `saturating_add` to avoid wrapping after `u64::MAX` skips; 7z's own counter
   (`formats/sevenz.rs:575`) was the one site still using bare `+= 1`. Switched to
   `duplicate_skips.saturating_add(1)`, matching the existing idiom exactly.
+- **`exarch-python` and `exarch-node`: a `PartialExtraction` error dropped `files_skipped` and
+  `warnings` when converted to the language-level exception/error (#508)**: both bindings'
+  `convert_error` (`crates/exarch-python/src/error.rs`, `crates/exarch-node/src/error.rs`) only
+  forwarded `files_extracted`/`bytes_written` from the `ExtractionReport` attached to
+  `CoreError::PartialExtraction`, even though `exarch-core` has populated `files_skipped`/
+  `warnings` on that report since #505 — the CLI got the fix in #503, but the bindings were
+  never updated. Python's `convert_error` now also attaches `files_skipped` (`int`) and `warnings`
+  (`list[str]`) to the raised exception; Node's now also appends `filesSkipped=N` and a
+  Rust-`Debug`-formatted `warnings=[...]` fragment to the thrown error's message, following the
+  same `key=value` convention as the existing `filesExtracted`/`bytesWritten` suffix. The
+  `warnings=[...]` fragment on the Node side is for human/log inspection only — it is not
+  guaranteed valid JSON and must not be `JSON.parse`d.
 - **`exarch-core`: TAR, ZIP, and 7z pushed one unbounded, path-bearing warning `String` per entry
   rejected by the extension allowlist (#495)**: `common::check_extension_allowed` (shared by all
   three format handlers) pushed a `"skipped entry with disallowed extension: {path}"` warning

--- a/crates/exarch-node/index.d.ts
+++ b/crates/exarch-node/index.d.ts
@@ -653,6 +653,14 @@ export interface CreationReport {
  * - `INVALID_ARCHIVE`: Archive is corrupted
  * - `IO_ERROR`: I/O operation failed
  *
+ * When extraction fails after some files were already written (a partial
+ * extraction), the message additionally carries
+ * `filesExtracted=N, bytesWritten=M, filesSkipped=K, warnings=[...]`
+ * appended after the error-code prefix. The `warnings=[...]` fragment is
+ * Rust's `Debug`-formatted `Vec<String>` rendering — it is for human/log
+ * inspection only, is not guaranteed to be valid JSON, and must not be
+ * `JSON.parse`d.
+ *
  * # Examples
  *
  * ```javascript

--- a/crates/exarch-node/src/error.rs
+++ b/crates/exarch-node/src/error.rs
@@ -165,15 +165,15 @@ pub fn convert_error(err: CoreError) -> Error {
         CoreError::PartialExtraction { source, report } => {
             // Preserve the specific error code (SYMLINK_ESCAPE, QUOTA_EXCEEDED, etc.) from
             // the inner source so JavaScript callers can distinguish the error type. The
-            // partial-extraction report fields from #210 are appended for caller
-            // inspection.
+            // partial-extraction report fields from #210, plus filesSkipped/warnings from
+            // #508, are appended for caller inspection.
             let inner = convert_error(*source);
-            let mut msg = String::with_capacity(inner.reason.len() + 64);
+            let mut msg = String::with_capacity(inner.reason.len() + 96);
             msg.push_str(&inner.reason);
             let _ = write!(
                 &mut msg,
-                " | filesExtracted={}, bytesWritten={}",
-                report.files_extracted, report.bytes_written
+                " | filesExtracted={}, bytesWritten={}, filesSkipped={}, warnings={:?}",
+                report.files_extracted, report.bytes_written, report.files_skipped, report.warnings
             );
             Error::new(Status::GenericFailure, msg)
         }
@@ -462,6 +462,50 @@ mod tests {
         assert!(
             msg.contains("bytesWritten=1024"),
             "message must contain bytesWritten=1024, got: {msg}"
+        );
+    }
+
+    /// Regression test for #508: `convert_error` must also append
+    /// `filesSkipped` and `warnings` from the partial-extraction report,
+    /// alongside the pre-existing `filesExtracted`/`bytesWritten`. Uses a
+    /// skip-only report (`files_extracted: 0, bytes_written: 0`) matching
+    /// #505's original trigger — a failure that skipped entries without
+    /// extracting anything — and a realistic aggregated warning string
+    /// (see `formats::common`'s `"skipped N entries with disallowed
+    /// extensions"` convention) rather than an invented one, so the test
+    /// documents why the fix exists, not just that the fields are forwarded.
+    #[test]
+    fn test_partial_extraction_includes_files_skipped_and_warnings() {
+        use exarch_core::ExtractionReport;
+        use exarch_core::QuotaResource;
+
+        let report = ExtractionReport {
+            files_extracted: 0,
+            bytes_written: 0,
+            files_skipped: 2,
+            warnings: vec!["skipped 2 entries with disallowed extensions".to_string()],
+            ..ExtractionReport::default()
+        };
+        let source = CoreError::QuotaExceeded {
+            resource: QuotaResource::FileCount { current: 4, max: 3 },
+        };
+        let err = CoreError::PartialExtraction {
+            source: Box::new(source),
+            report,
+        };
+
+        let napi_err = convert_error(err);
+        let msg = &napi_err.reason;
+        assert!(
+            msg.contains("filesSkipped=2"),
+            "message must contain filesSkipped=2, got: {msg}"
+        );
+        // Only asserts a substring of the warning text, not the full
+        // Rust-`Debug`-formatted array, to avoid pinning the exact
+        // `{:?}` rendering as a change-detector (see #508 review M4).
+        assert!(
+            msg.contains("skipped 2 entries with disallowed extensions"),
+            "message must contain the warning text, got: {msg}"
         );
     }
 

--- a/crates/exarch-node/src/lib.rs
+++ b/crates/exarch-node/src/lib.rs
@@ -133,6 +133,14 @@ fn catch_panic_as_js_err<T>(context: &str, f: impl FnOnce() -> Result<T>) -> Res
 /// - `INVALID_ARCHIVE`: Archive is corrupted
 /// - `IO_ERROR`: I/O operation failed
 ///
+/// When extraction fails after some files were already written (a partial
+/// extraction), the message additionally carries
+/// `filesExtracted=N, bytesWritten=M, filesSkipped=K, warnings=[...]`
+/// appended after the error-code prefix. The `warnings=[...]` fragment is
+/// Rust's `Debug`-formatted `Vec<String>` rendering — it is for human/log
+/// inspection only, is not guaranteed to be valid JSON, and must not be
+/// `JSON.parse`d.
+///
 /// # Examples
 ///
 /// ```javascript

--- a/crates/exarch-node/tests/extract.test.js
+++ b/crates/exarch-node/tests/extract.test.js
@@ -70,6 +70,115 @@ describe('extractArchive (async)', () => {
 
     assert.ok(report.filesExtracted >= 1);
   });
+
+  // End-to-end regression test for #508: convert_error's PartialExtraction
+  // arm must forward filesSkipped/warnings, not just filesExtracted/
+  // bytesWritten. Exercises the real extraction path (not just
+  // convert_error directly, unlike the Rust-level unit tests) with an
+  // archive that both skips an extension-disallowed entry (non-fatal,
+  // extraction continues) and then trips a real failure (a file-count
+  // quota), so the resulting error carries a non-zero skip count and a
+  // real aggregated warning alongside the fatal QUOTA_EXCEEDED error.
+  it('carries filesSkipped and warnings on a real PartialExtraction', async () => {
+    const sourceDir = path.join(tempDir, 'source');
+    fs.mkdirSync(sourceDir);
+    // addAllowedExtension matches against the entry's extension without the
+    // leading dot, so 'blocked.exe' is rejected while the '.txt' files pass.
+    const blockedPath = path.join(sourceDir, 'blocked.exe');
+    const firstPath = path.join(sourceDir, 'first.txt');
+    const secondPath = path.join(sourceDir, 'second.txt');
+    fs.writeFileSync(blockedPath, 'MZ');
+    fs.writeFileSync(firstPath, 'ok');
+    fs.writeFileSync(secondPath, 'also ok');
+    // Pass explicit file paths (not the containing directory) so archive
+    // entry order matches this array's order deterministically: creation
+    // iterates `sources` in order (crates/exarch-core/src/creation/walker.rs),
+    // but a directory source is walked via `WalkDir` with no `.sort_by`, so
+    // its entry order is unspecified OS `read_dir` order — that would make
+    // `blocked.exe` sometimes lose the race against the quota trip, flaking
+    // this test across platforms (see #508 review S4).
+    createArchiveSync(archivePath, [blockedPath, firstPath, secondPath]);
+
+    const config = new SecurityConfig();
+    config.addAllowedExtension('txt');
+    config.setMaxFileCount(1);
+
+    await assert.rejects(
+      () => extractArchive(archivePath, outputDir, config),
+      (err) => {
+        assert.match(err.message, /^QUOTA_EXCEEDED/);
+        assert.match(err.message, /filesSkipped=1/);
+        assert.match(err.message, /disallowed extension/);
+        return true;
+      }
+    );
+  });
+
+  // End-to-end regression test for #508 (true skip-only scenario, now
+  // reachable via #509's ArchiveError::partial_or fix). The test above
+  // always has at least one file extracted before the fatal error, so it
+  // was already reachable as PartialExtraction even under the old, pre-#509
+  // partial_or (which only wrapped when something had actually been
+  // written). #508's repro steps describe the case where *nothing* is
+  // extracted before the failure — a skip-only report where
+  // filesExtracted/bytesWritten alone carry zero actionable information and
+  // filesSkipped/warnings are the only signal. This archive has an
+  // extension-disallowed entry (non-fatal skip) immediately followed by a
+  // symlink escape (fatal, and the very first entry that would have written
+  // anything), so the resulting error carries filesExtracted=0/bytesWritten=0.
+  it('carries filesSkipped and warnings on a skip-only PartialExtraction', async (t) => {
+    if (process.platform === 'win32') {
+      return t.skip('symlink creation requires elevated privileges on Windows');
+    }
+
+    // Two single-entry directories, not one shared directory or two bare
+    // file paths:
+    // - A bare (non-directory) symlink source hits a real quirk in
+    //   `collect_entries`'s single-file branch (walker.rs): it calls
+    //   `std::fs::metadata` (follows symlinks) instead of
+    //   `symlink_metadata`, so `metadata.is_symlink()` is always false and
+    //   the symlink gets archived as a plain File — extension-checked and
+    //   content-copied like any other file, defeating this test. Routing it
+    //   through a directory walk (`FilteredWalker`, which correctly uses
+    //   `follow_links(false)`/lstat semantics) preserves its symlink type.
+    // - Each directory holds exactly one entry, so within-directory walk
+    //   order can't matter, while the top-level `sources` array order
+    //   (`collect_entries` iterates it with a plain `for` loop) still
+    //   deterministically puts `blocked.exe` before the escape attempt —
+    //   same entry-order concern as the test above (#508 review S4).
+    const blockedDir = path.join(tempDir, 'blocked-dir');
+    fs.mkdirSync(blockedDir);
+    fs.writeFileSync(path.join(blockedDir, 'blocked.exe'), 'MZ');
+
+    const linkDir = path.join(tempDir, 'link-dir');
+    fs.mkdirSync(linkDir);
+    // The symlink target must exist on disk at archive-creation time —
+    // `collect_entries` checks `Path::exists()`, which follows symlinks and
+    // errors with SOURCE_NOT_FOUND for a dangling one. Point it at a real
+    // file one level above `linkDir` (`../outside.txt`); once extracted, the
+    // link lands directly under `outputDir`, so the same relative target
+    // resolves outside the extraction destination — a genuine escape.
+    fs.writeFileSync(path.join(tempDir, 'outside.txt'), 'should not be reachable');
+    fs.symlinkSync('../outside.txt', path.join(linkDir, 'evil_link'));
+
+    createArchiveSync(archivePath, [blockedDir, linkDir]);
+
+    const config = new SecurityConfig();
+    config.addAllowedExtension('txt');
+    config.setAllowSymlinks(true);
+
+    await assert.rejects(
+      () => extractArchive(archivePath, outputDir, config),
+      (err) => {
+        assert.match(err.message, /^SYMLINK_ESCAPE/);
+        assert.match(err.message, /filesExtracted=0/);
+        assert.match(err.message, /bytesWritten=0/);
+        assert.match(err.message, /filesSkipped=1/);
+        assert.match(err.message, /disallowed extension/);
+        return true;
+      }
+    );
+  });
 });
 
 describe('extractArchiveSync', () => {

--- a/crates/exarch-python/exarch.pyi
+++ b/crates/exarch-python/exarch.pyi
@@ -611,12 +611,14 @@ def extract_archive(
     Note:
         When extraction fails after some files have already been written to disk,
         the specific exception (e.g. ``SymlinkEscapeError``) is raised with
-        ``files_extracted`` and ``bytes_written`` attributes attached. Detect a
-        partial extraction via ``hasattr(e, "files_extracted")`` — but see
+        ``files_extracted``, ``bytes_written``, ``files_skipped``, and
+        ``warnings`` attributes attached. Detect a partial extraction via
+        ``hasattr(e, "files_extracted")`` — but see
         ``extract_archive_with_progress`` below: a raising ``progress`` callback
-        over an otherwise-successful extraction attaches the same two attribute
-        names, distinguished by a ``progress_callback_error`` marker attribute
-        this function's own exceptions never carry.
+        over an otherwise-successful extraction attaches ``files_extracted`` and
+        ``bytes_written`` (not ``files_skipped``/``warnings``), distinguished by
+        a ``progress_callback_error`` marker attribute this function's own
+        exceptions never carry.
     """
     ...
 
@@ -669,7 +671,8 @@ def extract_archive_with_progress(
 
         When extraction fails after some files have already been written to disk,
         the specific exception (e.g. ``SymlinkEscapeError``) is raised with
-        ``files_extracted`` and ``bytes_written`` attributes attached.
+        ``files_extracted``, ``bytes_written``, ``files_skipped``, and
+        ``warnings`` attributes attached.
 
         If ``progress`` itself raises, extraction is **not** aborted early — the
         underlying progress-callback contract has no cancellation signal, so
@@ -821,10 +824,14 @@ class PathTraversalError(ArchiveError):
     Attributes:
         files_extracted: Number of files successfully extracted before the error.
         bytes_written: Total bytes written to disk before the error.
+        files_skipped: Number of entries skipped due to security checks before the error.
+        warnings: Warning messages generated before the error.
     """
 
     files_extracted: int
     bytes_written: int
+    files_skipped: int
+    warnings: list[str]
 
 class SymlinkEscapeError(ArchiveError):
     """
@@ -836,10 +843,14 @@ class SymlinkEscapeError(ArchiveError):
     Attributes:
         files_extracted: Number of files successfully extracted before the error.
         bytes_written: Total bytes written to disk before the error.
+        files_skipped: Number of entries skipped due to security checks before the error.
+        warnings: Warning messages generated before the error.
     """
 
     files_extracted: int
     bytes_written: int
+    files_skipped: int
+    warnings: list[str]
 
 class HardlinkEscapeError(ArchiveError):
     """
@@ -851,10 +862,14 @@ class HardlinkEscapeError(ArchiveError):
     Attributes:
         files_extracted: Number of files successfully extracted before the error.
         bytes_written: Total bytes written to disk before the error.
+        files_skipped: Number of entries skipped due to security checks before the error.
+        warnings: Warning messages generated before the error.
     """
 
     files_extracted: int
     bytes_written: int
+    files_skipped: int
+    warnings: list[str]
 
 class ZipBombError(ArchiveError):
     """
@@ -866,10 +881,14 @@ class ZipBombError(ArchiveError):
     Attributes:
         files_extracted: Number of files successfully extracted before the error.
         bytes_written: Total bytes written to disk before the error.
+        files_skipped: Number of entries skipped due to security checks before the error.
+        warnings: Warning messages generated before the error.
     """
 
     files_extracted: int
     bytes_written: int
+    files_skipped: int
+    warnings: list[str]
 
 class InvalidPermissionsError(ArchiveError):
     """
@@ -881,10 +900,14 @@ class InvalidPermissionsError(ArchiveError):
     Attributes:
         files_extracted: Number of files successfully extracted before the error.
         bytes_written: Total bytes written to disk before the error.
+        files_skipped: Number of entries skipped due to security checks before the error.
+        warnings: Warning messages generated before the error.
     """
 
     files_extracted: int
     bytes_written: int
+    files_skipped: int
+    warnings: list[str]
 
 class QuotaExceededError(ArchiveError):
     """
@@ -896,10 +919,14 @@ class QuotaExceededError(ArchiveError):
     Attributes:
         files_extracted: Number of files successfully extracted before the error.
         bytes_written: Total bytes written to disk before the error.
+        files_skipped: Number of entries skipped due to security checks before the error.
+        warnings: Warning messages generated before the error.
     """
 
     files_extracted: int
     bytes_written: int
+    files_skipped: int
+    warnings: list[str]
 
 class SecurityViolationError(ArchiveError):
     """
@@ -911,10 +938,14 @@ class SecurityViolationError(ArchiveError):
     Attributes:
         files_extracted: Number of files successfully extracted before the error.
         bytes_written: Total bytes written to disk before the error.
+        files_skipped: Number of entries skipped due to security checks before the error.
+        warnings: Warning messages generated before the error.
     """
 
     files_extracted: int
     bytes_written: int
+    files_skipped: int
+    warnings: list[str]
 
 class UnsupportedFormatError(ArchiveError):
     """Archive format not supported."""

--- a/crates/exarch-python/src/error.rs
+++ b/crates/exarch-python/src/error.rs
@@ -119,7 +119,8 @@ pub fn convert_error(err: CoreError) -> PyErr {
         CoreError::PartialExtraction { source, report } => {
             // Recover the specific exception type (SymlinkEscapeError, HardlinkEscapeError,
             // etc.) so callers can catch the precise error. The partial-extraction report
-            // attributes from #210 are attached to that concrete exception instead.
+            // attributes from #210, plus files_skipped/warnings from #508, are attached to
+            // that concrete exception instead.
             let source_err = convert_error(*source);
             Python::attach(|py| {
                 let exc_value = source_err.value(py);
@@ -127,6 +128,8 @@ pub fn convert_error(err: CoreError) -> PyErr {
                 // the workspace forbids unwrap/expect outside tests.
                 let _ = exc_value.setattr("files_extracted", report.files_extracted);
                 let _ = exc_value.setattr("bytes_written", report.bytes_written);
+                let _ = exc_value.setattr("files_skipped", report.files_skipped);
+                let _ = exc_value.setattr("warnings", report.warnings);
                 source_err
             })
         }
@@ -664,6 +667,56 @@ mod tests {
                 .expect("bytes_written not u64");
             assert_eq!(files, 3);
             assert_eq!(bytes, 1024);
+        });
+    }
+
+    /// Regression test for #508: `convert_error` must also attach
+    /// `files_skipped` and `warnings` from the partial-extraction report,
+    /// alongside the pre-existing `files_extracted`/`bytes_written`. Uses a
+    /// skip-only report (`files_extracted: 0, bytes_written: 0`) matching
+    /// #505's original trigger — a failure that skipped entries without
+    /// extracting anything — and a realistic aggregated warning string (see
+    /// `formats::common`'s `"skipped N entries with disallowed extensions"`
+    /// convention) rather than an invented one, so the test documents why
+    /// the fix exists, not just that the fields are forwarded.
+    #[test]
+    fn test_partial_extraction_includes_files_skipped_and_warnings() {
+        use exarch_core::ExtractionReport;
+        use exarch_core::QuotaResource;
+
+        let report = ExtractionReport {
+            files_extracted: 0,
+            bytes_written: 0,
+            files_skipped: 2,
+            warnings: vec!["skipped 2 entries with disallowed extensions".to_string()],
+            ..ExtractionReport::default()
+        };
+        let source = CoreError::QuotaExceeded {
+            resource: QuotaResource::FileCount { current: 4, max: 3 },
+        };
+        let err = CoreError::PartialExtraction {
+            source: Box::new(source),
+            report,
+        };
+
+        let py_err = convert_error(err);
+        Python::attach(|py| {
+            let exc_value = py_err.value(py);
+            let files_skipped: usize = exc_value
+                .getattr("files_skipped")
+                .expect("files_skipped missing")
+                .extract()
+                .expect("files_skipped not usize");
+            let warnings: Vec<String> = exc_value
+                .getattr("warnings")
+                .expect("warnings missing")
+                .extract()
+                .expect("warnings not list[str]");
+            assert_eq!(files_skipped, 2);
+            assert_eq!(
+                warnings,
+                vec!["skipped 2 entries with disallowed extensions"]
+            );
         });
     }
 

--- a/crates/exarch-python/tests/test_cve_regression.py
+++ b/crates/exarch-python/tests/test_cve_regression.py
@@ -265,6 +265,93 @@ def test_partial_extraction_preserves_hardlink_escape_type(temp_dir):
     assert err.files_extracted >= 1
 
 
+def test_partial_extraction_carries_files_skipped_and_warnings(temp_dir):
+    """
+    End-to-end regression test for #508.
+
+    `convert_error`'s `PartialExtraction` arm must forward `files_skipped`
+    and `warnings` from the core `ExtractionReport`, not just
+    `files_extracted`/`bytes_written` (the #210 capability). This exercises
+    the real extraction path (not just `convert_error` directly, unlike the
+    Rust-level unit tests) with an archive that both skips an
+    extension-disallowed entry (non-fatal, extraction continues) and then
+    trips a real failure (a file-count quota), so the resulting
+    `PartialExtraction` report has a non-zero skip count and a real
+    aggregated warning alongside the fatal error.
+    """
+    import tarfile
+
+    archive = temp_dir / "partial_skip_and_warn.tar.gz"
+    blocked = tarfile.TarInfo("dist/blocked.exe")
+    blocked.type = tarfile.REGTYPE
+    first = tarfile.TarInfo("dist/first.txt")
+    first.type = tarfile.REGTYPE
+    second = tarfile.TarInfo("dist/second.txt")
+    second.type = tarfile.REGTYPE
+    _make_tar_gz(
+        archive,
+        [(blocked, b"MZ"), (first, b"ok"), (second, b"also ok")],
+    )
+
+    output_dir = temp_dir / "out"
+    output_dir.mkdir()
+    # `add_allowed_extension` matches against `Path::extension()`, which never
+    # includes the leading dot — pass "txt", not ".txt".
+    config = exarch.SecurityConfig().add_allowed_extension("txt").with_max_file_count(1)
+
+    with pytest.raises(exarch.QuotaExceededError) as exc_info:
+        exarch.extract_archive(archive, output_dir, config)
+
+    err = exc_info.value
+    assert err.files_extracted >= 1
+    assert err.files_skipped > 0
+    assert err.warnings
+    assert any("disallowed extension" in w for w in err.warnings)
+
+
+def test_partial_extraction_skip_only_carries_files_skipped_and_warnings(temp_dir):
+    """
+    End-to-end regression test for #508 (true skip-only scenario, now
+    reachable via #509's `ArchiveError::partial_or` fix).
+
+    The scenario above (test_partial_extraction_carries_files_skipped_and_warnings)
+    always had at least one file extracted before the fatal error, so it was
+    already reachable as `PartialExtraction` even under the old, pre-#509
+    `partial_or` (which only wrapped when something had actually been
+    written). #508's repro steps describe the case where *nothing* was
+    extracted before the failure — a skip-only report where
+    `files_extracted`/`bytes_written` alone "carry zero actionable
+    information" and `files_skipped`/`warnings` are the only signal. This
+    builds an archive with an extension-disallowed entry (non-fatal skip)
+    immediately followed by a symlink escape (fatal, and the very first
+    entry that would have written anything), so the resulting
+    `PartialExtraction` report has zero extracted files/bytes.
+    """
+    import tarfile
+
+    archive = temp_dir / "partial_skip_only.tar.gz"
+    blocked = tarfile.TarInfo("dist/blocked.exe")
+    blocked.type = tarfile.REGTYPE
+    link = tarfile.TarInfo("dist/evil_link")
+    link.type = tarfile.SYMTYPE
+    link.linkname = "../../outside.txt"
+    _make_tar_gz(archive, [(blocked, b"MZ"), (link, None)])
+
+    output_dir = temp_dir / "out"
+    output_dir.mkdir()
+    config = exarch.SecurityConfig().add_allowed_extension("txt").with_allow_symlinks(True)
+
+    with pytest.raises(exarch.SymlinkEscapeError) as exc_info:
+        exarch.extract_archive(archive, output_dir, config)
+
+    err = exc_info.value
+    assert err.files_extracted == 0
+    assert err.bytes_written == 0
+    assert err.files_skipped > 0
+    assert err.warnings
+    assert any("disallowed extension" in w for w in err.warnings)
+
+
 def test_progress_bytes_written_not_stale(temp_dir):
     """
     Regression test for #285.


### PR DESCRIPTION
## Summary

- `convert_error`'s `PartialExtraction` arm in both `exarch-python` and `exarch-node` only forwarded `files_extracted`/`bytes_written` from the `ExtractionReport`, silently dropping `files_skipped` and `warnings`. A skip-only failure (entries rejected by an extension allowlist or duplicate checks, followed by a fatal error before anything was written) reached Python/Node callers with zero actionable information, even though `exarch-core` has populated those two fields on the report since #505.
- Python's `convert_error` now attaches `files_skipped`/`warnings` as exception attributes; Node's now appends `filesSkipped=N`/`warnings=[...]` to the error message, following the existing `key=value` convention.
- Updated `exarch.pyi`'s exception stubs, `exarch-node`'s doc comments (regenerating `index.d.ts`), and `CHANGELOG.md`.
- Added end-to-end regression tests (pytest + node:test) covering both the original quota-trip scenario and the true skip-only scenario (`files_extracted == 0`) that motivated this issue, now reachable after #509.

Filed a separate follow-up for an unrelated bug found while building the Node test: #510 (a symlink passed directly as a top-level creation source is silently archived as a plain file).

Closes #508

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` (1162 passed)
- [x] `cargo test --doc --workspace --all-features`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace`
- [x] `cargo nextest run -p exarch-node --all-features` (141 passed)
- [x] `cargo check`/`cargo clippy -p exarch-python --all-targets --all-features -- -D warnings`
- [x] `pytest` against a `maturin develop` build (50 passed, 1 pre-existing skip)
- [x] `npm test` against a built addon (125 passed)