### PR TITLE
fix(core): archive direct symlink sources as links, not dereferenced content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,6 +209,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`exarch-core`: a symlink passed directly as a top-level `create` source was silently
+  dereferenced into its target's file content instead of being archived as a link (#510)**:
+  `creation::walker::collect_entries`'s single-file branch (taken when a source argument is not a
+  directory) used `std::fs::metadata` (stat, follows symlinks) to classify the source and check its
+  existence, so a symlink argument was misclassified as `EntryType::File` and a dangling symlink
+  (target missing) failed existence checks with `SourceNotFound`, even though the identical
+  directory-walk path already used lstat semantics and archived symlinks under a directory
+  correctly. Both checks now use `std::fs::symlink_metadata` (lstat), so a symlink source
+  classifies as `EntryType::Symlink` and a dangling symlink is no longer rejected as missing.
+  Because the fix makes ZIP's `EntryType::Symlink` arm reachable for the first time (previously
+  dead code — `walkdir` always dereferences directory-walk roots), `create_zip_internal_with_progress`
+  also gained the `follow_symlinks` handling ZIP creation was missing: with `--follow-symlinks` it
+  now embeds the target file's content, matching TAR's existing behavior, instead of silently
+  producing an empty archive with `files_added: 0` and no warning.
+
+  This is a behavior change for `exarch-core`, `exarch create <archive> <symlink>`, and the
+  Python/Node.js bindings that call it: `exarch create a.tar link.txt` now stores a real symlink
+  entry rather than the target's dereferenced content, so extracting that archive requires
+  `--allow-symlinks` (deny-by-default) where it previously round-tripped without it.
 - **`exarch-core`: hardened ZIP's `by_index()`/`name()` error paths inside `extract()`'s entry loop
   to route through the same warning aggregation and `ArchiveError::partial_or` wrapping as other
   failures in the loop**: `formats/zip.rs`'s extraction loop opened each entry via

--- a/crates/exarch-core/src/creation/walker.rs
+++ b/crates/exarch-core/src/creation/walker.rs
@@ -227,11 +227,15 @@ pub fn collect_entries<P: AsRef<Path>, State>(
     for source in sources {
         let path = source.as_ref();
 
-        if !path.exists() {
+        // `symlink_metadata` (lstat) is required here instead of `exists`/`metadata`
+        // (stat) so that a dangling symlink (target missing) is still treated as a
+        // present source; it is later classified as EntryType::Symlink below. The
+        // result is reused in the single-file branch to avoid a second lstat.
+        let Ok(metadata) = path.symlink_metadata() else {
             return Err(ArchiveError::SourceNotFound {
                 path: path.to_path_buf(),
             });
-        }
+        };
 
         if path.is_dir() {
             let walker = FilteredWalker::new(path, config);
@@ -239,8 +243,10 @@ pub fn collect_entries<P: AsRef<Path>, State>(
                 entries.push(entry?);
             }
         } else {
-            // For single files, we need to create a FilteredEntry manually
-            let metadata = std::fs::metadata(path)?;
+            // For single files, we need to create a FilteredEntry manually.
+            // `symlink_metadata` (lstat) is required here instead of `metadata` (stat)
+            // so that a symlink passed directly as a top-level source is classified as
+            // EntryType::Symlink rather than silently dereferenced into its target.
             let size = if metadata.is_file() {
                 metadata.len()
             } else {
@@ -710,6 +716,65 @@ mod tests {
                 .to_str()
                 .unwrap()
                 .contains("test.txt")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_collect_entries_single_file_symlink_not_dereferenced() {
+        let temp = TempDir::new().unwrap();
+        let target_path = temp.path().join("target.txt");
+        let link_path = temp.path().join("evil_link");
+        fs::write(&target_path, "content").unwrap();
+        std::os::unix::fs::symlink(&target_path, &link_path).unwrap();
+
+        let config = CreationConfig::default();
+        let sources = [&link_path];
+
+        let entries = collect_entries(&sources, &config).unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(
+            entries[0].entry_type,
+            EntryType::Symlink {
+                target: target_path,
+            }
+        );
+        assert!(
+            entries[0]
+                .archive_path
+                .to_str()
+                .unwrap()
+                .contains("evil_link")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_collect_entries_dangling_symlink_source_not_rejected() {
+        let temp = TempDir::new().unwrap();
+        let missing_target = temp.path().join("nowhere.txt");
+        let link_path = temp.path().join("dangling_link");
+        std::os::unix::fs::symlink(&missing_target, &link_path).unwrap();
+
+        let config = CreationConfig::default();
+        let sources = [&link_path];
+
+        let entries = collect_entries(&sources, &config).unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(
+            entries[0].entry_type,
+            EntryType::Symlink {
+                target: missing_target,
+            }
+        );
+        assert!(
+            entries[0]
+                .archive_path
+                .to_str()
+                .unwrap()
+                .contains("dangling_link")
         );
     }
 

--- a/crates/exarch-core/src/creation/zip.rs
+++ b/crates/exarch-core/src/creation/zip.rs
@@ -206,7 +206,18 @@ fn create_zip_internal_with_progress<W: Write + Seek, P: AsRef<Path>>(
             }
             EntryType::Symlink { .. } => {
                 tracker.on_entry_start(&entry.archive_path);
-                if !config.follow_symlinks {
+                if config.follow_symlinks {
+                    add_file_to_zip_with_progress_and_buffer(
+                        &mut zip,
+                        &entry.path,
+                        &entry.archive_path,
+                        config,
+                        &mut report,
+                        &options,
+                        tracker.callback(),
+                        &mut buffer,
+                    )?;
+                } else {
                     report.files_skipped += 1;
                     report.add_warning(format!("Skipped symlink: {}", entry.path.display()));
                 }
@@ -751,6 +762,42 @@ mod tests {
 
         let warning = &report.warnings[0];
         assert!(warning.contains("Skipped symlink"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_create_zip_follow_symlinks_embeds_target_content() {
+        let temp = TempDir::new().unwrap();
+        let output = temp.path().join("output.zip");
+
+        let source_dir = TempDir::new().unwrap();
+        fs::write(source_dir.path().join("target.txt"), "content").unwrap();
+        std::os::unix::fs::symlink(
+            source_dir.path().join("target.txt"),
+            source_dir.path().join("link.txt"),
+        )
+        .unwrap();
+
+        let config = CreationConfig::default()
+            .with_exclude_patterns(vec![])
+            .with_include_hidden(true)
+            .with_follow_symlinks(true)
+            .validate()
+            .unwrap();
+
+        let report = create_zip(&output, &[source_dir.path()], &config).unwrap();
+
+        // Both target.txt and the followed link.txt must be written as regular entries.
+        assert_eq!(report.files_added, 2);
+        assert_eq!(report.files_skipped, 0);
+        assert!(!report.has_warnings());
+
+        let file = File::open(&output).unwrap();
+        let mut archive = zip::ZipArchive::new(file).unwrap();
+        let mut entry = archive.by_name("link.txt").unwrap();
+        let mut contents = String::new();
+        entry.read_to_string(&mut contents).unwrap();
+        assert_eq!(contents, "content");
     }
 
     #[test]

--- a/skills/exarch-cli/SKILL.md
+++ b/skills/exarch-cli/SKILL.md
@@ -137,6 +137,11 @@ exarch create out.tar.gz src/ --json
 | `--max-file-size <BYTES>` | none | Skip source files larger than this (`K`/`M`/`G`/`T` suffixes). |
 | `--preserve-permissions[=true\|false]` | `true` | Preserve platform permission bits. Pass `--preserve-permissions=false` for a portable, permission-agnostic archive. |
 
+> [!NOTE]
+> ZIP has no symlink entry type. With `--follow-symlinks` off (default), a symlink passed
+> directly as a source is skipped (warning + `files_skipped`), not archived. TAR always stores
+> it as a real symlink entry regardless of the flag.
+
 `exarch` refuses to *create* 7z archives (7z is extract-only) and refuses to create archives
 under ZIP-family extensions that carry extra format semantics: `.jar`, `.war`, `.ear`, `.nar`,
 `.nbm`, `.apk`, `.aab`, `.ipa`, `.appx`, `.msix`, `.whl`, `.vsix`, `.xpi`, `.epub` — use plain


### PR DESCRIPTION
## Summary

- `creation::walker::collect_entries`'s single-file branch used `std::fs::metadata`/`Path::exists` (stat semantics, follows symlinks) instead of `std::fs::symlink_metadata` (lstat), so a symlink passed directly as a top-level `create` source was misclassified as `EntryType::File` (target content dereferenced and embedded) and a dangling symlink failed existence checks with `SourceNotFound` — unlike the directory-walk path, which already used lstat semantics correctly.
- Fixing the classification made ZIP creation's `EntryType::Symlink` arm reachable for the first time (previously dead code, since `walkdir` always dereferences directory-walk roots). That arm was a no-op when `follow_symlinks` was true, silently producing an empty archive (`files_added: 0`, exit 0, no warning). It now embeds the target file's content, matching TAR's existing behavior.
- Documented the resulting ZIP/TAR asymmetry with `--follow-symlinks` off in `skills/exarch-cli/SKILL.md` (ZIP has no symlink entry type, so it skips + warns rather than archiving).

This is a behavior change: `exarch create a.tar link.txt` now stores a real symlink entry rather than dereferenced content, so extracting requires `--allow-symlinks` (deny-by-default) where it previously round-tripped without it. Documented in `CHANGELOG.md`.

A separate, pre-existing bug was found during review (a directory-symlink top-level source crashes with an internal path-normalization error) — different root cause, filed separately as #512, not fixed here.

Closes #510

## Test plan

- [x] `cargo nextest run -p exarch-core --all-features` — 944/944 pass
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace`
- [x] New regression tests: symlink-as-top-level-source classification, ZIP `--follow-symlinks` embeds target content, dangling symlink as direct source no longer rejected