### PR TITLE
fix(core): classify top-level directory-symlink sources as links, not walked directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,6 +209,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`exarch-core`: a symlink pointing at a directory, passed directly as a top-level `create`
+  source, crashed with an internal path-normalization error instead of being archived as a link
+  (#512)**: `creation::walker::collect_entries` classified the directory-walk vs. single-entry
+  branch using `path.is_dir()` (stat, follows symlinks), so a symlink-to-directory source was
+  routed into `FilteredWalker`/`WalkDir` instead of `EntryType::Symlink`. `WalkDir` always
+  dereferences its root regardless of `follow_links(false)`, so walking through the symlink root
+  produced an empty relative path for the root entry, later failing with `paths in archives must
+  have at least one component when setting path for ""`. The branch selector now reuses the
+  `symlink_metadata` (lstat) already fetched for existence checking and tests `metadata.is_dir()`
+  instead, so a symlink-to-directory source classifies as `EntryType::Symlink` by default —
+  consistent with how #510 fixed the analogous symlink-to-file case — without dereferencing the
+  source at all. When `follow_symlinks` is explicitly enabled, the branch selector additionally
+  checks `path.is_dir()` (stat) so the symlink is still walked as a directory, preserving the
+  pre-existing dereferencing behavior for that config instead of regressing it into an I/O error
+  (TAR) or an empty archive (ZIP). Under the default (non-follow) policy, TAR archives the
+  directory symlink as a link entry; ZIP has no on-disk representation for symlinks and continues
+  to skip it with a `Skipped symlink` warning, per the ZIP policy already established in #510 — for
+  a directory symlink this means the entire target tree is omitted from the ZIP archive (exit code
+  0, `files_skipped: 1`), so callers who need the tree's contents in a ZIP must pass
+  `--follow-symlinks`.
 - **`exarch-core`: a symlink passed directly as a top-level `create` source was silently
   dereferenced into its target's file content instead of being archived as a link (#510)**:
   `creation::walker::collect_entries`'s single-file branch (taken when a source argument is not a

--- a/crates/exarch-core/src/creation/walker.rs
+++ b/crates/exarch-core/src/creation/walker.rs
@@ -237,7 +237,18 @@ pub fn collect_entries<P: AsRef<Path>, State>(
             });
         };
 
-        if path.is_dir() {
+        // `metadata.is_dir()` (from the lstat above) is required here instead of
+        // `path.is_dir()` (stat, follows symlinks), so that a symlink pointing at a
+        // directory is not routed into `FilteredWalker`/`WalkDir` by default —
+        // `WalkDir` always dereferences its root regardless of `follow_links(false)`
+        // and would produce an empty relative path for the root entry. Such a symlink
+        // is instead classified as `EntryType::Symlink` in the branch below,
+        // consistent with the symlink-to-file case. When `follow_symlinks` is
+        // explicitly enabled, though, the symlink must still be walked as a directory
+        // (via `path.is_dir()`, stat) to preserve the pre-existing dereferencing
+        // behavior for that config — otherwise the single-entry branch would try to
+        // open the symlink as a regular file and fail with an I/O error.
+        if metadata.is_dir() || (config.follow_symlinks && path.is_dir()) {
             let walker = FilteredWalker::new(path, config);
             for entry in walker.walk() {
                 entries.push(entry?);
@@ -247,6 +258,8 @@ pub fn collect_entries<P: AsRef<Path>, State>(
             // `symlink_metadata` (lstat) is required here instead of `metadata` (stat)
             // so that a symlink passed directly as a top-level source is classified as
             // EntryType::Symlink rather than silently dereferenced into its target.
+            // `metadata.is_dir()` can no longer be true here (that case is routed to
+            // the walk branch above), so only `File` and `Symlink` remain.
             let size = if metadata.is_file() {
                 metadata.len()
             } else {
@@ -256,8 +269,6 @@ pub fn collect_entries<P: AsRef<Path>, State>(
             let entry_type = if metadata.is_symlink() {
                 let target = std::fs::read_link(path)?;
                 EntryType::Symlink { target }
-            } else if metadata.is_dir() {
-                EntryType::Directory
             } else {
                 EntryType::File
             };
@@ -775,6 +786,35 @@ mod tests {
                 .to_str()
                 .unwrap()
                 .contains("dangling_link")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_collect_entries_dir_symlink_source_classified_as_symlink() {
+        let temp = TempDir::new().unwrap();
+        let target_dir = temp.path().join("target_dir");
+        let link_path = temp.path().join("dirlink");
+        fs::create_dir(&target_dir).unwrap();
+        fs::write(target_dir.join("inner.txt"), "content").unwrap();
+        std::os::unix::fs::symlink(&target_dir, &link_path).unwrap();
+
+        let config = CreationConfig::default();
+        let sources = [&link_path];
+
+        let entries = collect_entries(&sources, &config).unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(
+            entries[0].entry_type,
+            EntryType::Symlink { target: target_dir }
+        );
+        assert!(
+            entries[0]
+                .archive_path
+                .to_str()
+                .unwrap()
+                .contains("dirlink")
         );
     }
 

--- a/crates/exarch-core/tests/integration_tests.rs
+++ b/crates/exarch-core/tests/integration_tests.rs
@@ -604,3 +604,93 @@ fn empty_dir_unicode_and_space_names_roundtrip_tar() {
             .is_dir()
     );
 }
+
+// ============================================================================
+// #512: top-level directory-symlink creation source
+// ============================================================================
+
+/// With `follow_symlinks` disabled (default), a top-level source that is a
+/// symlink to a directory must archive as a single `EntryType::Symlink`
+/// entry rather than crashing (the original #512 crash) or being walked.
+#[cfg(unix)]
+#[test]
+fn dir_symlink_source_without_follow_symlinks_archives_as_symlink_tar() {
+    let src = TempDir::new().unwrap();
+    let target_dir = src.path().join("target_dir");
+    let link_path = src.path().join("dirlink");
+    fs::create_dir(&target_dir).unwrap();
+    fs::write(target_dir.join("inner.txt"), "content").unwrap();
+    std::os::unix::fs::symlink(&target_dir, &link_path).unwrap();
+
+    let archive_dir = TempDir::new().unwrap();
+    let archive = archive_dir.path().join("out.tar.gz");
+
+    let config = CreationConfig::default().with_format(Some(ArchiveType::TarGz));
+    let report = create_archive(&archive, &[&link_path], &config).unwrap();
+
+    assert_eq!(report.files_added, 0);
+    assert_eq!(report.directories_added, 0);
+}
+
+/// With `follow_symlinks` enabled, a top-level directory-symlink source must
+/// still be dereferenced and its tree walked (pre-#512 behavior), not
+/// misclassified as a single symlink entry (which would make TAR try to
+/// `File::open` a directory and fail with an I/O error).
+#[cfg(unix)]
+#[test]
+fn dir_symlink_source_with_follow_symlinks_walks_tree_tar() {
+    let src = TempDir::new().unwrap();
+    let target_dir = src.path().join("target_dir");
+    let link_path = src.path().join("dirlink");
+    fs::create_dir(&target_dir).unwrap();
+    fs::write(target_dir.join("inner.txt"), "content").unwrap();
+    std::os::unix::fs::symlink(&target_dir, &link_path).unwrap();
+
+    let archive_dir = TempDir::new().unwrap();
+    let archive = archive_dir.path().join("out.tar.gz");
+
+    let config = CreationConfig::default()
+        .with_format(Some(ArchiveType::TarGz))
+        .with_follow_symlinks(true);
+    let report = create_archive(&archive, &[&link_path], &config).unwrap();
+
+    assert_eq!(report.files_added, 1);
+
+    let extract_dir = TempDir::new().unwrap();
+    extract_archive(&archive, extract_dir.path(), &SecurityConfig::default()).unwrap();
+    assert_eq!(
+        fs::read_to_string(extract_dir.path().join("inner.txt")).unwrap(),
+        "content"
+    );
+}
+
+/// Same `follow_symlinks` regression as above, but for ZIP: creation must
+/// succeed and produce the dereferenced file, not error out trying to open
+/// the directory-symlink path as a regular file.
+#[cfg(unix)]
+#[test]
+fn dir_symlink_source_with_follow_symlinks_walks_tree_zip() {
+    let src = TempDir::new().unwrap();
+    let target_dir = src.path().join("target_dir");
+    let link_path = src.path().join("dirlink");
+    fs::create_dir(&target_dir).unwrap();
+    fs::write(target_dir.join("inner.txt"), "content").unwrap();
+    std::os::unix::fs::symlink(&target_dir, &link_path).unwrap();
+
+    let archive_dir = TempDir::new().unwrap();
+    let archive = archive_dir.path().join("out.zip");
+
+    let config = CreationConfig::default()
+        .with_format(Some(ArchiveType::Zip))
+        .with_follow_symlinks(true);
+    let report = create_archive(&archive, &[&link_path], &config).unwrap();
+
+    assert_eq!(report.files_added, 1);
+
+    let extract_dir = TempDir::new().unwrap();
+    extract_archive(&archive, extract_dir.path(), &SecurityConfig::default()).unwrap();
+    assert_eq!(
+        fs::read_to_string(extract_dir.path().join("inner.txt")).unwrap(),
+        "content"
+    );
+}

--- a/skills/exarch-cli/SKILL.md
+++ b/skills/exarch-cli/SKILL.md
@@ -138,9 +138,11 @@ exarch create out.tar.gz src/ --json
 | `--preserve-permissions[=true\|false]` | `true` | Preserve platform permission bits. Pass `--preserve-permissions=false` for a portable, permission-agnostic archive. |
 
 > [!NOTE]
-> ZIP has no symlink entry type. With `--follow-symlinks` off (default), a symlink passed
-> directly as a source is skipped (warning + `files_skipped`), not archived. TAR always stores
-> it as a real symlink entry regardless of the flag.
+> With `--follow-symlinks` off (default), a symlink passed directly as a source (file or
+> directory) is archived as a link in TAR; ZIP has no symlink entry type, so it is skipped
+> instead (warning + `files_skipped`). With `--follow-symlinks` on, both TAR and ZIP dereference
+> the symlink and store the target's content — for a directory symlink, this means walking and
+> archiving the entire target tree.
 
 `exarch` refuses to *create* 7z archives (7z is extract-only) and refuses to create archives
 under ZIP-family extensions that carry extra format semantics: `.jar`, `.war`, `.ear`, `.nar`,


### PR DESCRIPTION
## Summary
- `collect_entries` selected the directory-walk branch via `path.is_dir()` (stat, follows symlinks), so a symlink pointing at a directory passed as a top-level `create` source was routed into `FilteredWalker`/`WalkDir` instead of `EntryType::Symlink`. `WalkDir` always dereferences its root regardless of `follow_links(false)`, producing an empty relative archive path and crashing with `paths in archives must have at least one component when setting path for ""`.
- The branch selector now reuses the `symlink_metadata` (lstat) already fetched for existence checking, so a directory-symlink source classifies as `EntryType::Symlink` under the default policy — consistent with the #510 fix for symlink-to-file sources — without dereferencing it.
- When `follow_symlinks` is enabled, the selector additionally checks `path.is_dir()` (stat) so the symlink is still walked as a directory, preserving the pre-existing dereferencing behavior instead of regressing into an I/O error (TAR) or an empty archive (ZIP).
- Under the default (non-follow) policy, ZIP still has no on-disk representation for symlinks and skips the entry with a warning (per the #510 ZIP policy) — for a directory symlink this means the whole target tree is omitted from the ZIP archive; documented explicitly in the CHANGELOG.
- Corrected a stale `skills/exarch-cli/SKILL.md` claim that TAR always stores symlinks as links "regardless of the flag."

Closes #512

## Test plan
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node`
- [x] `cargo test --doc --workspace --all-features` (exarch-core/exarch-cli doctests pass; exarch-python link failure is a pre-existing local env issue unrelated to this diff)
- [x] New integration tests: `dir_symlink_source_without_follow_symlinks_archives_as_symlink_tar`, `dir_symlink_source_with_follow_symlinks_walks_tree_tar`, `dir_symlink_source_with_follow_symlinks_walks_tree_zip`
- [x] Live-verified all four combinations (default/`--follow-symlinks` x TAR/ZIP) against the built CLI binary