### PR TITLE
fix(core): harden files_skipped counter against overflow across all format handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,6 +209,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`exarch-core`: `files_skipped` was incremented via a plain `+= 1` in six sites across
+  extraction and creation, inconsistent with the `checked_add`-based hardening already applied to
+  TAR's own `files_skipped` counter (#515)**: `formats/common.rs`'s `check_extension_allowed`,
+  `extract_file_with_permit`, and `create_symlink`, `formats/sevenz.rs`'s `process_entry_inner`,
+  and `creation/zip.rs` and `creation/tar.rs`'s skip sites all used bare `+= 1`, while
+  `formats/tar.rs:392` already used `checked_add(1).ok_or(ArchiveError::QuotaExceeded { resource:
+  IntegerOverflow })?` after #506's `duplicate_skips` hardening. The two `Result`-returning
+  extraction sites in `common.rs` and the one in `sevenz.rs` now match that same `checked_add` +
+  fail-closed pattern; `check_extension_allowed` (a `bool`-returning function that cannot propagate
+  `?`) and the `creation/`-side sites now use `saturating_add`, matching every sibling counter in
+  those same functions (`disallowed_extension_skips`, and `CreationReport`'s `files_added`/
+  `directories_added`/`symlinks_added`, none of which have a checked variant). Added a regression
+  test proving the `checked_add` extraction path fails closed with `QuotaExceeded { resource:
+  IntegerOverflow }` at `usize::MAX` instead of silently wrapping.
 - **`exarch-core`: a symlink pointing at a directory, passed directly as a top-level `create`
   source, crashed with an internal path-normalization error instead of being archived as a link
   (#512)**: `creation::walker::collect_entries` classified the directory-walk vs. single-entry

--- a/crates/exarch-core/src/creation/tar.rs
+++ b/crates/exarch-core/src/creation/tar.rs
@@ -393,7 +393,7 @@ fn add_symlink_to_tar<W: Write>(
     report: &mut CreationReport,
 ) -> Result<()> {
     // On non-Unix platforms, skip symlinks
-    report.files_skipped += 1;
+    report.files_skipped = report.files_skipped.saturating_add(1);
     report.add_warning("Symlinks not supported on this platform");
     Ok(())
 }

--- a/crates/exarch-core/src/creation/zip.rs
+++ b/crates/exarch-core/src/creation/zip.rs
@@ -218,7 +218,7 @@ fn create_zip_internal_with_progress<W: Write + Seek, P: AsRef<Path>>(
                         &mut buffer,
                     )?;
                 } else {
-                    report.files_skipped += 1;
+                    report.files_skipped = report.files_skipped.saturating_add(1);
                     report.add_warning(format!("Skipped symlink: {}", entry.path.display()));
                 }
                 tracker.on_entry_complete(&entry.archive_path);
@@ -270,7 +270,7 @@ fn add_file_to_zip_with_progress_and_buffer<W: Write + Seek>(
     if let Some(max_size) = config.max_file_size
         && size > max_size
     {
-        report.files_skipped += 1;
+        report.files_skipped = report.files_skipped.saturating_add(1);
         report.add_warning(format!(
             "Skipped file (too large): {} ({} bytes)",
             file_path.display(),

--- a/crates/exarch-core/src/formats/common.rs
+++ b/crates/exarch-core/src/formats/common.rs
@@ -448,7 +448,7 @@ pub fn check_extension_allowed(
         return true;
     }
 
-    report.files_skipped += 1;
+    report.files_skipped = report.files_skipped.saturating_add(1);
     *disallowed_extension_skips = disallowed_extension_skips.saturating_add(1);
     false
 }
@@ -700,7 +700,13 @@ pub fn extract_file_with_permit<R: Read>(
     let output_file = match create_file_with_mode(&output_path, mode, skip_duplicates) {
         Ok(file) => file,
         Err(e) if skip_duplicates && e.kind() == std::io::ErrorKind::AlreadyExists => {
-            report.files_skipped += 1;
+            report.files_skipped =
+                report
+                    .files_skipped
+                    .checked_add(1)
+                    .ok_or(ArchiveError::QuotaExceeded {
+                        resource: QuotaResource::IntegerOverflow,
+                    })?;
             *duplicate_skips = duplicate_skips.saturating_add(1);
             return Ok(());
         }
@@ -824,7 +830,13 @@ pub fn create_symlink(
 
         if link_path.symlink_metadata().is_ok() {
             if skip_duplicates {
-                report.files_skipped += 1;
+                report.files_skipped =
+                    report
+                        .files_skipped
+                        .checked_add(1)
+                        .ok_or(ArchiveError::QuotaExceeded {
+                            resource: QuotaResource::IntegerOverflow,
+                        })?;
                 *duplicate_skips = duplicate_skips.saturating_add(1);
                 return Ok(());
             }
@@ -1060,6 +1072,62 @@ mod tests {
         assert!(
             !temp.path().join("test.txt").exists(),
             "overflow-rejected entry must not touch the filesystem"
+        );
+    }
+
+    /// Regression test for #515: `files_skipped` must fail closed with
+    /// `QuotaExceeded { resource: IntegerOverflow }` instead of wrapping (or
+    /// panicking, in debug builds) once it reaches `usize::MAX`, mirroring
+    /// `test_extract_file_with_permit_integer_overflow_check` for
+    /// `bytes_written`.
+    #[test]
+    fn test_extract_file_with_permit_files_skipped_overflow_check() {
+        let temp = TempDir::new().expect("failed to create temp dir");
+        let dest = DestDir::new(temp.path().to_path_buf()).expect("failed to create dest");
+        let mut report = ExtractionReport::default();
+        let mut copy_buffer = CopyBuffer::new();
+        let mut dir_cache = DirCache::new();
+        let mut duplicate_skips = 0u64;
+
+        // Set files_skipped to usize::MAX so the duplicate-skip path's
+        // increment would overflow.
+        report.files_skipped = usize::MAX;
+
+        let config = SecurityConfig::default().validate().expect("valid config");
+        let permit = QuotaTracker::new()
+            .reserve(0, &config)
+            .expect("reservation should succeed");
+        let safe_path = SafePath::validate(&PathBuf::from("test.txt"), &dest, &config)
+            .expect("path should be valid");
+
+        // Pre-create the destination file so create_file_with_mode's
+        // create_new(true) hits AlreadyExists, taking the duplicate-skip
+        // branch that increments files_skipped.
+        std::fs::write(temp.path().join("test.txt"), b"existing").expect("failed to seed file");
+
+        let mut reader = Cursor::new(b"test data");
+
+        let result = extract_file_with_permit(
+            &mut reader,
+            &safe_path,
+            Some(0o644),
+            permit,
+            &dest,
+            &mut report,
+            None,
+            &mut copy_buffer,
+            &mut dir_cache,
+            true,
+            &mut duplicate_skips,
+            &mut NoopProgress,
+        );
+
+        assert!(result.is_err());
+        assert_matches!(
+            result.unwrap_err(),
+            ArchiveError::QuotaExceeded {
+                resource: QuotaResource::IntegerOverflow
+            }
         );
     }
 

--- a/crates/exarch-core/src/formats/sevenz.rs
+++ b/crates/exarch-core/src/formats/sevenz.rs
@@ -571,7 +571,10 @@ impl<R: Read + Seek> SevenZArchive<R> {
                 let existing = lstat_dest(&dest_path)?;
 
                 if existing.is_some() && skip_duplicates {
-                    report.files_skipped += 1;
+                    report.files_skipped =
+                        report.files_skipped.checked_add(1).ok_or_else(|| {
+                            sevenz_rust2::Error::Other("files_skipped overflow".into())
+                        })?;
                     *duplicate_skips = duplicate_skips.saturating_add(1);
                     return Ok(0);
                 }


### PR DESCRIPTION
## Summary

- `report.files_skipped` was incremented via a plain `+= 1` in six sites across extraction (`formats/common.rs`, `formats/sevenz.rs`) and creation (`creation/zip.rs`, `creation/tar.rs`), inconsistent with the `checked_add`-based hardening already applied to TAR's own `files_skipped` counter at `formats/tar.rs:392` (following #506's `duplicate_skips` hardening).
- `Result`-returning extraction sites (`common.rs::extract_file_with_permit`, `common.rs::create_symlink`, `sevenz.rs::process_entry_inner`) now use `checked_add(1)` and propagate a `QuotaExceeded { resource: IntegerOverflow }` (or the 7z-equivalent error), matching the `tar.rs:392` precedent exactly.
- `check_extension_allowed` (`bool`-returning, cannot propagate `?`) and the `creation/`-side sites (`creation/zip.rs:221,273`, `creation/tar.rs:396`) now use `saturating_add`, matching every sibling counter in those same functions — none of which has a checked variant.
- Added a regression test (`test_extract_file_with_permit_files_skipped_overflow_check`) proving the `checked_add` extraction path fails closed with `QuotaExceeded { resource: IntegerOverflow }` at `usize::MAX` instead of silently wrapping.

Note: the issue as filed cited `formats/zip.rs:221,273`, but those line numbers actually correspond to `creation/zip.rs` — ZIP extraction routes entirely through the shared `formats/common.rs` helpers and has no independent `files_skipped` site. `creation/tar.rs:396` was an additional site found during review, not listed in the original issue.

Closes #515

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` (1170 tests)
- [x] `cargo test --doc --workspace --all-features`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace`
- [x] New regression test exercises the `usize::MAX` overflow path and asserts fail-closed behavior