### PR TITLE
fix(core): enforce actual decompressed size against declared entry size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **ZIP extraction trusted the archive-declared uncompressed size for zip-bomb ratio detection and
+  quota reservation, but never verified it against what decompression actually produced
+  (GHSA-5j8q-wxg5-hj4r)**: `formats/zip.rs`'s `ZipEntryAdapter::get_sizes` reads `uncompressed_size`
+  straight from the entry's local/central-directory header — attacker-controlled bytes — and that
+  same declared value fed both `security::zipbomb::validate_compression_ratio` and
+  `QuotaTracker::reserve` before a single byte was decompressed. The actual copy
+  (`copy::copy_with_buffer`, invoked from `formats::common::extract_file_with_permit`) then read from
+  the real DEFLATE-decompressing stream in a loop with no ceiling tied to the declared/reserved size,
+  so a ZIP entry declaring a small `uncompressed_size` alongside a real DEFLATE stream that inflated
+  to a much larger payload extracted successfully, writing far more than the configured
+  `max_file_size` to disk with no warning. `copy_with_buffer` now takes the declared size as an
+  `expected_size` parameter and enforces it as a hard streaming ceiling — checked after every
+  buffered read, not only at the end — aborting with `ArchiveError::SecurityViolation` the instant
+  actual bytes exceed it, and rejecting a short stream (fewer bytes than declared) the same way once
+  EOF is reached; a legitimate encoder never lies about this, so the post-copy check is exact-match,
+  not a tolerance. (`SecurityViolation` rather than `QuotaExceeded`, deliberately: `expected_size` here
+  is the archive's own possibly-forged size, not `config.max_file_size`, so a quota-shaped error would
+  carry the CLI's "raise --max-file-size" hint — wrong advice for a metadata mismatch.)
+  `extract_file_with_permit` (shared by TAR and ZIP) wraps the write in a `TempFileGuard` so an aborted
+  copy removes the file it created instead of leaving a partial one on disk; when overwriting a
+  pre-existing destination (`--force`, `skip_duplicates = false`) the guard is not armed, since that
+  path already truncates the destination in place before any size check runs and deleting the
+  now-truncated file on abort would only destroy more of what was there, not less.
+
+  7z's two write paths (`write_file_direct`, `write_file_with_permit`) previously bypassed
+  `copy_with_buffer` entirely via `std::io::copy`; both now route through it with `entry.size` as the
+  declared size. TAR (via the `tar` crate's `Entry` reader) and 7z (via `sevenz-rust2`'s bounded
+  reader) already cap how many bytes a single entry's reader yields to its own declared size upstream,
+  so for those two formats the new ceiling is defense-in-depth against a future upstream regression
+  rather than closing a live vulnerability the way it does for ZIP — only the short-stream/mismatch
+  direction of the new check is reachable through them today. Applying it uniformly still closes the
+  structural gap (no format-specific patch needed if that upstream guarantee ever changes) and keeps
+  all three formats' extraction paths consistent.
+
 ### Performance
 
 - **7z extraction was 35-101% slower than `sevenz_rust2::decompress_file` on the same archive,

--- a/crates/exarch-core/src/copy.rs
+++ b/crates/exarch-core/src/copy.rs
@@ -10,6 +10,14 @@
 //! - Preserves quota overflow detection via checked arithmetic
 //! - No unsafe code
 //! - Buffer size is constant and stack-allocated
+//! - When called with a declared `expected_size` (GHSA-5j8q-wxg5-hj4r),
+//!   enforces it as a hard streaming ceiling rather than trusting it: the copy
+//!   aborts the instant more bytes have been decompressed than the archive
+//!   declared, and a short read (fewer bytes than declared) is rejected once
+//!   the source reaches EOF. This closes the gap where a forged
+//!   `uncompressed_size` header let compression-ratio and quota checks (which
+//!   only see the declared size) pass while the real decompressed stream was
+//!   unbounded.
 
 use std::io::Read;
 use std::io::Write;
@@ -64,7 +72,40 @@ impl Default for CopyBuffer {
 /// This is an optimized version of `std::io::copy` that:
 /// - Uses a caller-provided buffer (avoiding heap allocation)
 /// - Uses checked arithmetic to detect quota overflows
+/// - Enforces `expected_size`, if given, as a hard ceiling on the stream rather
+///   than trusting it as pre-validated metadata
 /// - Returns the total number of bytes copied
+///
+/// # Security - Streaming Size Ceiling (GHSA-5j8q-wxg5-hj4r)
+///
+/// `expected_size` is the declared uncompressed size a caller already used
+/// to pass compression-ratio and quota checks (both of which only see
+/// archive-supplied metadata, never actual decompressed bytes). Trusting
+/// that declared size for those checks but not for the copy itself let a
+/// forged small `uncompressed_size` sail through validation while the
+/// decompressing `reader` produced an unbounded number of real bytes on
+/// disk. When `expected_size` is `Some`, this function closes that gap in
+/// two ways:
+///
+/// - **Streaming ceiling**: `total` is checked against `expected_size` after
+///   every buffer-sized read, so the copy aborts with
+///   [`ArchiveError::SecurityViolation`] the moment more bytes have been
+///   decompressed than declared, not after the fact.
+/// - **Post-copy exact match**: once the reader reaches EOF, `total` must equal
+///   `expected_size` exactly. A legitimate encoder never lies about this; any
+///   mismatch (necessarily `total < expected_size`, since a larger `total`
+///   already aborted above) is rejected the same way, with
+///   [`ArchiveError::SecurityViolation`].
+///
+/// Both directions use `SecurityViolation` rather than
+/// [`ArchiveError::QuotaExceeded`]: `expected_size` here is the archive's own
+/// (possibly forged) declared size, not the configured
+/// `max_file_size`/`max_total_size` limit, so a `QuotaExceeded`-shaped error
+/// would surface a "raise the configured limit" remedy hint that makes no sense
+/// for a metadata mismatch the caller cannot fix by reconfiguring anything.
+///
+/// Callers that do not yet know a size (`expected_size: None`) get no
+/// additional enforcement beyond the pre-existing overflow guard.
 ///
 /// # Errors
 ///
@@ -72,16 +113,14 @@ impl Default for CopyBuffer {
 /// - Reading from the source fails
 /// - Writing to the destination fails
 /// - Total bytes written would overflow u64 (quota protection)
-///
-/// # Security
-///
-/// Quota overflow is explicitly checked using `checked_add`, ensuring
-/// that malicious archives cannot bypass size limits via integer overflow.
+/// - `expected_size` is `Some` and the actual byte count exceeds or falls short
+///   of it
 #[inline]
-pub fn copy_with_buffer<R: Read, W: Write>(
+pub fn copy_with_buffer<R: Read + ?Sized, W: Write + ?Sized>(
     reader: &mut R,
     writer: &mut W,
     buffer: &mut CopyBuffer,
+    expected_size: Option<u64>,
 ) -> Result<u64, ArchiveError> {
     let mut total: u64 = 0;
 
@@ -93,16 +132,52 @@ pub fn copy_with_buffer<R: Read, W: Write>(
             Err(e) => return Err(ArchiveError::Io(e)),
         };
 
-        writer
-            .write_all(&buffer.buf[..bytes_read])
-            .map_err(ArchiveError::Io)?;
-
         // SECURITY: Detect overflow to prevent quota bypass
         total = total
             .checked_add(bytes_read as u64)
             .ok_or(ArchiveError::QuotaExceeded {
                 resource: crate::QuotaResource::IntegerOverflow,
             })?;
+
+        // SECURITY: Enforce the declared size as a hard streaming ceiling
+        // (GHSA-5j8q-wxg5-hj4r) instead of only checking it once at the end.
+        // Checked before the write, so the chunk that would push `total` over
+        // the ceiling is never written at all — not "at most one buffer's
+        // worth of excess on disk", but zero.
+        //
+        // Uses SecurityViolation, not QuotaExceeded: `expected` is the
+        // archive's own declared size, not `config.max_file_size`, so a
+        // QuotaExceeded-shaped error would carry the CLI's "raise
+        // --max-file-size" hint — actively wrong advice for a forged-metadata
+        // mismatch the caller cannot fix by reconfiguring anything.
+        if let Some(expected) = expected_size
+            && total > expected
+        {
+            return Err(ArchiveError::SecurityViolation {
+                reason: format!(
+                    "decompressed size exceeded the declared uncompressed size of \
+                     {expected} bytes"
+                ),
+            });
+        }
+
+        writer
+            .write_all(&buffer.buf[..bytes_read])
+            .map_err(ArchiveError::Io)?;
+    }
+
+    // SECURITY: A short stream (fewer bytes than declared) is just as much a
+    // forged-metadata signal as an overlong one; the streaming ceiling above
+    // only catches the "too many bytes" direction.
+    if let Some(expected) = expected_size
+        && total != expected
+    {
+        return Err(ArchiveError::SecurityViolation {
+            reason: format!(
+                "decompressed size ({total} bytes) does not match the declared \
+                 uncompressed size ({expected} bytes)"
+            ),
+        });
     }
 
     Ok(total)
@@ -133,7 +208,7 @@ mod tests {
         let mut input = Cursor::new(Vec::<u8>::new());
         let mut output = Vec::new();
 
-        let result = copy_with_buffer(&mut input, &mut output, &mut buffer);
+        let result = copy_with_buffer(&mut input, &mut output, &mut buffer, None);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), 0);
         assert_eq!(output.len(), 0);
@@ -146,7 +221,7 @@ mod tests {
         let mut input = Cursor::new(input_data);
         let mut output = Vec::new();
 
-        let result = copy_with_buffer(&mut input, &mut output, &mut buffer);
+        let result = copy_with_buffer(&mut input, &mut output, &mut buffer, None);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), input_data.len() as u64);
         assert_eq!(output, input_data);
@@ -160,7 +235,7 @@ mod tests {
         let mut input = Cursor::new(&input_data);
         let mut output = Vec::new();
 
-        let result = copy_with_buffer(&mut input, &mut output, &mut buffer);
+        let result = copy_with_buffer(&mut input, &mut output, &mut buffer, None);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), input_data.len() as u64);
         assert_eq!(output, input_data);
@@ -173,7 +248,7 @@ mod tests {
         let mut input = Cursor::new(&input_data);
         let mut output = Vec::new();
 
-        let result = copy_with_buffer(&mut input, &mut output, &mut buffer);
+        let result = copy_with_buffer(&mut input, &mut output, &mut buffer, None);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), COPY_BUFFER_SIZE as u64);
         assert_eq!(output, input_data);
@@ -187,7 +262,7 @@ mod tests {
         let mut input = Cursor::new(&input_data);
         let mut output = Vec::new();
 
-        let result = copy_with_buffer(&mut input, &mut output, &mut buffer);
+        let result = copy_with_buffer(&mut input, &mut output, &mut buffer, None);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), input_data.len() as u64);
         assert_eq!(output, input_data);
@@ -201,7 +276,7 @@ mod tests {
         let data1 = b"First copy";
         let mut input1 = Cursor::new(data1);
         let mut output1 = Vec::new();
-        let result1 = copy_with_buffer(&mut input1, &mut output1, &mut buffer);
+        let result1 = copy_with_buffer(&mut input1, &mut output1, &mut buffer, None);
         assert!(result1.is_ok());
         assert_eq!(output1, data1);
 
@@ -209,7 +284,7 @@ mod tests {
         let data2 = b"Second copy with different data";
         let mut input2 = Cursor::new(data2);
         let mut output2 = Vec::new();
-        let result2 = copy_with_buffer(&mut input2, &mut output2, &mut buffer);
+        let result2 = copy_with_buffer(&mut input2, &mut output2, &mut buffer, None);
         assert!(result2.is_ok());
         assert_eq!(output2, data2);
     }
@@ -226,7 +301,7 @@ mod tests {
         let mut input = Cursor::new(&input_data);
         let mut output = Vec::new();
 
-        let result = copy_with_buffer(&mut input, &mut output, &mut buffer);
+        let result = copy_with_buffer(&mut input, &mut output, &mut buffer, None);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), input_data.len() as u64);
         assert_eq!(output, input_data);
@@ -276,7 +351,7 @@ mod tests {
         let mut buffer = CopyBuffer::new();
         let mut output = Vec::new();
 
-        let result = copy_with_buffer(&mut reader, &mut output, &mut buffer);
+        let result = copy_with_buffer(&mut reader, &mut output, &mut buffer, None);
         assert!(result.is_ok(), "copy should handle interrupted reads");
         assert_eq!(
             output, test_data,
@@ -319,7 +394,7 @@ mod tests {
         };
 
         let mut buffer = CopyBuffer::new();
-        let result = copy_with_buffer(&mut input, &mut writer, &mut buffer);
+        let result = copy_with_buffer(&mut input, &mut writer, &mut buffer, None);
 
         assert!(result.is_err(), "copy should propagate write errors");
         match result {
@@ -327,6 +402,108 @@ mod tests {
                 assert_eq!(e.kind(), ErrorKind::Other);
             }
             _ => panic!("expected IO error"),
+        }
+    }
+
+    // Regression test for GHSA-5j8q-wxg5-hj4r: a forged small
+    // `expected_size` must not let the real decompressed stream grow
+    // unbounded. Reproduces the PoC shape (declared size far smaller than
+    // actual content) directly against `copy_with_buffer`, independent of
+    // any specific archive format's decompressor.
+    #[test]
+    fn test_copy_forged_expected_size_aborts_streaming() {
+        let mut buffer = CopyBuffer::new();
+        // Declares 50 bytes but the source actually produces ~1MB, mirroring
+        // a ZIP entry with a forged uncompressed_size header.
+        let real_data = vec![0x42u8; 1024 * 1024];
+        let mut input = Cursor::new(&real_data);
+        let mut output = Vec::new();
+
+        let result = copy_with_buffer(&mut input, &mut output, &mut buffer, Some(50));
+
+        assert!(
+            result.is_err(),
+            "streaming past the declared size must abort, got: {result:?}"
+        );
+        match result {
+            Err(ArchiveError::SecurityViolation { reason }) => {
+                assert!(
+                    reason.contains("50 bytes"),
+                    "error must name the declared ceiling (50), got: {reason:?}"
+                );
+            }
+            other => {
+                panic!("expected SecurityViolation naming the 50-byte ceiling, got: {other:?}")
+            }
+        }
+        // The excess must never fully land in the destination.
+        assert!(
+            output.len() < real_data.len(),
+            "aborted copy must not have written the full oversized payload"
+        );
+    }
+
+    /// A stream that ends short of its declared size (undersized) is just as
+    /// much a forged-metadata signal as an oversized one and must be
+    /// rejected once EOF is reached, even though it never trips the
+    /// streaming ceiling.
+    #[test]
+    fn test_copy_undersized_stream_rejected_after_eof() {
+        let mut buffer = CopyBuffer::new();
+        let data = b"short";
+        let mut input = Cursor::new(data);
+        let mut output = Vec::new();
+
+        let result = copy_with_buffer(&mut input, &mut output, &mut buffer, Some(1000));
+
+        assert!(
+            result.is_err(),
+            "actual size short of declared size must be rejected, got: {result:?}"
+        );
+        assert!(matches!(
+            result,
+            Err(ArchiveError::SecurityViolation { .. })
+        ));
+    }
+
+    /// A stream matching its declared size exactly must succeed, exercising
+    /// the boundary between the streaming ceiling and the post-copy check.
+    #[test]
+    fn test_copy_exact_expected_size_succeeds() {
+        let mut buffer = CopyBuffer::new();
+        let data = vec![0x99u8; 4096];
+        let mut input = Cursor::new(&data);
+        let mut output = Vec::new();
+
+        let result = copy_with_buffer(&mut input, &mut output, &mut buffer, Some(4096));
+
+        assert_eq!(result.unwrap(), 4096);
+        assert_eq!(output, data);
+    }
+
+    /// One byte over the declared size must abort even though the excess is
+    /// well within a single buffer read, pinning the "checked every
+    /// iteration, not just at the end" requirement at the smallest possible
+    /// margin.
+    #[test]
+    fn test_copy_one_byte_over_expected_size_aborts() {
+        let mut buffer = CopyBuffer::new();
+        let data = vec![0x77u8; 101];
+        let mut input = Cursor::new(&data);
+        let mut output = Vec::new();
+
+        let result = copy_with_buffer(&mut input, &mut output, &mut buffer, Some(100));
+
+        match result {
+            Err(ArchiveError::SecurityViolation { reason }) => {
+                assert!(
+                    reason.contains("100 bytes"),
+                    "error must name the declared ceiling (100), got: {reason:?}"
+                );
+            }
+            other => {
+                panic!("expected SecurityViolation naming the 100-byte ceiling, got: {other:?}")
+            }
         }
     }
 
@@ -338,7 +515,7 @@ mod tests {
             let mut buffer = CopyBuffer::new();
             let mut input = Cursor::new(&data);
             let mut output = Vec::new();
-            let result = copy_with_buffer(&mut input, &mut output, &mut buffer);
+            let result = copy_with_buffer(&mut input, &mut output, &mut buffer, None);
             prop_assert!(result.is_ok(), "copy should succeed");
             prop_assert_eq!(result.unwrap(), data.len() as u64, "should report correct size");
             prop_assert_eq!(output, data, "output must match input exactly");
@@ -352,7 +529,7 @@ mod tests {
             let data = vec![0x42u8; size];
             let mut input = Cursor::new(&data);
             let mut output = Vec::new();
-            let result = copy_with_buffer(&mut input, &mut output, &mut buffer);
+            let result = copy_with_buffer(&mut input, &mut output, &mut buffer, None);
             prop_assert!(result.is_ok(), "copy should succeed for size {}", size);
             prop_assert_eq!(output.len(), size, "output size must match input");
             prop_assert!(output.iter().all(|&b| b == 0x42), "all bytes must be preserved");
@@ -366,12 +543,12 @@ mod tests {
             let mut buffer = CopyBuffer::new();
             let mut input1 = Cursor::new(&data1);
             let mut output1 = Vec::new();
-            let result1 = copy_with_buffer(&mut input1, &mut output1, &mut buffer);
+            let result1 = copy_with_buffer(&mut input1, &mut output1, &mut buffer, None);
             prop_assert!(result1.is_ok());
             prop_assert_eq!(output1, data1);
             let mut input2 = Cursor::new(&data2);
             let mut output2 = Vec::new();
-            let result2 = copy_with_buffer(&mut input2, &mut output2, &mut buffer);
+            let result2 = copy_with_buffer(&mut input2, &mut output2, &mut buffer, None);
             prop_assert!(result2.is_ok());
             prop_assert_eq!(output2, data2);
         }

--- a/crates/exarch-core/src/formats/common.rs
+++ b/crates/exarch-core/src/formats/common.rs
@@ -607,6 +607,21 @@ pub fn create_file_with_mode(
 /// - Buffered I/O (64KB buffer)
 /// - Exclusive file creation with permission enforcement (Unix only)
 /// - Quota tracking with overflow protection
+/// - A hard streaming ceiling on `expected_size`, so a forged declared size
+///   cannot decouple what was quota-checked from what is actually written
+///
+/// # Security - Streaming Size Enforcement (GHSA-5j8q-wxg5-hj4r)
+///
+/// `expected_size` is the same declared size the caller already used for
+/// compression-ratio and quota validation — metadata read from the archive,
+/// not measured from real bytes. This function does not merely trust it a
+/// second time: it is threaded into [`copy_with_buffer`] as a hard ceiling
+/// enforced on every buffered read, so a forged small `expected_size` cannot
+/// let the real decompressed stream grow unbounded, and a short stream (less
+/// than declared) is rejected once it reaches EOF. On either violation, the
+/// partially-written file is removed via [`TempFileGuard`] before the error
+/// propagates — a rejected entry never leaves oversized or truncated content
+/// on disk.
 ///
 /// # Permission Enforcement
 ///
@@ -643,7 +658,9 @@ pub fn create_file_with_mode(
 ///   quota tracker; consumed by value and otherwise unused
 /// * `dest` - Destination directory
 /// * `report` - Extraction statistics (updated)
-/// * `expected_size` - Expected file size (if known) for quota pre-check
+/// * `expected_size` - Declared uncompressed size (if known); used for the
+///   quota pre-check and, per the security note above, enforced as a hard
+///   streaming ceiling and exact post-copy match
 /// * `copy_buffer` - Reusable buffer for I/O operations
 /// * `dir_cache` - Directory cache to reduce redundant mkdir syscalls
 /// * `duplicate_skips` - Counter incremented (not pushed as a warning string)
@@ -658,6 +675,8 @@ pub fn create_file_with_mode(
 /// - Quota would be exceeded (checked before write)
 /// - File creation fails
 /// - I/O error during copy
+/// - `expected_size` is `Some` and the actual decompressed byte count exceeds
+///   or falls short of it (forged size metadata)
 #[allow(clippy::too_many_arguments)]
 #[inline]
 pub fn extract_file_with_permit<R: Read>(
@@ -713,9 +732,29 @@ pub fn extract_file_with_permit<R: Read>(
         Err(e) => return Err(e.into()),
     };
 
+    // SECURITY: guards against leaving a partial file on disk when
+    // copy_with_buffer aborts mid-stream because expected_size was forged
+    // (GHSA-5j8q-wxg5-hj4r) — the `?` below returns before `persist()` runs,
+    // so the guard's Drop removes whatever was written so far.
+    //
+    // Only armed when `skip_duplicates` is true: that is exactly the branch
+    // where `create_file_with_mode` used `create_new(true)` above, so
+    // `output_path` is guaranteed to have held nothing before this call and
+    // deleting it on abort loses nothing. When `skip_duplicates` is false
+    // (`--force`/overwrite), `create_file_with_mode` already truncated a
+    // possibly pre-existing file in place before any of this ran — deleting
+    // that truncated stub on abort would be new behavior this security fix
+    // has no reason to introduce (unlike 7z's temp+rename, TAR/ZIP's
+    // in-place overwrite was never atomic; restoring the original on failure
+    // would need that same restructuring, tracked separately, not folded
+    // into this patch).
+    let guard = skip_duplicates.then(|| TempFileGuard::new(output_path));
     let mut buffered_writer = BufWriter::with_capacity(64 * 1024, output_file);
-    let bytes_written = copy_with_buffer(reader, &mut buffered_writer, copy_buffer)?;
+    let bytes_written = copy_with_buffer(reader, &mut buffered_writer, copy_buffer, expected_size)?;
     buffered_writer.flush()?;
+    if let Some(guard) = guard {
+        guard.persist();
+    }
 
     if bytes_written > 0 {
         progress.on_bytes_written(bytes_written);
@@ -1128,6 +1167,156 @@ mod tests {
             ArchiveError::QuotaExceeded {
                 resource: QuotaResource::IntegerOverflow
             }
+        );
+    }
+
+    /// Regression test for GHSA-5j8q-wxg5-hj4r: a reader that produces far
+    /// more bytes than the entry's declared `expected_size` (the
+    /// proof-of-concept shape — a ZIP local/central-directory header lying
+    /// about `uncompressed_size`) must abort extraction with a security
+    /// error and must not leave an oversized (or any) file behind on disk.
+    #[test]
+    fn test_extract_file_with_permit_forged_size_aborts_and_cleans_up() {
+        let temp = TempDir::new().expect("failed to create temp dir");
+        let dest = DestDir::new(temp.path().to_path_buf()).expect("failed to create dest");
+        let mut report = ExtractionReport::default();
+        let mut copy_buffer = CopyBuffer::new();
+        let mut dir_cache = DirCache::new();
+
+        let config = SecurityConfig::default().validate().expect("valid config");
+        // Declares 50 bytes, mirroring the PoC's forged uncompressed_size.
+        let permit = QuotaTracker::new()
+            .reserve(50, &config)
+            .expect("reservation should succeed");
+        let safe_path = SafePath::validate(&PathBuf::from("bomb.txt"), &dest, &config)
+            .expect("path should be valid");
+
+        // The "decompressed" stream actually produces far more than declared.
+        let real_data = vec![0x41u8; 200 * 1024];
+        let mut reader = Cursor::new(&real_data);
+
+        let result = extract_file_with_permit(
+            &mut reader,
+            &safe_path,
+            Some(0o644),
+            permit,
+            &dest,
+            &mut report,
+            Some(50),
+            &mut copy_buffer,
+            &mut dir_cache,
+            true,
+            &mut 0u64,
+            &mut NoopProgress,
+        );
+
+        assert_matches!(
+            result,
+            Err(ArchiveError::SecurityViolation { .. }),
+            "streaming past the declared size must abort with a security error, got: {result:?}"
+        );
+        assert!(
+            !temp.path().join("bomb.txt").exists(),
+            "aborted extraction must not leave a partial or oversized file on disk"
+        );
+    }
+
+    /// A stream that ends short of its declared `expected_size` is rejected
+    /// too, and the partial file it produced is removed rather than left
+    /// truncated on disk.
+    #[test]
+    fn test_extract_file_with_permit_undersized_stream_cleans_up() {
+        let temp = TempDir::new().expect("failed to create temp dir");
+        let dest = DestDir::new(temp.path().to_path_buf()).expect("failed to create dest");
+        let mut report = ExtractionReport::default();
+        let mut copy_buffer = CopyBuffer::new();
+        let mut dir_cache = DirCache::new();
+
+        let config = SecurityConfig::default().validate().expect("valid config");
+        let permit = QuotaTracker::new()
+            .reserve(1000, &config)
+            .expect("reservation should succeed");
+        let safe_path = SafePath::validate(&PathBuf::from("short.txt"), &dest, &config)
+            .expect("path should be valid");
+
+        let mut reader = Cursor::new(b"too short");
+
+        let result = extract_file_with_permit(
+            &mut reader,
+            &safe_path,
+            Some(0o644),
+            permit,
+            &dest,
+            &mut report,
+            Some(1000),
+            &mut copy_buffer,
+            &mut dir_cache,
+            true,
+            &mut 0u64,
+            &mut NoopProgress,
+        );
+
+        assert_matches!(
+            result,
+            Err(ArchiveError::SecurityViolation { .. }),
+            "actual size short of declared size must be rejected, got: {result:?}"
+        );
+        assert!(
+            !temp.path().join("short.txt").exists(),
+            "rejected entry must not leave a truncated file on disk"
+        );
+    }
+
+    /// Security-review follow-up for GHSA-5j8q-wxg5-hj4r: with
+    /// `skip_duplicates = false` (`--force`), a pre-existing destination
+    /// file must not be *deleted* by an aborted forged-size entry. The
+    /// `TempFileGuard` added for the streaming ceiling is only armed when
+    /// this call created the file itself (`skip_duplicates = true`,
+    /// `create_new`); the overwrite branch already truncated the
+    /// pre-existing file in place before any size check ran (pre-existing,
+    /// non-atomic behavior this security fix does not change), so on abort
+    /// the truncated file is left as-is rather than additionally deleted.
+    #[test]
+    fn test_extract_file_with_permit_force_overwrite_forged_size_does_not_delete_destination() {
+        let temp = TempDir::new().expect("failed to create temp dir");
+        let dest = DestDir::new(temp.path().to_path_buf()).expect("failed to create dest");
+        let mut report = ExtractionReport::default();
+        let mut copy_buffer = CopyBuffer::new();
+        let mut dir_cache = DirCache::new();
+
+        // Pre-existing destination file, as if from a prior extraction.
+        std::fs::write(temp.path().join("target.txt"), b"pre-existing content")
+            .expect("failed to seed file");
+
+        let config = SecurityConfig::default().validate().expect("valid config");
+        let permit = QuotaTracker::new()
+            .reserve(50, &config)
+            .expect("reservation should succeed");
+        let safe_path = SafePath::validate(&PathBuf::from("target.txt"), &dest, &config)
+            .expect("path should be valid");
+
+        let real_data = vec![0x41u8; 200 * 1024];
+        let mut reader = Cursor::new(&real_data);
+
+        let result = extract_file_with_permit(
+            &mut reader,
+            &safe_path,
+            Some(0o644),
+            permit,
+            &dest,
+            &mut report,
+            Some(50),
+            &mut copy_buffer,
+            &mut dir_cache,
+            false, // skip_duplicates = false: --force overwrite
+            &mut 0u64,
+            &mut NoopProgress,
+        );
+
+        assert_matches!(result, Err(ArchiveError::SecurityViolation { .. }));
+        assert!(
+            temp.path().join("target.txt").exists(),
+            "aborted --force overwrite must not delete the destination path entirely"
         );
     }
 

--- a/crates/exarch-core/src/formats/sevenz.rs
+++ b/crates/exarch-core/src/formats/sevenz.rs
@@ -125,6 +125,8 @@ use crate::ProgressCallback;
 use crate::Result;
 use crate::SecurityConfig;
 use crate::config::Validated;
+use crate::copy::CopyBuffer;
+use crate::copy::copy_with_buffer;
 use crate::error::QuotaResource;
 use crate::security::EntryValidator;
 use crate::security::quota::QuotaPermit;
@@ -305,14 +307,27 @@ impl<R: Read + Seek> SevenZArchive<R> {
 /// function cannot be called at all without moving a genuine permit out of
 /// the validated entry.
 ///
+/// # Security - Streaming Size Enforcement (GHSA-5j8q-wxg5-hj4r)
+///
+/// `expected_size` is `entry.size` — the declared uncompressed size read
+/// from 7z's own (attacker-controlled) archive metadata, the same value
+/// already used to authorize `permit`. The copy goes through
+/// [`copy_with_buffer`], which enforces it as a hard streaming ceiling and
+/// an exact post-copy match rather than trusting it a second time, closing
+/// the same gap TAR/ZIP close via [`common::extract_file_with_permit`].
+///
 /// # Errors
 ///
-/// Returns an error if file creation, the copy, or the underlying I/O fails.
+/// Returns an error if file creation, the copy, or the underlying I/O fails,
+/// or if the actual decompressed byte count exceeds or falls short of
+/// `expected_size`.
 fn write_file_direct(
     reader: &mut dyn Read,
     dest_path: &Path,
+    expected_size: u64,
+    copy_buffer: &mut CopyBuffer,
     _permit: QuotaPermit,
-) -> std::result::Result<u64, sevenz_rust2::Error> {
+) -> Result<u64> {
     let file = common::create_file_with_mode(dest_path, None, true)?;
     // A decode failure partway through the copy would otherwise leave a
     // truncated file at dest_path (issue #492 adversarial review, finding
@@ -320,11 +335,17 @@ fn write_file_direct(
     // beforehand, it is always safe to remove whatever we just started
     // writing there. Mirrors write_file_with_permit_using's TempFileGuard
     // use, just applied directly to dest_path instead of a temp path.
+    //
+    // Declared before `writer` takes ownership of `file` below: Rust drops
+    // locals in reverse declaration order, so on an error unwind `writer`
+    // (and the `file` it owns) drops — and closes the fd — before `guard`
+    // attempts to remove the path. Reversing this order would let the guard
+    // try to unlink a still-open file, a silent no-op on Windows.
     let guard = common::TempFileGuard::new(dest_path.to_path_buf());
     // 64KiB write buffering to cut per-file syscall count (finding M2),
     // matching TAR/ZIP's common::extract_file_with_permit.
     let mut writer = std::io::BufWriter::with_capacity(64 * 1024, file);
-    let bytes_written = std::io::copy(reader, &mut writer)?;
+    let bytes_written = copy_with_buffer(reader, &mut writer, copy_buffer, Some(expected_size))?;
     writer.flush()?;
     guard.persist();
     Ok(bytes_written)
@@ -361,26 +382,42 @@ fn write_file_direct(
 /// collision (`ErrorKind::AlreadyExists`), a fresh counter value is drawn
 /// and creation is retried up to [`MAX_TEMP_FILE_CREATE_ATTEMPTS`] times.
 ///
+/// # Security - Streaming Size Enforcement (GHSA-5j8q-wxg5-hj4r)
+///
+/// Same enforcement as [`write_file_direct`]: the copy runs through
+/// [`copy_with_buffer`] with `expected_size` (`entry.size`) as a hard
+/// streaming ceiling and exact post-copy match, not trusted metadata.
+///
 /// # Errors
 ///
 /// Returns an error if a unique temp file cannot be created within
-/// [`MAX_TEMP_FILE_CREATE_ATTEMPTS`] attempts, or if the copy or rename
-/// fails.
+/// [`MAX_TEMP_FILE_CREATE_ATTEMPTS`] attempts, if the copy or rename fails,
+/// or if the actual decompressed byte count exceeds or falls short of
+/// `expected_size`.
 fn write_file_with_permit(
     reader: &mut dyn Read,
     dest_path: &Path,
+    expected_size: u64,
+    copy_buffer: &mut CopyBuffer,
     permit: QuotaPermit,
-) -> std::result::Result<u64, sevenz_rust2::Error> {
+) -> Result<u64> {
     let pid = id();
     let original_name = dest_path
         .file_name()
         .map_or_else(|| "file".to_string(), |n| n.to_string_lossy().to_string());
 
-    write_file_with_permit_using(reader, dest_path, permit, || {
-        let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
-        let temp_name = format!(".{original_name}.exarch-tmp-{pid}-{counter}");
-        dest_path.with_file_name(&temp_name)
-    })
+    write_file_with_permit_using(
+        reader,
+        dest_path,
+        expected_size,
+        copy_buffer,
+        permit,
+        || {
+            let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+            let temp_name = format!(".{original_name}.exarch-tmp-{pid}-{counter}");
+            dest_path.with_file_name(&temp_name)
+        },
+    )
 }
 
 /// Implementation behind [`write_file_with_permit`], parameterized over the
@@ -395,17 +432,26 @@ fn write_file_with_permit(
 /// multi-threaded execution (only nextest's one-test-per-process model would
 /// make that safe).
 ///
+/// # Security - Streaming Size Enforcement (GHSA-5j8q-wxg5-hj4r)
+///
+/// Same enforcement as [`write_file_direct`]: the copy runs through
+/// [`copy_with_buffer`] with `expected_size` as a hard streaming ceiling and
+/// exact post-copy match, not trusted metadata.
+///
 /// # Errors
 ///
 /// Returns an error if a unique temp file cannot be created within
-/// [`MAX_TEMP_FILE_CREATE_ATTEMPTS`] attempts, or if the copy or rename
-/// fails.
+/// [`MAX_TEMP_FILE_CREATE_ATTEMPTS`] attempts, if the copy or rename fails,
+/// or if the actual decompressed byte count exceeds or falls short of
+/// `expected_size`.
 fn write_file_with_permit_using(
     reader: &mut dyn Read,
     dest_path: &Path,
+    expected_size: u64,
+    copy_buffer: &mut CopyBuffer,
     _permit: QuotaPermit,
     mut next_candidate_path: impl FnMut() -> PathBuf,
-) -> std::result::Result<u64, sevenz_rust2::Error> {
+) -> Result<u64> {
     let mut created: Option<(PathBuf, std::fs::File)> = None;
     for _ in 0..MAX_TEMP_FILE_CREATE_ATTEMPTS {
         let candidate_path = next_candidate_path();
@@ -420,7 +466,7 @@ fn write_file_with_permit_using(
         }
     }
 
-    let (temp_path, mut temp_file) = created.ok_or_else(|| {
+    let (temp_path, temp_file) = created.ok_or_else(|| {
         std::io::Error::new(
             ErrorKind::AlreadyExists,
             format!(
@@ -430,16 +476,23 @@ fn write_file_with_permit_using(
         )
     })?;
 
+    // Declared before `writer` takes ownership of `temp_file` below, for the
+    // same reason as write_file_direct's `guard`: reverse-declaration-order
+    // drop means `writer` (owning `temp_file`) closes the fd before
+    // `temp_guard` attempts to remove `temp_path` on an error unwind,
+    // instead of racing a still-open handle (a silent no-op on Windows).
+    // `temp_file` is moved into `writer` rather than merely borrowed so
+    // there is no separate `temp_file` binding left to outlive `writer`.
     let temp_guard = common::TempFileGuard::new(temp_path.clone());
     // 64KiB write buffering to cut per-file syscall count (issue #492
     // adversarial review, finding M2), matching TAR/ZIP's
     // common::extract_file_with_permit.
-    let bytes_written = {
-        let mut writer = std::io::BufWriter::with_capacity(64 * 1024, &mut temp_file);
-        let bytes_written = std::io::copy(reader, &mut writer)?;
-        writer.flush()?;
-        bytes_written
-    };
+    let mut writer = std::io::BufWriter::with_capacity(64 * 1024, temp_file);
+    let bytes_written = copy_with_buffer(reader, &mut writer, copy_buffer, Some(expected_size))?;
+    writer.flush()?;
+    // Explicit close before rename: renaming a still-open file is fine on
+    // Unix but the handle should not outlive its purpose regardless.
+    drop(writer);
     std::fs::rename(&temp_path, dest_path)?;
     temp_guard.persist();
 
@@ -518,7 +571,8 @@ impl<R: Read + Seek> SevenZArchive<R> {
         config: &SecurityConfig<Validated>,
         duplicate_skips: &mut u64,
         disallowed_extension_skips: &mut u64,
-        pending_io_error: &mut Option<std::io::Error>,
+        pending_error: &mut Option<ArchiveError>,
+        copy_buffer: &mut CopyBuffer,
     ) -> std::result::Result<u64, sevenz_rust2::Error> {
         let entry_type = SevenZEntryAdapter::to_entry_type(entry).map_err(|e| {
             sevenz_rust2::Error::Other(format!("entry type detection failed: {e}").into())
@@ -606,8 +660,8 @@ impl<R: Read + Seek> SevenZArchive<R> {
                     // opening a directory for write) instead of recursively
                     // deleting the pre-existing directory tree (issue #483).
                     //
-                    // Stashed as a raw `io::Error` and returned out-of-band
-                    // via `pending_io_error` instead of `.into()`-converting
+                    // Stashed as a raw ArchiveError and returned out-of-band
+                    // via `pending_error` instead of `.into()`-converting
                     // to `sevenz_rust2::Error` here: that round-trip goes
                     // through `From<sevenz_rust2::Error> for ArchiveError`,
                     // which stringifies the error and re-derives its
@@ -620,7 +674,9 @@ impl<R: Read + Seek> SevenZArchive<R> {
                     // constructed here for the same reason: nothing about
                     // this error should ever again be at the mercy of that
                     // heuristic.
-                    *pending_io_error = Some(std::io::Error::from(ErrorKind::IsADirectory));
+                    *pending_error = Some(ArchiveError::Io(std::io::Error::from(
+                        ErrorKind::IsADirectory,
+                    )));
                     return Err(sevenz_rust2::Error::Other(
                         "destination path is a pre-existing directory".into(),
                     ));
@@ -640,6 +696,15 @@ impl<R: Read + Seek> SevenZArchive<R> {
                 // The overwrite branch keeps temp+rename so a decode failure
                 // mid-stream cannot leave a truncated file where the
                 // original stood.
+                //
+                // Both branches enforce entry.size as a hard streaming
+                // ceiling and exact post-copy match (GHSA-5j8q-wxg5-hj4r, see
+                // write_file_direct/write_file_with_permit); a violation
+                // there returns Err(ArchiveError) which does not implement
+                // Into<sevenz_rust2::Error>, so it is stashed out-of-band via
+                // `pending_error` (same reasoning as the IsADirectory case
+                // above) rather than round-tripped through the lossy string
+                // conversion.
                 let bytes_written = if existing.is_some() {
                     // 7z uses temp+rename (unlike TAR/ZIP which truncate
                     // in-place via File::create). Remove the existing
@@ -649,10 +714,14 @@ impl<R: Read + Seek> SevenZArchive<R> {
                     // symlink) can reach here: directories and Unix symlinks
                     // were already rejected above.
                     std::fs::remove_file(&dest_path)?;
-                    write_file_with_permit(reader, &dest_path, permit)?
+                    write_file_with_permit(reader, &dest_path, entry.size, copy_buffer, permit)
                 } else {
-                    write_file_direct(reader, &dest_path, permit)?
-                };
+                    write_file_direct(reader, &dest_path, entry.size, copy_buffer, permit)
+                }
+                .map_err(|e| {
+                    *pending_error = Some(e);
+                    sevenz_rust2::Error::Other("extraction aborted by security policy".into())
+                })?;
                 report.bytes_written = report
                     .bytes_written
                     .checked_add(bytes_written)
@@ -716,13 +785,25 @@ impl<R: Read + Seek> SevenZArchive<R> {
             /// extension is not in the allowlist. Aggregated the
             /// same way as `duplicate_skips` (issue #495).
             disallowed_extension_skips: u64,
-            /// Set when `process_entry_inner` needs its caller to construct
-            /// `ArchiveError::Io` directly from a raw `io::Error`, bypassing
-            /// the lossy `sevenz_rust2::Error` -> `ArchiveError` conversion
-            /// (issue #483 S1) that stringifies errors and would otherwise
-            /// collapse a specific `ErrorKind` to `Other` and re-classify by
-            /// substring match on the resulting text.
-            pending_io_error: Option<std::io::Error>,
+            /// Set when `process_entry_inner` needs its caller to propagate a
+            /// precise `ArchiveError` directly, bypassing the lossy
+            /// `sevenz_rust2::Error` -> `ArchiveError` conversion (issue
+            /// #483 S1) that stringifies errors and would otherwise collapse
+            /// a specific `ErrorKind` to `Other` and re-classify by
+            /// substring match on the resulting text. Used for the
+            /// `IsADirectory` case and for `write_file_direct`/
+            /// `write_file_with_permit`'s streaming-size violations
+            /// (GHSA-5j8q-wxg5-hj4r), neither of which has a meaningful
+            /// `sevenz_rust2::Error` representation to round-trip through.
+            pending_error: Option<ArchiveError>,
+            /// Single reusable copy buffer for the whole extraction, mirroring
+            /// TAR/ZIP's per-archive `CopyBuffer` (`tar.rs`, `zip.rs`).
+            /// Previously `write_file_direct`/`write_file_with_permit_using`
+            /// each allocated a fresh 64KiB `CopyBuffer` per file entry — the
+            /// same per-file cost #492 removed from 7z's write path — so this
+            /// hoists it here instead of threading a freshly-allocated one
+            /// through `process_entry_inner` on every call.
+            copy_buffer: CopyBuffer,
         }
 
         let mut ctx = SzContext {
@@ -732,7 +813,8 @@ impl<R: Read + Seek> SevenZArchive<R> {
             current_idx: 0,
             duplicate_skips: 0,
             disallowed_extension_skips: 0,
-            pending_io_error: None,
+            pending_error: None,
+            copy_buffer: CopyBuffer::new(),
         };
 
         // Extraction callback - called for each entry.
@@ -764,7 +846,8 @@ impl<R: Read + Seek> SevenZArchive<R> {
                 config,
                 &mut ctx.duplicate_skips,
                 &mut ctx.disallowed_extension_skips,
-                &mut ctx.pending_io_error,
+                &mut ctx.pending_error,
+                &mut ctx.copy_buffer,
             );
 
             // INVARIANT: every branch below must call on_entry_complete exactly once.
@@ -798,15 +881,25 @@ impl<R: Read + Seek> SevenZArchive<R> {
         common::push_disallowed_extension_warning(&mut accumulated, ctx.disallowed_extension_skips);
 
         let e = match result {
-            Ok(()) => return Ok(accumulated),
-            // A stashed `pending_io_error` takes priority: it means
+            Ok(()) => {
+                // `pending_error` is only ever set immediately before
+                // `process_entry_inner` returns an `Err` for the same entry
+                // (issue #483 S1 pattern); if the overall callback loop
+                // succeeded, nothing should have stashed a pending error.
+                debug_assert!(
+                    ctx.pending_error.is_none(),
+                    "pending_error must be unset when for_each_entries reports success"
+                );
+                return Ok(accumulated);
+            }
+            // A stashed `pending_error` takes priority: it means
             // `process_entry_inner` already resolved the precise error and
             // the `sevenz_rust2::Error` in `e` is just a same-iteration abort
             // signal, not the real failure (issue #483 S1).
             Err(e) => ctx
-                .pending_io_error
+                .pending_error
                 .take()
-                .map_or_else(|| ArchiveError::from(e), ArchiveError::Io),
+                .unwrap_or_else(|| ArchiveError::from(e)),
         };
         Err(ArchiveError::partial_or(accumulated, e))
     }
@@ -1246,13 +1339,20 @@ mod tests {
         let mut next_candidate = 0u32;
         let temp_dir_path = temp.path().to_path_buf();
         let mut reader = Cursor::new(b"legit content".to_vec());
-        let bytes_written =
-            write_file_with_permit_using(&mut reader, &dest_path, test_permit(), || {
+        let mut copy_buffer = CopyBuffer::new();
+        let bytes_written = write_file_with_permit_using(
+            &mut reader,
+            &dest_path,
+            13,
+            &mut copy_buffer,
+            test_permit(),
+            || {
                 let path = temp_dir_path.join(format!(".candidate-{next_candidate}.tmp"));
                 next_candidate += 1;
                 path
-            })
-            .expect("should retry past every planted symlink and succeed");
+            },
+        )
+        .expect("should retry past every planted symlink and succeed");
 
         assert_eq!(bytes_written, 13);
         assert_eq!(std::fs::read(&dest_path).unwrap(), b"legit content");
@@ -1297,11 +1397,19 @@ mod tests {
         let mut next_candidate = 0u32;
         let temp_dir_path = temp.path().to_path_buf();
         let mut reader = Cursor::new(b"legit content".to_vec());
-        let result = write_file_with_permit_using(&mut reader, &dest_path, test_permit(), || {
-            let path = temp_dir_path.join(format!(".candidate-{next_candidate}.tmp"));
-            next_candidate += 1;
-            path
-        });
+        let mut copy_buffer = CopyBuffer::new();
+        let result = write_file_with_permit_using(
+            &mut reader,
+            &dest_path,
+            13,
+            &mut copy_buffer,
+            test_permit(),
+            || {
+                let path = temp_dir_path.join(format!(".candidate-{next_candidate}.tmp"));
+                next_candidate += 1;
+                path
+            },
+        );
 
         assert!(
             result.is_err(),
@@ -1312,6 +1420,84 @@ mod tests {
         for victim_path in &victims {
             assert!(!victim_path.exists());
         }
+    }
+
+    /// Regression test for GHSA-5j8q-wxg5-hj4r on 7z's fast write path
+    /// (`write_file_direct`, used when nothing occupies the destination): a
+    /// reader producing far more bytes than `expected_size` (standing in for
+    /// a forged `entry.size` from 7z's own archive metadata) must abort with
+    /// an error and must not leave an oversized file on disk.
+    #[test]
+    #[cfg(unix)]
+    fn test_write_file_direct_forged_size_aborts_and_cleans_up() {
+        let temp = TempDir::new().unwrap();
+        let dest_path = temp.path().join("bomb.bin");
+
+        let real_data = vec![0x41u8; 200 * 1024];
+        let mut reader = Cursor::new(&real_data);
+        let mut copy_buffer = CopyBuffer::new();
+
+        let result =
+            write_file_direct(&mut reader, &dest_path, 50, &mut copy_buffer, test_permit());
+
+        assert!(
+            result.is_err(),
+            "streaming past expected_size must abort, got: {result:?}"
+        );
+        match result {
+            Err(ArchiveError::SecurityViolation { reason }) => {
+                assert!(
+                    reason.contains("50 bytes"),
+                    "error must name the declared ceiling (50), got: {reason:?}"
+                );
+            }
+            other => {
+                panic!("expected SecurityViolation naming the 50-byte ceiling, got: {other:?}")
+            }
+        }
+        assert!(
+            !dest_path.exists(),
+            "aborted write_file_direct must not leave a file on disk"
+        );
+    }
+
+    /// Same as [`test_write_file_direct_forged_size_aborts_and_cleans_up`]
+    /// but for the overwrite path (`write_file_with_permit`, temp-file +
+    /// rename): the forged-size abort must clean up the temp file and must
+    /// never reach `rename`, so the pre-existing destination is untouched.
+    #[test]
+    #[cfg(unix)]
+    fn test_write_file_with_permit_forged_size_aborts_and_leaves_original_untouched() {
+        let temp = TempDir::new().unwrap();
+        let dest_path = temp.path().join("existing.bin");
+        std::fs::write(&dest_path, b"original content").unwrap();
+
+        let real_data = vec![0x41u8; 200 * 1024];
+        let mut reader = Cursor::new(&real_data);
+        let mut copy_buffer = CopyBuffer::new();
+
+        let result =
+            write_file_with_permit(&mut reader, &dest_path, 50, &mut copy_buffer, test_permit());
+
+        assert!(
+            result.is_err(),
+            "streaming past expected_size must abort, got: {result:?}"
+        );
+        assert_eq!(
+            std::fs::read(&dest_path).unwrap(),
+            b"original content",
+            "aborted overwrite must leave the pre-existing destination untouched"
+        );
+        // No stray temp file (`.existing.bin.exarch-tmp-*`) left behind.
+        let leftovers: Vec<_> = std::fs::read_dir(temp.path())
+            .unwrap()
+            .filter_map(std::result::Result::ok)
+            .filter(|e| e.file_name() != dest_path.file_name().unwrap())
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "aborted write must not leave a temp file behind, found: {leftovers:?}"
+        );
     }
 
     #[test]
@@ -2234,7 +2420,8 @@ mod tests {
         let mut report = ExtractionReport::new();
         let mut duplicate_skips = 0u64;
         let mut disallowed_extension_skips = 0u64;
-        let mut pending_io_error = None;
+        let mut pending_error = None;
+        let mut copy_buffer = CopyBuffer::new();
 
         let mut entry = sevenz_rust2::ArchiveEntry::new_file("../../evil.txt");
         entry.has_stream = true;
@@ -2253,7 +2440,8 @@ mod tests {
             &config,
             &mut duplicate_skips,
             &mut disallowed_extension_skips,
-            &mut pending_io_error,
+            &mut pending_error,
+            &mut copy_buffer,
         );
 
         assert_matches!(
@@ -2281,7 +2469,8 @@ mod tests {
         let mut report = ExtractionReport::new();
         let mut duplicate_skips = u64::MAX;
         let mut disallowed_extension_skips = 0u64;
-        let mut pending_io_error = None;
+        let mut pending_error = None;
+        let mut copy_buffer = CopyBuffer::new();
 
         let mut entry = sevenz_rust2::ArchiveEntry::new_file("existing.txt");
         entry.has_stream = true;
@@ -2300,7 +2489,8 @@ mod tests {
             &config,
             &mut duplicate_skips,
             &mut disallowed_extension_skips,
-            &mut pending_io_error,
+            &mut pending_error,
+            &mut copy_buffer,
         );
 
         assert_matches!(

--- a/crates/exarch-core/tests/security/mod.rs
+++ b/crates/exarch-core/tests/security/mod.rs
@@ -8,3 +8,4 @@ mod symlink_target_validation;
 mod tar_budget_parity;
 mod tar_ghsa_2026;
 mod tar_metadata_bomb;
+mod zip_ghsa_5j8q;

--- a/crates/exarch-core/tests/security/zip_ghsa_5j8q.rs
+++ b/crates/exarch-core/tests/security/zip_ghsa_5j8q.rs
@@ -1,0 +1,240 @@
+//! Regression test for GHSA-5j8q-wxg5-hj4r: ZIP extraction trusted the
+//! archive-declared `uncompressed_size` field for zip-bomb ratio detection
+//! and quota reservation, but never verified it against the number of bytes
+//! actually produced by DEFLATE decompression. A ZIP entry could declare a
+//! small `uncompressed_size` (passing both checks) while its real DEFLATE
+//! stream decompressed to an arbitrarily large payload, since the copy loop
+//! had no ceiling tied to the declared/reserved size.
+//!
+//! This constructs a real, spec-valid DEFLATE ZIP entry at the raw byte
+//! level (the `zip` crate's writer computes sizes itself and cannot be made
+//! to lie), so the forged header is read by the same DEFLATE decompression
+//! path production traffic uses, not a mock.
+
+#![allow(clippy::unwrap_used, clippy::cast_possible_truncation)]
+
+use exarch_core::ArchiveError;
+use exarch_core::ExtractionOptions;
+use exarch_core::SecurityConfig;
+use exarch_core::formats::ArchiveFormat;
+use exarch_core::formats::ZipArchive;
+use flate2::Compression;
+use flate2::write::DeflateEncoder;
+use std::io::Cursor;
+use std::io::Write;
+use tempfile::TempDir;
+
+/// CRC32 (IEEE 802.3 polynomial) for raw ZIP construction.
+fn crc32_ieee(data: &[u8]) -> u32 {
+    let mut crc: u32 = 0xFFFF_FFFF;
+    for &byte in data {
+        crc ^= u32::from(byte);
+        for _ in 0..8 {
+            if crc & 1 != 0 {
+                crc = (crc >> 1) ^ 0xEDB8_8320;
+            } else {
+                crc >>= 1;
+            }
+        }
+    }
+    !crc
+}
+
+/// Raw-DEFLATEs `data` (RFC 1951, no zlib/gzip wrapper), the format ZIP's
+/// compression method 8 requires.
+fn deflate(data: &[u8]) -> Vec<u8> {
+    let mut encoder = DeflateEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(data).unwrap();
+    encoder.finish().unwrap()
+}
+
+/// Builds a single-entry, spec-valid DEFLATE ZIP archive whose local file
+/// header and central directory both declare `declared_uncompressed_size`
+/// for `entry_name`, regardless of what `real_payload` actually decompresses
+/// to. Mirrors the `PoC` shape from the advisory: a forged small
+/// `uncompressed_size` alongside a real, much larger compressed stream.
+#[allow(clippy::cast_possible_truncation)]
+fn build_forged_size_zip(
+    entry_name: &str,
+    real_payload: &[u8],
+    declared_uncompressed_size: u32,
+) -> Vec<u8> {
+    let compressed = deflate(real_payload);
+    let crc = crc32_ieee(real_payload);
+    let name_bytes = entry_name.as_bytes();
+    let name_len = name_bytes.len() as u16;
+    let compressed_len = compressed.len() as u32;
+
+    let mut buf: Vec<u8> = Vec::new();
+    let local_offset = 0u32;
+
+    // Local file header
+    buf.extend_from_slice(b"PK\x03\x04");
+    buf.extend_from_slice(&20u16.to_le_bytes()); // version needed (DEFLATE)
+    buf.extend_from_slice(&0u16.to_le_bytes()); // flags (no data descriptor)
+    buf.extend_from_slice(&8u16.to_le_bytes()); // compression: DEFLATE
+    buf.extend_from_slice(&0u16.to_le_bytes()); // mod time
+    buf.extend_from_slice(&0u16.to_le_bytes()); // mod date
+    buf.extend_from_slice(&crc.to_le_bytes());
+    buf.extend_from_slice(&compressed_len.to_le_bytes()); // compressed size (accurate)
+    buf.extend_from_slice(&declared_uncompressed_size.to_le_bytes()); // FORGED
+    buf.extend_from_slice(&name_len.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes()); // extra field length
+    buf.extend_from_slice(name_bytes);
+    buf.extend_from_slice(&compressed);
+
+    let central_dir_offset = buf.len() as u32;
+
+    // Central directory file header
+    buf.extend_from_slice(b"PK\x01\x02");
+    buf.extend_from_slice(&0x031eu16.to_le_bytes()); // version made by: Unix
+    buf.extend_from_slice(&20u16.to_le_bytes()); // version needed
+    buf.extend_from_slice(&0u16.to_le_bytes()); // flags
+    buf.extend_from_slice(&8u16.to_le_bytes()); // compression: DEFLATE
+    buf.extend_from_slice(&0u16.to_le_bytes()); // mod time
+    buf.extend_from_slice(&0u16.to_le_bytes()); // mod date
+    buf.extend_from_slice(&crc.to_le_bytes());
+    buf.extend_from_slice(&compressed_len.to_le_bytes()); // compressed size (accurate)
+    buf.extend_from_slice(&declared_uncompressed_size.to_le_bytes()); // FORGED
+    buf.extend_from_slice(&name_len.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes()); // extra length
+    buf.extend_from_slice(&0u16.to_le_bytes()); // comment length
+    buf.extend_from_slice(&0u16.to_le_bytes()); // disk number start
+    buf.extend_from_slice(&0u16.to_le_bytes()); // internal attributes
+    buf.extend_from_slice(&(0o100_644u32 << 16).to_le_bytes()); // external attributes
+    buf.extend_from_slice(&local_offset.to_le_bytes());
+    buf.extend_from_slice(name_bytes);
+
+    let central_dir_size = (buf.len() as u32) - central_dir_offset;
+
+    // End of central directory record
+    buf.extend_from_slice(b"PK\x05\x06");
+    buf.extend_from_slice(&0u16.to_le_bytes()); // disk number
+    buf.extend_from_slice(&0u16.to_le_bytes()); // disk with central dir
+    buf.extend_from_slice(&1u16.to_le_bytes()); // entries on this disk
+    buf.extend_from_slice(&1u16.to_le_bytes()); // total entries
+    buf.extend_from_slice(&central_dir_size.to_le_bytes());
+    buf.extend_from_slice(&central_dir_offset.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes()); // comment length
+
+    buf
+}
+
+/// Reproduces the advisory `PoC`: a ZIP entry declares `uncompressed_size = 50`
+/// in both the local file header and the central directory, but its DEFLATE
+/// stream really decompresses to several megabytes of repeated data. Both
+/// the zip-bomb ratio check and the quota pre-check only see the declared
+/// 50-byte size and pass; the streaming ceiling added for GHSA-5j8q-wxg5-hj4r
+/// must be what actually stops the oversized write.
+#[test]
+fn ghsa_5j8q_forged_small_uncompressed_size_aborts_and_cleans_up() {
+    let dest = TempDir::new().unwrap();
+    let config = SecurityConfig::default().validate().unwrap();
+
+    // Highly compressible so the real DEFLATE stream is tiny while still
+    // decompressing to several megabytes — the same shape a real
+    // decompression-bomb PoC uses.
+    let real_payload = vec![0x41u8; 4 * 1024 * 1024];
+    let data = build_forged_size_zip("bomb.txt", &real_payload, 50);
+
+    let mut archive = ZipArchive::new(Cursor::new(data)).unwrap();
+    let result = archive.extract(
+        dest.path(),
+        &config,
+        &ExtractionOptions::default(),
+        &mut exarch_core::NoopProgress,
+    );
+
+    match result {
+        Err(ArchiveError::SecurityViolation { reason }) => {
+            assert!(
+                reason.contains("50 bytes"),
+                "error must name the declared 50-byte ceiling, got: {reason:?}"
+            );
+        }
+        other => panic!("expected SecurityViolation naming the 50-byte ceiling, got: {other:?}"),
+    }
+
+    let extracted_path = dest.path().join("bomb.txt");
+    assert!(
+        !extracted_path.exists(),
+        "aborted extraction must not leave a partial or oversized file on disk"
+    );
+}
+
+/// Companion case: the declared size is forged to be *larger* than what the
+/// stream actually produces (an undersized real payload). This must also be
+/// rejected once the stream reaches EOF short of the declared size, even
+/// though it never trips the streaming ceiling.
+///
+/// Uses a compression-ratio-safe shape deliberately: the real payload is
+/// low-entropy but not compressible enough to make declared/compressed
+/// exceed `max_compression_ratio` (100:1) on its own, so this test actually
+/// exercises the new post-copy exact-match check in `copy_with_buffer`
+/// rather than being rejected earlier by the pre-existing `ZipBomb` ratio
+/// check (a previous version of this test used a tiny real payload declared
+/// as 1,000,000 bytes, which tripped `ZipBomb` before the new code ever ran).
+#[test]
+fn ghsa_5j8q_forged_oversized_declared_size_rejected_after_eof() {
+    let dest = TempDir::new().unwrap();
+    let config = SecurityConfig::default().validate().unwrap();
+
+    let real_payload: Vec<u8> = (0..10_000u32).map(|i| (i % 251) as u8).collect();
+    let declared = real_payload.len() as u32 * 2;
+    let data = build_forged_size_zip("liar.txt", &real_payload, declared);
+
+    let mut archive = ZipArchive::new(Cursor::new(data)).unwrap();
+    let result = archive.extract(
+        dest.path(),
+        &config,
+        &ExtractionOptions::default(),
+        &mut exarch_core::NoopProgress,
+    );
+
+    match result {
+        Err(ArchiveError::SecurityViolation { reason }) => {
+            assert!(
+                reason.contains(&declared.to_string()),
+                "error must name the declared size ({declared}), got: {reason:?}"
+            );
+        }
+        other => panic!(
+            "expected SecurityViolation from the post-copy exact-match check, got: {other:?}"
+        ),
+    }
+    assert!(
+        !dest.path().join("liar.txt").exists(),
+        "rejected entry must not leave a truncated file on disk"
+    );
+}
+
+/// Sanity check that the raw builder produces a well-formed archive when
+/// sizes are declared accurately, isolating the forged-size tests above from
+/// a bug in the builder itself.
+#[test]
+fn forged_size_zip_builder_round_trips_when_size_is_accurate() {
+    let dest = TempDir::new().unwrap();
+    let config = SecurityConfig::default().validate().unwrap();
+
+    // Low-repetition bytes so DEFLATE cannot compress this below the
+    // default max_compression_ratio (100:1) and trigger an unrelated
+    // ZipBomb rejection.
+    let real_payload: Vec<u8> = (0..10_000u32).map(|i| (i % 251) as u8).collect();
+    let declared = real_payload.len() as u32;
+    let data = build_forged_size_zip("honest.txt", &real_payload, declared);
+
+    let mut archive = ZipArchive::new(Cursor::new(data)).unwrap();
+    let result = archive.extract(
+        dest.path(),
+        &config,
+        &ExtractionOptions::default(),
+        &mut exarch_core::NoopProgress,
+    );
+
+    assert!(
+        result.is_ok(),
+        "accurate size must extract cleanly: {result:?}"
+    );
+    let extracted = std::fs::read(dest.path().join("honest.txt")).unwrap();
+    assert_eq!(extracted, real_payload);
+}


### PR DESCRIPTION
## Summary

- ZIP, TAR, and 7z extraction trusted the archive-declared uncompressed size for zip-bomb ratio detection (`validate_compression_ratio`) and quota reservation (`QuotaTracker`), but never verified it against the number of bytes actually produced by decompression, letting a forged small declared size bypass both defenses entirely while the real payload streamed to disk unbounded.
- `copy_with_buffer` now enforces the declared size as a hard streaming ceiling checked after every buffered read, and rejects a short stream at EOF as a `SecurityViolation`. Wired through the shared `extract_file_with_permit` path (TAR/ZIP) and 7z's write path, which previously bypassed the shared copy function entirely via `std::io::copy`.
- Partial files are cleaned up on abort via `TempFileGuard`, scoped to the create-new path only, so `--force` no longer additionally deletes a pre-existing destination on an aborted forged entry.
- 7z's `CopyBuffer` is now allocated once per archive (hoisted into `SzContext`) instead of per entry, avoiding a perf regression against the #492 baseline — confirmed via `cargo bench -p exarch-core --bench extraction -- sevenz_vs_reference` (no regression, still faster than the `sevenz_rust2` reference).

Fixes the advisory at https://github.com/bug-ops/exarch/security/advisories/GHSA-5j8q-wxg5-hj4r (critical, P0).

This went through the full team-develop security review chain: implementation, an adversarial critique (which caught a misleading error hint, a vacuous regression test, and the 7z buffer-allocation regression risk — all fixed), a mandatory `rust-security-maintenance` audit (which live-verified the PoC is closed and `cargo deny`/`cargo audit` are clean), and an independent code review that re-ran the full check suite and re-verified the fixes.

## Test plan

- [x] New regression test reproducing the advisory's PoC shape (forged small `uncompressed_size` + real large decompressed payload) via the public `ZipArchive::extract` API — confirms extraction aborts with `SecurityViolation` and leaves no file on disk
- [x] New regression test for the EOF short-stream mismatch direction (ratio-safe shape, so it actually exercises the new check rather than the pre-existing `ZipBomb` ratio check)
- [x] New regression test confirming `--force` no longer deletes a pre-existing destination on an aborted forged entry
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node`
- [x] `cargo test --doc --workspace --all-features`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace`
- [x] `cargo deny check` / `cargo audit`
- [x] `cargo bench -p exarch-core --bench extraction -- sevenz_vs_reference` (no regression from hoisting `CopyBuffer`)
- [x] Live PoC re-verified against the built CLI binary with a hand-forged ZIP