### PR TITLE
refactor(core): extract shared helper for checked files_skipped increment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Duplicate-file, duplicate-symlink, and duplicate-hardlink skip paths now share a
+  `common::checked_increment_files_skipped` helper (#518)** instead of repeating the same
+  checked-add-with-overflow-guard increment inline in `formats::common::extract_file_with_permit`,
+  `formats::common::create_symlink`, and `formats::tar::create_hardlink`. No behavior change; 7z's
+  analogous site is out of scope since it runs inside a `sevenz_rust2::Error`-returning closure and
+  cannot share this helper's signature.
 - **`formats::sevenz::extract_archive` now builds its duplicate-skip warning via the shared
   `common::push_duplicate_skip_warning` helper (#499)**, matching the TAR and ZIP handlers instead
   of re-implementing the singular/plural aggregation inline. No behavior or message change.

--- a/crates/exarch-core/src/formats/common.rs
+++ b/crates/exarch-core/src/formats/common.rs
@@ -405,6 +405,44 @@ pub fn push_disallowed_extension_warning(report: &mut ExtractionReport, count: u
     }
 }
 
+/// Increments `report.files_skipped`, failing closed with
+/// `QuotaExceeded { resource: IntegerOverflow }` instead of wrapping if the
+/// counter is already at its maximum.
+///
+/// Shared by the TAR and ZIP extractors' duplicate-file, duplicate-symlink,
+/// and duplicate-hardlink skip paths, which all perform this exact checked
+/// increment before recording the skip in their own per-cause counter (issue
+/// #518). 7z performs the same guard inline in `sevenz.rs` because it must
+/// return a `sevenz_rust2::Error`, not this function's `Result`.
+///
+/// # Errors
+///
+/// Returns [`ArchiveError::QuotaExceeded`] with
+/// [`QuotaResource::IntegerOverflow`] if `report.files_skipped` is already at
+/// its maximum value.
+///
+/// # Examples
+///
+/// ```ignore
+/// # use exarch_core::formats::common::checked_increment_files_skipped;
+/// # use exarch_core::ExtractionReport;
+/// let mut report = ExtractionReport::new();
+/// checked_increment_files_skipped(&mut report)?;
+/// assert_eq!(report.files_skipped, 1);
+/// # Ok::<(), exarch_core::ArchiveError>(())
+/// ```
+#[inline]
+pub fn checked_increment_files_skipped(report: &mut ExtractionReport) -> Result<()> {
+    report.files_skipped =
+        report
+            .files_skipped
+            .checked_add(1)
+            .ok_or(ArchiveError::QuotaExceeded {
+                resource: QuotaResource::IntegerOverflow,
+            })?;
+    Ok(())
+}
+
 /// Returns `true` if `path`'s extension passes `config`'s allowlist.
 ///
 /// If the extension is not allowed, records the skip (increments
@@ -719,13 +757,7 @@ pub fn extract_file_with_permit<R: Read>(
     let output_file = match create_file_with_mode(&output_path, mode, skip_duplicates) {
         Ok(file) => file,
         Err(e) if skip_duplicates && e.kind() == std::io::ErrorKind::AlreadyExists => {
-            report.files_skipped =
-                report
-                    .files_skipped
-                    .checked_add(1)
-                    .ok_or(ArchiveError::QuotaExceeded {
-                        resource: QuotaResource::IntegerOverflow,
-                    })?;
+            checked_increment_files_skipped(report)?;
             *duplicate_skips = duplicate_skips.saturating_add(1);
             return Ok(());
         }
@@ -869,13 +901,7 @@ pub fn create_symlink(
 
         if link_path.symlink_metadata().is_ok() {
             if skip_duplicates {
-                report.files_skipped =
-                    report
-                        .files_skipped
-                        .checked_add(1)
-                        .ok_or(ArchiveError::QuotaExceeded {
-                            resource: QuotaResource::IntegerOverflow,
-                        })?;
+                checked_increment_files_skipped(report)?;
                 *duplicate_skips = duplicate_skips.saturating_add(1);
                 return Ok(());
             }

--- a/crates/exarch-core/src/formats/tar.rs
+++ b/crates/exarch-core/src/formats/tar.rs
@@ -389,11 +389,7 @@ impl<R: Read> TarArchive<R> {
             Ok(file) => file,
             Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
                 if ctx.skip_duplicates {
-                    ctx.report.files_skipped = ctx.report.files_skipped.checked_add(1).ok_or(
-                        ArchiveError::QuotaExceeded {
-                            resource: crate::QuotaResource::IntegerOverflow,
-                        },
-                    )?;
+                    common::checked_increment_files_skipped(ctx.report)?;
                     *ctx.hardlink_duplicate_skips = ctx.hardlink_duplicate_skips.saturating_add(1);
                     return Ok(());
                 }


### PR DESCRIPTION
## Summary
- Extracted `common::checked_increment_files_skipped(report: &mut ExtractionReport) -> Result<()>` in `crates/exarch-core/src/formats/common.rs`, replacing the byte-for-byte identical `checked_add(1).ok_or(ArchiveError::QuotaExceeded { resource: QuotaResource::IntegerOverflow })` pattern at three call sites:
  - `extract_file_with_permit` (duplicate-file skip)
  - `create_symlink` (duplicate-symlink skip)
  - `tar::create_hardlink` (duplicate-hardlink skip)
- Pure refactor, no behavior change. Mirrors the precedent set by `check_extension_allowed` and `push_duplicate_skip_warning` for this exact class of duplication.
- 7z's analogous site (`formats/sevenz.rs:628-631`) intentionally left untouched — it lives inside a `sevenz_rust2::Error`-returning closure and cannot share this helper's signature.

Closes #518

## Test plan
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` (1182/1182 passed)
- [x] `cargo test --doc --workspace --all-features` (117 passed, 28 ignored)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] `CHANGELOG.md` updated under `[Unreleased]`