### PR TITLE
fix(cli): preserve destination on atomic force failure, fix violation hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -251,6 +251,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`exarch-cli`: `extract --atomic --force` deleted a pre-existing destination directory before
+  extraction was known to succeed, defeating the point of `--atomic` (#519)**: `commands/extract.rs`
+  pre-removed `output_dir` with `remove_dir_all` so the subsequent rename in `exarch-core`'s
+  `extract_atomic` (which refuses to replace an existing directory by design) would succeed — but
+  the removal ran before extraction was attempted, so a failed extraction (security violation,
+  malformed archive, disk full, etc.) left the original destination permanently gone with no
+  recovery, worse than plain `--force`. The CLI no longer pre-deletes; for this specific combination
+  it now extracts into a temp directory beside the destination (non-atomic), and only after
+  extraction fully succeeds does it perform its own swap: the existing destination is renamed aside
+  to a backup path, the extracted content is renamed into place, and only then is the backup
+  removed. If the final rename into place fails, the backup is renamed back and the CLI reports
+  clearly whether that restore succeeded — including the backup path if it didn't, so the original
+  content can still be recovered manually. A pre-existing destination that exists but is not a
+  directory (e.g. a regular file) is now rejected with an explicit error instead of being silently
+  replaced. Any other `--atomic`/`--force` combination is unaffected.
+- **`exarch-cli`: the `SecurityViolation` HINT suggested policy flags (`--allow-symlinks`,
+  `--allow-hardlinks`, `--allow-solid-archives`, `--banned-component`) even for violations none of
+  those flags control — most notably the GHSA-5j8q-wxg5-hj4r declared/decompressed size mismatch,
+  but also roughly ten other reasons such as password-protected archives, unsupported compression
+  methods, or invalid entry paths (#520)**: `error.rs`'s `convert_extraction_error` attached the
+  same generic HINT to every `SecurityViolation` regardless of `reason` (a free-form `String`, not
+  a structured enum). It now checks `reason` against the known prefixes exarch-core uses for the
+  four categories the flags actually relax and only shows the flag-specific HINT for those; every
+  other `SecurityViolation` gets a HINT stating that it cannot be relaxed via any policy flag.
 - **`exarch-core`: `files_skipped` was incremented via a plain `+= 1` in six sites across
   extraction and creation, inconsistent with the `checked_add`-based hardening already applied to
   TAR's own `files_skipped` counter (#515)**: `formats/common.rs`'s `check_extension_allowed`,

--- a/crates/exarch-cli/Cargo.toml
+++ b/crates/exarch-cli/Cargo.toml
@@ -24,13 +24,13 @@ exarch-core.workspace = true
 indicatif = { workspace = true, features = ["improved_unicode"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+tempfile.workspace = true
 
 [dev-dependencies]
 assert_cmd.workspace = true
 flate2.workspace = true
 predicates.workspace = true
 tar.workspace = true
-tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/crates/exarch-cli/src/commands/extract.rs
+++ b/crates/exarch-cli/src/commands/extract.rs
@@ -34,6 +34,109 @@ fn run_extraction(
     )
 }
 
+/// Extracts into a fresh temp directory next to `output_dir`, then swaps it
+/// into place over the pre-existing `output_dir`.
+///
+/// Used only for `--atomic --force` when `output_dir` already exists. Core's
+/// own atomic path (`ExtractionOptions::atomic`) never replaces an existing
+/// directory, so this performs the replacement itself, strictly after
+/// extraction has already succeeded: the original destination is moved aside
+/// to a backup path, the extracted content is moved into place, and only
+/// then is the backup removed. If moving the extracted content into place
+/// fails, the backup is moved back so the original destination is restored.
+fn run_atomic_force_extraction(
+    archive: &Path,
+    output_dir: &Path,
+    config: &SecurityConfig,
+    options: &ExtractionOptions,
+    progress: &mut dyn ProgressCallback,
+    allow_symlinks: bool,
+) -> Result<ExtractionReport> {
+    let canonical_output = output_dir
+        .canonicalize()
+        .with_context(|| format!("failed to resolve destination: {}", output_dir.display()))?;
+    let parent = canonical_output
+        .parent()
+        .with_context(|| format!("destination has no parent: {}", output_dir.display()))?;
+
+    let temp_dir = tempfile::tempdir_in(parent)
+        .with_context(|| format!("failed to create temp directory in {}", parent.display()))?;
+
+    let report = run_extraction(
+        archive,
+        temp_dir.path(),
+        config,
+        options,
+        progress,
+        allow_symlinks,
+    )?;
+
+    // Extraction succeeded. Reserve a unique, currently-vacant sibling path
+    // for the backup: renaming onto an existing path (even an empty
+    // directory) is unsupported on Windows, so the reserved path must be
+    // freed before use.
+    let backup_dir = tempfile::tempdir_in(parent)
+        .with_context(|| format!("failed to reserve backup path in {}", parent.display()))?;
+    let backup_path = backup_dir.keep();
+    std::fs::remove_dir(&backup_path)
+        .with_context(|| format!("failed to free backup path: {}", backup_path.display()))?;
+
+    std::fs::rename(&canonical_output, &backup_path).with_context(|| {
+        format!(
+            "failed to move existing destination {} aside before replacing it",
+            canonical_output.display()
+        )
+    })?;
+
+    let temp_path = temp_dir.keep();
+    if let Err(e) = std::fs::rename(&temp_path, &canonical_output) {
+        // Restore the original destination; the new extraction is discarded.
+        // The restore's own outcome must be checked, not assumed: claiming
+        // "restored" when the rename-back itself failed would tell the user
+        // their data is safe while it actually sits at an unprinted temp path.
+        let restore_result = std::fs::rename(&backup_path, &canonical_output);
+        let _ = std::fs::remove_dir_all(&temp_path);
+        return Err(e).with_context(|| match restore_result {
+            Ok(()) => format!(
+                "failed to move extracted content into {}; original destination restored",
+                canonical_output.display()
+            ),
+            Err(restore_err) => format!(
+                "failed to move extracted content into {}; the original destination could NOT \
+                 be restored ({restore_err}) — its original contents are preserved at {} and \
+                 must be recovered manually",
+                canonical_output.display(),
+                backup_path.display()
+            ),
+        });
+    }
+
+    let _ = std::fs::remove_dir_all(&backup_path);
+
+    Ok(report)
+}
+
+/// Determines whether `--atomic --force` must replace a pre-existing
+/// `output_dir` via [`run_atomic_force_extraction`].
+///
+/// Gated on `is_dir()`, not `exists()`: a pre-existing non-directory
+/// destination (a regular file, a symlink to one, etc.) must never be
+/// silently replaced by the swap — that would reproduce the exact data-loss
+/// class #519 was filed for, just on a different destination type. Returns
+/// an error instead of proceeding when that happens.
+fn resolve_atomic_force_replace(args: &ExtractArgs, output_dir: &Path) -> Result<bool> {
+    if !(args.atomic && args.force && output_dir.exists()) {
+        return Ok(false);
+    }
+    if !output_dir.is_dir() {
+        anyhow::bail!(
+            "cannot use --atomic --force: destination {} already exists and is not a directory",
+            output_dir.display()
+        );
+    }
+    Ok(true)
+}
+
 /// Expands a list of extension tokens that may contain comma-separated values
 /// into individual lowercase extension strings without leading dots.
 fn parse_extensions(raw: &[String]) -> Vec<String> {
@@ -185,18 +288,17 @@ pub fn execute(
             .count()
     };
 
-    let options = ExtractionOptions::default()
-        .with_atomic(args.atomic)
-        .with_skip_duplicates(!args.force);
+    // --atomic + --force over a pre-existing destination needs a swap that
+    // core's `extract_atomic` doesn't perform itself (it refuses to replace
+    // an existing directory, by design, so a pre-existing destination is
+    // never touched if extraction fails). The CLI performs that swap only
+    // after extraction has already fully succeeded; see
+    // `run_atomic_force_extraction`.
+    let atomic_force_replace = resolve_atomic_force_replace(args, &output_dir)?;
 
-    // When --atomic + --force: remove existing destination after successful
-    // extraction (handled inside extract_atomic via rename semantics) but we
-    // must pre-remove if it exists so rename can succeed (on most platforms
-    // rename over an existing non-empty dir fails).
-    if args.atomic && args.force && output_dir.exists() {
-        std::fs::remove_dir_all(&output_dir)
-            .with_context(|| format!("failed to remove existing dir: {}", output_dir.display()))?;
-    }
+    let options = ExtractionOptions::default()
+        .with_atomic(args.atomic && !atomic_force_replace)
+        .with_skip_duplicates(!args.force);
 
     let mut progress: Box<dyn ProgressCallback> = if verbose {
         Box::new(VerboseProgress::new())
@@ -206,14 +308,25 @@ pub fn execute(
         Box::new(NoopProgress)
     };
 
-    let report = run_extraction(
-        &args.archive,
-        &output_dir,
-        &config,
-        &options,
-        progress.as_mut(),
-        args.allow_symlinks,
-    )?;
+    let report = if atomic_force_replace {
+        run_atomic_force_extraction(
+            &args.archive,
+            &output_dir,
+            &config,
+            &options,
+            progress.as_mut(),
+            args.allow_symlinks,
+        )?
+    } else {
+        run_extraction(
+            &args.archive,
+            &output_dir,
+            &config,
+            &options,
+            progress.as_mut(),
+            args.allow_symlinks,
+        )?
+    };
 
     formatter.format_extraction_result(&report)?;
 

--- a/crates/exarch-cli/src/error.rs
+++ b/crates/exarch-cli/src/error.rs
@@ -84,6 +84,38 @@ impl fmt::Display for PartialExtractionContext {
 
 impl std::error::Error for PartialExtractionContext {}
 
+/// Fixed literal prefixes `exarch-core` builds `SecurityViolation.reason`
+/// strings from for the four categories the CLI's policy flags
+/// (`--allow-symlinks`, `--allow-hardlinks`, `--allow-solid-archives`,
+/// `--banned-component`) actually relax. Verified against the exact
+/// construction call sites: `types/safe_symlink.rs`, `security/hardlink.rs`,
+/// `formats/sevenz.rs`, and `types/safe_path.rs` / `types/safe_symlink.rs`
+/// (banned components can appear either in the entry path itself or in a
+/// symlink's target, hence two prefixes for that one category).
+const RELAXABLE_VIOLATION_PREFIXES: &[&str] = &[
+    "symlinks not allowed",
+    "hardlinks not allowed",
+    "solid 7z archives are not allowed",
+    "banned path component:",
+    "symlink target contains banned component:",
+];
+
+/// Returns `true` if `reason` names a `SecurityViolation` category one of the
+/// CLI's policy flags can actually relax.
+///
+/// Matches with `starts_with`, anchored at the very beginning of `reason`:
+/// each prefix above is the fixed literal text `exarch-core` writes before
+/// any attacker-controlled data (an entry path, a component name, etc.), so
+/// a forged archive cannot spoof this classification by choosing path
+/// components that happen to contain one of these prefixes elsewhere in the
+/// string — only a `reason` that genuinely originates from one of these
+/// call sites starts with it.
+fn is_relaxable_by_policy_flag(reason: &str) -> bool {
+    RELAXABLE_VIOLATION_PREFIXES
+        .iter()
+        .any(|prefix| reason.starts_with(prefix))
+}
+
 /// Converts `ArchiveError` to user-friendly anyhow error with context.
 ///
 /// The original `ArchiveError` is preserved as the error source so that
@@ -185,12 +217,32 @@ pub fn convert_extraction_error(
         ArchiveError::InvalidCompressionLevel { level } => {
             format!("Invalid compression level {level}: must be between 1 and 9.")
         }
-        ArchiveError::SecurityViolation { .. } => format!(
-            "Security violation while processing '{}'\n\
-             HINT: If this archive is from a trusted source, relax the relevant policy flag \
-             (--allow-symlinks, --allow-hardlinks, --allow-solid-archives, --banned-component).",
-            archive.display(),
-        ),
+        // `SecurityViolation.reason` is a free-form String with no structured
+        // variant to distinguish its cause, and the CLI's four policy flags
+        // only relax a handful of them (symlinks, hardlinks, solid archives,
+        // banned components) — roughly a dozen others (GHSA-5j8q-wxg5-hj4r's
+        // declared/decompressed size mismatch, encrypted/password-protected
+        // entries, unsupported compression methods, oversized symlink
+        // targets, disallowed TAR entry types, null bytes or empty/oversized
+        // paths, etc.) cannot be relaxed by any flag at all. Rather than
+        // special-casing the one known mismatch, classify by the fixed
+        // literal prefix each relaxable category's reason is built from (see
+        // `is_relaxable_by_policy_flag`) and give every non-matching reason a
+        // HINT that does not point at a flag that cannot fix it.
+        ArchiveError::SecurityViolation { reason } => {
+            let hint = if is_relaxable_by_policy_flag(reason) {
+                "If this archive is from a trusted source, relax the relevant policy flag \
+                 (--allow-symlinks, --allow-hardlinks, --allow-solid-archives, \
+                 --banned-component)."
+            } else {
+                "This archive was rejected by a security check that cannot be relaxed via any \
+                 policy flag."
+            };
+            format!(
+                "Security violation while processing '{}'\nHINT: {hint}",
+                archive.display(),
+            )
+        }
     };
     anyhow::Error::from(err).context(context)
 }
@@ -390,6 +442,35 @@ mod tests {
             1,
             "reason should appear exactly once, got: {msg}"
         );
+    }
+
+    // Regression test for issue #520: the GHSA-5j8q-wxg5-hj4r forged-size
+    // SecurityViolation must get its own accurate HINT, not the generic
+    // policy-flag one, since none of those flags can fix a size mismatch.
+
+    #[test]
+    fn test_security_violation_forged_size_hint_omits_policy_flags() {
+        let err = ArchiveError::SecurityViolation {
+            reason: "decompressed size exceeded the declared uncompressed size of 50 bytes"
+                .to_string(),
+        };
+        let converted = convert_extraction_error(err, Path::new("archive.zip"), false);
+        let msg = format!("{converted:#}");
+        assert!(
+            msg.contains("cannot be relaxed via any policy flag"),
+            "expected the size-mismatch-specific HINT, got: {msg}"
+        );
+        for flag in [
+            "--allow-symlinks",
+            "--allow-hardlinks",
+            "--allow-solid-archives",
+            "--banned-component",
+        ] {
+            assert!(
+                !msg.contains(flag),
+                "forged-size HINT must not mention {flag}, got: {msg}"
+            );
+        }
     }
 
     #[test]

--- a/crates/exarch-cli/tests/cli_tests.rs
+++ b/crates/exarch-cli/tests/cli_tests.rs
@@ -2532,3 +2532,276 @@ fn test_extract_known_limitation_cli_rejects_legitimate_sparse_hole_above_synthe
         .failure()
         .stderr(predicate::str::contains("failed to list archive"));
 }
+
+// ============================================================================
+// --atomic --force destination safety (#519)
+// ============================================================================
+
+/// Regression test for #519: `--atomic --force` extracting a valid archive
+/// over a pre-existing non-empty destination must fully replace it.
+#[test]
+fn test_extract_atomic_force_success_replaces_destination() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let dest = temp.path().join("dest");
+    std::fs::create_dir_all(&dest).expect("create pre-existing destination");
+    std::fs::write(dest.join("old.txt"), b"OLD CONTENT").expect("seed pre-existing file");
+
+    exarch_cmd()
+        .arg("extract")
+        .arg("--atomic")
+        .arg("--force")
+        .arg(fixture_path("sample.tar.gz"))
+        .arg(&dest)
+        .assert()
+        .success();
+
+    assert!(
+        dest.join("sample.txt").exists(),
+        "destination must contain the newly extracted archive content"
+    );
+    assert!(
+        !dest.join("old.txt").exists(),
+        "pre-existing destination content must be fully replaced on success"
+    );
+}
+
+/// Regression test for #519: `--atomic --force` used to unconditionally
+/// `remove_dir_all` the destination before extraction even started, so a
+/// mid-extraction failure permanently destroyed pre-existing content. The fix
+/// extracts into a temp directory and only swaps it into place after
+/// extraction fully succeeds, so a failed extraction must leave the
+/// pre-existing destination completely untouched — same files, same
+/// content, no partial archive content leaked in, and no leftover
+/// swap/backup directories next to it.
+#[test]
+fn test_extract_atomic_force_failure_leaves_destination_untouched() {
+    // The archive lives in a separate temp dir from `dest`'s parent, so the
+    // sibling-directory check below only ever sees directories the CLI itself
+    // created (or failed to clean up), not this test's own fixture file.
+    let archive_temp = TempDir::new().expect("failed to create archive temp dir");
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let dest = temp.path().join("dest");
+    std::fs::create_dir_all(&dest).expect("create pre-existing destination");
+    std::fs::write(dest.join("old.txt"), b"OLD CONTENT").expect("seed pre-existing file");
+
+    // Symlinks are rejected during extraction (not during the CLI's list
+    // pre-flight) since --allow-symlinks defaults to false, so this archive
+    // passes listing and fails partway through the actual extraction copy —
+    // exactly the failure shape #519 needs to exercise.
+    let archive_path = archive_temp.path().join("symlink_escape.tar.gz");
+    create_symlink_escape_tar_gz(&archive_path);
+
+    exarch_cmd()
+        .arg("extract")
+        .arg("--atomic")
+        .arg("--force")
+        .arg(&archive_path)
+        .arg(&dest)
+        .assert()
+        .failure();
+
+    let contents = std::fs::read(dest.join("old.txt")).expect("pre-existing file must survive");
+    assert_eq!(
+        contents, b"OLD CONTENT",
+        "pre-existing destination content must be byte-for-byte unchanged after a failed extraction"
+    );
+    assert!(
+        !dest.join("evil_link").exists(),
+        "no content from the failed extraction attempt must leak into the destination"
+    );
+
+    let siblings: Vec<_> = std::fs::read_dir(temp.path())
+        .expect("read temp dir")
+        .map(|e| e.expect("dir entry").file_name())
+        .collect();
+    assert_eq!(
+        siblings,
+        vec![std::ffi::OsString::from("dest")],
+        "no leftover temp/backup swap directories must remain next to the destination: {siblings:?}"
+    );
+}
+
+// ============================================================================
+// SecurityViolation HINT text specificity (#520)
+// ============================================================================
+
+/// CRC32 (IEEE 802.3 polynomial) for raw ZIP construction.
+fn crc32_ieee(data: &[u8]) -> u32 {
+    let mut crc: u32 = 0xFFFF_FFFF;
+    for &byte in data {
+        crc ^= u32::from(byte);
+        for _ in 0..8 {
+            if crc & 1 != 0 {
+                crc = (crc >> 1) ^ 0xEDB8_8320;
+            } else {
+                crc >>= 1;
+            }
+        }
+    }
+    !crc
+}
+
+/// Raw-DEFLATEs `data` (RFC 1951, no zlib/gzip wrapper), the format ZIP's
+/// compression method 8 requires.
+fn raw_deflate(data: &[u8]) -> Vec<u8> {
+    use flate2::Compression;
+    use flate2::write::DeflateEncoder;
+    use std::io::Write;
+
+    let mut encoder = DeflateEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(data).expect("deflate payload");
+    encoder.finish().expect("finish deflate stream")
+}
+
+/// Builds a single-entry, spec-valid DEFLATE ZIP archive whose local file
+/// header and central directory both declare `declared_uncompressed_size`
+/// for `entry_name`, regardless of what `real_payload` actually decompresses
+/// to. Mirrors the GHSA-5j8q-wxg5-hj4r advisory `PoC` shape (see
+/// `exarch-core/tests/security/zip_ghsa_5j8q.rs`): a forged small
+/// `uncompressed_size` alongside a real, much larger compressed stream.
+#[allow(clippy::cast_possible_truncation)]
+fn build_forged_size_zip(
+    entry_name: &str,
+    real_payload: &[u8],
+    declared_uncompressed_size: u32,
+) -> Vec<u8> {
+    let compressed = raw_deflate(real_payload);
+    let crc = crc32_ieee(real_payload);
+    let name_bytes = entry_name.as_bytes();
+    let name_len = name_bytes.len() as u16;
+    let compressed_len = compressed.len() as u32;
+
+    let mut buf: Vec<u8> = Vec::new();
+    let local_offset = 0u32;
+
+    buf.extend_from_slice(b"PK\x03\x04");
+    buf.extend_from_slice(&20u16.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes());
+    buf.extend_from_slice(&8u16.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes());
+    buf.extend_from_slice(&crc.to_le_bytes());
+    buf.extend_from_slice(&compressed_len.to_le_bytes());
+    buf.extend_from_slice(&declared_uncompressed_size.to_le_bytes()); // FORGED
+    buf.extend_from_slice(&name_len.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes());
+    buf.extend_from_slice(name_bytes);
+    buf.extend_from_slice(&compressed);
+
+    let central_dir_offset = buf.len() as u32;
+
+    buf.extend_from_slice(b"PK\x01\x02");
+    buf.extend_from_slice(&0x031eu16.to_le_bytes());
+    buf.extend_from_slice(&20u16.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes());
+    buf.extend_from_slice(&8u16.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes());
+    buf.extend_from_slice(&crc.to_le_bytes());
+    buf.extend_from_slice(&compressed_len.to_le_bytes());
+    buf.extend_from_slice(&declared_uncompressed_size.to_le_bytes()); // FORGED
+    buf.extend_from_slice(&name_len.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes());
+    buf.extend_from_slice(&(0o100_644u32 << 16).to_le_bytes());
+    buf.extend_from_slice(&local_offset.to_le_bytes());
+    buf.extend_from_slice(name_bytes);
+
+    let central_dir_size = (buf.len() as u32) - central_dir_offset;
+
+    buf.extend_from_slice(b"PK\x05\x06");
+    buf.extend_from_slice(&0u16.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes());
+    buf.extend_from_slice(&1u16.to_le_bytes());
+    buf.extend_from_slice(&1u16.to_le_bytes());
+    buf.extend_from_slice(&central_dir_size.to_le_bytes());
+    buf.extend_from_slice(&central_dir_offset.to_le_bytes());
+    buf.extend_from_slice(&0u16.to_le_bytes());
+
+    buf
+}
+
+/// Regression test for #520: the GHSA-5j8q-wxg5-hj4r forged-size
+/// `SecurityViolation` cannot be worked around with any policy flag, so its
+/// HINT must not suggest `--allow-symlinks`, `--allow-hardlinks`,
+/// `--allow-solid-archives`, or `--banned-component` the way the generic
+/// `SecurityViolation` HINT does.
+#[test]
+fn test_extract_forged_size_hint_omits_policy_flags() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let archive_path = temp.path().join("bomb.zip");
+    // Highly compressible so the real DEFLATE stream is tiny while still
+    // decompressing to several megabytes, well past the declared 50 bytes.
+    let real_payload = vec![0x41u8; 4 * 1024 * 1024];
+    std::fs::write(
+        &archive_path,
+        build_forged_size_zip("bomb.txt", &real_payload, 50),
+    )
+    .expect("write forged-size zip fixture");
+    let out_dir = temp.path().join("out");
+
+    let output = exarch_cmd()
+        .arg("extract")
+        .arg(&archive_path)
+        .arg(&out_dir)
+        .assert()
+        .failure()
+        .get_output()
+        .stderr
+        .clone();
+
+    let stderr = std::str::from_utf8(&output).expect("stderr is not valid UTF-8");
+    assert!(
+        stderr.contains("cannot be relaxed via any policy flag"),
+        "expected the size-mismatch-specific HINT, got: {stderr}"
+    );
+    for flag in [
+        "--allow-symlinks",
+        "--allow-hardlinks",
+        "--allow-solid-archives",
+        "--banned-component",
+    ] {
+        assert!(
+            !stderr.contains(flag),
+            "forged-size HINT must not mention {flag} (it cannot fix a size mismatch), got: {stderr}"
+        );
+    }
+}
+
+/// Companion to [`test_extract_forged_size_hint_omits_policy_flags`]: a
+/// genuine banned-path-component `SecurityViolation` (unrelated to
+/// GHSA-5j8q-wxg5-hj4r) must still get the original generic HINT naming all
+/// four policy flags, proving #520's new guarded match arm did not swallow
+/// the pre-existing categories.
+#[test]
+fn test_extract_banned_component_hint_still_names_policy_flags() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let archive_path = temp.path().join("banned.tar.gz");
+    create_tar_gz_with_component(&archive_path, ".customdir");
+    let out_dir = temp.path().join("out");
+    std::fs::create_dir_all(&out_dir).expect("create out dir");
+
+    let output = exarch_cmd()
+        .arg("extract")
+        .arg(&archive_path)
+        .arg(&out_dir)
+        .arg("--banned-component")
+        .arg(".customdir")
+        .assert()
+        .failure()
+        .get_output()
+        .stderr
+        .clone();
+
+    let stderr = std::str::from_utf8(&output).expect("stderr is not valid UTF-8");
+    for flag in [
+        "--allow-symlinks",
+        "--allow-hardlinks",
+        "--allow-solid-archives",
+        "--banned-component",
+    ] {
+        assert!(stderr.contains(flag), "HINT missing flag {flag}: {stderr}");
+    }
+}


### PR DESCRIPTION
## Summary
- `extract --atomic --force` no longer pre-deletes the destination directory before extraction is attempted. It now extracts into a temp directory and only swaps it into place after extraction fully succeeds, restoring the original destination if the final swap itself fails. A pre-existing destination that exists but is not a directory is now rejected explicitly instead of being silently replaced.
- The `SecurityViolation` HINT no longer suggests `--allow-symlinks`/`--allow-hardlinks`/`--allow-solid-archives`/`--banned-component` for violations none of those flags control (most notably the GHSA-5j8q-wxg5-hj4r declared/decompressed size mismatch, plus roughly ten other reasons). The flag-specific hint is now shown only for the categories the flags actually relax.

Closes #519
Closes #520

## Test plan
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` (1187 passed)
- [x] `cargo test --doc --workspace --all-features` (117 passed)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace`
- [x] 7 new regression tests: destination byte-for-byte preserved when `--atomic --force` extraction fails mid-way; success-path swap still replaces destination; HINT text assertions for both the size-mismatch case and an unrelated banned-component violation
- [x] Live-verified against the real binary: file-as-destination now bails safely with content untouched; symlink-escape mid-extraction failure under `--atomic --force` leaves a pre-existing destination unchanged