### PR TITLE
fix: TAR non-UTF8 entry names not flagged by verify; duplicated IoError message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -251,6 +251,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`exarch-core`: `verify`/`list` reported `PASS` for a TAR archive containing a non-UTF8 entry
+  name that may fail to extract on filesystems requiring UTF-8 names (#528)**: TAR entry names are
+  stored byte-exact (no lossy conversion) in `ArchiveEntry.path`, but
+  `inspection::verify::check_heuristics` never checked whether that path was valid UTF-8, so
+  `verify_manifest` collected no issue for such an entry and `determine_status` returned `Pass`
+  even though extraction could fail depending on the destination filesystem (e.g. APFS, NTFS —
+  Linux ext4/xfs/btrfs accept arbitrary byte-string names and are unaffected). `check_heuristics`
+  now pushes a `Medium`-severity `SuspiciousPath` issue — worded as a portability risk, not a
+  claim about the host running `verify`, since an archive is often vetted on one machine before
+  being shipped to another — for any entry whose path is not valid UTF-8, flipping the overall
+  `status` to `Warning` and `suspicious_entries` accordingly. `security_status` is unaffected, since
+  `SuspiciousPath` was already excluded from `determine_security_status`'s category filter (this is
+  not a security issue, only a portability one).
+- **`exarch-cli`: the `ArchiveError::Io` context duplicated the wrapped I/O error's own message,
+  printing both the "I/O error" phrase and the OS error text twice (#528)**: `error.rs`'s
+  `convert_extraction_error` built the `Io` arm's context by re-interpolating the inner `io::Error`'s
+  Display text (`"I/O error while processing '{path}': {io_err}"`), but `ArchiveError::Io` itself
+  already displays as `"I/O error: {io_err}"`, and anyhow's `{:#}` rendering appends that source after
+  the context — doubling both the phrase and the OS error text in `--json` and human-text output
+  alike. Same duplication class as #403's `SecurityViolation` fix, different arm. The context no
+  longer re-embeds the inner error's text.
 - **`exarch-cli`: `extract --atomic --force` deleted a pre-existing destination directory before
   extraction was known to succeed, defeating the point of `--atomic` (#519)**: `commands/extract.rs`
   pre-removed `output_dir` with `remove_dir_all` so the subsequent rename in `exarch-core`'s

--- a/crates/exarch-cli/src/error.rs
+++ b/crates/exarch-cli/src/error.rs
@@ -173,13 +173,7 @@ pub fn convert_extraction_error(
              HINT: Use --allow-hardlinks to extract hardlinks (only if trusted source).",
             archive.display(),
         ),
-        ArchiveError::Io(io_err) => {
-            format!(
-                "I/O error while processing '{}': {}",
-                archive.display(),
-                io_err
-            )
-        }
+        ArchiveError::Io(_) => format!("Failed to process '{}'", archive.display()),
         ArchiveError::UnknownFormat { path } => format!(
             "Cannot determine archive format: {}\n\
              HINT: Supported formats: tar, tar.gz, tar.bz2, tar.xz, tar.zstd, zip",
@@ -360,6 +354,30 @@ mod tests {
         let converted = convert_extraction_error(err, Path::new("archive.tar.gz"), false);
         let msg = format!("{converted:?}");
         assert!(msg.contains("I/O error"));
+    }
+
+    // Regression test for issue #528: the `Io` arm's context must not
+    // re-embed the wrapped `io::Error`'s own Display text, since anyhow's
+    // `{:#}` rendering already appends the source error after the context.
+    #[test]
+    fn test_io_error_no_duplication() {
+        let io_err = io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Illegal byte sequence (os error 92)",
+        );
+        let err = ArchiveError::Io(io_err);
+        let converted = convert_extraction_error(err, Path::new("nonutf8.tar"), false);
+        let msg = format!("{converted:#}");
+        assert_eq!(
+            msg.matches("Illegal byte sequence (os error 92)").count(),
+            1,
+            "OS error text should appear exactly once, got: {msg}"
+        );
+        assert_eq!(
+            msg.matches("I/O error").count(),
+            1,
+            "\"I/O error\" phrase should appear exactly once, got: {msg}"
+        );
     }
 
     // Regression tests for issue #204: PartialExtraction wrapping HardlinkEscape /

--- a/crates/exarch-core/src/inspection/verify.rs
+++ b/crates/exarch-core/src/inspection/verify.rs
@@ -43,11 +43,21 @@ pub(crate) fn verify_manifest(
 
     for entry in &manifest.entries {
         let entry_issues = verify_entry(entry, config, &temp_dest, &mut quota_tracker);
-        if !entry_issues.is_empty() {
-            suspicious_entries += 1;
-            issues.extend(entry_issues);
-        }
         let heuristic_issues = check_heuristics(entry);
+
+        // Info/Low heuristics (e.g. suspicious extension) never flip `status`
+        // away from `Pass`, so they historically weren't counted as
+        // "suspicious". A Medium+ heuristic does flip `status`, so it must
+        // count too, or the report becomes self-contradictory (Warning with
+        // zero suspicious entries).
+        let has_medium_plus_heuristic = heuristic_issues
+            .iter()
+            .any(|i| i.severity >= IssueSeverity::Medium);
+        if !entry_issues.is_empty() || has_medium_plus_heuristic {
+            suspicious_entries += 1;
+        }
+
+        issues.extend(entry_issues);
         issues.extend(heuristic_issues);
     }
 
@@ -264,6 +274,27 @@ fn check_heuristics(entry: &ArchiveEntry) -> Vec<VerificationIssue> {
         });
     }
 
+    // Non-UTF8 name detection: TAR entry names are stored byte-exact, so a
+    // name that isn't valid UTF-8 is a portability risk — it extracts fine
+    // on filesystems that accept arbitrary byte-string names (e.g. Linux
+    // ext4/xfs/btrfs) but can fail on ones that require valid UTF-8 (e.g.
+    // APFS, NTFS). This check is host-agnostic by design: `verify` is also
+    // used to vet archives before shipping them to a different host, so the
+    // warning must not depend on which filesystem happens to be running it.
+    if entry.path.to_str().is_none() {
+        issues.push(VerificationIssue {
+            severity: IssueSeverity::Medium,
+            category: IssueCategory::SuspiciousPath,
+            entry_path: Some(entry.path.clone()),
+            message: format!(
+                "Entry name is not valid UTF-8; extraction may fail on filesystems that require \
+                 UTF-8 names (e.g. APFS, NTFS): {}",
+                entry.path.display()
+            ),
+            context: None,
+        });
+    }
+
     issues
 }
 
@@ -425,6 +456,52 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn test_check_heuristics_non_utf8_name() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        let entry = crate::inspection::manifest::ArchiveEntry {
+            path: PathBuf::from(OsStr::from_bytes(b"weird-\xFF\xFE-name.txt")),
+            entry_type: ManifestEntryType::File,
+            size: 100,
+            compressed_size: None,
+            mode: Some(0o644),
+            modified: None,
+            symlink_target: None,
+            hardlink_target: None,
+        };
+
+        let issues = check_heuristics(&entry);
+        assert!(!issues.is_empty());
+        assert!(issues.iter().any(|i| {
+            i.category == IssueCategory::SuspiciousPath && i.severity == IssueSeverity::Medium
+        }));
+    }
+
+    // False-positive guard for #528: a plain, valid-UTF8, non-suspicious
+    // entry name must not trigger the new non-UTF8-name heuristic.
+    #[test]
+    fn test_check_heuristics_valid_utf8_name_no_warning() {
+        let entry = crate::inspection::manifest::ArchiveEntry {
+            path: PathBuf::from("safe/file.txt"),
+            entry_type: ManifestEntryType::File,
+            size: 100,
+            compressed_size: None,
+            mode: Some(0o644),
+            modified: None,
+            symlink_target: None,
+            hardlink_target: None,
+        };
+
+        let issues = check_heuristics(&entry);
+        assert!(
+            issues.is_empty(),
+            "valid UTF-8 name must not trigger any heuristic issue, got: {issues:?}"
+        );
+    }
+
     #[test]
     fn test_verify_archive_safe() {
         let mut temp_file = NamedTempFile::with_suffix(".tar").unwrap();
@@ -559,6 +636,51 @@ mod tests {
                 .iter()
                 .any(|i| i.message.contains("null bytes")),
             "expected an issue mentioning null bytes, got: {:?}",
+            report.issues
+        );
+    }
+
+    // Regression test for #528: a TAR entry name that is not valid UTF-8 is
+    // stored byte-exact in the manifest and may fail to extract on this
+    // filesystem, but previously nothing in the verification pipeline
+    // checked for it, so `verify` reported `Pass` for an archive that
+    // `extract` would later fail on.
+    //
+    // Unix-only: the `tar` crate's `bytes2path` requires valid UTF-8 on
+    // non-Unix targets (see `tar::header::bytes2path`), so on Windows
+    // `entry.path()` itself errors out during listing and `verify_archive`
+    // returns `Err` before ever reaching `check_heuristics` — a different,
+    // pre-existing cross-platform divergence outside this fix's scope.
+    #[cfg(unix)]
+    #[test]
+    fn test_verify_archive_non_utf8_name_reports_warning_not_pass() {
+        use crate::test_utils::tar_with_nonutf8_name;
+
+        let mut temp_file = NamedTempFile::with_suffix(".tar").unwrap();
+        temp_file
+            .write_all(&tar_with_nonutf8_name(b"weird-\xFF\xFE-name.txt", b"hello"))
+            .unwrap();
+        temp_file.flush().unwrap();
+
+        let config = SecurityConfig::default();
+        let report = verify_archive(temp_file.path(), &config)
+            .expect("verify_archive must report a non-UTF8 entry name, not error out");
+
+        assert_eq!(
+            report.status,
+            VerificationStatus::Warning,
+            "non-UTF8 entry name must surface as a Warning, not silently Pass"
+        );
+        assert_eq!(
+            report.suspicious_entries, 1,
+            "a Medium+ heuristic issue must be reflected in suspicious_entries, \
+             or the report is self-contradictory (Warning with 0 suspicious entries)"
+        );
+        assert!(
+            report.issues.iter().any(|i| {
+                i.category == IssueCategory::SuspiciousPath && i.message.contains("not valid UTF-8")
+            }),
+            "expected a SuspiciousPath issue mentioning UTF-8, got: {:?}",
             report.issues
         );
     }
@@ -728,6 +850,11 @@ mod tests {
                 .iter()
                 .any(|i| i.category == IssueCategory::SuspiciousPath),
             "Should have SuspiciousPath issue for .sh extension"
+        );
+        assert_eq!(
+            report.suspicious_entries, 0,
+            "Info/Low-severity heuristic issues (executable, suspicious extension) must not \
+             count toward suspicious_entries — only Medium+ issues do"
         );
     }
 

--- a/crates/exarch-core/src/test_utils.rs
+++ b/crates/exarch-core/src/test_utils.rs
@@ -452,6 +452,21 @@ pub fn tar_with_pax_linkpath(pax_linkpath: &[u8], typeflag: u8) -> Vec<u8> {
     tar_with_pax_record("linkpath", pax_linkpath, b"link_entry", typeflag, b"")
 }
 
+/// Builds a raw ustar-format TAR archive with a single regular-file entry
+/// whose `name` field is `name_bytes`, which may not be valid UTF-8.
+///
+/// Writes the header directly rather than through `tar::Header::set_path`
+/// (which requires a `Path`), so arbitrary non-UTF8 byte sequences can be
+/// used as the entry name for extractability regression tests.
+#[must_use]
+pub fn tar_with_nonutf8_name(name_bytes: &[u8], data: &[u8]) -> Vec<u8> {
+    let mut tar = Vec::new();
+    tar.extend_from_slice(&raw_tar_header(name_bytes, data.len(), b'0'));
+    pad_tar_block(&mut tar, data);
+    tar.extend(std::iter::repeat_n(0u8, 1024));
+    tar
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

- `verify`/`list` reported `PASS` for a TAR archive containing a non-UTF8 entry name, even though that name could fail to extract on filesystems requiring UTF-8 names (e.g. APFS, NTFS). `check_heuristics` now surfaces a `Medium`-severity `SuspiciousPath` issue for such entries, worded as a portability risk (not a claim about the host running `verify`, since archives are often vetted on one machine before being shipped elsewhere). The issue also counts toward `suspicious_entries` so the report isn't self-contradictory (`Warning` with zero suspicious entries).
- `extract`'s `IoError` message duplicated the wrapped I/O error's own text — `convert_extraction_error`'s `Io` arm re-interpolated the inner `io::Error`'s Display text into its context string, while `ArchiveError::Io` already displays as `"I/O error: {io_err}"`; anyhow's alternate rendering then printed both the phrase and the OS error text twice. Same duplication class as #403's `SecurityViolation` fix, different arm.

`security_status` is unaffected — `SuspiciousPath` was already excluded from `determine_security_status`'s category filter, consistent with this being a portability issue, not a security one.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` (1191/1191 passed)
- [x] `cargo test --doc --workspace --all-features` (scoped to exarch-core/exarch-cli; unscoped workspace run has a pre-existing, unrelated exarch-python doc-test linking failure)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --all-features`
- [x] New regression tests: `test_io_error_no_duplication`, `test_check_heuristics_non_utf8_name`, `test_check_heuristics_valid_utf8_name_no_warning` (false-positive guard), `test_verify_archive_non_utf8_name_reports_warning_not_pass` (`#[cfg(unix)]` — non-UTF8 names are rejected by the `tar` crate at listing time on non-Unix targets), plus an explicit `suspicious_entries == 0` assertion added to the existing Info/Low heuristic test to lock in that only Medium+ issues are counted
- [x] Live-tested against the built CLI binary: `verify --json`/`extract --json` on a hand-crafted non-UTF8-name TAR, `verify --strict` exit code

Closes #528