### PR TITLE
fix(cli): pin destination identity before resolving atomic-force swap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   via `tempfile`/`xattr`) as a direct, Unix-only dependency of `exarch-cli`.
 
   **Behavior change on Unix**: `--atomic --force` now requires read permission on the destination's
-  parent directory (needed to obtain a real directory file descriptor; there is no portable Unix
-  equivalent of Linux's permission-free `O_PATH` for this). It does **not** require read permission
-  on the destination directory itself — the identity recheck uses `statat`, which needs only search
-  permission on the already-open parent.
+  parent directory for every invocation, including when the destination does not yet exist (needed to
+  obtain a real directory file descriptor; there is no portable Unix equivalent of Linux's
+  permission-free `O_PATH` for this). It does **not** require read permission on the destination
+  directory itself — the identity recheck uses `statat`, which needs only search permission on the
+  already-open parent.
+
+- **`extract --atomic --force` followed a destination that was itself a symlink (GHSA-x8wr-7ww2-c94x)**:
+  the destination was resolved by path — `exists()`, `is_dir()`, then `canonicalize()` — and the swap's
+  parent and entry name were both derived from the *canonicalized* result, so a symlink at the
+  destination silently retargeted the swap at the directory it pointed to. Because the swap ends in
+  `remove_dir_all` on the displaced backup, this destroyed the redirected directory's original
+  contents: attacker-directed destructive replacement of any directory writable by the invoking user,
+  requiring only write access to the destination's containing directory and no race to win. The
+  destination's parent is now canonicalized and pinned by a file descriptor, while the destination's
+  own name is taken lexically and never canonicalized; its type is checked with `statat(SYMLINK_NOFOLLOW)`,
+  so every check and every rename names the same entry inside the same pinned parent.
+
+  **Breaking change**: `--atomic --force` onto a destination that is itself a symlink (or, on Windows,
+  a junction or other reparse point) is now rejected on all platforms — pass the resolved target path
+  instead (`--atomic --force "$(readlink -f /path/to/link)"`). Symlinked *intermediate* path components
+  remain supported, and a destination that is a symlink to a regular file now reports the symlink error
+  rather than #525's "not a directory". **Scope**: only `--atomic --force` performs this swap and only
+  it applies this restriction; plain `extract`, `--atomic` without `--force`, and the Rust/Python/Node
+  APIs still resolve a symlinked destination root through `DestDir` (see #533).
 
 - **`PartialExtraction`-wrapped errors lost their category-specific HINT text (#527)**:
   `convert_extraction_error` (`crates/exarch-cli/src/error.rs`) special-cased

--- a/crates/exarch-cli/src/commands/atomic_swap.rs
+++ b/crates/exarch-cli/src/commands/atomic_swap.rs
@@ -11,11 +11,27 @@
 //! `parent` once and performing every subsequent operation `*at`-relative
 //! to that file descriptor: once opened, the descriptor identifies an
 //! inode, not a path, so no later rename of an intermediate component can
-//! retarget it.
+//! retarget it. [`PinnedDir::entry_status`]'s [`DestEntryKind`]
+//! classification closes the complementary *final*-component vector
+//! (GHSA-x8wr-7ww2-c94x) on every platform: the destination entry itself
+//! being a symlink or junction is rejected rather than followed.
 
 use std::ffi::OsStr;
 use std::io;
 use std::path::Path;
+
+/// Classification of a directory entry inspected by
+/// [`PinnedDir::entry_status`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum DestEntryKind {
+    /// The entry is a directory — the only kind `--atomic --force` may swap.
+    Directory,
+    /// The entry is a symlink (or, on Windows, a junction or other reparse
+    /// point) — always rejected, regardless of what it points at.
+    Symlink,
+    /// Neither a directory nor a symlink (a regular file, FIFO, etc.).
+    Other,
+}
 
 /// A directory pinned by an open file descriptor.
 ///
@@ -47,14 +63,20 @@ impl PinnedDir {
             rustix::fs::OFlags::RDONLY
                 | rustix::fs::OFlags::DIRECTORY
                 | rustix::fs::OFlags::CLOEXEC
-                | rustix::fs::OFlags::NOFOLLOW,
+                | rustix::fs::OFlags::NOFOLLOW
+                // `O_DIRECTORY` alone rejects a non-directory, but on some
+                // platforms a FIFO planted at `parent` can still stall the
+                // open itself waiting for a writer before that rejection is
+                // reached; `NONBLOCK` makes the open fail immediately
+                // instead of hanging the process.
+                | rustix::fs::OFlags::NONBLOCK,
             rustix::fs::Mode::empty(),
         )?;
         Ok(Self(std::fs::File::from(fd)))
     }
 
-    /// Returns the `(dev, ino)` identity of the directory entry `name`
-    /// inside the pinned directory.
+    /// Classifies the directory entry `name` inside the pinned directory and
+    /// returns its `(dev, ino)` identity, in the same syscall.
     ///
     /// Uses `statat` rather than `openat` + `fstat` deliberately: `statat`
     /// only needs search permission on the pinned directory (already
@@ -62,11 +84,11 @@ impl PinnedDir {
     /// would additionally require read permission on the destination entry
     /// — a requirement the previous path-based flow never had. `NOFOLLOW`
     /// makes this fail closed if `name` has become a symlink since it was
-    /// last checked, rather than silently resolving through it; the explicit
-    /// `FileType` check right after does the same for `name` having become
-    /// any *other* non-directory (regular file, FIFO, etc.), restoring the
-    /// guarantee the old `openat(O_DIRECTORY)` implementation gave for free
-    /// — `statat` alone happily returns an identity for any entry type.
+    /// last checked, rather than silently resolving through it: unlike the
+    /// identity-only check this replaces, a symlink is reported as
+    /// [`DestEntryKind::Symlink`] rather than an error — the kind is
+    /// returned, never used here to decide anything, so callers decide what
+    /// to do with it.
     // `st_dev`/`st_ino` are platform-native integer types: `i32`/`u64` on
     // macOS, `u64`/`u64` on 64-bit glibc Linux. `try_from` is therefore a
     // genuine conversion on macOS's `st_dev` but a same-type no-op for
@@ -80,16 +102,18 @@ impl PinnedDir {
     // unrepresentable values compare equal to each other, silently
     // defeating the identity check this feeds.
     #[allow(clippy::useless_conversion)]
-    pub(super) fn entry_identity(&self, name: &OsStr) -> io::Result<(u64, u64)> {
+    pub(super) fn entry_status(&self, name: &OsStr) -> io::Result<(DestEntryKind, (u64, u64))> {
         let stat = rustix::fs::statat(&self.0, name, rustix::fs::AtFlags::SYMLINK_NOFOLLOW)?;
-        if rustix::fs::FileType::from_raw_mode(stat.st_mode) != rustix::fs::FileType::Directory {
-            return Err(rustix::io::Errno::NOTDIR.into());
-        }
+        let kind = match rustix::fs::FileType::from_raw_mode(stat.st_mode) {
+            rustix::fs::FileType::Directory => DestEntryKind::Directory,
+            rustix::fs::FileType::Symlink => DestEntryKind::Symlink,
+            _ => DestEntryKind::Other,
+        };
         let dev =
             u64::try_from(stat.st_dev).map_err(|_| io::Error::other("unrepresentable st_dev"))?;
         let ino =
             u64::try_from(stat.st_ino).map_err(|_| io::Error::other("unrepresentable st_ino"))?;
-        Ok((dev, ino))
+        Ok((kind, (dev, ino)))
     }
 
     /// Renames `from` to `to`, both resolved relative to the pinned
@@ -109,12 +133,13 @@ impl PinnedDir {
 
 /// Non-Unix fallback: plain path-based operations.
 ///
-/// This does not close the TOCTOU window issue #526 addresses — it is a
-/// documented residual, not a claimed guarantee. Symlink creation is a
-/// privileged operation on Windows (unlike Unix), which substantially
-/// narrows who can plant the redirect in the first place; fully closing the
-/// window there would need a distinct, Windows-specific mechanism and is
-/// out of scope for this fix.
+/// This does not close the TOCTOU window issue #526 addresses on an
+/// *intermediate* path component — it is a documented residual, not a
+/// claimed guarantee; fully closing it there would need a distinct,
+/// Windows-specific fd-pinning mechanism and is out of scope for this fix.
+/// The *final* component — the destination itself being a symlink or
+/// junction — is closed on this platform too, by
+/// [`entry_status`](PinnedDir::entry_status)'s reparse-point check below.
 #[cfg(not(unix))]
 pub(super) struct PinnedDir {
     parent: std::path::PathBuf,
@@ -132,14 +157,28 @@ impl PinnedDir {
         })
     }
 
-    /// Always reports a matching identity: verifying without re-walking
-    /// the path is exactly the capability this platform lacks, so the
-    /// check is a no-op here rather than a false guarantee.
+    /// Classifies the directory entry `name` and reports its identity.
+    ///
+    /// Identity is always `(0, 0)`: verifying without re-walking the path is
+    /// exactly the capability this platform lacks, so the check is a no-op
+    /// here rather than a false guarantee. The *kind* classification is
+    /// real, though — [`is_reparse_point`] checks
+    /// `FILE_ATTRIBUTE_REPARSE_POINT` tag-agnostically on Windows, so
+    /// junctions and any other reparse point are reported as
+    /// [`DestEntryKind::Symlink`], not just true symlinks.
     // `&self` is part of the shared signature with the Unix impl, which
     // does need it; this stub simply doesn't.
     #[allow(clippy::unused_self)]
-    pub(super) fn entry_identity(&self, _name: &OsStr) -> io::Result<(u64, u64)> {
-        Ok((0, 0))
+    pub(super) fn entry_status(&self, name: &OsStr) -> io::Result<(DestEntryKind, (u64, u64))> {
+        let metadata = std::fs::symlink_metadata(self.parent.join(name))?;
+        let kind = if is_reparse_point(&metadata) {
+            DestEntryKind::Symlink
+        } else if metadata.is_dir() {
+            DestEntryKind::Directory
+        } else {
+            DestEntryKind::Other
+        };
+        Ok((kind, (0, 0)))
     }
 
     pub(super) fn rename(&self, from: &OsStr, to: &OsStr) -> io::Result<()> {
@@ -151,9 +190,31 @@ impl PinnedDir {
     }
 }
 
+/// Reports whether `metadata` carries `FILE_ATTRIBUTE_REPARSE_POINT`.
+///
+/// Deliberately tag-agnostic: it does not distinguish a true symlink from a
+/// junction or any other reparse tag, so it covers junctions — the
+/// practical Windows redirect primitive, which (unlike a true symlink)
+/// needs no elevation to create — without depending on which specific tag
+/// an attacker used.
+#[cfg(windows)]
+fn is_reparse_point(metadata: &std::fs::Metadata) -> bool {
+    use std::os::windows::fs::MetadataExt as _;
+    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
+    metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+}
+
+/// Non-Windows, non-Unix fallback: this platform has no reparse-point
+/// concept, so a true symlink is the only redirect primitive to check for.
+#[cfg(all(not(unix), not(windows)))]
+fn is_reparse_point(metadata: &std::fs::Metadata) -> bool {
+    metadata.file_type().is_symlink()
+}
+
 #[cfg(all(test, unix))]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
+    use super::DestEntryKind;
     use super::PinnedDir;
     use std::ffi::OsStr;
     use std::os::unix::fs::PermissionsExt;
@@ -190,7 +251,7 @@ mod tests {
     }
 
     #[test]
-    fn entry_identity_mismatch_is_detectable_after_destination_is_swapped() {
+    fn entry_status_identity_mismatch_is_detectable_after_destination_is_swapped() {
         let root = tempfile::tempdir().expect("tempdir");
         let parent = root.path().join("parent");
         std::fs::create_dir(&parent).expect("create parent");
@@ -199,66 +260,117 @@ mod tests {
 
         let pin = PinnedDir::open(&parent).expect("pin parent");
         let name = OsStr::new("dest");
-        let snapshot = pin.entry_identity(name).expect("snapshot identity");
+        let (kind, snapshot) = pin.entry_status(name).expect("snapshot identity");
+        assert_eq!(kind, DestEntryKind::Directory);
 
         let moved_aside = parent.join("dest.old");
         std::fs::rename(&dest, &moved_aside).expect("move dest aside");
         std::fs::create_dir(&dest).expect("create replacement dest");
 
-        let recheck = pin.entry_identity(name).expect("recheck identity");
+        let (kind, recheck) = pin.entry_status(name).expect("recheck identity");
+        assert_eq!(kind, DestEntryKind::Directory);
         assert_ne!(
             snapshot, recheck,
             "identity must change when the destination entry is swapped for a new one"
         );
     }
 
-    /// Regression test for the R1 finding: `statat` alone happily returns an
-    /// identity for any entry type, so `entry_identity` must reject a
-    /// non-directory entry explicitly rather than silently treating it like
-    /// a directory — restoring the guarantee the old `openat(O_DIRECTORY)`
-    /// implementation gave for free.
+    /// Unit-level pin (v3 spec) that `entry_status` classifies a symlink
+    /// entry as `DestEntryKind::Symlink`, distinct from `Directory` for a
+    /// real directory entry — the classification `resolve_atomic_force_replace`
+    /// relies on to reject a symlinked destination.
     #[test]
-    fn entry_identity_rejects_non_directory_entry() {
+    fn entry_status_returns_symlink_kind_for_a_planted_symlink() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let parent = root.path().join("parent");
+        std::fs::create_dir(&parent).expect("create parent");
+        let real_dir = root.path().join("real_dir");
+        std::fs::create_dir(&real_dir).expect("create real_dir");
+        let link = parent.join("link");
+        symlink(&real_dir, &link).expect("plant symlink");
+
+        let pin = PinnedDir::open(&parent).expect("pin parent");
+        let (kind, _) = pin
+            .entry_status(OsStr::new("link"))
+            .expect("a symlink entry must be classified, not rejected as an error");
+        assert_eq!(
+            kind,
+            DestEntryKind::Symlink,
+            "expected a symlink to be classified as Symlink"
+        );
+    }
+
+    /// Unit-level pin (v3 spec) that a missing entry fails with `NotFound`,
+    /// distinguishable from the `Symlink`/`Other` success-path values above
+    /// — callers must be able to tell "nothing here yet" from "something
+    /// here that must be rejected" without inspecting the error message.
+    #[test]
+    fn entry_status_on_missing_entry_is_not_found() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let parent = root.path().join("parent");
+        std::fs::create_dir(&parent).expect("create parent");
+
+        let pin = PinnedDir::open(&parent).expect("pin parent");
+        let err = pin
+            .entry_status(OsStr::new("does_not_exist"))
+            .expect_err("a missing entry must be an error, not a classified value");
+        assert_eq!(
+            err.kind(),
+            std::io::ErrorKind::NotFound,
+            "expected a not-found failure specifically, got: {err}"
+        );
+    }
+
+    /// Regression test for the R1 finding, reshaped for `entry_status`
+    /// (E4): `statat` alone happily returns an identity for any entry type,
+    /// so a non-directory entry must be classified as
+    /// `DestEntryKind::Other` on the success path rather than silently
+    /// treated like a directory — restoring the guarantee the old
+    /// `openat(O_DIRECTORY)` implementation gave for free. Unlike the
+    /// superseded `entry_identity`, this is no longer an error: `Other` is
+    /// a value the caller inspects and rejects itself.
+    #[test]
+    fn entry_status_returns_other_kind_for_non_directory_entry() {
         let root = tempfile::tempdir().expect("tempdir");
         let parent = root.path().join("parent");
         std::fs::create_dir(&parent).expect("create parent");
         std::fs::write(parent.join("not_a_dir"), b"x").expect("create regular file");
 
         let pin = PinnedDir::open(&parent).expect("pin parent");
-        let err = pin
-            .entry_identity(OsStr::new("not_a_dir"))
-            .expect_err("a regular file must be rejected, not silently identified");
+        let (kind, _) = pin
+            .entry_status(OsStr::new("not_a_dir"))
+            .expect("a regular file must be classified, not rejected as an error");
         assert_eq!(
-            err.kind(),
-            std::io::ErrorKind::NotADirectory,
-            "expected a not-a-directory failure specifically, got: {err}"
+            kind,
+            DestEntryKind::Other,
+            "expected a regular file to be classified as Other"
         );
     }
 
-    /// Regression test for the S1 finding: `entry_identity` must not require
+    /// Regression test for the S1 finding: `entry_status` must not require
     /// read permission on the destination entry itself — only search
     /// permission on the pinned parent, which `PinnedDir::open` already
     /// established. Before switching from `openat`+`fstat` to `statat`,
     /// this failed with `EACCES` on a destination with no read bit set.
     #[test]
-    fn entry_identity_does_not_require_read_permission_on_the_entry() {
+    fn entry_status_does_not_require_read_permission_on_the_entry() {
         let root = tempfile::tempdir().expect("tempdir");
         let parent = root.path().join("parent");
         std::fs::create_dir(&parent).expect("create parent");
         let dest = parent.join("dest");
         std::fs::create_dir(&dest).expect("create dest");
-        // Write+execute only, no read bit: `entry_identity` must still work.
+        // Write+execute only, no read bit: `entry_status` must still work.
         std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(0o311))
             .expect("restrict dest permissions");
 
         let pin = PinnedDir::open(&parent).expect("pin parent");
-        let result = pin.entry_identity(OsStr::new("dest"));
+        let result = pin.entry_status(OsStr::new("dest"));
 
         // Restore permissions before any panic-driven cleanup runs.
         std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(0o755))
             .expect("restore dest permissions");
 
-        result.expect("entry_identity must succeed without read permission on the entry");
+        result.expect("entry_status must succeed without read permission on the entry");
     }
 
     /// Pins the accepted residual noted in [`PinnedDir::open`]'s doc

--- a/crates/exarch-cli/src/commands/extract.rs
+++ b/crates/exarch-cli/src/commands/extract.rs
@@ -2,6 +2,7 @@
 
 use crate::cli::ExtractArgs;
 use crate::commands::apply_size_limits;
+use crate::commands::atomic_swap::DestEntryKind;
 use crate::commands::atomic_swap::PinnedDir;
 use crate::error::add_archive_context;
 use crate::output::OutputFormatter;
@@ -19,7 +20,10 @@ use exarch_core::extract_archive_with_options_and_progress;
 use exarch_core::list_archive;
 use std::env;
 use std::ffi::OsStr;
+use std::ffi::OsString;
+use std::io;
 use std::path::Path;
+use std::path::PathBuf;
 
 fn run_extraction(
     archive: &Path,
@@ -36,60 +40,76 @@ fn run_extraction(
     )
 }
 
-/// Extracts into a fresh temp directory next to `output_dir`, then swaps it
-/// into place over the pre-existing `output_dir`.
+/// Everything [`run_atomic_force_extraction`] needs, resolved and pinned by
+/// [`resolve_atomic_force_replace`] before extraction starts.
+struct AtomicForceTarget {
+    /// The destination's parent, pinned by an open file descriptor.
+    pin: PinnedDir,
+    /// The destination's final path component, resolved via
+    /// [`Path::file_name`] — never a raw path fragment. See the invariant
+    /// note at its point of derivation in [`resolve_atomic_force_replace`].
+    dest_name: OsString,
+    /// The `(dev, ino)` identity `entry_status` reported for `dest_name`
+    /// when it confirmed the destination was a directory, carried forward
+    /// rather than re-derived so the kind/identity pair snapshotted here is
+    /// the one [`verify_destination_unchanged`] rechecks against.
+    dest_id: (u64, u64),
+    /// The pinned parent's canonical path, for temp/backup directory
+    /// creation and error messages.
+    parent_display: PathBuf,
+    /// The destination's display path, for error messages.
+    dest_display: PathBuf,
+}
+
+/// Extracts into a fresh temp directory next to the destination, then swaps
+/// it into place over the pre-existing destination.
 ///
-/// Used only for `--atomic --force` when `output_dir` already exists. Core's
-/// own atomic path (`ExtractionOptions::atomic`) never replaces an existing
-/// directory, so this performs the replacement itself, strictly after
-/// extraction has already succeeded: the original destination is moved aside
-/// to a backup path, the extracted content is moved into place, and only
-/// then is the backup removed. If moving the extracted content into place
-/// fails, the backup is moved back so the original destination is restored.
+/// Used only for `--atomic --force` when the destination already exists.
+/// Core's own atomic path (`ExtractionOptions::atomic`) never replaces an
+/// existing directory, so this performs the replacement itself, strictly
+/// after extraction has already succeeded: the original destination is
+/// moved aside to a backup path, the extracted content is moved into place,
+/// and only then is the backup removed. If moving the extracted content
+/// into place fails, the backup is moved back so the original destination
+/// is restored.
 ///
-/// On Unix, `parent` is pinned by an open file descriptor ([`PinnedDir`])
-/// and every rename/remove below is resolved relative to that descriptor
-/// rather than by path, closing the TOCTOU window where an *intermediate*
-/// path component is replaced with a symlink mid-swap (issue #526). A
-/// dev/ino identity recheck immediately before the destructive swap
-/// (see [`verify_destination_unchanged`]) additionally narrows — it does
-/// not close — the remaining window around the *final* component itself:
-/// the fd-pin cannot cover a change to the entry it was opened for, and the
-/// recheck is itself a check-then-use relative to the rename that follows
-/// it, just one shrunk from extraction-duration to two syscalls wide.
+/// On Unix, `target.pin` pins the destination's parent directory by an open
+/// file descriptor and every rename/remove below is resolved relative to
+/// that descriptor rather than by path, closing the TOCTOU window where an
+/// *intermediate* path component is replaced with a symlink mid-swap (issue
+/// #526). A dev/ino identity recheck immediately before the destructive
+/// swap (see [`verify_destination_unchanged`]) additionally narrows — it
+/// does not close — the remaining window around the *final* component
+/// itself: the fd-pin cannot cover a change to the entry it was opened for,
+/// and the recheck is itself a check-then-use relative to the rename that
+/// follows it, just one shrunk from extraction-duration to two syscalls
+/// wide.
 fn run_atomic_force_extraction(
     archive: &Path,
-    output_dir: &Path,
+    target: AtomicForceTarget,
     config: &SecurityConfig,
     options: &ExtractionOptions,
     progress: &mut dyn ProgressCallback,
     allow_symlinks: bool,
 ) -> Result<ExtractionReport> {
-    let canonical_output = output_dir
-        .canonicalize()
-        .with_context(|| format!("failed to resolve destination: {}", output_dir.display()))?;
-    let parent = canonical_output
-        .parent()
-        .with_context(|| format!("destination has no parent: {}", output_dir.display()))?;
-    let dest_name = canonical_output
-        .file_name()
-        .with_context(|| format!("destination has no file name: {}", output_dir.display()))?;
-
-    let pin = PinnedDir::open(parent)
-        .with_context(|| format!("failed to pin destination parent: {}", parent.display()))?;
-    let dest_id = pin.entry_identity(dest_name).with_context(|| {
-        format!(
-            "failed to inspect destination: {}",
-            canonical_output.display()
-        )
-    })?;
+    let AtomicForceTarget {
+        pin,
+        dest_name,
+        dest_id,
+        parent_display,
+        dest_display,
+    } = target;
 
     // Path-based: `tempfile` has no fd-relative constructor. If `parent`
     // were redirected between the pin above and here, every fd-relative
     // call below fails closed with `ENOENT` before anything destructive
     // happens, so this does not reopen the window `PinnedDir` closes.
-    let temp_dir = tempfile::tempdir_in(parent)
-        .with_context(|| format!("failed to create temp directory in {}", parent.display()))?;
+    let temp_dir = tempfile::tempdir_in(&parent_display).with_context(|| {
+        format!(
+            "failed to create temp directory in {}",
+            parent_display.display()
+        )
+    })?;
     // Derived now, before any destructive operation below, so that a
     // (practically unreachable, `tempfile` always yields a named path)
     // `file_name()` failure can never surface *after* the destination has
@@ -115,8 +135,12 @@ fn run_atomic_force_extraction(
     // freed before use.
     //
     // Path-based for the same reason as the temp dir above.
-    let backup_dir = tempfile::tempdir_in(parent)
-        .with_context(|| format!("failed to reserve backup path in {}", parent.display()))?;
+    let backup_dir = tempfile::tempdir_in(&parent_display).with_context(|| {
+        format!(
+            "failed to reserve backup path in {}",
+            parent_display.display()
+        )
+    })?;
     let backup_path = backup_dir.keep();
     let backup_name = backup_path
         .file_name()
@@ -124,22 +148,22 @@ fn run_atomic_force_extraction(
     pin.remove_dir(backup_name)
         .with_context(|| format!("failed to free backup path: {}", backup_path.display()))?;
 
-    verify_destination_unchanged(&pin, dest_name, dest_id, &canonical_output)?;
+    verify_destination_unchanged(&pin, &dest_name, dest_id, &dest_display)?;
 
-    pin.rename(dest_name, backup_name).with_context(|| {
+    pin.rename(&dest_name, backup_name).with_context(|| {
         format!(
             "failed to move existing destination {} aside before replacing it",
-            canonical_output.display()
+            dest_display.display()
         )
     })?;
 
     let temp_path = temp_dir.keep();
-    if let Err(e) = pin.rename(&temp_name, dest_name) {
+    if let Err(e) = pin.rename(&temp_name, &dest_name) {
         // Restore the original destination; the new extraction is discarded.
         // The restore's own outcome must be checked, not assumed: claiming
         // "restored" when the rename-back itself failed would tell the user
         // their data is safe while it actually sits at an unprinted temp path.
-        let restore_result = pin.rename(backup_name, dest_name);
+        let restore_result = pin.rename(backup_name, &dest_name);
         // Path-based, but safe: std's Unix `remove_dir_all` has been
         // `O_NOFOLLOW`-rooted and fd-recursive since the CVE-2022-21658
         // hardening, so it cannot be tricked into descending a planted
@@ -149,13 +173,13 @@ fn run_atomic_force_extraction(
         return Err(e).with_context(|| match restore_result {
             Ok(()) => format!(
                 "failed to move extracted content into {}; original destination restored",
-                canonical_output.display()
+                dest_display.display()
             ),
             Err(restore_err) => format!(
                 "failed to move extracted content into {}; the original destination could NOT \
                  be restored ({restore_err}) — its original contents are preserved at {} and \
                  must be recovered manually",
-                canonical_output.display(),
+                dest_display.display(),
                 backup_path.display()
             ),
         });
@@ -168,7 +192,7 @@ fn run_atomic_force_extraction(
 }
 
 /// Aborts with a distinct, actionable error if `pin`'s entry `name` no
-/// longer identifies `expected`.
+/// longer identifies `expected`, or is no longer a directory at all.
 ///
 /// Called by [`run_atomic_force_extraction`] immediately before the
 /// destructive first swap rename. `display` is used only to build the error
@@ -179,13 +203,13 @@ fn verify_destination_unchanged(
     expected: (u64, u64),
     display: &Path,
 ) -> Result<()> {
-    let current = pin.entry_identity(name).with_context(|| {
+    let (kind, current) = pin.entry_status(name).with_context(|| {
         format!(
             "failed to inspect destination before swap: {}",
             display.display()
         )
     })?;
-    if current != expected {
+    if kind != DestEntryKind::Directory || current != expected {
         anyhow::bail!(
             "destination changed on disk during extraction; refusing to swap: {}",
             display.display()
@@ -194,25 +218,148 @@ fn verify_destination_unchanged(
     Ok(())
 }
 
-/// Determines whether `--atomic --force` must replace a pre-existing
-/// `output_dir` via [`run_atomic_force_extraction`].
+/// Determines whether `--atomic --force` must replace the destination via
+/// [`run_atomic_force_extraction`], resolving and pinning everything the
+/// swap will need.
 ///
-/// Gated on `is_dir()`, not `exists()`: a pre-existing non-directory
-/// destination (a regular file, a symlink to one, etc.) must never be
-/// silently replaced by the swap — that would reproduce the exact data-loss
-/// class #519 was filed for, just on a different destination type. Returns
-/// an error instead of proceeding when that happens.
-fn resolve_atomic_force_replace(args: &ExtractArgs, output_dir: &Path) -> Result<bool> {
-    if !(args.atomic && args.force && output_dir.exists()) {
-        return Ok(false);
+/// Returns `Ok(None)` whenever nothing can pre-exist at the destination
+/// (nothing to swap, so the caller falls through to core's own atomic
+/// extraction), and `Ok(Some(_))` only once the destination has been
+/// confirmed to be a real, on-disk directory reachable through the pinned
+/// parent.
+///
+/// A pre-existing non-directory destination (a regular file, a symlink to
+/// one, etc.) is rejected with an error rather than silently replaced —
+/// that would reproduce the exact data-loss class #519 was filed for, just
+/// on a different destination type. This is a deliberate asymmetry: the
+/// same condition on a non-final path *component* (a parent that turns out
+/// to be a regular file, or is simply absent) only routes to `Ok(None)`,
+/// because there the object in question isn't the thing that would be
+/// destroyed — it only tells us there is nothing to destroy.
+///
+/// On Unix this now requires read permission on the destination's parent
+/// directory for *every* `--atomic --force` invocation, including when the
+/// destination does not yet exist — the pin below is unconditional, unlike
+/// the old `exists()`-gated flow (see `PinnedDir::open`'s doc comment).
+fn resolve_atomic_force_replace(
+    args: &ExtractArgs,
+    output_dir: &Path,
+) -> Result<Option<AtomicForceTarget>> {
+    if !(args.atomic && args.force) {
+        return Ok(None);
     }
-    if !output_dir.is_dir() {
-        anyhow::bail!(
+
+    // `dest_name` must stay `file_name()`-derived: `file_name()` strips a
+    // trailing separator, and a trailing separator makes even
+    // `SYMLINK_NOFOLLOW` resolve through the symlink (`"link/"` -> target).
+    let (parent_path, dest_name): (PathBuf, OsString) = match output_dir.file_name() {
+        Some(name) => {
+            // `parent()` is `None` only for the root or an empty path, both
+            // of which have no `file_name()` either — this branch is only
+            // reached when `file_name()` was `Some`, so `parent()` here is
+            // always `Some`, possibly empty (`Path::new("dest").parent()`
+            // is `Some("")`).
+            let parent = match output_dir.parent() {
+                Some(p) if !p.as_os_str().is_empty() => p.to_path_buf(),
+                _ => PathBuf::from("."),
+            };
+            (parent, name.to_os_string())
+        }
+        // `output_dir` is/ends in `.`, `..`, or `/`: there is no
+        // `file_name()`-derivable final component to take by path, so
+        // resolve the whole thing through `canonicalize()` instead and take
+        // its (already slash-free) `file_name()`.
+        None => match output_dir.canonicalize() {
+            Ok(canonical) => {
+                let parent = canonical
+                    .parent()
+                    .with_context(|| {
+                        format!("destination has no parent: {}", output_dir.display())
+                    })?
+                    .to_path_buf();
+                let dest_name = canonical
+                    .file_name()
+                    .with_context(|| {
+                        format!("destination has no file name: {}", output_dir.display())
+                    })?
+                    .to_os_string();
+                (parent, dest_name)
+            }
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => {
+                return Err(e).with_context(|| {
+                    format!("failed to resolve destination: {}", output_dir.display())
+                });
+            }
+        },
+    };
+
+    let canonical_parent = match parent_path.canonicalize() {
+        Ok(c) => c,
+        Err(e)
+            if matches!(
+                e.kind(),
+                io::ErrorKind::NotFound | io::ErrorKind::NotADirectory
+            ) =>
+        {
+            return Ok(None);
+        }
+        Err(e) => {
+            return Err(e).with_context(|| {
+                format!(
+                    "failed to resolve destination parent: {}",
+                    parent_path.display()
+                )
+            });
+        }
+    };
+
+    // Every error here is a hard failure, never a silent `Ok(None)`: step 3
+    // above already established that `canonical_parent` exists, so any
+    // failure opening it now means either it changed underneath us or
+    // permissions are wrong — both must fail closed rather than falling
+    // through to the unprotected path. Note this is a strictly broader
+    // permission requirement than the old path-based flow: it now applies
+    // even when nothing pre-exists at the destination, since the `exists()`
+    // gate that used to skip straight to `Ok(None)`/`Ok(false)` is gone.
+    let pin = PinnedDir::open(&canonical_parent).with_context(|| {
+        format!(
+            "failed to pin destination parent: {}",
+            canonical_parent.display()
+        )
+    })?;
+
+    let dest_display = canonical_parent.join(&dest_name);
+    let (kind, dest_id) = match pin.entry_status(&dest_name) {
+        Ok(status) => status,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => {
+            return Err(e).with_context(|| {
+                format!("failed to inspect destination: {}", dest_display.display())
+            });
+        }
+    };
+
+    match kind {
+        DestEntryKind::Directory => {}
+        DestEntryKind::Symlink => anyhow::bail!(
+            "cannot use --atomic --force: destination {} is a symlink; pass the resolved \
+             target path instead",
+            dest_display.display()
+        ),
+        DestEntryKind::Other => anyhow::bail!(
             "cannot use --atomic --force: destination {} already exists and is not a directory",
-            output_dir.display()
-        );
+            dest_display.display()
+        ),
     }
-    Ok(true)
+
+    Ok(Some(AtomicForceTarget {
+        pin,
+        dest_name,
+        dest_id,
+        parent_display: canonical_parent,
+        dest_display,
+    }))
 }
 
 /// Expands a list of extension tokens that may contain comma-separated values
@@ -372,10 +519,10 @@ pub fn execute(
     // never touched if extraction fails). The CLI performs that swap only
     // after extraction has already fully succeeded; see
     // `run_atomic_force_extraction`.
-    let atomic_force_replace = resolve_atomic_force_replace(args, &output_dir)?;
+    let atomic_force_target = resolve_atomic_force_replace(args, &output_dir)?;
 
     let options = ExtractionOptions::default()
-        .with_atomic(args.atomic && !atomic_force_replace)
+        .with_atomic(args.atomic && atomic_force_target.is_none())
         .with_skip_duplicates(!args.force);
 
     let mut progress: Box<dyn ProgressCallback> = if verbose {
@@ -386,10 +533,10 @@ pub fn execute(
         Box::new(NoopProgress)
     };
 
-    let report = if atomic_force_replace {
+    let report = if let Some(target) = atomic_force_target {
         run_atomic_force_extraction(
             &args.archive,
-            &output_dir,
+            target,
             &config,
             &options,
             progress.as_mut(),
@@ -418,7 +565,7 @@ mod tests {
     /// Regression test for critic finding S2: the identity-mismatch abort
     /// branch in [`run_atomic_force_extraction`] previously had zero test
     /// coverage — only the OS-level property it relies on
-    /// (`PinnedDir::entry_identity` differing for different inodes) was
+    /// (`PinnedDir::entry_status` differing for different inodes) was
     /// tested, not this code's use of it. Exercises both outcomes of
     /// [`verify_destination_unchanged`] directly: unchanged passes, and a
     /// destination swapped for a freshly created replacement with the same
@@ -435,7 +582,7 @@ mod tests {
 
         let pin = PinnedDir::open(&parent).expect("pin parent");
         let dest_name = OsStr::new("dest");
-        let expected = pin.entry_identity(dest_name).expect("snapshot identity");
+        let (_, expected) = pin.entry_status(dest_name).expect("snapshot identity");
 
         verify_destination_unchanged(&pin, dest_name, expected, &dest)
             .expect("unchanged destination must pass verification");
@@ -445,6 +592,41 @@ mod tests {
 
         let err = verify_destination_unchanged(&pin, dest_name, expected, &dest)
             .expect_err("swapped destination must be rejected");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("destination changed on disk during extraction; refusing to swap"),
+            "error must carry the distinct refusing-to-swap message, got: {msg}"
+        );
+    }
+
+    /// Regression test for the v3 spec's `verify_destination_unchanged`
+    /// change: the identity check alone is not enough once the entry can be
+    /// swapped for a *same-inode-impossible* but differently-kinded
+    /// replacement — specifically, the destination being replaced with a
+    /// symlink must be rejected by the explicit `DestEntryKind::Directory`
+    /// assertion, not just by an identity mismatch (which a real attacker
+    /// cannot control precisely enough to rely on alone).
+    #[test]
+    #[cfg(unix)]
+    #[allow(clippy::unwrap_used, clippy::expect_used)]
+    fn verify_destination_unchanged_detects_destination_replaced_with_symlink() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let parent = root.path().join("parent");
+        std::fs::create_dir(&parent).expect("create parent");
+        let dest = parent.join("dest");
+        std::fs::create_dir(&dest).expect("create dest");
+        let decoy = root.path().join("decoy");
+        std::fs::create_dir(&decoy).expect("create decoy");
+
+        let pin = PinnedDir::open(&parent).expect("pin parent");
+        let dest_name = OsStr::new("dest");
+        let (_, expected) = pin.entry_status(dest_name).expect("snapshot identity");
+
+        std::fs::remove_dir(&dest).expect("remove dest");
+        std::os::unix::fs::symlink(&decoy, &dest).expect("plant symlink over dest");
+
+        let err = verify_destination_unchanged(&pin, dest_name, expected, &dest)
+            .expect_err("destination replaced with a symlink must be rejected");
         let msg = format!("{err:#}");
         assert!(
             msg.contains("destination changed on disk during extraction; refusing to swap"),

--- a/crates/exarch-cli/tests/cli_tests.rs
+++ b/crates/exarch-cli/tests/cli_tests.rs
@@ -2652,17 +2652,20 @@ fn test_extract_atomic_force_rejects_non_directory_destination() {
     );
 }
 
-/// Regression test for #525/#526: when `output_dir` is a symlink to a
-/// directory, `--atomic --force` must replace the *target* directory's
-/// contents while leaving the symlink itself intact and still pointing at
-/// the same target path. This is also the proof that the #526 fd-pinned
-/// swap (which resolves `parent`/`dest_name` from `canonicalize()`'s fully
-/// resolved output) does not regress this final-component-is-a-symlink
-/// behavior: `renameat` on the pinned parent acts on the same real
-/// directory a path-based `rename` would.
+/// Regression test for GHSA-x8wr-7ww2-c94x: when `output_dir` is a symlink,
+/// `--atomic --force` must reject it outright rather than following it — the
+/// destination's own name is now taken lexically and never canonicalized,
+/// so a symlink at the destination itself is classified via
+/// `statat(SYMLINK_NOFOLLOW)` and refused instead of being silently
+/// resolved to whatever it points at. This inverts and replaces
+/// `test_extract_atomic_force_symlink_destination_preserves_symlink`, which
+/// pinned the now-removed behavior (#525/#526): following a symlinked
+/// destination let an attacker who controls the destination's containing
+/// directory redirect — and, via the swap's `remove_dir_all`, destructively
+/// replace — any directory writable by the invoking user.
 #[test]
 #[cfg(unix)]
-fn test_extract_atomic_force_symlink_destination_preserves_symlink() {
+fn test_extract_atomic_force_rejects_symlink_destination() {
     let temp = TempDir::new().expect("failed to create temp dir");
     let real_dest = temp.path().join("real_dest");
     std::fs::create_dir_all(&real_dest).expect("create real destination directory");
@@ -2678,7 +2681,8 @@ fn test_extract_atomic_force_symlink_destination_preserves_symlink() {
         .arg(fixture_path("sample.tar.gz"))
         .arg(&symlink_dest)
         .assert()
-        .success();
+        .failure()
+        .stderr(predicate::str::contains("is a symlink"));
 
     assert!(
         symlink_dest
@@ -2686,20 +2690,16 @@ fn test_extract_atomic_force_symlink_destination_preserves_symlink() {
             .expect("read symlink metadata")
             .file_type()
             .is_symlink(),
-        "the destination symlink itself must survive the swap"
+        "the destination symlink itself must be left untouched"
     );
     assert_eq!(
-        std::fs::read_link(&symlink_dest).expect("read symlink target"),
-        real_dest,
-        "the symlink must still point at the same target path"
+        std::fs::read(real_dest.join("old.txt")).expect("pre-existing file must survive"),
+        b"OLD CONTENT",
+        "the symlink's target directory's pre-existing content must be unchanged when rejected"
     );
     assert!(
-        real_dest.join("sample.txt").exists(),
-        "the symlink's target directory must contain the newly extracted content"
-    );
-    assert!(
-        !real_dest.join("old.txt").exists(),
-        "the symlink's target directory's pre-existing content must be fully replaced"
+        !real_dest.join("sample.txt").exists(),
+        "no content from the rejected extraction attempt must leak into the target directory"
     );
 
     let siblings: Vec<_> = std::fs::read_dir(temp.path())
@@ -2716,6 +2716,509 @@ fn test_extract_atomic_force_symlink_destination_preserves_symlink() {
         ],
         "no leftover temp/backup swap directories must remain next to the destination: {siblings:?}"
     );
+}
+
+/// Regression test (v4 D2): a trailing slash on a symlinked destination
+/// must not defeat the rejection above. `SYMLINK_NOFOLLOW` alone is *not*
+/// sufficient here — a trailing slash makes `statat`/`open` follow the
+/// symlink regardless of the no-follow flag (verified: `"link/"` resolves
+/// to the target's inode, `"link"` does not) — so this test is the one
+/// guard against a future regression back toward deriving `dest_name` from
+/// a raw path fragment instead of `Path::file_name()`, which strips the
+/// trailing separator before the name ever reaches `statat`. This vector
+/// was never reachable against the shipped fd-pinning design (#531); it
+/// guards a design invariant, not a live defect in `main`.
+#[test]
+#[cfg(unix)]
+fn test_extract_atomic_force_rejects_symlink_destination_with_trailing_slash() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let real_dest = temp.path().join("real_dest");
+    std::fs::create_dir_all(&real_dest).expect("create real destination directory");
+    std::fs::write(real_dest.join("old.txt"), b"OLD CONTENT").expect("seed pre-existing file");
+
+    let symlink_dest = temp.path().join("dest_link");
+    std::os::unix::fs::symlink(&real_dest, &symlink_dest).expect("create symlink to destination");
+    let mut symlink_dest_with_slash = symlink_dest.into_os_string();
+    symlink_dest_with_slash.push("/");
+
+    exarch_cmd()
+        .arg("extract")
+        .arg("--atomic")
+        .arg("--force")
+        .arg(fixture_path("sample.tar.gz"))
+        .arg(&symlink_dest_with_slash)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("is a symlink"));
+
+    assert_eq!(
+        std::fs::read(real_dest.join("old.txt")).expect("pre-existing file must survive"),
+        b"OLD CONTENT",
+        "the symlink's target directory's pre-existing content must be unchanged when rejected"
+    );
+}
+
+/// Regression test (S5(i)): a destination that does not yet exist, whose
+/// parent does, must take the `Ok(None)` path and fall through to core's
+/// own atomic extraction rather than being rejected. Zero coverage before
+/// this fix and the highest silent-regression risk in this change, since
+/// nothing here previously exercised `entry_status`'s `NotFound` mapping.
+#[test]
+fn test_extract_atomic_force_fresh_destination_succeeds() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let dest = temp.path().join("dest");
+
+    exarch_cmd()
+        .arg("extract")
+        .arg("--atomic")
+        .arg("--force")
+        .arg(fixture_path("sample.tar.gz"))
+        .arg(&dest)
+        .assert()
+        .success();
+
+    assert!(
+        dest.join("sample.txt").exists(),
+        "a fresh destination must be created and populated"
+    );
+}
+
+/// Regression test (S5(ii)): a *dangling* symlink at the destination (its
+/// target does not exist) must still be rejected as a symlink, not treated
+/// as `NotFound`/`Ok(None)`. `statat(SYMLINK_NOFOLLOW)` reports the
+/// symlink's own kind regardless of whether its target resolves, so this
+/// pins that `entry_status` is checked on the link itself, never on
+/// whatever (if anything) it points to.
+#[test]
+#[cfg(unix)]
+fn test_extract_atomic_force_rejects_dangling_symlink_destination() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let dangling_target = temp.path().join("does_not_exist");
+    let symlink_dest = temp.path().join("dest_link");
+    std::os::unix::fs::symlink(&dangling_target, &symlink_dest)
+        .expect("create dangling symlink destination");
+
+    exarch_cmd()
+        .arg("extract")
+        .arg("--atomic")
+        .arg("--force")
+        .arg(fixture_path("sample.tar.gz"))
+        .arg(&symlink_dest)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("is a symlink"));
+
+    assert!(
+        symlink_dest
+            .symlink_metadata()
+            .expect("read symlink metadata")
+            .file_type()
+            .is_symlink(),
+        "the dangling destination symlink itself must be left untouched"
+    );
+}
+
+/// Regression test (S5(iii)-a): a bare relative destination (no directory
+/// prefix) exercises `output_dir.parent() == Some("")`, which
+/// `resolve_atomic_force_replace` must normalize to `"."` rather than
+/// passing the empty path to `canonicalize()`.
+#[test]
+#[cfg(unix)]
+fn test_extract_atomic_force_relative_bare_destination_succeeds() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let dest = temp.path().join("dest");
+    std::fs::create_dir_all(&dest).expect("create pre-existing destination");
+    std::fs::write(dest.join("old.txt"), b"OLD CONTENT").expect("seed pre-existing file");
+
+    exarch_cmd()
+        .current_dir(temp.path())
+        .arg("extract")
+        .arg("--atomic")
+        .arg("--force")
+        .arg(fixture_path("sample.tar.gz"))
+        .arg("dest")
+        .assert()
+        .success();
+
+    assert!(
+        dest.join("sample.txt").exists(),
+        "destination must contain the newly extracted archive content"
+    );
+    assert!(
+        !dest.join("old.txt").exists(),
+        "pre-existing destination content must be fully replaced on success"
+    );
+}
+
+/// Regression test (S5(iii)-b): a trailing slash on an ordinary (non-symlink)
+/// destination must resolve identically to the same path without one —
+/// `Path::file_name()` strips the trailing separator on the direct branch
+/// too, not only in the `canonicalize()` fallback. Distinct from
+/// `test_extract_atomic_force_rejects_symlink_destination_with_trailing_slash`,
+/// which pins the rejection case; this pins the success case.
+#[test]
+#[cfg(unix)]
+fn test_extract_atomic_force_trailing_slash_destination_succeeds() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let dest = temp.path().join("dest");
+    std::fs::create_dir_all(&dest).expect("create pre-existing destination");
+    std::fs::write(dest.join("old.txt"), b"OLD CONTENT").expect("seed pre-existing file");
+
+    let mut dest_with_slash = dest.clone().into_os_string();
+    dest_with_slash.push("/");
+
+    exarch_cmd()
+        .arg("extract")
+        .arg("--atomic")
+        .arg("--force")
+        .arg(fixture_path("sample.tar.gz"))
+        .arg(&dest_with_slash)
+        .assert()
+        .success();
+
+    assert!(
+        dest.join("sample.txt").exists(),
+        "destination must contain the newly extracted archive content"
+    );
+    assert!(
+        !dest.join("old.txt").exists(),
+        "pre-existing destination content must be fully replaced on success"
+    );
+}
+
+/// Regression test (N1): a destination of `.` must still work — before this
+/// fix, `output_dir.file_name()` is `None` for `.`, so this fell through to
+/// a hard-fail on `canonicalize()`/`file_name()` chaining. Now `.` and
+/// paths ending in it are resolved via the `canonicalize()` fallback, whose
+/// resulting name is already slash- and dot-free.
+#[test]
+#[cfg(unix)]
+fn test_extract_atomic_force_dot_destination_succeeds() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let dest = temp.path().join("dest");
+    std::fs::create_dir_all(&dest).expect("create pre-existing destination");
+    std::fs::write(dest.join("old.txt"), b"OLD CONTENT").expect("seed pre-existing file");
+
+    exarch_cmd()
+        .current_dir(&dest)
+        .arg("extract")
+        .arg("--atomic")
+        .arg("--force")
+        .arg(fixture_path("sample.tar.gz"))
+        .arg(".")
+        .assert()
+        .success();
+
+    assert!(
+        dest.join("sample.txt").exists(),
+        "destination must contain the newly extracted archive content"
+    );
+    assert!(
+        !dest.join("old.txt").exists(),
+        "pre-existing destination content must be fully replaced on success"
+    );
+}
+
+/// Sibling of the `.` case above: a trailing-slash-terminated `./` must
+/// resolve identically (`Path::file_name()` is `None` for both).
+#[test]
+#[cfg(unix)]
+fn test_extract_atomic_force_dot_slash_destination_succeeds() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let dest = temp.path().join("dest");
+    std::fs::create_dir_all(&dest).expect("create pre-existing destination");
+    std::fs::write(dest.join("old.txt"), b"OLD CONTENT").expect("seed pre-existing file");
+
+    exarch_cmd()
+        .current_dir(&dest)
+        .arg("extract")
+        .arg("--atomic")
+        .arg("--force")
+        .arg(fixture_path("sample.tar.gz"))
+        .arg("./")
+        .assert()
+        .success();
+
+    assert!(
+        dest.join("sample.txt").exists(),
+        "destination must contain the newly extracted archive content"
+    );
+    assert!(
+        !dest.join("old.txt").exists(),
+        "pre-existing destination content must be fully replaced on success"
+    );
+}
+
+/// Sibling of the `.` case above using `..`: resolved via the same
+/// `canonicalize()` fallback (`Path::file_name()` is also `None` for `..`).
+#[test]
+#[cfg(unix)]
+fn test_extract_atomic_force_dotdot_destination_succeeds() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let dest = temp.path().join("dest");
+    let cwd = dest.join("subdir");
+    std::fs::create_dir_all(&cwd).expect("create pre-existing destination and cwd subdir");
+    std::fs::write(dest.join("old.txt"), b"OLD CONTENT").expect("seed pre-existing file");
+
+    exarch_cmd()
+        .current_dir(&cwd)
+        .arg("extract")
+        .arg("--atomic")
+        .arg("--force")
+        .arg(fixture_path("sample.tar.gz"))
+        .arg("..")
+        .assert()
+        .success();
+
+    assert!(
+        dest.join("sample.txt").exists(),
+        "destination must contain the newly extracted archive content"
+    );
+    assert!(
+        !dest.join("old.txt").exists(),
+        "pre-existing destination content must be fully replaced on success"
+    );
+}
+
+/// Regression test (N2): a destination whose parent doesn't exist yet
+/// either (a fresh, multi-level-nested path) must still succeed — before
+/// this fix, `canonicalize()` on a not-yet-existing nested parent returned
+/// `NotFound`, hard-failing instead of falling through to core's own atomic
+/// extraction, which creates the necessary directories itself.
+#[test]
+fn test_extract_atomic_force_nested_fresh_destination_succeeds() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let dest = temp.path().join("new").join("deep").join("dir");
+
+    exarch_cmd()
+        .arg("extract")
+        .arg("--atomic")
+        .arg("--force")
+        .arg(fixture_path("sample.tar.gz"))
+        .arg(&dest)
+        .assert()
+        .success();
+
+    assert!(
+        dest.join("sample.txt").exists(),
+        "a fresh, multi-level-nested destination must be created and populated"
+    );
+}
+
+/// A symlinked *intermediate* path component must remain fully supported —
+/// only the destination's own final component is rejected when it is a
+/// symlink. `resolve_atomic_force_replace` canonicalizes the destination's
+/// parent (resolving any symlinked prefix) but takes the destination's own
+/// name lexically, so `link_mid/dest` still finds and replaces the real
+/// `real_mid/dest` directory.
+#[test]
+#[cfg(unix)]
+fn test_extract_atomic_force_symlinked_intermediate_component_still_succeeds() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let real_mid = temp.path().join("real_mid");
+    std::fs::create_dir_all(&real_mid).expect("create real intermediate directory");
+    let dest = real_mid.join("dest");
+    std::fs::create_dir_all(&dest).expect("create pre-existing destination");
+    std::fs::write(dest.join("old.txt"), b"OLD CONTENT").expect("seed pre-existing file");
+
+    let link_mid = temp.path().join("link_mid");
+    std::os::unix::fs::symlink(&real_mid, &link_mid).expect("symlink intermediate component");
+
+    exarch_cmd()
+        .arg("extract")
+        .arg("--atomic")
+        .arg("--force")
+        .arg(fixture_path("sample.tar.gz"))
+        .arg(link_mid.join("dest"))
+        .assert()
+        .success();
+
+    assert!(
+        dest.join("sample.txt").exists(),
+        "destination reached through a symlinked intermediate component must be populated"
+    );
+    assert!(
+        !dest.join("old.txt").exists(),
+        "pre-existing destination content must be fully replaced on success"
+    );
+    assert_eq!(
+        std::fs::read_link(&link_mid).expect("read symlink target"),
+        real_mid,
+        "the intermediate symlink itself must be untouched by the swap"
+    );
+}
+
+/// A destination that is the filesystem root has no parent to pin — this
+/// must still be rejected, unchanged from before this fix (today's
+/// `canonical_output.parent()` is already `None` there). Safe to exercise
+/// against the real `/`: `resolve_atomic_force_replace` bails at the
+/// parent-less check before any filesystem write is attempted.
+#[test]
+#[cfg(unix)]
+fn test_extract_atomic_force_rejects_filesystem_root_destination() {
+    exarch_cmd()
+        .arg("extract")
+        .arg("--atomic")
+        .arg("--force")
+        .arg(fixture_path("sample.tar.gz"))
+        .arg("/")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("destination has no parent"));
+}
+
+/// Regression pin for the G1 finding: dropping the `exists()` gate means
+/// `resolve_atomic_force_replace` now pins the destination's parent for
+/// *every* `--atomic --force` invocation, not only when something already
+/// exists there to replace. A `0311` (write+execute, no read) parent used
+/// to work for a fresh destination (`mkdir`/`realpath` succeed without read);
+/// it must now fail, since obtaining a real directory file descriptor
+/// requires read permission on the parent (see `PinnedDir::open`'s doc
+/// comment and `parent_without_read_permission_is_rejected` in
+/// `atomic_swap.rs`, which pins the same residual for a pre-existing
+/// destination).
+#[test]
+#[cfg(unix)]
+fn test_extract_atomic_force_requires_parent_read_permission_even_for_fresh_destination() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let parent = temp.path().join("parent");
+    std::fs::create_dir(&parent).expect("create parent");
+    std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o311))
+        .expect("restrict parent permissions");
+    let dest = parent.join("dest");
+
+    let assert = exarch_cmd()
+        .arg("extract")
+        .arg("--atomic")
+        .arg("--force")
+        .arg(fixture_path("sample.tar.gz"))
+        .arg(&dest)
+        .assert();
+
+    std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o755))
+        .expect("restore parent permissions so tempdir cleanup can proceed");
+
+    if assert.get_output().status.success() {
+        eprintln!(
+            "skipping: extraction into a read-restricted parent unexpectedly succeeded \
+             (running as root?)"
+        );
+        return;
+    }
+    assert
+        .failure()
+        .stderr(predicate::str::contains("failed to pin destination parent"));
+}
+
+/// Windows-only regression test (v3/v4): a junction at the destination must
+/// be rejected the same way a Unix symlink is. `entry_status` classifies
+/// `FILE_ATTRIBUTE_REPARSE_POINT` tag-agnostically as
+/// `DestEntryKind::Symlink`, so this covers junctions — the practical
+/// Windows redirect primitive, which (unlike a true symlink) needs no
+/// elevation to create — without depending on which specific reparse tag an
+/// attacker used. `mklink /J` requires no elevation either, so this fixture
+/// does not need an elevated CI runner.
+#[test]
+#[cfg(windows)]
+fn test_extract_atomic_force_rejects_junction_destination() {
+    let temp = TempDir::new().expect("failed to create temp dir");
+    let real_dest = temp.path().join("real_dest");
+    std::fs::create_dir_all(&real_dest).expect("create real destination directory");
+    std::fs::write(real_dest.join("old.txt"), b"OLD CONTENT").expect("seed pre-existing file");
+
+    let junction_dest = temp.path().join("dest_junction");
+    let status = std::process::Command::new("cmd")
+        .arg("/C")
+        .arg("mklink")
+        .arg("/J")
+        .arg(&junction_dest)
+        .arg(&real_dest)
+        .status()
+        .expect("run mklink");
+    assert!(
+        status.success(),
+        "mklink /J must succeed to create the junction fixture"
+    );
+
+    exarch_cmd()
+        .arg("extract")
+        .arg("--atomic")
+        .arg("--force")
+        .arg(fixture_path("sample.tar.gz"))
+        .arg(&junction_dest)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("is a symlink"));
+
+    assert_eq!(
+        std::fs::read(real_dest.join("old.txt")).expect("pre-existing file must survive"),
+        b"OLD CONTENT",
+        "the junction's target directory's pre-existing content must be unchanged when rejected"
+    );
+}
+
+/// Regression test reproducing the original GHSA-x8wr-7ww2-c94x `PoC`: tightly
+/// toggles the destination between a real directory and a symlink to
+/// `attacker_dir` while `--atomic --force` runs, many times, and asserts
+/// the invariant the fix establishes rather than a probability — every
+/// trial is either a clean failure or a success with `attacker_dir`
+/// completely untouched. Success with archive content landing under
+/// `attacker_dir` (the original vulnerability) must never be observed.
+#[test]
+#[cfg(unix)]
+fn test_extract_atomic_force_survives_destination_symlink_race() {
+    const TRIALS: usize = 30;
+
+    for trial in 0..TRIALS {
+        let temp = TempDir::new().expect("failed to create temp dir");
+
+        let attacker_dir = temp.path().join("attacker_dir");
+        std::fs::create_dir_all(&attacker_dir).expect("create attacker dir");
+        std::fs::write(attacker_dir.join("canary.txt"), b"CANARY").expect("seed canary");
+
+        let dest = temp.path().join("dest");
+        std::fs::create_dir_all(&dest).expect("create initial dest");
+
+        let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let toggler_stop = std::sync::Arc::clone(&stop);
+        let toggler_dest = dest.clone();
+        let toggler_attacker = attacker_dir.clone();
+        let toggler = std::thread::spawn(move || {
+            while !toggler_stop.load(std::sync::atomic::Ordering::Relaxed) {
+                let _ = std::fs::remove_dir(&toggler_dest);
+                let _ = std::os::unix::fs::symlink(&toggler_attacker, &toggler_dest);
+                let _ = std::fs::remove_file(&toggler_dest);
+                let _ = std::fs::create_dir(&toggler_dest);
+            }
+        });
+
+        let output = exarch_cmd()
+            .arg("extract")
+            .arg("--atomic")
+            .arg("--force")
+            .arg(fixture_path("sample.tar.gz"))
+            .arg(&dest)
+            .output()
+            .expect("run exarch");
+
+        stop.store(true, std::sync::atomic::Ordering::Relaxed);
+        toggler.join().expect("toggler thread must not panic");
+
+        let canary = std::fs::read(attacker_dir.join("canary.txt"))
+            .expect("attacker_dir's own canary must always survive");
+        assert_eq!(
+            canary, b"CANARY",
+            "trial {trial}: attacker_dir must never be modified by the swap"
+        );
+        assert!(
+            !attacker_dir.join("sample.txt").exists(),
+            "trial {trial}: archive content must never land under attacker_dir — this is the \
+             exact vulnerability the fix closes (extraction success = {})",
+            output.status.success()
+        );
+    }
 }
 
 // ============================================================================

--- a/skills/exarch-cli/SKILL.md
+++ b/skills/exarch-cli/SKILL.md
@@ -95,7 +95,7 @@ Key flags (all optional):
 | Flag | Default | Purpose |
 |---|---|---|
 | `--force` | off | Overwrite existing files at the destination. |
-| `--atomic` | off | Extract to a temp dir, rename into place on success, clean up on failure. With `--force`, the pre-existing destination is removed only after successful extraction (right before rename), minimizing the window with no valid data. |
+| `--atomic` | off | Extract to a temp dir, rename into place on success, clean up on failure. With `--force`, the pre-existing destination is removed only after successful extraction (right before rename), minimizing the window with no valid data. With `--force`, a destination that is itself a symlink is now rejected — pass the resolved target path instead. |
 | `--preserve-permissions` | off | Preserve file permissions from the archive (setuid/setgid are still stripped regardless). |
 | `--max-files` | 10000 | Max number of entries to extract. |
 | `--max-total-size` | 500 MB | Max cumulative extracted size. Accepts `K`/`M`/`G`/`T` suffixes, e.g. `2G`. |


### PR DESCRIPTION
## Summary

- `extract --atomic --force` resolved the destination by path (`exists()`, `is_dir()`, then `canonicalize()`) before any file descriptor pinned it. A symlink planted at the destination itself was silently followed, retargeting the entire swap — including the final `remove_dir_all` on the displaced backup — at whatever directory the symlink pointed to. This let an attacker with write access to the destination's containing directory destructively replace any directory writable by the invoking user, deterministically and with no race to win.
- Fixes GHSA-x8wr-7ww2-c94x (private security advisory, severity high, CWE-59/CWE-367).
- The destination's parent is now canonicalized and pinned by a file descriptor (`PinnedDir`); the destination's own name is taken lexically from `Path::file_name()` and never canonicalized, with its type checked via `statat(SYMLINK_NOFOLLOW)` (`DestEntryKind`/`entry_status`), so every check and every rename names the same entry inside the same pinned parent.
- **Breaking change**: `--atomic --force` onto a destination that is itself a symlink (or, on Windows, a junction/reparse point) is now rejected on all platforms — pass the resolved target path instead. Symlinked *intermediate* path components remain supported. Only `--atomic --force` is affected; plain `extract`, `--atomic` without `--force`, and the Rust/Python/Node APIs are unchanged (tracked as a separate policy question in #533).

## Review process

This fix went through 4 rounds of adversarial architect/critic review before implementation (catching a deterministic trailing-slash bypass in the originally-proposed design, a macOS-only fail-open regression in the error-mapping logic, and two functional regressions against common invocations), plus an execution-verified implementation critique and an independently-verified code review. Full detail in `.local/handoff/` on this branch.

Follow-up filed: #533 (P2, whether non-atomic extraction paths should also reject a symlinked destination root — deliberately out of scope for this hotfix).

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude exarch-python --exclude exarch-node` (1216 passed)
- [x] `cargo test --doc --workspace --all-features --exclude exarch-python --exclude exarch-node` (117 passed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --all-features --workspace`
- [x] Live-verified against the built binary: symlink destination, dangling symlink, trailing-slash symlink, FIFO destination (no hang), fresh/nested/relative/`.`/`..` destinations
- [x] 30-trial race test reproducing the original PoC, asserting a hard invariant (never success with content under the attacker directory) rather than a probability