### PR TITLE
fix(core): use component-aware comparison in macOS/Windows containment check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Case-insensitive containment check accepted a sibling of the destination root sharing a name prefix on macOS/Windows (GHSA-wcmx-7f9h-5mv5)**:
+  `paths_start_with` (`crates/exarch-core/src/types/safe_path.rs`), used by `SafePath`'s macOS/Windows
+  containment check, compared paths as raw lowercased strings, so `/tmp/destevil` was wrongly treated as
+  contained within `/tmp/dest` (`"...destevil".starts_with("...dest")` is true with no component
+  boundary). The check now compares `Path::components()` pairwise, case-folding each segment, matching
+  the already-correct non-macOS Unix behavior except case-insensitively.
+
 ### Changed
 
 - **`exarch-cli`'s `--atomic --force` swap path now bundles the pinned temp directory's

--- a/crates/exarch-core/src/types/safe_path.rs
+++ b/crates/exarch-core/src/types/safe_path.rs
@@ -343,12 +343,25 @@ impl SafePath {
 ///
 /// On case-insensitive filesystems (macOS, Windows), attackers can bypass
 /// path validation using different case (e.g., `../../USERS/victim/.ssh/`).
+///
+/// Compares `path` and `base` component-by-component rather than as raw
+/// strings, so a shared name prefix without a component boundary (e.g. base
+/// `/tmp/dest` against sibling `/tmp/destevil`) is correctly rejected. See
+/// GHSA-wcmx-7f9h-5mv5.
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 fn paths_start_with(path: &Path, base: &Path) -> bool {
-    // Convert both paths to lowercase strings for comparison
-    let path_str = path.to_string_lossy().to_lowercase();
-    let base_str = base.to_string_lossy().to_lowercase();
-    path_str.starts_with(&base_str)
+    let mut path_components = path.components();
+    for base_component in base.components() {
+        let Some(path_component) = path_components.next() else {
+            return false;
+        };
+        let path_str = path_component.as_os_str().to_string_lossy().to_lowercase();
+        let base_str = base_component.as_os_str().to_string_lossy().to_lowercase();
+        if path_str != base_str {
+            return false;
+        }
+    }
+    true
 }
 
 /// Case-sensitive path prefix check for Unix (not macOS).
@@ -1201,5 +1214,59 @@ mod tests {
                 "path '{p}' must be rejected as path traversal"
             );
         }
+    }
+
+    // --- Tests for GHSA-wcmx-7f9h-5mv5 (case-insensitive prefix bypass) ---
+
+    #[test]
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    fn test_paths_start_with_rejects_sibling_sharing_name_prefix_ghsa_wcmx() {
+        // GHSA-wcmx-7f9h-5mv5: the previous implementation compared paths as
+        // raw strings, so `/tmp/destevil`.starts_with(`/tmp/dest`) was true
+        // even though `destevil` is a sibling directory, not a subdirectory
+        // of `dest`.
+        let base = Path::new("/tmp/dest");
+        let sibling = Path::new("/tmp/destevil");
+        assert!(
+            !paths_start_with(sibling, base),
+            "sibling directory sharing a name prefix must not be treated as contained"
+        );
+    }
+
+    #[test]
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    fn test_paths_start_with_accepts_genuine_subdirectory() {
+        let base = Path::new("/tmp/dest");
+        let child = Path::new("/tmp/dest/sub");
+        assert!(
+            paths_start_with(child, base),
+            "genuine subdirectory must still be accepted as contained"
+        );
+    }
+
+    #[test]
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    fn test_paths_start_with_is_case_insensitive() {
+        let base = Path::new("/tmp/dest");
+        let child = Path::new("/tmp/Dest/sub");
+        assert!(
+            paths_start_with(child, base),
+            "differing-case containment must still be accepted on case-insensitive filesystems"
+        );
+    }
+
+    #[test]
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    fn test_paths_start_with_rejects_when_base_has_more_components_than_path() {
+        // Regression for a `break`-instead-of-`return false` mutant: when
+        // `base` has more components than `path`, the `path` component
+        // iterator is exhausted mid-loop and the function must reject
+        // immediately, not fall through the loop to the trailing `true`.
+        let base = Path::new("/tmp/dest/sub/extra");
+        let shorter = Path::new("/tmp/dest/sub");
+        assert!(
+            !paths_start_with(shorter, base),
+            "a path shorter than base must never be treated as containing base"
+        );
     }
 }

--- a/crates/exarch-core/tests/security/mod.rs
+++ b/crates/exarch-core/tests/security/mod.rs
@@ -3,6 +3,7 @@
 mod cve_regression;
 mod hardlink_quota_bypass;
 mod partial_report_skip_and_fail;
+mod safe_path_ghsa_wcmx;
 mod sevenz_traversal;
 mod symlink_target_validation;
 mod tar_budget_parity;

--- a/crates/exarch-core/tests/security/safe_path_ghsa_wcmx.rs
+++ b/crates/exarch-core/tests/security/safe_path_ghsa_wcmx.rs
@@ -9,7 +9,11 @@
 //! the containment check runs against an actually canonicalized path — the
 //! same code path a crafted archive entry resolving through a symlinked
 //! directory would take — rather than a synthetic `Path` value.
-
+//!
+//! Unix-only: the attack requires a real on-disk symlink, and the whole
+//! file (not just the test function) must be gated so its imports don't
+//! become unused-import errors under `-D warnings` on non-Unix targets.
+#![cfg(unix)]
 #![allow(clippy::unwrap_used)]
 
 use exarch_core::ArchiveError;
@@ -21,7 +25,6 @@ use std::path::PathBuf;
 use tempfile::TempDir;
 
 #[test]
-#[cfg(unix)]
 fn ghsa_wcmx_sibling_reached_via_symlink_is_rejected() {
     use std::os::unix::fs::symlink;
 

--- a/crates/exarch-core/tests/security/safe_path_ghsa_wcmx.rs
+++ b/crates/exarch-core/tests/security/safe_path_ghsa_wcmx.rs
@@ -1,0 +1,57 @@
+//! End-to-end regression test for GHSA-wcmx-7f9h-5mv5: on case-insensitive
+//! filesystems (macOS, Windows), `SafePath`'s containment check compared a
+//! canonicalized parent directory against the destination root as a raw
+//! string prefix, so a sibling of the destination root sharing a name prefix
+//! (e.g. `dest` vs. `destevil`) was wrongly treated as contained within
+//! `dest`.
+//!
+//! This drives the attack through a real, pre-existing on-disk symlink so
+//! the containment check runs against an actually canonicalized path — the
+//! same code path a crafted archive entry resolving through a symlinked
+//! directory would take — rather than a synthetic `Path` value.
+
+#![allow(clippy::unwrap_used)]
+
+use exarch_core::ArchiveError;
+use exarch_core::DestDir;
+use exarch_core::SafePath;
+use exarch_core::SecurityConfig;
+use std::assert_matches;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+#[test]
+#[cfg(unix)]
+fn ghsa_wcmx_sibling_reached_via_symlink_is_rejected() {
+    use std::os::unix::fs::symlink;
+
+    let temp = TempDir::new().unwrap();
+
+    // Destination root: <temp>/dest
+    let dest_root = temp.path().join("dest");
+    std::fs::create_dir(&dest_root).unwrap();
+    let dest = DestDir::new(dest_root.clone()).unwrap();
+
+    // Pre-existing sibling directory that shares `dest_root`'s name as a
+    // string prefix but is NOT a subdirectory of it: <temp>/destevil.
+    let sibling = temp.path().join("destevil");
+    std::fs::create_dir(&sibling).unwrap();
+
+    // A symlink inside `dest` resolving to the sibling, so the validated
+    // entry's canonicalized parent is the sibling directory rather than
+    // `dest_root` itself.
+    let escape_link = dest_root.join("escape");
+    symlink(&sibling, &escape_link).unwrap();
+
+    let config = SecurityConfig::default().validate().unwrap();
+    let entry_path = PathBuf::from("escape/secret.txt");
+
+    let result = SafePath::validate(&entry_path, &dest, &config);
+
+    assert_matches!(
+        result,
+        Err(ArchiveError::PathTraversal { .. }),
+        "sibling directory reached via symlink and sharing a name prefix with \
+         the destination root must be rejected, got: {result:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- `paths_start_with()` in `crates/exarch-core/src/types/safe_path.rs` (macOS/Windows arm) compared paths as raw lowercased strings, so a sibling directory sharing the destination root's name as a string prefix (e.g. `/tmp/destevil` vs `/tmp/dest`) was incorrectly treated as contained within it. The non-macOS Unix arm was unaffected — it already used `Path::starts_with`, which is component-aware.
- Replaced the macOS/Windows arm with a component-wise, case-insensitive comparison matching the same semantics as the correct Unix arm.
- Added unit tests covering the sibling bypass, genuine subdirectories, case-insensitivity, and the base-longer-than-path short-circuit branch, plus an end-to-end regression test driving the attack through a real on-disk symlink (`crates/exarch-core/tests/security/safe_path_ghsa_wcmx.rs`).

Fixes GHSA-wcmx-7f9h-5mv5 (draft private security advisory — https://github.com/bug-ops/exarch/security/advisories/GHSA-wcmx-7f9h-5mv5).

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy -p exarch-core --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run -p exarch-core --all-features` (971/971 passed)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p exarch-core --all-features`
- [x] Both new GHSA-wcmx regression tests independently confirmed to execute (not skipped) and pass
- [x] Verified the new tests fail against the pre-fix implementation and pass against the fix